### PR TITLE
CI: factor out env setup as composite action

### DIFF
--- a/.github/actions/setup_build_env/action.yml
+++ b/.github/actions/setup_build_env/action.yml
@@ -1,0 +1,87 @@
+# Assumes:
+# - CWD is the root directory of your project (e.g. reflex/)
+# - You have a poetry.lock file in the root directory of your project
+# - You have a pyproject.toml file in the root directory of your project
+name: 'Setup Reflex build environment'
+description: 'Sets up Python, install poetry (cached), install project deps (cached)'
+inputs:
+  python-version:
+    description: 'Python version setup'
+    required: true
+  poetry-version:
+    description: 'Poetry version to install'
+    required: false
+    default: '1.3.1'
+  run-poetry-install:
+    description: 'Whether to run poetry install on current dir'
+    required: false
+    default: false
+  create-venv-at-path:
+    description: 'Path to venv (if poetry install is enabled)'
+    required: false
+    default: '.venv'
+  shell:
+    description: 'Shell to use for running commands'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python ${{ inputs.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Restore cached poetry install
+      id: restore-poetry-cache
+      uses: actions/cache/restore@v3
+      with:
+        path: ~/.local
+        key: python-${{ inputs.python-version }}-poetry-${{ inputs.poetry-version }}
+
+    - if: steps.restore-poetry-cache.outputs.cache-hit != 'true'
+      name: Install Poetry
+      uses: snok/install-poetry@v1
+      with:
+        version: ${{ inputs.poetry-version }}
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+
+    - if: steps.restore-poetry-cache.outputs.cache-hit != 'true'
+      name: Save poetry install to cache
+      uses: actions/cache/save@v3
+      with:
+        path: ~/.local
+        key: ${{ steps.restore-poetry-cache.outputs.cache-primary-key }}
+
+    - name: Restore cached project python deps
+      id: restore-pydeps-cache
+      uses: actions/cache/restore@v3
+      with:
+        path: ${{ inputs.create-venv-at-path }}
+        key: python-${{ inputs.python-version }}-pydeps-${{ hashFiles('**/poetry.lock') }}
+
+    - if: ${{ inputs.run-poetry-install == 'true' && steps.restore-pydeps-cache.outputs.cache-hit != 'true' }}
+      name: Run poetry install (will get cached)
+      shell: ${{ inputs.shell }}
+      # We skip over installing the root package (the current project code under CI)
+      # Root package should not be cached - its content is not reflected in poetry.lock / cache key
+      run: |
+         python -m venv ${{ inputs.create-venv-at-path }}
+         source ${{ inputs.create-venv-at-path }}/bin/activate
+         poetry install --no-interaction --no-root
+
+    - if: steps.restore-pydeps-cache.outputs.cache-hit != 'true'
+      name: Save Python deps to cache
+      uses: actions/cache/save@v3
+      with:
+        path: ${{ inputs.create-venv-at-path }}
+        key: ${{ steps.restore-pydeps-cache.outputs.cache-primary-key }}
+
+    - if: ${{ inputs.run-poetry-install == 'true' }}
+      name: Run poetry install (including root package)
+      shell: ${{ inputs.shell }}
+      # Here we really install the root package (the current project code under CI).env:
+      # This should not be cached.
+      run: |
+        source ${{ inputs.create-venv-at-path }}/bin/activate
+        poetry install --only-root --no-interaction

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,34 +19,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+    - uses: ./.github/actions/setup_build_env
       with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: cache poetry install
-      uses: actions/cache@v2
-      with:
-        path: ~/.local
-        key: python-${{ matrix.python-version }}-poetry-1.3.1
-
-    - uses: snok/install-poetry@v1
-      with:
-        version: 1.3.1
-        virtualenvs-create: true
-        virtualenvs-in-project: true
-
-    - name: cache deps
-      id: cache-deps
-      uses: actions/cache@v2
-      with:
-        path: .venv
-        key: python-${{ matrix.python-version }}-pydeps-${{ hashFiles('**/poetry.lock') }}
-
-    - run: poetry install --no-interaction --no-root
-      if: steps.cache-deps.outputs.cache-hit != 'true'
-    - run: poetry install --no-interaction
+          python-version: ${{ matrix.python-version }}
+          run-poetry-install: true
+          shell: bash
+          create-venv-at-path: .venv
     - run: poetry run pytest tests --cov --no-cov-on-fail --cov-report=
     - run: poetry run pyright reflex tests
     - run: poetry run ruff check . --format github

--- a/.github/workflows/integration_examples.yml
+++ b/.github/workflows/integration_examples.yml
@@ -24,10 +24,12 @@ jobs:
       with:
           node-version: ${{ matrix.node-version }}
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+    - uses: ./.github/actions/setup_build_env
       with:
         python-version: ${{ matrix.python-version }}
+        run-poetry-install: true
+        shell: bash
+        create-venv-at-path: .venv
     
     # Clone Reflex Website Repo For integration tests
     - name: Clone Reflex Examples Repo
@@ -36,34 +38,13 @@ jobs:
         repository: pynecone-io/pynecone-examples
         path: pynecone-examples
 
-    - name: cache poetry install
-      uses: actions/cache@v2
-      with:
-        path: ~/.local
-        key: python-${{ matrix.python-version }}-poetry-1.3.1
-
-    - uses: snok/install-poetry@v1
-      with:
-        version: 1.3.1
-        virtualenvs-create: true
-        virtualenvs-in-project: true
-
-    - name: cache deps
-      id: cache-deps
-      uses: actions/cache@v2
-      with:
-        path: .venv
-        key: python-${{ matrix.python-version }}-pydeps-${{ hashFiles('**/poetry.lock') }}
-
-    - name: Poetry Install
-      run: poetry install --no-interaction
-    - name: Install Requirements
+    - name: Install requirements for counter example
       working-directory: ./pynecone-examples/counter
       run: poetry run pip install -r requirements.txt
-    - name: Init Website
+    - name: Reflex init for counter example
       working-directory: ./pynecone-examples/counter
       run: poetry run reflex init
-    - name: Validate Reflex's own installation of Node
+    - name: Validate Reflex's own installation of Node, following init
       run: |
         /home/runner/.reflex/.nvm/versions/node/v*/bin/npm -v
         /home/runner/.reflex/.nvm/versions/node/v*/bin/node -v

--- a/.github/workflows/integration_website.yml
+++ b/.github/workflows/integration_website.yml
@@ -24,10 +24,12 @@ jobs:
       with:
           node-version: ${{ matrix.node-version }}
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+    - uses: ./.github/actions/setup_build_env
       with:
         python-version: ${{ matrix.python-version }}
+        run-poetry-install: true
+        shell: bash
+        create-venv-at-path: .venv
 
       # Clone Reflex Website Repo For integration tests
     - name: Clone Reflex Website Repo
@@ -36,32 +38,10 @@ jobs:
         repository: pynecone-io/pcweb
         path: pcweb
 
-    # Install poetry
-    - name: cache poetry install
-      uses: actions/cache@v2
-      with:
-        path: ~/.local
-        key: python-${{ matrix.python-version }}-poetry-1.3.1
-
-    - uses: snok/install-poetry@v1
-      with:
-        version: 1.3.1
-        virtualenvs-create: true
-        virtualenvs-in-project: true
-
-    - name: cache deps
-      id: cache-deps
-      uses: actions/cache@v2
-      with:
-        path: .venv
-        key: python-${{ matrix.python-version }}-pydeps-${{ hashFiles('**/poetry.lock') }}
-
-    - name: Poetry Install
-      run: poetry install --no-interaction
-    - name: Install Requirements
+    - name: Install Requirements for reflex-web
       working-directory: ./pcweb
       run: poetry run pip install -r requirements.txt
-    - name: Init Website
+    - name: Init Website for reflex-web
       working-directory: ./pcweb
       run: poetry run reflex init
     - name: Run Website and Check for errors

--- a/.github/workflows/reflex_init_test.yml
+++ b/.github/workflows/reflex_init_test.yml
@@ -6,6 +6,8 @@ on:
       - main
 
 jobs:
+  # TODO we can extend to various starting points (e.g. Ubuntu with node, without node, with unzip, without unzip, etc.)
+  # Currently starting point is: Ubuntu + unzip, xz-utils, Python suite.  No node.
   reflex-install-and-init:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Main goals:
- Factor out "setup python" / "install poetry" // "poetry install" into a single place (rather than duplicated in every job.  The mechanic here is [Composite Actions](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action).
- This new composite action `setup_build_env` will have a refreshed caching implementation. It should be correct as of right now - if caching doesn't work in future, we can focus on this one place to fix.

* Caching - cache poetry installation, cache project deps installed using "poetry install" (pyproject.toml format deps only).  Note this matches existing caching behavior.  I.e. if we are integration testing against the counter app, we don't cache the latter's requirements correctly today anyway.  Fixing this can be a future exercise.

Why now?
We want to beef up CI infra in various dimensions in near future.  Such as including Windows, MacOS in a first class way, or adding UI based tests, etc.  We need to deduplicate some code now to keep things more maintainable over time.