### PR TITLE
Allow custom Tailwind content

### DIFF
--- a/reflex/app.py
+++ b/reflex/app.py
@@ -503,14 +503,11 @@ class App(Base):
         compile_results.append(compiler.compile_theme(self.style))
 
         # Compile the Tailwind config.
-        config.tailwind["content"] = config.tailwind.get(
-            "content", constants.TAILWIND_CONTENT
-        )
-        compile_results.append(
-            compiler.compile_tailwind(
-                config.tailwind if config.tailwind is not None else {}
+        if config.tailwind:
+            config.tailwind["content"] = config.tailwind.get(
+                "content", constants.TAILWIND_CONTENT
             )
-        )
+            compile_results.append(compiler.compile_tailwind(config.tailwind))
 
         # Write the pages at the end to trigger the NextJS hot reload only once.
         thread_pool = ThreadPool()

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -503,7 +503,7 @@ class App(Base):
         compile_results.append(compiler.compile_theme(self.style))
 
         # Compile the Tailwind config.
-        if config.tailwind:
+        if config.tailwind is not None:
             config.tailwind["content"] = config.tailwind.get(
                 "content", constants.TAILWIND_CONTENT
             )

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -503,11 +503,12 @@ class App(Base):
         compile_results.append(compiler.compile_theme(self.style))
 
         # Compile the Tailwind config.
+        config.tailwind["content"] = config.tailwind.get(
+            "content", constants.TAILWIND_CONTENT
+        )
         compile_results.append(
             compiler.compile_tailwind(
-                dict(**config.tailwind, content=constants.TAILWIND_CONTENT)
-                if config.tailwind is not None
-                else {}
+                config.tailwind if config.tailwind is not None else {}
             )
         )
 


### PR DESCRIPTION
Closes #1378.

If a user supplies a content key, then it replaces the default. I think this works better than merging the user-supplied content with the default content. If a user wants to merge the default content as well, they can import `constants.TAILWIND_CONTENT` and add that manually. This keeps the abstraction barrier intact while making the API explicit and predictable.

Here’s how it looks for a user to merge the default Tailwind content with their own contents:

```python
TailwindConfig(
    ...,
    tailwind={
        "content": rx.constants.TAILWIND_CONTENT + ["custom_content.py"],
    },
)
```