### PR TITLE
Wrap Input and TextArea with DebounceInput for full control

### DIFF
--- a/integration/test_input.py
+++ b/integration/test_input.py
@@ -10,7 +10,7 @@ from reflex.testing import AppHarness
 
 
 def FullyControlledInput():
-    """App using a fully controlled input with debounce wrapper."""
+    """App using a fully controlled input with implicit debounce wrapper."""
     import reflex as rx
 
     class State(rx.State):
@@ -21,12 +21,10 @@ def FullyControlledInput():
     @app.add_page
     def index():
         return rx.fragment(
-            rx.debounce_input(
-                rx.input(
-                    on_change=State.set_text, id="debounce_input_input"  # type: ignore
-                ),
+            rx.input(
+                id="debounce_input_input",
+                on_change=State.set_text,  # type: ignore
                 value=State.text,
-                debounce_timeout=0,
             ),
             rx.input(value=State.text, id="value_input"),
             rx.input(on_change=State.set_text, id="on_change_input"),  # type: ignore

--- a/reflex/components/forms/input.py
+++ b/reflex/components/forms/input.py
@@ -3,6 +3,7 @@
 from typing import Dict
 
 from reflex.components.component import EVENT_ARG, Component
+from reflex.components.forms.debounce import DebounceInput
 from reflex.components.libs.chakra import ChakraComponent
 from reflex.utils import imports
 from reflex.vars import ImportVar, Var
@@ -79,15 +80,11 @@ class Input(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            ValueError: If the value is a state Var.
         """
         if isinstance(props.get("value"), Var) and props.get("on_change"):
-            raise ValueError(
-                "Input value cannot be bound to a state Var with on_change handler.\n"
-                "Provide value prop to rx.debounce_input with rx.input as a child "
-                "component to create a fully controlled input."
+            # create a debounced input if the user requests full control to avoid typing jank
+            return DebounceInput.create(
+                super().create(*children, **props), debounce_timeout=0
             )
         return super().create(*children, **props)
 

--- a/reflex/components/forms/textarea.py
+++ b/reflex/components/forms/textarea.py
@@ -3,6 +3,7 @@
 from typing import Dict
 
 from reflex.components.component import EVENT_ARG, Component
+from reflex.components.forms.debounce import DebounceInput
 from reflex.components.libs.chakra import ChakraComponent
 from reflex.vars import Var
 
@@ -66,14 +67,10 @@ class TextArea(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            ValueError: If the value is a state Var.
         """
         if isinstance(props.get("value"), Var) and props.get("on_change"):
-            raise ValueError(
-                "TextArea value cannot be bound to a state Var with on_change handler.\n"
-                "Provide value prop to rx.debounce_input with rx.text_area as a child "
-                "component to create a fully controlled input."
+            # create a debounced input if the user requests full control to avoid typing jank
+            return DebounceInput.create(
+                super().create(*children, **props), debounce_timeout=0
             )
         return super().create(*children, **props)

--- a/tests/components/forms/test_debounce.py
+++ b/tests/components/forms/test_debounce.py
@@ -1,0 +1,119 @@
+"""Test that DebounceInput collapses nested forms."""
+
+import pytest
+
+import reflex as rx
+from reflex.vars import BaseVar
+
+
+def test_render_no_child():
+    """DebounceInput raises RuntimeError if no child is provided."""
+    with pytest.raises(RuntimeError):
+        _ = rx.debounce_input().render()
+
+
+def test_render_no_child_recursive():
+    """DebounceInput raises RuntimeError if no child is provided."""
+    with pytest.raises(RuntimeError):
+        _ = rx.debounce_input(rx.debounce_input(rx.debounce_input())).render()
+
+
+def test_render_many_child():
+    """DebounceInput raises RuntimeError if more than 1 child is provided."""
+    with pytest.raises(RuntimeError):
+        _ = rx.debounce_input("foo", "bar").render()
+
+
+class S(rx.State):
+    """Example state for debounce tests."""
+
+    value: str = ""
+
+    def on_change(self, v: str):
+        """Dummy on_change handler.
+
+
+        Args:
+            v: The changed value.
+        """
+        pass
+
+
+def test_render_child_props():
+    """DebounceInput should render props from child component."""
+    tag = rx.debounce_input(
+        rx.input(
+            foo="bar",
+            baz="quuc",
+            value="real",
+            on_change=S.on_change,
+        )
+    )._render()
+    assert tag.props["sx"] == {"foo": "bar", "baz": "quuc"}
+    assert tag.props["value"] == BaseVar(
+        name="real", type_=str, is_local=True, is_string=False
+    )
+    assert len(tag.props["onChange"].events) == 1
+    assert tag.props["onChange"].events[0].handler == S.on_change
+    assert tag.contents == ""
+
+
+def test_render_child_props_recursive():
+    """DebounceInput should render props from child component.
+
+    If the child component is a DebounceInput, then props will be copied from it
+    recursively.
+    """
+    tag = rx.debounce_input(
+        rx.debounce_input(
+            rx.debounce_input(
+                rx.debounce_input(
+                    rx.input(
+                        foo="bar",
+                        baz="quuc",
+                        value="real",
+                        on_change=S.on_change,
+                    ),
+                    value="inner",
+                    force_notify_on_blur=False,
+                ),
+                debounce_timeout=42,
+            ),
+            value="outer",
+        ),
+        force_notify_by_enter=False,
+    )._render()
+    assert tag.props["sx"] == {"foo": "bar", "baz": "quuc"}
+    assert tag.props["value"] == BaseVar(
+        name="real", type_=str, is_local=True, is_string=False
+    )
+    assert tag.props["forceNotifyOnBlur"].name == "false"
+    assert tag.props["forceNotifyByEnter"].name == "false"
+    assert tag.props["debounceTimeout"] == 42
+    assert len(tag.props["onChange"].events) == 1
+    assert tag.props["onChange"].events[0].handler == S.on_change
+    assert tag.contents == ""
+
+
+def test_full_control_implicit_debounce():
+    """DebounceInput is used when value and on_change are used together."""
+    tag = rx.input(
+        value=S.value,
+        on_change=S.on_change,
+    )._render()
+    assert tag.props["debounceTimeout"] == 0
+    assert len(tag.props["onChange"].events) == 1
+    assert tag.props["onChange"].events[0].handler == S.on_change
+    assert tag.contents == ""
+
+
+def test_full_control_implicit_debounce_text_area():
+    """DebounceInput is used when value and on_change are used together."""
+    tag = rx.text_area(
+        value=S.value,
+        on_change=S.on_change,
+    )._render()
+    assert tag.props["debounceTimeout"] == 0
+    assert len(tag.props["onChange"].events) == 1
+    assert tag.props["onChange"].events[0].handler == S.on_change
+    assert tag.contents == ""


### PR DESCRIPTION
When the caller supplies a `value` prop as a state `Var` and also provides an `on_change` handler, automatically wrap it in a `DebounceInput` component with zero timeout to avoid typing jank.

Update `DebounceInput` component to allow arbitrarily nested hierarchies of `DebounceInput`, making it simpler to reuse and override `DebounceInput` props, even when auto-created components are in the tree.

Update integration test to use implicit fully controlled input (like a naive user).

Add component-level tests for debounce to validate prop combining behavior.