### PR TITLE
Synchronize Event Namespace

### DIFF
--- a/reflex/app.py
+++ b/reflex/app.py
@@ -97,6 +97,9 @@ class App(Base):
         Args:
             *args: Args to initialize the app with.
             **kwargs: Kwargs to initialize the app with.
+
+        Raises:
+            ValueError: If the event namespace is not provided in the config.
         """
         super().__init__(*args, **kwargs)
 
@@ -129,7 +132,10 @@ class App(Base):
         # Create the socket app. Note event endpoint constant replaces the default 'socket.io' path.
         self.socket_app = ASGIApp(self.sio, socketio_path="")
         namespace = config.get_event_namespace()
-        assert namespace
+
+        if not namespace:
+            raise ValueError("event namespace must be provided in the config.")
+
         # Create the event namespace and attach the main app. Not related to any paths.
         self.event_namespace = EventNamespace(namespace, self)
 

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -128,9 +128,10 @@ class App(Base):
 
         # Create the socket app. Note event endpoint constant replaces the default 'socket.io' path.
         self.socket_app = ASGIApp(self.sio, socketio_path="")
-
+        namespace = config.get_event_namespace()
+        assert namespace
         # Create the event namespace and attach the main app. Not related to any paths.
-        self.event_namespace = EventNamespace("/event", self)
+        self.event_namespace = EventNamespace(namespace, self)
 
         # Register the event namespace with the socket.
         self.sio.register_namespace(self.event_namespace)

--- a/reflex/config.py
+++ b/reflex/config.py
@@ -255,8 +255,12 @@ class Config(Base):
             except AttributeError:
                 pass
 
-    def get_event_namespace(self):
-        """Get the websocket event namespace."""
+    def get_event_namespace(self) -> Optional[str]:
+        """Get the websocket event namespace.
+
+        Returns:
+            The namespace for websocket.
+        """
         if self.event_namespace:
             return f'/{self.event_namespace.strip("/")}'
 

--- a/reflex/config.py
+++ b/reflex/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import os
+import re
 import sys
 import urllib.parse
 from typing import Any, Dict, List, Optional
@@ -206,6 +207,9 @@ class Config(Base):
     # Whether to enable or disable nextJS gzip compression.
     next_compression: bool = True
 
+    # The event namespace for ws connection
+    event_namespace: Optional[str] = constants.EVENT_NAMESPACE
+
     def __init__(self, *args, **kwargs):
         """Initialize the config values.
 
@@ -250,6 +254,15 @@ class Config(Base):
                 setattr(self, field, getattr(constants, f"{field.upper()}"))
             except AttributeError:
                 pass
+
+    def get_event_namespace(self):
+        """Get the websocket event namespace."""
+        if self.event_namespace:
+            return f'/{self.event_namespace.strip("/")}'
+
+        event_url = constants.Endpoint.EVENT.get_url()
+        match = re.match(r"^\w+://[^/]+(/.*)?$", event_url)
+        return match.group(1) if match else None
 
 
 def get_config() -> Config:

--- a/reflex/config.py
+++ b/reflex/config.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import importlib
 import os
-import re
 import sys
 import urllib.parse
 from typing import Any, Dict, List, Optional
@@ -265,8 +264,7 @@ class Config(Base):
             return f'/{self.event_namespace.strip("/")}'
 
         event_url = constants.Endpoint.EVENT.get_url()
-        match = re.match(r"^\w+://[^/]+(/.*)?$", event_url)
-        return match.group(1) if match else None
+        return urllib.parse.urlsplit(event_url).path
 
 
 def get_config() -> Config:

--- a/reflex/constants.py
+++ b/reflex/constants.py
@@ -193,7 +193,8 @@ OLD_CONFIG_FILE = f"pcconfig{PY_EXT}"
 PRODUCTION_BACKEND_URL = "https://{username}-{app_name}.api.pynecone.app"
 # Token expiration time in seconds.
 TOKEN_EXPIRATION = 60 * 60
-
+# The event namespace for websocket
+EVENT_NAMESPACE = get_value("EVENT_NAMESPACE")
 
 # Env modes
 class Env(str, Enum):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ import pytest
 
 import reflex as rx
 from reflex import constants
-from reflex.config import DBConfig
+from reflex.config import DBConfig, get_config
 from reflex.constants import get_value
 
 
@@ -133,3 +133,27 @@ def test_get_value(monkeypatch, key, value, expected_value_type_in_config):
     casted_value = get_value(key, type_=expected_value_type_in_config)
 
     assert isinstance(casted_value, expected_value_type_in_config)
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected",
+    [
+        ({"app_name": "test_app", "api_url": "http://example.com"}, "/event"),
+        ({"app_name": "test_app", "api_url": "http://example.com/api"}, "/api/event"),
+        ({"app_name": "test_app", "event_namespace": "/event"}, "/event"),
+        ({"app_name": "test_app", "event_namespace": "event"}, "/event"),
+    ],
+)
+def test_event_name_space(mocker, kwargs, expected):
+    """Test the event namespace.
+
+    Args:
+        mocker: The pytest mock object.
+        kwargs: The Config kwargs.
+        expected: Expected namespace
+    """
+    conf = rx.Config(**kwargs)
+    mocker.patch("reflex.config.get_config", return_value=conf)
+
+    config = get_config()
+    assert config.get_event_namespace() == expected

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -142,9 +142,10 @@ def test_get_value(monkeypatch, key, value, expected_value_type_in_config):
         ({"app_name": "test_app", "api_url": "http://example.com/api"}, "/api/event"),
         ({"app_name": "test_app", "event_namespace": "/event"}, "/event"),
         ({"app_name": "test_app", "event_namespace": "event"}, "/event"),
+        ({"app_name": "test_app", "event_namespace": "event/"}, "/event"),
     ],
 )
-def test_event_name_space(mocker, kwargs, expected):
+def test_event_namespace(mocker, kwargs, expected):
     """Test the event namespace.
 
     Args:


### PR DESCRIPTION
The web socket event namespace is hardcoded as `/event`, this means if your `api_url` contains a path to a resource or location (eg. `http://example.com/api`) there's a desynchronization btn the event URL (which becomes `ws://example.com/api/event`) and the namespace for the web socket (which remains `/event`). This PR synchronizes the event URL and the namespace implicitly by inferring the namespace from the event URL. It also adds an attribute(`event_namespace`) to the `Config` class which can be overridden.

fixes #1342 