### PR TITLE
ComputedVar dependency tracking: require caller to pass objclass

### DIFF
--- a/pynecone/state.py
+++ b/pynecone/state.py
@@ -100,7 +100,7 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
         self.computed_var_dependencies = defaultdict(set)
         for cvar_name, cvar in self.computed_vars.items():
             # Add the dependencies.
-            for var in cvar.deps():
+            for var in cvar.deps(objclass=type(self)):
                 self.computed_var_dependencies[var].add(cvar_name)
 
         # Initialize the mutable fields.
@@ -484,9 +484,7 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
                 func = arglist_factory(param)
             else:
                 continue
-            # link dynamically created ComputedVar to this state class for dep determination
-            func.__objclass__ = cls
-            func.fget.__name__ = param
+            func.fget.__name__ = param  # to allow passing as a prop
             cls.vars[param] = cls.computed_vars[param] = func.set_state(cls)  # type: ignore
             setattr(cls, param, func)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -120,7 +120,9 @@ def test_add_page_set_route_dynamic(app: App, index_page, windows_platform: bool
     app.add_page(index_page, route=route)
     assert set(app.pages.keys()) == {"test/[dynamic]"}
     assert "dynamic" in app.state.computed_vars
-    assert app.state.computed_vars["dynamic"].deps() == {"router_data"}
+    assert app.state.computed_vars["dynamic"].deps(objclass=DefaultState) == {
+        "router_data"
+    }
     assert "router_data" in app.state().computed_var_dependencies
 
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -858,7 +858,11 @@ def test_conditional_computed_vars():
     assert ms._dirty_computed_vars(from_vars={"flag"}) == {"rendered_var"}
     assert ms._dirty_computed_vars(from_vars={"t2"}) == {"rendered_var"}
     assert ms._dirty_computed_vars(from_vars={"t1"}) == {"rendered_var"}
-    assert ms.computed_vars["rendered_var"].deps() == {"flag", "t1", "t2"}
+    assert ms.computed_vars["rendered_var"].deps(objclass=MainState) == {
+        "flag",
+        "t1",
+        "t2",
+    }
 
 
 def test_event_handlers_convert_to_fns(test_state, child_state):


### PR DESCRIPTION
While writing tests for #956, I discovered another case where the missing `__objclass__` exception popped up unexpectedly: trying to call a mock attached to a `State`. So setting out to generalize the fix for #952, I realized that the only caller of `ComputedVar.deps()` is `State` itself, and it can easily pass a reference to its own type instead of having the descriptor tracking/caching the `__objclass__` attribute. This means it will also work with any dynamically added computed_var, without having to patch anything through.

I'm hoping this is the last tweak needed to this section of code, and it looks like it leaves the design simpler.

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran tests with your changes locally?