### PR TITLE
[Fixes #1351] print SQL execution statements if SQLALCHEMY_ECHO constant is set for debugging

### DIFF
--- a/reflex/constants.py
+++ b/reflex/constants.py
@@ -124,6 +124,8 @@ RUN_BACKEND_PROD_WINDOWS = f"uvicorn --timeout-keep-alive {TIMEOUT}".split()
 # Socket.IO web server
 PING_INTERVAL = 25
 PING_TIMEOUT = 120
+# flag to make the engine print all the SQL statements it executes
+SQLALCHEMY_ECHO = get_value("SQLALCHEMY_ECHO", False, type_=bool)
 
 # Compiler variables.
 # The extension for compiled Javascript files.

--- a/reflex/model.py
+++ b/reflex/model.py
@@ -40,9 +40,12 @@ def get_engine(url: Optional[str] = None):
         console.print(
             "[red]Database is not initialized, run [bold]reflex db init[/bold] first."
         )
+    echo_db_query = False
+    if conf.env == constants.Env.DEV and constants.SQLALCHEMY_ECHO:
+        echo_db_query = True
     return sqlmodel.create_engine(
         url,
-        echo=False,
+        echo=echo_db_query,
         connect_args={"check_same_thread": False} if conf.admin_dash else {},
     )
 


### PR DESCRIPTION
Implements the exact behavior similar to `SQLALCHEMY_ECHO` config parameter in `flask-sqlalchemy`. Defaults to `False`. Ideally this shouldn't be set in `production` environment, so this constant is respected in `dev` mode only. This PR closes #1351 