### PR TITLE
link: clear `as` property if link has no href

### DIFF
--- a/reflex/components/navigation/link.py
+++ b/reflex/components/navigation/link.py
@@ -51,7 +51,7 @@ class Link(ChakraComponent):
             raise ValueError("Link without a child will not display")
         elif href is None and len(children):
             # Don't use a NextLink if there is no href.
-            props["as_"] = "Link"
+            props["as_"] = ""
         if href:
             props["href"] = href
         return super().create(*children, **props)


### PR DESCRIPTION
The component is _already_ a Link, so rendering it as a Link doesn't make sense, and also doesn't work because `"Link"` is not the same as `{Link}`.

Fix pynecone-io/pynecone-examples#105 pynecone-io/pynecone-examples#110

Follow-up for #1178
