### PR TITLE
state.js: do not shadow outer `state` var when updating state

### DIFF
--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -222,7 +222,7 @@ export const processEvent = async (
   const event = state.events.shift();
 
   // Set new events to avoid reprocessing the same event.
-  setState(state => ({ ...state, events: state.events }));
+  setState(currentState => ({ ...currentState, events: state.events }));
 
   // Process events with handlers via REST and all others via websockets.
   let eventSent = false;


### PR DESCRIPTION
avoid double events, fix #1329