### PR TITLE
fail faster in integration test

### DIFF
--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -10,11 +10,20 @@ export PYTHONUNBUFFERED=1
 # Start the server in the background
 reflex run --loglevel debug --env "$2" & pid=$!
 
-# TODO does this even work on windows? Not clear, possibly not impactful though.
-trap "kill -INT $pid ||:" EXIT
+# Within the context of this bash, $pid_in_bash is what we need to pass to "kill" on exit
+# This is true on all platforms.
+pid_in_bash=$pid
+trap "kill -INT $pid_in_bash ||:" EXIT
 
 echo "Started server with PID $pid"
 
 # Assume we run from the root of the repo
 popd
+
+# In Windows, our Python script below needs to work with the WINPID
+if [ -f /proc/$pid/winpid ]; then
+  pid=$(cat /proc/$pid/winpid)
+  echo "Windows detected, passing winpid $pid to port waiter"
+fi
+
 python scripts/wait_for_listening_port.py 3000 8000 --timeout=600 --server-pid "$pid"


### PR DESCRIPTION
Checking if a pid exists in a portable way (across OSes) was not immediately apparent before to me (@jackie-pc), so was left out of the big CI merge.

This is the quick follow up to do this properly (so we don't wait 10 min) if `reflex run` already died early.