### PR TITLE
dev-mode compile: purge .web dir at last min to reduce downtime window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ examples/
 .idea
 .vscode
 .coverage
+venv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@ repos:
     rev: v0.0.244
     hooks:
     - id: ruff
+      args: [--fix, --exit-non-zero-on-fix]
 
   - repo: https://github.com/RobertCraigie/pyright-python
     rev: v1.1.313

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -473,9 +473,6 @@ class App(Base):
         # Get the env mode.
         config = get_config()
 
-        # Empty the .web pages directory
-        compiler.purge_web_pages_dir()
-
         # Store the compile results.
         compile_results = []
 
@@ -505,6 +502,8 @@ class App(Base):
         # Get the results.
         compile_results = [result.get() for result in compile_results]
 
+        # TODO the compile tasks below may also benefit from parallelization
+
         # Compile the custom components.
         compile_results.append(compiler.compile_components(custom_components))
 
@@ -521,10 +520,12 @@ class App(Base):
             )
             compile_results.append(compiler.compile_tailwind(config.tailwind))
 
+        # Empty the .web pages directory
+        compiler.purge_web_pages_dir()
+
         # Write the pages at the end to trigger the NextJS hot reload only once.
         thread_pool = ThreadPool()
         for output_path, code in compile_results:
-            compiler_utils.write_page(output_path, code)
             thread_pool.apply_async(compiler_utils.write_page, args=(output_path, code))
         thread_pool.close()
         thread_pool.join()

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -467,6 +467,7 @@ class App(Base):
         )
         task = progress.add_task("Compiling: ", total=len(self.pages))
 
+        # TODO: include all work done in progress indicator, not just self.pages
         for render, kwargs in DECORATED_ROUTES:
             self.add_page(render, **kwargs)
 
@@ -478,9 +479,11 @@ class App(Base):
 
         # Compile the pages in parallel.
         custom_components = set()
+        # TODO Anecdotally, processes=2 works 10% faster (cpu_count=12)
         thread_pool = ThreadPool()
         with progress:
             for route, component in self.pages.items():
+                # TODO: this progress does not reflect actual threaded task completion
                 progress.advance(task)
                 component.add_style(self.style)
                 compile_results.append(
@@ -502,7 +505,7 @@ class App(Base):
         # Get the results.
         compile_results = [result.get() for result in compile_results]
 
-        # TODO the compile tasks below may also benefit from parallelization
+        # TODO the compile tasks below may also benefit from parallelization too
 
         # Compile the custom components.
         compile_results.append(compiler.compile_components(custom_components))

--- a/reflex/utils/imports.py
+++ b/reflex/utils/imports.py
@@ -9,7 +9,7 @@ ImportDict = Dict[str, Set[ImportVar]]
 
 
 def merge_imports(*imports) -> ImportDict:
-    """Merge two import dicts together.
+    """Merge multiple import dicts together.
 
     Args:
         *imports: The list of import dicts to merge.


### PR DESCRIPTION
Bringing up the app in dev mode (`reflex run`), causes multiple compilations.  Existing compilation flow involves purging the `.web` dir unnecessarily early, resulting in a long window (~ full compile duration) of downtime.  I.e. browser starts misbehaving during recompile / hot reload cycle.

This PR aims to shorten the downtime window by purging prior compiled `.web` artifacts as late as possible, just before we write the newly compiled `.web` files.

Some drive-by minor changes as well:
* Double write of the final `.web` artifacts.
* Add some .gitignore entries (for IntelliJ, common `venv` folder)