### PR TITLE
Fix db_url set to empty string in default pcconfig.py

### DIFF
--- a/pynecone/.templates/jinja/app/pcconfig.py.jinja2
+++ b/pynecone/.templates/jinja/app/pcconfig.py.jinja2
@@ -5,6 +5,6 @@ class {{ config_name }}(pc.Config):
 
 config = {{ config_name }}(
     app_name="{{ app_name }}",
-    db_url="{{ db_url }}",
+    db_url="{{ const.db_url }}",
     env=pc.Env.DEV,
 )

--- a/pynecone/compiler/templates.py
+++ b/pynecone/compiler/templates.py
@@ -38,6 +38,7 @@ class PyneconeJinjaEnvironment(Environment):
             "toggle_color_mode": constants.TOGGLE_COLOR_MODE,
             "use_color_mode": constants.USE_COLOR_MODE,
             "hydrate": constants.HYDRATE,
+            "db_url": constants.DB_URL,
         }
 
 


### PR DESCRIPTION
Set `const.db_url` to `constants.DB_URL` in the default jinja template
environment to retain parity with pre-jinja templating of pcconfig.py

Update pcconfig.pc.jinja2 to reference `const.db_url` instead of unqualified
`db_url`...at this point is there a use case for templating the database url at
all? or will it always be a constant?

Fix #1021

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?