### PR TITLE
Add trailing slash for paths

### DIFF
--- a/reflex/.templates/web/next.config.js
+++ b/reflex/.templates/web/next.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   reactStrictMode: true,
   compress: true,
+  trailingSlash: true,
 };

--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -199,7 +199,6 @@ def deploy(
         return
 
     # Compile the app in production mode.
-    console.info("Compiling production app")
     export(loglevel=loglevel)
 
     # Exit early if this is a dry run.


### PR DESCRIPTION
This allows `reflex export` to work better with static hosting like S3, as it will create a subdirectory with an `index.html` file for every path.