### PR TITLE
utils/state.js: check whether event.preventDefault is undefined

### DIFF
--- a/pynecone/.templates/web/utils/state.js
+++ b/pynecone/.templates/web/utils/state.js
@@ -285,7 +285,7 @@ export const isTrue = (val) => {
  * @param event
  */
 export const preventDefault = (event) => {
-  if (event && event.hasOwnProperty("preventDefault")) {
+  if (event && event.preventDefault) {
     event.preventDefault();
   }
 };


### PR DESCRIPTION
often events will inherit from `Event`, which defines `preventDefault`, in these cases `preventDefault` will be inherited and `hasOwnProperty('preventDefault')` will return false

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran tests with your changes locally?

# Example

(Note `pc init` is required to pick up `utils/state.js` changes!)

```python
import pynecone as pc


class State(pc.State):
    foo: int = 42
    label: str = ""

    def on_load(self):
        print("Page loaded")
        self.label = ""

    def on_submit(self):
        print(f"Form submitted: {self.foo}")
        self.label = f"The answer is {self.foo}"
        self.foo = int(self.foo) + 1



def index() -> pc.Component:
    return pc.center(
        pc.vstack(
            pc.cond(
                State.label,
                pc.heading(State.label),
                pc.box(),
            ),
            pc.form(
                pc.number_input(value=State.foo, on_change=State.set_foo),
                pc.button("Submit", type_="submit"),
                on_submit=State.on_submit,
            ),
        ),
        padding_top="10%",
    )


app = pc.App(state=State)
app.add_page(index, on_load=State.on_load)
app.compile()
```

Before the fix, this code doesn't really work, because submitting the form causes a page load, which rehydrates the state and breaks `pc.redirect` and other constructs.

After the fix, each time the form is submitted, the label is updated and no page reload is observed.