### PR TITLE
allowed flex to accept lists

### DIFF
--- a/reflex/components/layout/flex.py
+++ b/reflex/components/layout/flex.py
@@ -2,6 +2,7 @@
 
 from reflex.components.libs.chakra import ChakraComponent
 from reflex.vars import Var
+from typing import Union
 
 
 class Flex(ChakraComponent):
@@ -16,7 +17,7 @@ class Flex(ChakraComponent):
     basis: Var[str]
 
     # Shorthand for flexDirection style prop
-    direction: Var[str]
+    direction: Var[Union[str, list]]
 
     # Shorthand for flexGrow style prop
     grow: Var[str]
@@ -25,7 +26,7 @@ class Flex(ChakraComponent):
     justify: Var[str]
 
     # Shorthand for flexWrap style prop
-    wrap: Var[str]
+    wrap: Var[Union[str, list]]
 
     # Shorthand for flexShrink style prop
     shrink: Var[str]


### PR DESCRIPTION
changed "wrap" and "direction" to allow lists instead of just strings
closes #1494 
closes #1495 

I also wanted to point out that one of the tests is failing, but I'm unsure if it's relevant to my changes. It has to do with a syntax error in a completely different file. Here's the output:
`=============================================== short test summary info ===============================================
FAILED tests/test_model.py::test_automigration - sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) near "DROP": syntax error
============================================ 1 failed, 529 passed in 6.52s ============================================`

Not sure if that's relevant, but I wanted to point it out. 
### All Submissions:

- [ x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [ x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### New Feature Submission:

- [ x] Does your submission pass the tests? 
- [ x] Have you linted your code locally prior to submission?


