### PR TITLE
hydrate_middleware: always emit a full dict() when hydrating

### DIFF
--- a/pynecone/middleware/hydrate_middleware.py
+++ b/pynecone/middleware/hydrate_middleware.py
@@ -38,19 +38,25 @@ class HydrateMiddleware(Middleware):
             else:
                 load_event = None
 
+            updates = []
+
+            # first get the initial state
+            delta = format.format_state({state.get_name(): state.dict()})
+            if delta:
+                updates.append(StateUpdate(delta=delta))
+
+            # then apply changes from on_load event handlers on top of that
             if load_event:
                 if not isinstance(load_event, List):
                     load_event = [load_event]
-                updates = []
                 for single_event in load_event:
                     updates.append(
                         await self.execute_load_event(
                             state, single_event, event.token, event.payload
                         )
                     )
-                return updates
-            delta = format.format_state({state.get_name(): state.dict()})
-            return StateUpdate(delta=delta) if delta else None
+
+            return updates
 
     async def execute_load_event(
         self, state: State, load_event: EventHandler, token: str, payload: Dict

--- a/pynecone/middleware/hydrate_middleware.py
+++ b/pynecone/middleware/hydrate_middleware.py
@@ -13,6 +13,12 @@ if TYPE_CHECKING:
     from pynecone.app import App
 
 
+IS_HYDRATED = "is_hydrated"
+
+
+State.add_var(IS_HYDRATED, type_=bool, default_value=False)
+
+
 class HydrateMiddleware(Middleware):
     """Middleware to handle initial app hydration."""
 
@@ -55,6 +61,12 @@ class HydrateMiddleware(Middleware):
                             state, single_event, event.token, event.payload
                         )
                     )
+            # extra message telling the client state that hydration is complete
+            updates.append(
+                StateUpdate(
+                    delta=format.format_state({state.get_name(): {IS_HYDRATED: True}})
+                )
+            )
 
             return updates
 

--- a/tests/middleware/test_hydrate_middleware.py
+++ b/tests/middleware/test_hydrate_middleware.py
@@ -10,6 +10,8 @@ from pynecone.state import State
 class TestState(State):
     """A test state with no return in handler."""
 
+    __test__ = False
+
     num: int = 0
 
     def test_handler(self):
@@ -19,6 +21,8 @@ class TestState(State):
 
 class TestState2(State):
     """A test state with return in handler."""
+
+    __test__ = False
 
     num: int = 0
     name: str
@@ -40,11 +44,23 @@ class TestState2(State):
 class TestState3(State):
     """A test state with async handler."""
 
+    __test__ = False
+
     num: int = 0
 
     async def test_handler(self):
         """Test handler."""
         self.num += 1
+
+
+@pytest.fixture
+def hydrate_middleware() -> HydrateMiddleware:
+    """Fixture creates an instance of HydrateMiddleware per test case.
+
+    Returns:
+        instance of HydrateMiddleware
+    """
+    return HydrateMiddleware()
 
 
 @pytest.mark.asyncio
@@ -56,30 +72,33 @@ class TestState3(State):
         (TestState3, {"test_state3": {"num": 1}}, "event3"),
     ],
 )
-async def test_preprocess(state, request, event_fixture, expected):
+async def test_preprocess(state, hydrate_middleware, request, event_fixture, expected):
     """Test that a state hydrate event is processed correctly.
 
     Args:
         state: state to process event
+        hydrate_middleware: instance of HydrateMiddleware
         request: pytest fixture request
         event_fixture: The event fixture(an Event)
         expected: expected delta
     """
     app = App(state=state, load_events={"index": state.test_handler})
 
-    hydrate_middleware = HydrateMiddleware()
     result = await hydrate_middleware.preprocess(
         app=app, event=request.getfixturevalue(event_fixture), state=state()
     )
     assert isinstance(result, List)
-    assert result[0].delta == expected
+    assert len(result) == 2
+    assert result[0].delta == {state().get_name(): state().dict()}
+    assert result[1].delta == expected
 
 
 @pytest.mark.asyncio
-async def test_preprocess_multiple_load_events(event1):
+async def test_preprocess_multiple_load_events(hydrate_middleware, event1):
     """Test that a state hydrate event for multiple on-load events is processed correctly.
 
     Args:
+        hydrate_middleware: instance of HydrateMiddleware
         event1: an Event.
     """
     app = App(
@@ -87,10 +106,29 @@ async def test_preprocess_multiple_load_events(event1):
         load_events={"index": [TestState.test_handler, TestState.test_handler]},
     )
 
-    hydrate_middleware = HydrateMiddleware()
     result = await hydrate_middleware.preprocess(
         app=app, event=event1, state=TestState()
     )
     assert isinstance(result, List)
-    assert result[0].delta == {"test_state": {"num": 1}}
-    assert result[1].delta == {"test_state": {"num": 2}}
+    assert len(result) == 3
+    assert result[0].delta == {"test_state": TestState().dict()}
+    assert result[1].delta == {"test_state": {"num": 1}}
+    assert result[2].delta == {"test_state": {"num": 2}}
+
+
+@pytest.mark.asyncio
+async def test_preprocess_no_events(hydrate_middleware, event1):
+    """Test that app without on_load is processed correctly.
+
+    Args:
+        hydrate_middleware: instance of HydrateMiddleware
+        event1: an Event.
+    """
+    result = await hydrate_middleware.preprocess(
+        app=App(state=TestState),
+        event=event1,
+        state=TestState(),
+    )
+    assert isinstance(result, List)
+    assert len(result) == 1
+    assert result[0].delta == {"test_state": TestState().dict()}

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -6,6 +6,7 @@ from plotly.graph_objects import Figure
 from pynecone.base import Base
 from pynecone.constants import RouteVar
 from pynecone.event import Event
+from pynecone.middleware.hydrate_middleware import IS_HYDRATED
 from pynecone.state import State
 from pynecone.utils import format
 from pynecone.var import BaseVar, ComputedVar
@@ -191,6 +192,7 @@ def test_class_vars(test_state):
     """
     cls = type(test_state)
     assert set(cls.vars.keys()) == {
+        IS_HYDRATED,  # added by hydrate_middleware to all State
         "num1",
         "num2",
         "key",


### PR DESCRIPTION
Ensure the client has access to the full state, even when on_load handlers are provided.

Update tests to assert that the first StateUpdate emitted by preprocess is the full original dict from the state without any changes applied.

Add new test to assert that middleware only includes the original dict from the state when no on_load events are defined.

Fix #842

------------------

State.is_hydrated: client-side bool to check is backend state has arrived

* `hydrate_middleware.HydrateMiddleware` registers a new Var on the base State object: `is_hydrated`.
    
* during `preprocess` of hydrate events, additional `StateUpdate` with the payload `{"is_hydrated": true}` is emitted after normal hydrate.
    
the client side is able to render alternate content based on whether the initial hydrate event has returned via `State.is_hydrated`.
    
 fix #841

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?