### PR TITLE
Yield with uploads

### DIFF
--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -323,20 +323,7 @@ export const uploadFiles = async (state, setResult, handler) => {
   }
 
   // Send the file to the server.
-  await axios.post(UPLOADURL, formdata, headers).then((response) => {
-    // Apply the delta and set the result.
-    const update = response.data;
-    applyDelta(state, update.delta);
-
-    // Set processing to false and return.
-    setResult({
-      state: state,
-      events: update.events,
-      final: true,
-      processing: false,
-    });
-  });
-
+  await axios.post(UPLOADURL, formdata, headers);
   return true;
 };
 

--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -338,12 +338,11 @@ export const uploadFiles = async (state, setResult, handler) => {
           console.log(error.request);
         } else {
           // Something happened in setting up the request that triggered an Error
-          console.log('Error', error.message);
+          console.log(error.message);
         }
         return false;
       }
     )
-  //  return true;
 };
 
 /**

--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -323,8 +323,27 @@ export const uploadFiles = async (state, setResult, handler) => {
   }
 
   // Send the file to the server.
-  await axios.post(UPLOADURL, formdata, headers);
-  return true;
+  await axios.post(UPLOADURL, formdata, headers)
+    .then(() => { return true; })
+    .catch(
+      error => {
+        if (error.response) {
+          // The request was made and the server responded with a status code
+          // that falls out of the range of 2xx
+          console.log(error.response.data);
+        } else if (error.request) {
+          // The request was made but no response was received
+          // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
+          // http.ClientRequest in node.js
+          console.log(error.request);
+        } else {
+          // Something happened in setting up the request that triggered an Error
+          console.log('Error', error.message);
+        }
+        return false;
+      }
+    )
+  //  return true;
 };
 
 /**

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -594,9 +594,6 @@ def upload(app: App):
         Args:
             files: The file(s) to upload.
 
-        Returns:
-            The state update after processing the event.
-
         Raises:
             ValueError: if there are no args with supported annotation.
         """

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -643,7 +643,7 @@ def upload(app: App):
             update = await app.postprocess(state, event, update)
             # Send update to client
             await asyncio.create_task(
-                app.event_namespace.emit(
+                app.event_namespace.emit(  # type: ignore
                     str(constants.SocketEvent.EVENT), update.json(), to=sid
                 )
             )

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -646,10 +646,11 @@ def upload(app: App):
         async for update in state._process(event):
             # Postprocess the event.
             update = await app.postprocess(state, event, update)
-
             # Send update to client
-            await app.event_namespace.emit(
-                str(constants.SocketEvent.EVENT), update.json(), to=sid
+            await asyncio.create_task(
+                app.event_namespace.emit(
+                    str(constants.SocketEvent.EVENT), update.json(), to=sid
+                )
             )
 
         # Set the state for the session.

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -635,7 +635,7 @@ async def test_upload_file(fixture, request, delta):
         delta: Expected delta
     """
     app = App(state=request.getfixturevalue(fixture))
-    app.event_namespace.emit = AsyncMock()
+    app.event_namespace.emit = AsyncMock()  # type: ignore
     current_state = app.state_manager.get_state("token")
     data = b"This is binary data"
 
@@ -655,7 +655,7 @@ async def test_upload_file(fixture, request, delta):
     await upload_fn([file1, file2])
     state_update = StateUpdate(delta=delta, events=[], final=True)
 
-    app.event_namespace.emit.assert_called_with(
+    app.event_namespace.emit.assert_called_with(  # type: ignore
         "event", state_update.json(), to=current_state.get_sid()
     )
     assert app.state_manager.get_state("token").dict()["img_list"] == [


### PR DESCRIPTION
This PR should have uploads working with `yield`. The code below should work:

```python
import reflex as rx


class State(rx.State):
    img : list[str] = []
    val : str = "new"

    async def handle_upload(self, files : list[rx.UploadFile]):
        for file in files:
            upload_data = await file.read()
            outfile = f".web/public/{file.filename}"

            # Save the file.
            with open(outfile, "wb") as file_object:
                file_object.write(upload_data)

            # Update the img var.
            self.img.append(file.filename)

        yield State.set_value("Finished uploading")

    def set_value(self, val: str):
        self.val = val

    def upload_and_update(self, files : list[rx.UploadFile] ):

        yield State.set_value("uploading value")
        yield State.handle_upload(files)


def index():
    return rx.center(
        rx.vstack(
            rx.text(State.val),
            rx.upload(
                rx.button("Select File"),
                rx.text("Drag and drop files here or click to select files"),
                border="1px dotted black",
                padding="20em",
            ),
            rx.button(
                "Upload",
                on_click=lambda: State.handle_upload(rx.upload_files())
            ),
            rx.foreach(State.img, lambda img: rx.image(src=img)),
        )
    )


app = rx.App(state=State)
app.add_page(index)
app.compile()


```