### PR TITLE
scripts/integration: fix mismerge -- wait for $check_ports

### DIFF
--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -33,4 +33,4 @@ if [ -f /proc/$pid/winpid ]; then
   echo "Windows detected, passing winpid $pid to port waiter"
 fi
 
-python scripts/wait_for_listening_port.py 3000 8000 --timeout=600 --server-pid "$pid"
+python scripts/wait_for_listening_port.py $check_ports --timeout=600 --server-pid "$pid"


### PR DESCRIPTION
error introduced via https://github.com/reflex-dev/reflex/pull/1478/commits/1e2a5aad0ba6b53e8ee3b0609f72146bf8b17f0b