### PR TITLE
[Fix: issue 652] Fix escaping quotes in dict values

### DIFF
--- a/pynecone/components/tags/tag.py
+++ b/pynecone/components/tags/tag.py
@@ -127,6 +127,8 @@ class Tag(Base):
         # Format all the props.
         return os.linesep.join(
             f"{name}={self.format_prop(prop)}"
+            if name != "sx"
+            else f"{name}={self.format_style(prop)}"
             for name, prop in sorted(self.props.items())
             if prop is not None
         )
@@ -209,3 +211,23 @@ class Tag(Base):
             Whether the prop is valid.
         """
         return prop is not None and not (isinstance(prop, dict) and len(prop) == 0)
+
+    @staticmethod
+    def format_style(prop: dict) -> str:
+        """Format style.
+
+        Args:
+            prop: The style.
+
+        Returns:
+            The formatted style.
+        """
+        ret = utils.json_dumps(prop)
+
+        # This substitution is necessary to unwrap var values.
+        if ret.find('"{') > 0:
+            ret = re.sub('"{', "", ret)
+            ret = re.sub('}"', "", ret)
+            ret = re.sub('\\\\"', '"', ret)
+
+        return utils.wrap(ret, "{", check_first=False)

--- a/tests/components/test_tag.py
+++ b/tests/components/test_tag.py
@@ -154,3 +154,30 @@ def test_format_cond_tag():
         cond=BaseVar(name="logged_in", type_=bool),
     )
     assert str(tag) == "{logged_in ? <h1>True content</h1> : <h2>False content</h2>}"
+
+
+@pytest.mark.parametrize(
+    "prop,valid",
+    [
+        (
+            {"fontFamily": "{hello_state.font_family}"},
+            '{{"fontFamily": hello_state.font_family}}',
+        ),
+        (
+            {"fontFamily": '"Fira Code", Menlo, Consolas, monospace'},
+            '{{"fontFamily": "\\"Fira Code\\", Menlo, ' 'Consolas, monospace"}}',
+        ),
+        (
+            {"fontFamily": "Menlo, Consolas, monospace"},
+            '{{"fontFamily": "Menlo, Consolas, monospace"}}',
+        ),
+    ],
+)
+def test_format_style(prop: dict, valid: str):
+    """Test format style.
+
+    Args:
+        prop: The prop to test.
+        valid: The expected validity of the prop.
+    """
+    assert Tag.format_style(prop) == valid


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Description
Fix escaping quotes in dict values
Close https://github.com/pynecone-io/pynecone/issues/652

