### PR TITLE
Disable fully controlled Input and TextArea

### DIFF
--- a/reflex/components/forms/debounce.py
+++ b/reflex/components/forms/debounce.py
@@ -31,6 +31,9 @@ class DebounceInput(Component):
     # If true, notify when form control loses focus
     force_notify_on_blur: Var[bool] = True  # type: ignore
 
+    # If provided, create a fully-controlled input
+    value: Var[str]
+
     def _render(self) -> Tag:
         """Carry first child props directly on this tag.
 

--- a/reflex/components/forms/input.py
+++ b/reflex/components/forms/input.py
@@ -2,7 +2,7 @@
 
 from typing import Dict
 
-from reflex.components.component import EVENT_ARG
+from reflex.components.component import EVENT_ARG, Component
 from reflex.components.libs.chakra import ChakraComponent
 from reflex.utils import imports
 from reflex.vars import ImportVar, Var
@@ -68,6 +68,28 @@ class Input(ChakraComponent):
             "on_key_down": EVENT_ARG.key,
             "on_key_up": EVENT_ARG.key,
         }
+
+    @classmethod
+    def create(cls, *children, **props) -> Component:
+        """Create an Input component.
+
+        Args:
+            children: The children of the component.
+            props: The properties of the component.
+
+        Returns:
+            The component.
+
+        Raises:
+            ValueError: If the value is a state Var.
+        """
+        if isinstance(props.get("value"), Var) and props.get("on_change"):
+            raise ValueError(
+                "Input value cannot be bound to a state Var with on_change handler.\n"
+                "Provide value prop to rx.debounce_input with rx.input as a child "
+                "component to create a fully controlled input."
+            )
+        return super().create(*children, **props)
 
 
 class InputGroup(ChakraComponent):

--- a/reflex/components/forms/textarea.py
+++ b/reflex/components/forms/textarea.py
@@ -2,7 +2,7 @@
 
 from typing import Dict
 
-from reflex.components.component import EVENT_ARG
+from reflex.components.component import EVENT_ARG, Component
 from reflex.components.libs.chakra import ChakraComponent
 from reflex.vars import Var
 
@@ -55,3 +55,25 @@ class TextArea(ChakraComponent):
             "on_key_down": EVENT_ARG.key,
             "on_key_up": EVENT_ARG.key,
         }
+
+    @classmethod
+    def create(cls, *children, **props) -> Component:
+        """Create an Input component.
+
+        Args:
+            children: The children of the component.
+            props: The properties of the component.
+
+        Returns:
+            The component.
+
+        Raises:
+            ValueError: If the value is a state Var.
+        """
+        if isinstance(props.get("value"), Var) and props.get("on_change"):
+            raise ValueError(
+                "TextArea value cannot be bound to a state Var with on_change handler.\n"
+                "Provide value prop to rx.debounce_input with rx.text_area as a child "
+                "component to create a fully controlled input."
+            )
+        return super().create(*children, **props)


### PR DESCRIPTION
Due to event ordering issues, fully controlled inputs do not work without some client-side buffer to maintain the value while the state is settling.

To avoid user frustration, fail during compile time when attemping to use a fully controlled input, and suggest the use of debounce_input if such a control is desired, to avoid dropped events and broken typing.

Add additional integration test for one-way bound inputs.