### PR TITLE
Add vars and components for working with color_mode

### DIFF
--- a/pynecone/.templates/apps/default/default.py
+++ b/pynecone/.templates/apps/default/default.py
@@ -14,7 +14,8 @@ class State(pc.State):
 
 
 def index() -> pc.Component:
-    return pc.center(
+    return pc.fragment(
+        pc.color_mode_button(pc.color_mode_icon(), float="right"),
         pc.vstack(
             pc.heading("Welcome to Pynecone!", font_size="2em"),
             pc.box("Get started by editing ", pc.code(filename, font_size="1em")),
@@ -25,13 +26,16 @@ def index() -> pc.Component:
                 padding="0.5em",
                 border_radius="0.5em",
                 _hover={
-                    "color": "rgb(107,99,246)",
+                    "color": pc.color_mode_cond(
+                        light="rgb(107,99,246)",
+                        dark="rgb(179, 175, 255)",
+                    )
                 },
             ),
             spacing="1.5em",
             font_size="2em",
+            padding_top="10%",
         ),
-        padding_top="10%",
     )
 
 

--- a/pynecone/__init__.py
+++ b/pynecone/__init__.py
@@ -31,6 +31,7 @@ from .model import session as session
 from .route import route as route
 from .state import ComputedVar as var
 from .state import State as State
+from .style import color_mode as color_mode
 from .style import toggle_color_mode as toggle_color_mode
 from .vars import Var as Var
 from .vars import cached_var as cached_var

--- a/pynecone/components/__init__.py
+++ b/pynecone/components/__init__.py
@@ -226,3 +226,6 @@ text = Text.create
 script = ScriptTag.create
 aspect_ratio = AspectRatio.create
 kbd = KeyboardKey.create
+color_mode_button = ColorModeButton.create
+color_mode_icon = ColorModeIcon.create
+color_mode_switch = ColorModeSwitch.create

--- a/pynecone/components/forms/__init__.py
+++ b/pynecone/components/forms/__init__.py
@@ -2,6 +2,12 @@
 
 from .button import Button, ButtonGroup
 from .checkbox import Checkbox, CheckboxGroup
+from .colormodeswitch import (
+    ColorModeButton,
+    ColorModeIcon,
+    ColorModeSwitch,
+    color_mode_cond,
+)
 from .copytoclipboard import CopyToClipboard
 from .editable import Editable, EditableInput, EditablePreview, EditableTextarea
 from .email import Email
@@ -32,4 +38,8 @@ from .switch import Switch
 from .textarea import TextArea
 from .upload import Upload
 
-__all__ = [f for f in dir() if f[0].isupper()]  # type: ignore
+helpers = [
+    "color_mode_cond",
+]
+
+__all__ = [f for f in dir() if f[0].isupper()] + helpers  # type: ignore

--- a/pynecone/components/forms/colormodeswitch.py
+++ b/pynecone/components/forms/colormodeswitch.py
@@ -1,0 +1,116 @@
+"""A switch component for toggling color_mode.
+
+To style components based on color mode, use style props with `color_mode_cond`:
+
+```
+pc.text(
+    "Hover over me",
+    _hover={
+        "background": pc.color_mode_cond(
+            light="var(--chakra-colors-gray-200)",
+            dark="var(--chakra-colors-gray-700)",
+        ),
+    },
+)
+```
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from pynecone.components.component import Component
+from pynecone.components.layout.cond import Cond, cond
+from pynecone.components.media.icon import Icon
+from pynecone.style import color_mode, toggle_color_mode
+from pynecone.vars import BaseVar
+
+from .button import Button
+from .switch import Switch
+
+DEFAULT_COLOR_MODE = "light"
+DEFAULT_LIGHT_ICON = Icon.create(tag="sun")
+DEFAULT_DARK_ICON = Icon.create(tag="moon")
+
+
+def color_mode_cond(light: Any, dark: Any = None) -> BaseVar | Component:
+    """Create a component or Prop based on color_mode.
+
+    Args:
+        light: The component or prop to render if color_mode is default
+        dark: The component or prop to render if color_mode is non-default
+
+    Returns:
+        The conditional component or prop.
+    """
+    return cond(
+        color_mode == DEFAULT_COLOR_MODE,
+        light,
+        dark,
+    )
+
+
+class ColorModeIcon(Cond):
+    """Displays the current color mode as an icon."""
+
+    @classmethod
+    def create(
+        cls,
+        light_component: Component | None = None,
+        dark_component: Component | None = None,
+    ):
+        """Create an icon component based on color_mode.
+
+        Args:
+            light_component: the component to display when color mode is default
+            dark_component: the component to display when color mode is dark (non-default)
+
+        Returns:
+            The conditionally rendered component
+        """
+        return color_mode_cond(
+            light=light_component or DEFAULT_LIGHT_ICON,
+            dark=dark_component or DEFAULT_DARK_ICON,
+        )
+
+
+class ColorModeSwitch(Switch):
+    """Switch for toggling chakra light / dark mode via toggle_color_mode."""
+
+    @classmethod
+    def create(cls, *children, **props):
+        """Create a switch component bound to color_mode.
+
+        Args:
+            *children: The children of the component.
+            **props: The props to pass to the component.
+
+        Returns:
+            The switch component.
+        """
+        return Switch.create(
+            *children,
+            is_checked=color_mode != DEFAULT_COLOR_MODE,
+            on_change=toggle_color_mode,
+            **props,
+        )
+
+
+class ColorModeButton(Button):
+    """Button for toggling chakra light / dark mode via toggle_color_mode."""
+
+    @classmethod
+    def create(cls, *children, **props):
+        """Create a button component that calls toggle_color_mode on click.
+
+        Args:
+            *children: The children of the component.
+            **props: The props to pass to the component.
+
+        Returns:
+            The switch component.
+        """
+        return Button.create(
+            *children,
+            on_click=toggle_color_mode,
+            **props,
+        )

--- a/pynecone/style.py
+++ b/pynecone/style.py
@@ -7,6 +7,7 @@ from pynecone.event import EventChain
 from pynecone.utils import format
 from pynecone.vars import BaseVar, Var
 
+color_mode = BaseVar(name=constants.COLOR_MODE, type_="str")
 toggle_color_mode = BaseVar(name=constants.TOGGLE_COLOR_MODE, type_=EventChain)
 
 


### PR DESCRIPTION
This came out of a discord discussion last week about how to react to the color mode.

* `pc.color_mode`: a BaseVar that accesses colorMode on the frontend (either `"light"` or `"dark"` currently)
* `pc.color_mode_cond`: a `pc.cond` wrapper that conditionally renders components or props based on the value of `color_mode` with the default baked into the component to avoid leaking implementation details into downstream code.
* `pc.color_mode_icon`: by default "sun" if light mode, "moon" if dark mode
* `pc.color_mode_switch`: a Switch component where is_checked depends on the color_mode and changing the value calls toggle_color_mode
* `pc.color_mode_button`: a Button component that calls toggle_color_mode on click

The default template has been updated to include a color_mode_button with color_mode_icon for toggling light/dark mode. The inline hover style has also been updated to use color_mode_cond to show a different highlight color based on the color_mode.

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?


### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### Testing

Currently i have not added test cases for these items because they are essentially wrapping other components. Not sure what relevant tests could be added without excessive mocking or a full end-to-end fixture.

### Forms?

I also wasn't entirely sure where these ColorMode components should end up... since they're wrapping Button and Switch, I put them under `forms`, but it didn't quite feel right. **Input is appreciated**.

https://github.com/pynecone-io/pynecone/assets/1524005/025f3423-2bb3-4fba-a967-b29060ec4553