### PR TITLE
rename rx.route decorator

### DIFF
--- a/reflex/__init__.py
+++ b/reflex/__init__.py
@@ -36,6 +36,7 @@ from .event import window_alert as window_alert
 from .middleware import Middleware as Middleware
 from .model import Model as Model
 from .model import session as session
+from .page import page as page
 from .route import route as route
 from .state import ComputedVar as var
 from .state import State as State

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -35,8 +35,10 @@ from reflex.config import get_config
 from reflex.event import Event, EventHandler, EventSpec
 from reflex.middleware import HydrateMiddleware, Middleware
 from reflex.model import Model
+from reflex.page import (
+    DECORATED_PAGES,
+)
 from reflex.route import (
-    DECORATED_ROUTES,
     catchall_in_route,
     catchall_prefix,
     get_route_args,
@@ -468,7 +470,7 @@ class App(Base):
         task = progress.add_task("Compiling: ", total=len(self.pages))
 
         # TODO: include all work done in progress indicator, not just self.pages
-        for render, kwargs in DECORATED_ROUTES:
+        for render, kwargs in DECORATED_PAGES:
             self.add_page(render, **kwargs)
 
         # Get the env mode.

--- a/reflex/page.py
+++ b/reflex/page.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import List, Optional, Union
 
+from reflex.components.component import Component
 from reflex.event import EventHandler
 
 DECORATED_PAGES = []
@@ -15,6 +16,7 @@ def page(
     image: Optional[str] = None,
     description: Optional[str] = None,
     meta: Optional[str] = None,
+    script_tags: Optional[List[Component]] = None,
     on_load: Optional[Union[EventHandler, List[EventHandler]]] = None,
 ):
     """Decorate a function as a page.
@@ -33,6 +35,7 @@ def page(
         description: The description of the page.
         meta: Additionnal meta to add to the page.
         on_load: The event handler(s) called when the page load.
+        script_tags: scripts to attach to the page
 
     Returns:
         The decorated function.
@@ -51,6 +54,8 @@ def page(
             kwargs["description"] = description
         if meta:
             kwargs["meta"] = meta
+        if script_tags:
+            kwargs["script_tags"] = script_tags
         if on_load:
             kwargs["on_load"] = on_load
 

--- a/reflex/page.py
+++ b/reflex/page.py
@@ -1,0 +1,61 @@
+"""The page decorator and associated variables and functions."""
+
+from __future__ import annotations
+
+from typing import List, Optional, Union
+
+from reflex.event import EventHandler
+
+DECORATED_PAGES = []
+
+
+def page(
+    route: Optional[str] = None,
+    title: Optional[str] = None,
+    image: Optional[str] = None,
+    description: Optional[str] = None,
+    meta: Optional[str] = None,
+    on_load: Optional[Union[EventHandler, List[EventHandler]]] = None,
+):
+    """Decorate a function as a page.
+
+    rx.App() will automatically call add_page() for any method decorated with page
+    when App.compile is called.
+
+    All defaults are None because they will use the one from add_page().
+
+    Note: the decorated functions still need to be imported.
+
+    Args:
+        route: The route to reach the page.
+        title: The title of the page.
+        image: The favicon of the page.
+        description: The description of the page.
+        meta: Additionnal meta to add to the page.
+        on_load: The event handler(s) called when the page load.
+
+    Returns:
+        The decorated function.
+    """
+    ...
+
+    def decorator(render_fn):
+        kwargs = {}
+        if route:
+            kwargs["route"] = route
+        if title:
+            kwargs["title"] = title
+        if image:
+            kwargs["image"] = image
+        if description:
+            kwargs["description"] = description
+        if meta:
+            kwargs["meta"] = meta
+        if on_load:
+            kwargs["on_load"] = on_load
+
+        DECORATED_PAGES.append((render_fn, kwargs))
+
+        return render_fn
+
+    return decorator

--- a/reflex/route.py
+++ b/reflex/route.py
@@ -7,8 +7,8 @@ from typing import Dict, List, Optional, Union
 
 from reflex import constants
 from reflex.event import EventHandler
-
-DECORATED_ROUTES = []
+from reflex.page import page
+from reflex.utils.console import deprecate
 
 
 def route(
@@ -37,25 +37,15 @@ def route(
     Returns:
         The decorated function.
     """
+    deprecate("@rx.route is deprecated and is being replaced by @rx.page instead")
 
-    def decorator(render_fn):
-        kwargs = {}
-        if route:
-            kwargs["route"] = route
-        if title:
-            kwargs["title"] = title
-        if image:
-            kwargs["image"] = image
-        if description:
-            kwargs["description"] = description
-        if on_load:
-            kwargs["on_load"] = on_load
-
-        DECORATED_ROUTES.append((render_fn, kwargs))
-
-        return render_fn
-
-    return decorator
+    return page(
+        route=route,
+        title=title,
+        image=image,
+        description=description,
+        on_load=on_load,
+    )
 
 
 def verify_route_validity(route: str) -> None:


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

### Type of change

- [x] Change some names with deprecation warning of old ones
- [x] This change requires a documentation update

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Description

Rename the decorator `@rx.route` as `@rx.page` for consistency across reflex.


