### PR TITLE
Remove curl and parallelize node/bun install

### DIFF
--- a/reflex/constants.py
+++ b/reflex/constants.py
@@ -56,29 +56,28 @@ BUN_VERSION = "0.7.0"
 BUN_ROOT_PATH = f"{REFLEX_DIR}/.bun"
 # The bun path.
 BUN_PATH = f"{BUN_ROOT_PATH}/bin/bun"
-# Command to install bun.
-INSTALL_BUN = f"curl -fsSL https://bun.sh/install | env BUN_INSTALL={BUN_ROOT_PATH} bash -s -- bun-v{BUN_VERSION}"
+# URL to bun install script.
+BUN_INSTALL_URL = "https://bun.sh/install"
 
 # NVM / Node config.
+# The NVM version.
+NVM_VERSION = "0.39.1"
 # The Node version.
 NODE_VERSION = "18.17.0"
 # The minimum required node version.
-MIN_NODE_VERSION = "16.8.0"
+NODE_VERSION_MIN = "16.8.0"
 # The directory to store nvm.
-NVM_ROOT_PATH = f"{REFLEX_DIR}/.nvm"
+NVM_DIR = f"{REFLEX_DIR}/.nvm"
 # The nvm path.
-NVM_PATH = f"{NVM_ROOT_PATH}/nvm.sh"
+NVM_PATH = f"{NVM_DIR}/nvm.sh"
 # The node bin path.
-NODE_BIN_PATH = f"{NVM_ROOT_PATH}/versions/node/v{NODE_VERSION}/bin"
+NODE_BIN_PATH = f"{NVM_DIR}/versions/node/v{NODE_VERSION}/bin"
 # The default path where node is installed.
 NODE_PATH = "node" if platform.system() == "Windows" else f"{NODE_BIN_PATH}/node"
 # The default path where npm is installed.
 NPM_PATH = "npm" if platform.system() == "Windows" else f"{NODE_BIN_PATH}/npm"
-# Command to install nvm.
-INSTALL_NVM = f"curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | env NVM_DIR={NVM_ROOT_PATH} bash"
-# Command to install node.
-INSTALL_NODE = f'bash -c "export NVM_DIR={NVM_ROOT_PATH} && . {NVM_ROOT_PATH}/nvm.sh && nvm install {NODE_VERSION}"'
-
+# The URL to the nvm install script.
+NVM_INSTALL_URL = f"https://raw.githubusercontent.com/nvm-sh/nvm/v{NVM_VERSION}/install.sh"
 
 # Files and directories used to init a new project.
 # The root directory of the reflex library.

--- a/reflex/constants.py
+++ b/reflex/constants.py
@@ -45,41 +45,9 @@ MODULE_NAME = "reflex"
 # The current version of Reflex.
 VERSION = metadata.version(MODULE_NAME)
 
-# Project dependencies.
-# The directory to store reflex dependencies.
-REFLEX_DIR = os.path.expandvars("$HOME/.reflex")
-
-# Bun config.
-# The Bun version.
-BUN_VERSION = "0.7.0"
-# The directory to store the bun.
-BUN_ROOT_PATH = f"{REFLEX_DIR}/.bun"
-# The bun path.
-BUN_PATH = f"{BUN_ROOT_PATH}/bin/bun"
-# URL to bun install script.
-BUN_INSTALL_URL = "https://bun.sh/install"
-
-# NVM / Node config.
-# The NVM version.
-NVM_VERSION = "0.39.1"
-# The Node version.
-NODE_VERSION = "18.17.0"
-# The minimum required node version.
-NODE_VERSION_MIN = "16.8.0"
-# The directory to store nvm.
-NVM_DIR = f"{REFLEX_DIR}/.nvm"
-# The nvm path.
-NVM_PATH = f"{NVM_DIR}/nvm.sh"
-# The node bin path.
-NODE_BIN_PATH = f"{NVM_DIR}/versions/node/v{NODE_VERSION}/bin"
-# The default path where node is installed.
-NODE_PATH = "node" if platform.system() == "Windows" else f"{NODE_BIN_PATH}/node"
-# The default path where npm is installed.
-NPM_PATH = "npm" if platform.system() == "Windows" else f"{NODE_BIN_PATH}/npm"
-# The URL to the nvm install script.
-NVM_INSTALL_URL = f"https://raw.githubusercontent.com/nvm-sh/nvm/v{NVM_VERSION}/install.sh"
-
 # Files and directories used to init a new project.
+# The directory to store reflex dependencies.
+REFLEX_DIR = os.path.expandvars(os.path.join("$HOME", f".{MODULE_NAME}"))
 # The root directory of the reflex library.
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # The name of the assets directory.
@@ -92,6 +60,36 @@ WEB_TEMPLATE_DIR = os.path.join(TEMPLATE_DIR, "web")
 ASSETS_TEMPLATE_DIR = os.path.join(TEMPLATE_DIR, APP_ASSETS_DIR)
 # The jinja template directory.
 JINJA_TEMPLATE_DIR = os.path.join(TEMPLATE_DIR, "jinja")
+
+# Bun config.
+# The Bun version.
+BUN_VERSION = "0.7.0"
+# The directory to store the bun.
+BUN_ROOT_PATH = os.path.join(REFLEX_DIR, ".bun")
+# The bun path.
+BUN_PATH = os.path.join(BUN_ROOT_PATH, "bin", "bun")
+# URL to bun install script.
+BUN_INSTALL_URL = "https://bun.sh/install"
+
+# NVM / Node config.
+# The NVM version.
+NVM_VERSION = "0.39.1"
+# The Node version.
+NODE_VERSION = "18.17.0"
+# The minimum required node version.
+NODE_VERSION_MIN = "16.8.0"
+# The directory to store nvm.
+NVM_DIR = os.path.join(REFLEX_DIR, ".nvm")
+# The nvm path.
+NVM_PATH = os.path.join(NVM_DIR, "nvm.sh")
+# The node bin path.
+NODE_BIN_PATH = os.path.join(NVM_DIR, "versions", "node", f"v{NODE_VERSION}", "bin")
+# The default path where node is installed.
+NODE_PATH = "node" if platform.system() == "Windows" else os.path.join(NODE_BIN_PATH, "node")
+# The default path where npm is installed.
+NPM_PATH = "npm" if platform.system() == "Windows" else os.path.join(NODE_BIN_PATH, "npm")
+# The URL to the nvm install script.
+NVM_INSTALL_URL = f"https://raw.githubusercontent.com/nvm-sh/nvm/v{NVM_VERSION}/install.sh"
 
 # The frontend directories in a project.
 # The web folder where the NextJS app is compiled to.

--- a/reflex/constants.py
+++ b/reflex/constants.py
@@ -85,11 +85,17 @@ NVM_PATH = os.path.join(NVM_DIR, "nvm.sh")
 # The node bin path.
 NODE_BIN_PATH = os.path.join(NVM_DIR, "versions", "node", f"v{NODE_VERSION}", "bin")
 # The default path where node is installed.
-NODE_PATH = "node" if platform.system() == "Windows" else os.path.join(NODE_BIN_PATH, "node")
+NODE_PATH = (
+    "node" if platform.system() == "Windows" else os.path.join(NODE_BIN_PATH, "node")
+)
 # The default path where npm is installed.
-NPM_PATH = "npm" if platform.system() == "Windows" else os.path.join(NODE_BIN_PATH, "npm")
+NPM_PATH = (
+    "npm" if platform.system() == "Windows" else os.path.join(NODE_BIN_PATH, "npm")
+)
 # The URL to the nvm install script.
-NVM_INSTALL_URL = f"https://raw.githubusercontent.com/nvm-sh/nvm/v{NVM_VERSION}/install.sh"
+NVM_INSTALL_URL = (
+    f"https://raw.githubusercontent.com/nvm-sh/nvm/v{NVM_VERSION}/install.sh"
+)
 
 # The frontend directories in a project.
 # The web folder where the NextJS app is compiled to.

--- a/reflex/utils/build.py
+++ b/reflex/utils/build.py
@@ -147,7 +147,7 @@ def export_app(
                 # Check for special strings and update the progress bar.
                 for special_string in checkpoints:
                     if special_string in line:
-                        if special_string == "Export successful":
+                        if special_string == checkpoints[-1]:
                             progress.update(task, completed=len(checkpoints))
                             break  # Exit the loop if the completion message is found
                         else:

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -314,7 +314,14 @@ def install_node():
 
     # Install node.
     print("installing node")
-    result = subprocess.run(["bash", "-c", f". {constants.NVM_DIR}/nvm.sh && nvm install {constants.NODE_VERSION}"], env=env)
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f". {constants.NVM_DIR}/nvm.sh && nvm install {constants.NODE_VERSION}",
+        ],
+        env=env,
+    )
     if result.returncode != 0:
         raise typer.Exit(code=result.returncode)
 

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -300,7 +300,6 @@ def download_and_run(url: str, *args, **env):
         f.write(response.text)
 
     # Run the script.
-    print("running script", script.name, env)
     env = {
         **os.environ,
         **env,

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -10,6 +10,7 @@ import re
 import subprocess
 import sys
 import tempfile
+import threading
 from datetime import datetime
 from fileinput import FileInput
 from pathlib import Path
@@ -416,8 +417,8 @@ def initialize_frontend_dependencies():
     path_ops.mkdir(constants.REFLEX_DIR)
 
     # Install the frontend dependencies.
-    initialize_bun()
-    initialize_node()
+    threading.Thread(target=initialize_bun).start()
+    threading.Thread(target=initialize_node).start()
 
     # Set up the web directory.
     initialize_web_directory()

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -284,7 +284,8 @@ def download_and_run(url: str, *args, **env):
         url: The url of the script.
         args: The arguments to pass to the script.
         env: The environment variables to use.
-    
+
+
     Raises:
         Exit: if installation failed
     """

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -417,11 +417,15 @@ def initialize_frontend_dependencies():
     path_ops.mkdir(constants.REFLEX_DIR)
 
     # Install the frontend dependencies.
-    threading.Thread(target=initialize_bun).start()
-    threading.Thread(target=initialize_node).start()
+    bun_thread = threading.Thread(target=initialize_bun).start()
+    node_thread = threading.Thread(target=initialize_node).start()
 
     # Set up the web directory.
     initialize_web_directory()
+
+    # Wait for bun and node to finish.
+    bun_thread.join()
+    node_thread.join()
 
 
 def check_admin_settings():

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -295,7 +295,7 @@ def download_and_run(url: str, *args, **env):
     with open(script.name, "w") as f:
         f.write(response.text)
 
-    # Run the nvm install script.
+    # Run the script.
     env = {
         **os.environ,
         **env,
@@ -359,7 +359,7 @@ def install_bun():
     if unzip_path is None:
         raise FileNotFoundError("Reflex requires unzip to be installed.")
 
-    # Get the bun install script.
+    # Run the bun install script.
     download_and_run(
         constants.BUN_INSTALL_URL,
         f"bun-v{constants.BUN_VERSION}",

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -296,6 +296,7 @@ def download_and_run(url: str, *args, **env):
         f.write(response.text)
 
     # Run the script.
+    print("running script", script.name, env)
     env = {
         **os.environ,
         **env,
@@ -363,7 +364,7 @@ def install_bun():
     download_and_run(
         constants.BUN_INSTALL_URL,
         f"bun-v{constants.BUN_VERSION}",
-        BUN_ROOT=constants.BUN_ROOT_PATH,
+        BUN_INSTALL=constants.BUN_ROOT_PATH,
     )
 
 
@@ -417,15 +418,19 @@ def initialize_frontend_dependencies():
     path_ops.mkdir(constants.REFLEX_DIR)
 
     # Install the frontend dependencies.
-    bun_thread = threading.Thread(target=initialize_bun).start()
-    node_thread = threading.Thread(target=initialize_node).start()
+    threads = [
+        threading.Thread(target=initialize_bun),
+        threading.Thread(target=initialize_node),
+    ]
+    for thread in threads:
+        thread.start()
 
     # Set up the web directory.
     initialize_web_directory()
 
-    # Wait for bun and node to finish.
-    bun_thread.join()
-    node_thread.join()
+    # Wait for the threads to finish.
+    for thread in threads:
+        thread.join()
 
 
 def check_admin_settings():

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -284,6 +284,9 @@ def download_and_run(url: str, *args, **env):
         url: The url of the script.
         args: The arguments to pass to the script.
         env: The environment variables to use.
+    
+    Raises:
+        Exit: if installation failed
     """
     # Download the script
     response = httpx.get(url)
@@ -311,7 +314,6 @@ def install_node():
        Independent of any existing system installations.
 
     Raises:
-        FileNotFoundError: if unzip or curl packages are not found.
         Exit: if installation failed
     """
     # NVM is not supported on Windows.
@@ -344,8 +346,7 @@ def install_bun():
     """Install bun onto the user's system.
 
     Raises:
-        FileNotFoundError: if unzip or curl packages are not found.
-        Exit: if installation failed
+        FileNotFoundError: If required packages are not found.
     """
     # Bun is not supported on Windows.
     if IS_WINDOWS:

--- a/reflex/utils/processes.py
+++ b/reflex/utils/processes.py
@@ -134,13 +134,15 @@ def new_process(args, **kwargs):
     Returns:
         Execute a child program in a new process.
     """
-    env = os.environ.copy()
-    env["PATH"] = os.pathsep.join([constants.NODE_BIN_PATH, env["PATH"]])
+    env = {
+        **os.environ,
+        "PATH": os.pathsep.join([constants.NODE_BIN_PATH, os.environ["PATH"]]),
+    }
     kwargs = {
         "env": env,
         "stderr": subprocess.STDOUT,
-        "stdout": subprocess.PIPE,  # Redirect stdout to a pipe
-        "universal_newlines": True,  # Set universal_newlines to True for text mode
+        "stdout": subprocess.PIPE,
+        "universal_newlines": True,
         "encoding": "UTF-8",
         **kwargs,
     }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -527,7 +527,7 @@ def test_node_install_windows(mocker):
 def test_node_install_unix(tmp_path, mocker):
     nvm_root_path = tmp_path / ".reflex" / ".nvm"
 
-    mocker.patch("reflex.utils.prerequisites.constants.NVM_ROOT_PATH", nvm_root_path)
+    mocker.patch("reflex.utils.prerequisites.constants.NVM_DIR", nvm_root_path)
     subprocess_run = mocker.patch(
         "reflex.utils.prerequisites.subprocess.run",
         return_value=subprocess.CompletedProcess(args="", returncode=0),
@@ -541,14 +541,15 @@ def test_node_install_unix(tmp_path, mocker):
     subprocess_run.call_count = 2
 
 
-def test_node_install_without_curl(mocker):
-    """Test that an error is thrown when installing node with curl not installed.
+def test_bun_install_without_unzip(mocker):
+    """Test that an error is thrown when installing bun with unzip not installed.
 
     Args:
         mocker: Pytest mocker object.
     """
-    mocker.patch("reflex.utils.prerequisites.path_ops.which", return_value=None)
+    mocker.patch("reflex.utils.path_ops.which", return_value=None)
+    mocker.patch("os.path.exists", return_value=False)
     mocker.patch("reflex.utils.prerequisites.IS_WINDOWS", False)
 
     with pytest.raises(FileNotFoundError):
-        prerequisites.install_node()
+        prerequisites.install_bun()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,6 +9,7 @@ import typer
 from packaging import version
 
 from reflex import Env, constants
+from reflex.base import Base
 from reflex.utils import build, format, imports, prerequisites, types
 from reflex.vars import Var
 
@@ -533,6 +534,12 @@ def test_node_install_unix(tmp_path, mocker):
         return_value=subprocess.CompletedProcess(args="", returncode=0),
     )
     mocker.patch("reflex.utils.prerequisites.IS_WINDOWS", False)
+
+    class Resp(Base):
+        status_code = 200
+        text = "test"
+
+    mocker.patch("httpx.get", return_value=Resp())
 
     prerequisites.install_node()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -540,6 +540,7 @@ def test_node_install_unix(tmp_path, mocker):
         text = "test"
 
     mocker.patch("httpx.get", return_value=Resp())
+    mocker.patch("reflex.utils.prerequisites.download_and_run")
 
     prerequisites.install_node()
 


### PR DESCRIPTION
Use `httpx` to install nvm and bun instead of curl, removing one dependency. Also parallelize the process to install nvm/bun during `reflex init`