### PR TITLE
Check bun installation exit code during reflex init

### DIFF
--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -281,6 +281,7 @@ def install_bun():
 
     Raises:
         FileNotFoundError: if unzip or curl packages are not found.
+        Exit: if installation failed
     """
     # Bun is not supported on Windows.
     if platform.system() == "Windows":
@@ -301,7 +302,10 @@ def install_bun():
         if unzip_path is None:
             raise FileNotFoundError("Reflex requires unzip to be installed.")
 
-        os.system(constants.INSTALL_BUN)
+        result = subprocess.run(constants.INSTALL_BUN, shell=True)
+
+        if result.returncode != 0:
+            raise typer.Exit(code=result.returncode)
 
 
 def install_frontend_packages(web_dir: str):


### PR DESCRIPTION
Closes: #1372 

- Replace `os.system` with `subprocess.run`
  - mostly because the return value for `os.system` is platform dependent and needs some modification before we can compare it to 0
  - what `subprocess.run` returns is a bit more easier to work with
- Check the return value of bun installation before proceeding with `reflex init`

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [ ] ~~Have you added an explanation of what your changes do and why you'd like us to include them?~~
- [ ] ~~Have you written new tests for your core changes, as applicable?~~
- [ ] ~~Have you successfully ran tests with your changes locally?~~

### **After** these steps, you're ready to open a pull request.

    a. Give a descriptive title to your PR.

    b. Describe your changes.

    c. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

