### PR TITLE
Trigger on_load when router completes navigation (second try)

### DIFF
--- a/pynecone/app.py
+++ b/pynecone/app.py
@@ -428,8 +428,8 @@ async def process(
     state = app.state_manager.get_state(event.token)
 
     # Add request data to the state.
-    state.router_data = event.router_data
-    state.router_data.update(
+    router_data = event.router_data
+    router_data.update(
         {
             constants.RouteVar.QUERY: format.format_query_params(event.router_data),
             constants.RouteVar.CLIENT_TOKEN: event.token,
@@ -438,10 +438,11 @@ async def process(
             constants.RouteVar.CLIENT_IP: client_ip,
         }
     )
-
-    # Also pass router_data to all substates. (TODO: this isn't recursive currently)
-    for _, substate in state.substates.items():
-        substate.router_data = state.router_data
+    # re-assign only when the value is different
+    if state.router_data != router_data:
+        # assignment will recurse into substates and force recalculation of
+        # dependent ComputedVar (dynamic route variables)
+        state.router_data = router_data
 
     # Preprocess the event.
     pre = await app.preprocess(state, event)

--- a/pynecone/compiler/templates.py
+++ b/pynecone/compiler/templates.py
@@ -175,6 +175,7 @@ PROCESSING = constants.PROCESSING
 SOCKET = constants.SOCKET
 STATE = constants.STATE
 EVENTS = constants.EVENTS
+HYDRATE = constants.HYDRATE
 SET_RESULT = format_state_setter(RESULT)
 READY = f"const {{ isReady }} = {ROUTER};"
 USE_EFFECT = path_ops.join(
@@ -202,6 +203,13 @@ USE_EFFECT = path_ops.join(
         "  }}",
         "  update()",
         "}})",
+        "useEffect(() => {{",
+        f"  const change_complete = () => Event([E('{{state}}.{HYDRATE}', {{{{}}}})])",
+        f"  {ROUTER}.events.on('routeChangeComplete', change_complete)",
+        "  return () => {{",
+        f"    {ROUTER}.events.off('routeChangeComplete', change_complete)",
+        "  }}",
+        f"}}}}, [{ROUTER}])",
     ]
 ).format
 

--- a/pynecone/constants.py
+++ b/pynecone/constants.py
@@ -263,6 +263,10 @@ class RouteArgType(SimpleNamespace):
     LIST = str("arg_list")
 
 
+# the name of the backend var containing path and client information
+ROUTER_DATA = "router_data"
+
+
 class RouteVar(SimpleNamespace):
     """Names of variables used in the router_data dict stored in State."""
 

--- a/pynecone/middleware/hydrate_middleware.py
+++ b/pynecone/middleware/hydrate_middleware.py
@@ -50,6 +50,8 @@ class HydrateMiddleware(Middleware):
             delta = format.format_state({state.get_name(): state.dict()})
             if delta:
                 updates.append(StateUpdate(delta=delta))
+            # since a full dict was captured, clean any dirtiness
+            state.clean()
 
             # then apply changes from on_load event handlers on top of that
             if load_event:

--- a/pynecone/state.py
+++ b/pynecone/state.py
@@ -542,6 +542,14 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
             self.dirty_vars.add(name)
             self.mark_dirty()
 
+        # For now, handle router_data updates as a special case
+        if name == constants.ROUTER_DATA:
+            self.dirty_vars.add(name)
+            self.mark_dirty()
+            # propagate router_data updates down the state tree
+            for substate in self.substates.values():
+                setattr(substate, name, value)
+
     def reset(self):
         """Reset all the base vars to their default values."""
         # Reset the base vars.

--- a/pynecone/state.py
+++ b/pynecone/state.py
@@ -100,7 +100,7 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
         self.computed_var_dependencies = defaultdict(set)
         for cvar_name, cvar in self.computed_vars.items():
             # Add the dependencies.
-            for var in cvar.deps():
+            for var in cvar.deps(objclass=type(self)):
                 self.computed_var_dependencies[var].add(cvar_name)
 
         # Initialize the mutable fields.
@@ -484,9 +484,7 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
                 func = arglist_factory(param)
             else:
                 continue
-            # link dynamically created ComputedVar to this state class for dep determination
-            func.__objclass__ = cls
-            func.fget.__name__ = param
+            func.fget.__name__ = param  # to allow passing as a prop
             cls.vars[param] = cls.computed_vars[param] = func.set_state(cls)  # type: ignore
             setattr(cls, param, func)
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,6 +5,7 @@ from typing import List, Tuple, Type
 import pytest
 from fastapi import UploadFile
 
+from pynecone import constants
 from pynecone.app import App, DefaultState, process, upload
 from pynecone.components import Box
 from pynecone.event import Event, get_hydrate_event
@@ -124,9 +125,9 @@ def test_add_page_set_route_dynamic(app: App, index_page, windows_platform: bool
     assert set(app.pages.keys()) == {"test/[dynamic]"}
     assert "dynamic" in app.state.computed_vars
     assert app.state.computed_vars["dynamic"].deps(objclass=DefaultState) == {
-        "router_data"
+        constants.ROUTER_DATA
     }
-    assert "router_data" in app.state().computed_var_dependencies
+    assert constants.ROUTER_DATA in app.state().computed_var_dependencies
 
 
 def test_add_page_set_route_nested(app: App, index_page, windows_platform: bool):
@@ -612,8 +613,10 @@ async def test_dynamic_route_var_route_change_completed_on_load(
     app.add_page(index_page, route=route, on_load=DynamicState.on_load)  # type: ignore
     assert arg_name in app.state.vars
     assert arg_name in app.state.computed_vars
-    assert app.state.computed_vars[arg_name].deps(objclass=DynamicState) == {"router_data"}
-    assert "router_data" in app.state().computed_var_dependencies
+    assert app.state.computed_vars[arg_name].deps(objclass=DynamicState) == {
+        constants.ROUTER_DATA
+    }
+    assert constants.ROUTER_DATA in app.state().computed_var_dependencies
 
     token = "mock_token"
     sid = "mock_sid"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -120,7 +120,9 @@ def test_add_page_set_route_dynamic(app: App, index_page, windows_platform: bool
     app.add_page(index_page, route=route)
     assert set(app.pages.keys()) == {"test/[dynamic]"}
     assert "dynamic" in app.state.computed_vars
-    assert app.state.computed_vars["dynamic"].deps() == {"router_data"}
+    assert app.state.computed_vars["dynamic"].deps(objclass=DefaultState) == {
+        "router_data"
+    }
     assert "router_data" in app.state().computed_var_dependencies
 
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -858,7 +858,11 @@ def test_conditional_computed_vars():
     assert ms._dirty_computed_vars(from_vars={"flag"}) == {"rendered_var"}
     assert ms._dirty_computed_vars(from_vars={"t2"}) == {"rendered_var"}
     assert ms._dirty_computed_vars(from_vars={"t1"}) == {"rendered_var"}
-    assert ms.computed_vars["rendered_var"].deps() == {"flag", "t1", "t2"}
+    assert ms.computed_vars["rendered_var"].deps(objclass=MainState) == {
+        "flag",
+        "t1",
+        "t2",
+    }
 
 
 def test_event_handlers_convert_to_fns(test_state, child_state):


### PR DESCRIPTION
Avoiding backend variables for the moment, and adding a new end-to-end test case.

(This PR is based on #963, [View just that diff 👈](https://github.com/pynecone-io/pynecone/pull/964/files/40a305d7d537ae26908ff9180db9bb44cdf43f32..3b9ce2fc6ab7ca88c60be922c935e0af7952e6d2))

* Only assign `router_data` if it has changed, not for every request. This
  allows ComputedVar that depends on router_data to be properly cached and
  recalculated when the router data actually changes.
* Recursively assign router_data down the state tree (acceptable now that
  assignment should be "rare", only when the actual router data has been changed)
* Use the `routeChangeComplete` event to trigger a state re-hydrate

Fix https://github.com/pynecone-io/pynecone/issues/609

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
