### PR TITLE
Trigger on_load when router completes navigation

### DIFF
--- a/pynecone/app.py
+++ b/pynecone/app.py
@@ -428,8 +428,8 @@ async def process(
     state = app.state_manager.get_state(event.token)
 
     # Add request data to the state.
-    state.router_data = event.router_data
-    state.router_data.update(
+    router_data = event.router_data
+    router_data.update(
         {
             constants.RouteVar.QUERY: format.format_query_params(event.router_data),
             constants.RouteVar.CLIENT_TOKEN: event.token,
@@ -438,10 +438,8 @@ async def process(
             constants.RouteVar.CLIENT_IP: client_ip,
         }
     )
-
-    # Also pass router_data to all substates. (TODO: this isn't recursive currently)
-    for _, substate in state.substates.items():
-        substate.router_data = state.router_data
+    if state.router_data != router_data:
+        state.router_data = router_data
 
     # Preprocess the event.
     pre = await app.preprocess(state, event)

--- a/pynecone/compiler/templates.py
+++ b/pynecone/compiler/templates.py
@@ -175,6 +175,7 @@ PROCESSING = constants.PROCESSING
 SOCKET = constants.SOCKET
 STATE = constants.STATE
 EVENTS = constants.EVENTS
+HYDRATE = constants.HYDRATE
 SET_RESULT = format_state_setter(RESULT)
 READY = f"const {{ isReady }} = {ROUTER};"
 USE_EFFECT = path_ops.join(
@@ -202,6 +203,13 @@ USE_EFFECT = path_ops.join(
         "  }}",
         "  update()",
         "}})",
+        "useEffect(() => {{",
+        f"  const change_complete = () => Event([E('{{state}}.{HYDRATE}', {{{{}}}})])",
+        f"  {ROUTER}.events.on('routeChangeComplete', change_complete)",
+        "  return () => {{",
+        f"    {ROUTER}.events.off('routeChangeComplete', change_complete)",
+        "  }}",
+        f"}}}}, [{ROUTER}])",
     ]
 ).format
 

--- a/pynecone/constants.py
+++ b/pynecone/constants.py
@@ -263,6 +263,10 @@ class RouteArgType(SimpleNamespace):
     LIST = str("arg_list")
 
 
+# the name of the backend var containing path and client information
+ROUTER_DATA = "router_data"
+
+
 class RouteVar(SimpleNamespace):
     """Names of variables used in the router_data dict stored in State."""
 

--- a/pynecone/state.py
+++ b/pynecone/state.py
@@ -68,9 +68,6 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
     # The set of dirty substates.
     dirty_substates: Set[str] = set()
 
-    # The routing path that triggered the state
-    router_data: Dict[str, Any] = {}
-
     # Mapping of var name to set of computed variables that depend on it
     computed_var_dependencies: Dict[str, Set[str]] = {}
 
@@ -167,6 +164,8 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
             if types.is_backend_variable(name)
             and name not in cls.inherited_backend_vars
         }
+        if parent_state is None:
+            cls.new_backend_vars[constants.ROUTER_DATA] = {}
 
         cls.backend_vars = {**cls.inherited_backend_vars, **cls.new_backend_vars}
 
@@ -217,7 +216,7 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
             "substates",
             "dirty_vars",
             "dirty_substates",
-            "router_data",
+            constants.ROUTER_DATA,
             "computed_var_dependencies",
         }
 
@@ -527,7 +526,7 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
             setattr(self.parent_state, name, value)
             return
 
-        if types.is_backend_variable(name):
+        if name in self.backend_vars:
             self.backend_vars.__setitem__(name, value)
             self.dirty_vars.add(name)
             self.mark_dirty()


### PR DESCRIPTION
* Move `router_data` to a backend var on the root state, allowing for more natural change tracking and avoid the need to recursively copy router_data into substates.
* Only assign `router_data` if it has changed, not for every request. This allows ComputedVar that depends on router_data to be properly cached and recalculated when the router data actually changes.
* Use the `routeChangeComplete` event to trigger a state re-hydrate when the page changes
  * Existing page `on_load` mechanism is used to handle the event server side.

Fix #609

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
