### PR TITLE
link: `as_={NextLink}` for next 13 compatibility

### DIFF
--- a/pynecone/components/navigation/link.py
+++ b/pynecone/components/navigation/link.py
@@ -1,9 +1,9 @@
 """A link component."""
 
-from pynecone.components.component import Component
 from pynecone.components.libs.chakra import ChakraComponent
 from pynecone.components.navigation.nextlink import NextLink
-from pynecone.vars import Var
+from pynecone.utils import imports
+from pynecone.vars import BaseVar, Var
 
 
 class Link(ChakraComponent):
@@ -21,21 +21,10 @@ class Link(ChakraComponent):
     text: Var[str]
 
     # What the link renders to.
-    as_: Var[str] = "span"  # type: ignore
+    as_: Var[str] = BaseVar.create("{NextLink}", is_local=False)  # type: ignore
 
     # If true, the link will open in new tab.
     is_external: Var[bool]
 
-    @classmethod
-    def create(cls, *children, **props) -> Component:
-        """Create a NextJS link component, wrapping a Chakra link component.
-
-        Args:
-            *children: The children to pass to the component.
-            **props: The attributes to pass to the component.
-
-        Returns:
-            The component.
-        """
-        kwargs = {"href": props.pop("href") if "href" in props else "#"}
-        return NextLink.create(super().create(*children, **props), **kwargs)
+    def _get_imports(self) -> imports.ImportDict:
+        return {**super()._get_imports(), **NextLink(href=self.href)._get_imports()}


### PR DESCRIPTION
> As of Next.js 13, the `Link` component directly renders an `a` element,
> therefore its child can no longer be another `a` element. The recommended way
> is to use the `as` property on Chakra UI components used as a link.

https://chakra-ui.com/docs/components/link/usage#usage-with-nextjs

Fix #1135

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

- [x] Bug fix (non-breaking change which fixes an issue)