### PR TITLE
add __main__ entry point to allow `python -m reflex`

### DIFF
--- a/reflex/__main__.py
+++ b/reflex/__main__.py
@@ -1,0 +1,6 @@
+"""reflex package invocation entry point."""
+
+from .reflex import cli
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
Whenever a cli entry point is shipped with a package, it's nice to also be able to invoke the package as a module when there is a need to disambiguate the python interpreter or allow invocation without PATH modifications (for example, when doing a local install ala #1414)