### PR TITLE
CI: separate pre-commit github action job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,8 +26,4 @@ jobs:
           shell: bash
           create-venv-at-path: .venv
     - run: poetry run pytest tests --cov --no-cov-on-fail --cov-report=
-    - run: poetry run pyright reflex tests
-    - run: poetry run ruff check . --format github
-    - run: find reflex tests -name "*.py" -not -path reflex/reflex.py | xargs poetry run darglint
-    - run: poetry run black --check reflex tests
     - run: poetry run coverage html

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,28 @@
+name: pre-commit
+
+on:
+  pull_request:
+    branches: [main] # TODO remove jackie-py-setup
+  push:
+    # Note even though this job is called "pre-commit" and runs "pre-commit", this job will run
+    # also POST-commit on main also!  In case there are mishandled merge conflicts / bad auto-resolves
+    # when merging into main branch.
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup_build_env
+        with:
+          # running vs. one version of Python is OK
+          # i.e. ruff, black, etc.
+          python-version: 3.11
+          run-poetry-install: true
+          shell: bash
+          create-venv-at-path: .venv
+      # TODO pre-commit related stuff can be cached too (not a bottleneck yet)
+      - run: |
+          poetry run pip install pre-commit
+          poetry run pre-commit run --all-files

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,7 +2,7 @@ name: pre-commit
 
 on:
   pull_request:
-    branches: [main] # TODO remove jackie-py-setup
+    branches: [main]
   push:
     # Note even though this job is called "pre-commit" and runs "pre-commit", this job will run
     # also POST-commit on main also!  In case there are mishandled merge conflicts / bad auto-resolves


### PR DESCRIPTION
Depends on #[1455](https://github.com/reflex-dev/reflex/pull/1455)

Pre-commit does not need to run in a matrix or on multiple OSes.
    
But unit tests DO. Separate it out. We will be reusing the unit test workflow (`build.yml`) for multiple OSes soon.
