### PR TITLE
[Fixes #1373] exact config values set in the main process can be seen and used by the subprocesses

### DIFF
--- a/reflex/constants.py
+++ b/reflex/constants.py
@@ -26,7 +26,7 @@ def get_value(key: str, default: Any = None, type_: Type = str) -> Type:
     Returns:
         the value of the constant in its designated type
     """
-    value = os.getenv(key, default)
+    value = os.getenv(f"RX_{key}", os.getenv(key, default))
     try:
         if value and type_ != str:
             value = eval(value)

--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -68,7 +68,7 @@ def init(
 @cli.command()
 def run(
     env: constants.Env = typer.Option(
-        get_config().env, help="The environment to run the app in."
+        constants.Env.DEV, help="The environment to run the app in."
     ),
     frontend: bool = typer.Option(
         False, "--frontend-only", help="Execute only frontend."
@@ -88,7 +88,9 @@ def run(
         )
     # Set ports as os env variables to take precedence over config and
     # .env variables(if override_os_envs flag in config is set to False).
+    # print(env.value)
     build.set_os_env(
+        env=str(env),
         frontend_port=frontend_port,
         backend_port=backend_port,
         backend_host=backend_host,


### PR DESCRIPTION
This refactor synchronizes configuration values between the main and sub processes. Also, as requested by @masenf , variables starting with `RX_` now takes precedence i.e `API_URL` works today and will still work, but if `RX_API_URL` is set, then `API_URL` will be ignored. This PR closes #1373 