### PR TITLE
Dynamic state: add_computed_var, add_event_handler

### DIFF
--- a/pynecone/state.py
+++ b/pynecone/state.py
@@ -390,7 +390,7 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
         # let substates know about the new variable
         def update_inherited_vars(state: Type[State]):
             for s in state.get_substates():
-                if getattr(s, "parent_state", None) is None:
+                if s.get_parent_state() is None:
                     continue  # no inherited vars for root state
                 s.inherited_vars[name] = var
                 update_inherited_vars(s)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -403,15 +403,19 @@ def test_get_class_var():
         )
 
 
+class TestSetVarState(State):
+    pass
+
+
 def test_set_class_var():
     """Test setting the var of a class."""
     with pytest.raises(AttributeError):
-        TestState.num3  # type: ignore
-    TestState._set_var(BaseVar(name="num3", type_=int).set_state(TestState))
-    var = TestState.num3  # type: ignore
+        TestSetVarState.num3  # type: ignore
+    TestSetVarState._set_var(BaseVar(name="num3", type_=int).set_state(TestSetVarState))
+    var = TestSetVarState.num3  # type: ignore
     assert var.name == "num3"
     assert var.type_ == int
-    assert var.state == TestState.get_full_name()
+    assert var.state == TestSetVarState.get_full_name()
 
 
 def test_set_parent_and_substates(test_state, child_state, grandchild_state):
@@ -1088,3 +1092,7 @@ def test_computed_var_depends_on_parent_non_cached():
         IS_HYDRATED: False,
     }
     assert counter == 6
+
+# Add var, then create substates
+#
+# Create substates, then add var


### PR DESCRIPTION
Deterministically add vars to the state tree at compile time, ensuring that new vars are reactive throughout all substates and accounted for in internal bookkeeping dicts (`_propagate_var`).

Add event handlers dynamically.

Allow "local" substates, defined within a function, for more complex generic components that extend state at compile time.

Track a copy of `inherited_vars` per state class, not directly referencing the parent state `vars`.

Fix #893

### All Submissions:

- [ ] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [ ] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### New Feature Submission:

- [ ] Does your submission pass the tests? 
- [ ] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.

    a. Give a descriptive title to your PR.

    b. Describe your changes.

    c. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

