### PR TITLE
@pc.cached_var: explicit opt-in for ComputedVar tracking

### DIFF
--- a/pynecone/__init__.py
+++ b/pynecone/__init__.py
@@ -31,3 +31,4 @@ from .state import ComputedVar as var
 from .state import State as State
 from .style import toggle_color_mode as toggle_color_mode
 from .vars import Var as Var
+from .vars import cached_var as cached_var

--- a/pynecone/state.py
+++ b/pynecone/state.py
@@ -688,22 +688,29 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
         # Return the state update.
         return StateUpdate(delta=delta, events=events)
 
+    def _always_dirty_computed_vars(self) -> Set[str]:
+        """The set of ComputedVars that always need to be recalculated.
+
+        Returns:
+            Set of all ComputedVar in this state where cache=False
+        """
+        return set(
+            cvar_name
+            for cvar_name, cvar in self.computed_vars.items()
+            if not cvar.cache
+        )
+
     def _mark_dirty_computed_vars(self) -> None:
         """Mark ComputedVars that need to be recalculated based on dirty_vars."""
-        # Mark all ComputedVars as dirty.
-        for cvar in self.computed_vars.values():
-            cvar.mark_dirty(instance=self)
-
-        # TODO: Uncomment the actual implementation below.
-        # dirty_vars = self.dirty_vars
-        # while dirty_vars:
-        #     calc_vars, dirty_vars = dirty_vars, set()
-        #     for cvar in self._dirty_computed_vars(from_vars=calc_vars):
-        #         self.dirty_vars.add(cvar)
-        #         dirty_vars.add(cvar)
-        #         actual_var = self.computed_vars.get(cvar)
-        #         if actual_var:
-        #             actual_var.mark_dirty(instance=self)
+        dirty_vars = self.dirty_vars
+        while dirty_vars:
+            calc_vars, dirty_vars = dirty_vars, set()
+            for cvar in self._dirty_computed_vars(from_vars=calc_vars):
+                self.dirty_vars.add(cvar)
+                dirty_vars.add(cvar)
+                actual_var = self.computed_vars.get(cvar)
+                if actual_var:
+                    actual_var.mark_dirty(instance=self)
 
     def _dirty_computed_vars(self, from_vars: Optional[Set[str]] = None) -> Set[str]:
         """Determine ComputedVars that need to be recalculated based on the given vars.
@@ -714,13 +721,11 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
         Returns:
             Set of computed vars to include in the delta.
         """
-        return set(self.computed_vars)
-        # TODO: Uncomment the actual implementation below.
-        # return set(
-        #     cvar
-        #     for dirty_var in from_vars or self.dirty_vars
-        #     for cvar in self.computed_var_dependencies[dirty_var]
-        # )
+        return set(
+            cvar
+            for dirty_var in from_vars or self.dirty_vars
+            for cvar in self.computed_var_dependencies[dirty_var]
+        )
 
     def get_delta(self) -> Delta:
         """Get the delta for the state.
@@ -730,11 +735,18 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
         """
         delta = {}
 
-        # Return the dirty vars and dependent computed vars
-        self._mark_dirty_computed_vars()
-        delta_vars = self.dirty_vars.intersection(self.base_vars).union(
-            self._dirty_computed_vars()
+        # Apply dirty variables down into substates
+        self.dirty_vars.update(self._always_dirty_computed_vars())
+        self.mark_dirty()
+
+        # Return the dirty vars for this instance, any cached/dependent computed vars,
+        # and always dirty computed vars (cache=False)
+        delta_vars = (
+            self.dirty_vars.intersection(self.base_vars)
+            .union(self._dirty_computed_vars())
+            .union(self._always_dirty_computed_vars())
         )
+
         subdelta = {
             prop: getattr(self, prop)
             for prop in delta_vars

--- a/pynecone/state.py
+++ b/pynecone/state.py
@@ -809,6 +809,12 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
         Returns:
             The object as a dictionary.
         """
+        if include_computed:
+            # Apply dirty variables down into substates to allow never-cached ComputedVar to
+            # trigger recalculation of dependent vars
+            self.dirty_vars.update(self._always_dirty_computed_vars())
+            self.mark_dirty()
+
         base_vars = {
             prop_name: self.get_value(getattr(self, prop_name))
             for prop_name in self.base_vars


### PR DESCRIPTION
Re-enable caching, but disable it by default. Users must opt-in to variable caching/dependency tracking, by using the new `@pc.cached_var` decorator.

* Add a `cache` boolean property to `ComputedVar`. If it is set to `False`, then all caching considerations are ignored. Additionally, any ComputedVar in a state with `cache=False` are considered "always dirty" and will be recalculated in `dict()` and `get_delta()`, even if their dependencies haven't changed.
* Any ComputedVar with `cache=True` that depends on an uncached variable will essentially become uncached and will be recalculated whenever the dependent var is recalculated (so, every time).
* Add a new `pc.cached_var` decorator which works just like `pc.var`, except sets `cache=True`

🎉 Hooray, PR number 1000!

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

**Really need to update pcweb to describe this new state caching functionality, expect a PR this weekend.**

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?