### PR TITLE
var: use typing.get_type_hints instead of __annotations__

### DIFF
--- a/pynecone/var.py
+++ b/pynecone/var.py
@@ -15,6 +15,7 @@ from typing import (
     Type,
     Union,
     _GenericAlias,  # type: ignore
+    get_type_hints,
 )
 
 from plotly.graph_objects import Figure
@@ -807,8 +808,9 @@ class ComputedVar(property, Var):
         Returns:
             The type of the var.
         """
-        if "return" in self.fget.__annotations__:
-            return self.fget.__annotations__["return"]
+        hints = get_type_hints(self.fget)
+        if "return" in hints:
+            return hints["return"]
         return Any
 
 


### PR DESCRIPTION
When using forward references or `from __future__ import annotations`, `__annotations__` will only contain the string of the type name, not the actual type. Using `typing.get_type_hints` internally resolves the string references back to their actual types for use at runtime.

Fixes #918

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran tests with your changes locally?