### PR TITLE
update templates to remove deprecation warning

### DIFF
--- a/reflex/.templates/apps/counter/counter.py
+++ b/reflex/.templates/apps/counter/counter.py
@@ -48,6 +48,6 @@ def index() -> rx.Component:
 
 
 # Add state and page to the app.
-app = rx.App(state=State)
+app = rx.App()
 app.add_page(index, title="Counter")
 app.compile()

--- a/reflex/.templates/apps/default/default.py
+++ b/reflex/.templates/apps/default/default.py
@@ -40,6 +40,6 @@ def index() -> rx.Component:
 
 
 # Add state and page to the app.
-app = rx.App(state=State)
+app = rx.App()
 app.add_page(index)
 app.compile()


### PR DESCRIPTION
follow up to #1361 

Remove the `state` `kwargs` in the templates so that new Apps do not throw warning