### PR TITLE
table: allow rows to be a Var

### DIFF
--- a/reflex/components/datadisplay/table.py
+++ b/reflex/components/datadisplay/table.py
@@ -104,7 +104,16 @@ class Tbody(ChakraComponent):
             Component: _description_
         """
         if len(children) == 0:
-            children = [Tr.create(cell_type="data", cells=row) for row in rows or []]
+            if isinstance(rows, Var):
+                children = [
+                    Foreach.create(
+                        rows, lambda row: Tr.create(cell_type="data", cells=row)
+                    )
+                ]
+            else:
+                children = [
+                    Tr.create(cell_type="data", cells=row) for row in rows or []
+                ]
         return super().create(*children, **props)
 
 


### PR DESCRIPTION
render the table correctly when rows is a Var, rather than some static data

Here's an example app I was playing with

```python
import reflex as rx


class Thing(rx.Model, table=True):
    a: str = "alpha"
    b: str = "bravo"
    c: str = "charlie"


class State(rx.State):
    _refresh: int = 0

    def on_submit(self, form_data):
        if any(form_data.values()):
            with rx.session() as session:
                session.add(Thing(**form_data))
                session.commit()
        yield self.do_refresh

    def do_refresh(self):
        self._refresh += 1

    @rx.cached_var
    def table_rows(self) -> list[list]:
        if self._refresh > 0:
            with rx.session() as session:
                return [
                    [getattr(t, field) for field in Thing.__fields__]
                    for t in session.exec(Thing.select.order_by(Thing.id.desc())).all()
                ]
        return []


def index() -> rx.Component:
    return rx.fragment(
        rx.color_mode_button(rx.color_mode_icon(), float="right"),
        rx.vstack(
            rx.form(
                *[
                    rx.input(placeholder=field, id=field)
                    for field in Thing.__fields__
                    if field != "id"
                ],
                rx.button("Save", type_="submit"),
                on_submit=[
                    State.on_submit,
                    *[
                        rx.set_value(field, "")
                        for field in Thing.__fields__
                        if field != "id"
                    ],
                ],
            ),
            rx.button("Reload", on_click=State.do_refresh),
            rx.table(
                headers=list(Thing.__fields__),
                rows=State.table_rows,
            ),
            padding_top="10%",
        ),
    )


app = rx.App(state=State)
app.add_page(index, on_load=State.do_refresh)
app.compile()
```