### PR TITLE
Event queue no longer part of reactive state

### DIFF
--- a/integration/test_event_chain.py
+++ b/integration/test_event_chain.py
@@ -280,11 +280,11 @@ def test_event_chain_click(event_chain, driver, button_id, exp_event_order):
     btn.click()
     if "redirect" in button_id:
         # wait a bit longer if we're redirecting
-        time.sleep(0.5)
+        time.sleep(1)
     if "many_events" in button_id:
         # wait a bit longer if we have loads of events
-        time.sleep(0.5)
-    time.sleep(0.2)
+        time.sleep(1)
+    time.sleep(0.5)
     backend_state = event_chain.app_instance.state_manager.states[token]
     assert backend_state.event_order == exp_event_order
 
@@ -327,6 +327,6 @@ def test_event_chain_on_load(event_chain, driver, uri, exp_event_order):
 
     token = event_chain.poll_for_value(token_input)
 
-    time.sleep(0.2)
+    time.sleep(0.5)
     backend_state = event_chain.app_instance.state_manager.states[token]
     assert backend_state.event_order == exp_event_order

--- a/integration/test_event_chain.py
+++ b/integration/test_event_chain.py
@@ -1,0 +1,332 @@
+"""Ensure that Event Chains are properly queued and handled between frontend and backend."""
+
+import time
+from typing import Generator
+
+import pytest
+from selenium.webdriver.common.by import By
+
+from reflex.testing import AppHarness
+
+MANY_EVENTS = 50
+
+
+def EventChain():
+    """App with chained event handlers."""
+    import reflex as rx
+
+    # repeated here since the outer global isn't exported into the App module
+    MANY_EVENTS = 50
+
+    class State(rx.State):
+        event_order: list[str] = []
+
+        @rx.var
+        def token(self) -> str:
+            return self.get_token()
+
+        def event_no_args(self):
+            self.event_order.append("event_no_args")
+
+        def event_arg(self, arg):
+            self.event_order.append(f"event_arg:{arg}")
+
+        def event_nested_1(self):
+            self.event_order.append("event_nested_1")
+            yield State.event_nested_2
+            yield State.event_arg("nested_1")  # type: ignore
+
+        def event_nested_2(self):
+            self.event_order.append("event_nested_2")
+            yield State.event_nested_3
+            yield rx.console_log("event_nested_2")
+            yield State.event_arg("nested_2")  # type: ignore
+
+        def event_nested_3(self):
+            self.event_order.append("event_nested_3")
+            yield State.event_no_args
+            yield State.event_arg("nested_3")  # type: ignore
+
+        def on_load_return_chain(self):
+            self.event_order.append("on_load_return_chain")
+            return [State.event_arg(1), State.event_arg(2), State.event_arg(3)]  # type: ignore
+
+        def on_load_yield_chain(self):
+            self.event_order.append("on_load_yield_chain")
+            yield State.event_arg(4)  # type: ignore
+            yield State.event_arg(5)  # type: ignore
+            yield State.event_arg(6)  # type: ignore
+
+        def click_return_event(self):
+            self.event_order.append("click_return_event")
+            return State.event_no_args
+
+        def click_return_events(self):
+            self.event_order.append("click_return_events")
+            return [
+                State.event_arg(7),  # type: ignore
+                rx.console_log("click_return_events"),
+                State.event_arg(8),  # type: ignore
+                State.event_arg(9),  # type: ignore
+            ]
+
+        def click_yield_chain(self):
+            self.event_order.append("click_yield_chain:0")
+            yield State.event_arg(10)  # type: ignore
+            self.event_order.append("click_yield_chain:1")
+            yield rx.console_log("click_yield_chain")
+            yield State.event_arg(11)  # type: ignore
+            self.event_order.append("click_yield_chain:2")
+            yield State.event_arg(12)  # type: ignore
+            self.event_order.append("click_yield_chain:3")
+
+        def click_yield_many_events(self):
+            self.event_order.append("click_yield_many_events")
+            for ix in range(MANY_EVENTS):
+                yield State.event_arg(ix)  # type: ignore
+                yield rx.console_log(f"many_events_{ix}")
+            self.event_order.append("click_yield_many_events_done")
+
+        def click_yield_nested(self):
+            self.event_order.append("click_yield_nested")
+            yield State.event_nested_1
+            yield State.event_arg("yield_nested")  # type: ignore
+
+        def redirect_return_chain(self):
+            self.event_order.append("redirect_return_chain")
+            yield rx.redirect("/on-load-return-chain")
+
+        def redirect_yield_chain(self):
+            self.event_order.append("redirect_yield_chain")
+            yield rx.redirect("/on-load-yield-chain")
+
+    app = rx.App(state=State)
+
+    @app.add_page
+    def index():
+        return rx.fragment(
+            rx.input(value=State.token, readonly=True, id="token"),
+            rx.button(
+                "Return Event",
+                id="return_event",
+                on_click=State.click_return_event,
+            ),
+            rx.button(
+                "Return Events",
+                id="return_events",
+                on_click=State.click_return_events,
+            ),
+            rx.button(
+                "Yield Chain",
+                id="yield_chain",
+                on_click=State.click_yield_chain,
+            ),
+            rx.button(
+                "Yield Many events",
+                id="yield_many_events",
+                on_click=State.click_yield_many_events,
+            ),
+            rx.button(
+                "Yield Nested",
+                id="yield_nested",
+                on_click=State.click_yield_nested,
+            ),
+            rx.button(
+                "Redirect Yield Chain",
+                id="redirect_yield_chain",
+                on_click=State.redirect_yield_chain,
+            ),
+            rx.button(
+                "Redirect Return Chain",
+                id="redirect_return_chain",
+                on_click=State.redirect_return_chain,
+            ),
+        )
+
+    def on_load_return_chain():
+        return rx.fragment(
+            rx.text("return"),
+            rx.input(value=State.token, readonly=True, id="token"),
+        )
+
+    def on_load_yield_chain():
+        return rx.fragment(
+            rx.text("yield"),
+            rx.input(value=State.token, readonly=True, id="token"),
+        )
+
+    app.add_page(on_load_return_chain, on_load=State.on_load_return_chain)  # type: ignore
+    app.add_page(on_load_yield_chain, on_load=State.on_load_yield_chain)  # type: ignore
+
+    app.compile()
+
+
+@pytest.fixture(scope="session")
+def event_chain(tmp_path_factory) -> Generator[AppHarness, None, None]:
+    """Start EventChain app at tmp_path via AppHarness.
+
+    Args:
+        tmp_path_factory: pytest tmp_path_factory fixture
+
+    Yields:
+        running AppHarness instance
+    """
+    with AppHarness.create(
+        root=tmp_path_factory.mktemp("event_chain"),
+        app_source=EventChain,  # type: ignore
+    ) as harness:
+        yield harness
+
+
+@pytest.fixture
+def driver(event_chain: AppHarness):
+    """Get an instance of the browser open to the event_chain app.
+
+    Args:
+        event_chain: harness for EventChain app
+
+    Yields:
+        WebDriver instance.
+    """
+    assert event_chain.app_instance is not None, "app is not running"
+    driver = event_chain.frontend()
+    try:
+        assert event_chain.poll_for_clients()
+        yield driver
+    finally:
+        driver.quit()
+
+
+@pytest.mark.parametrize(
+    ("button_id", "exp_event_order"),
+    [
+        ("return_event", ["click_return_event", "event_no_args"]),
+        (
+            "return_events",
+            ["click_return_events", "event_arg:7", "event_arg:8", "event_arg:9"],
+        ),
+        (
+            "yield_chain",
+            [
+                "click_yield_chain:0",
+                "click_yield_chain:1",
+                "click_yield_chain:2",
+                "click_yield_chain:3",
+                "event_arg:10",
+                "event_arg:11",
+                "event_arg:12",
+            ],
+        ),
+        (
+            "yield_many_events",
+            [
+                "click_yield_many_events",
+                "click_yield_many_events_done",
+                *[f"event_arg:{ix}" for ix in range(MANY_EVENTS)],
+            ],
+        ),
+        (
+            "yield_nested",
+            [
+                "click_yield_nested",
+                "event_nested_1",
+                "event_arg:yield_nested",
+                "event_nested_2",
+                "event_arg:nested_1",
+                "event_nested_3",
+                "event_arg:nested_2",
+                "event_no_args",
+                "event_arg:nested_3",
+            ],
+        ),
+        (
+            "redirect_return_chain",
+            [
+                "redirect_return_chain",
+                "on_load_return_chain",
+                "event_arg:1",
+                "event_arg:2",
+                "event_arg:3",
+            ],
+        ),
+        (
+            "redirect_yield_chain",
+            [
+                "redirect_yield_chain",
+                "on_load_yield_chain",
+                "event_arg:4",
+                "event_arg:5",
+                "event_arg:6",
+            ],
+        ),
+    ],
+)
+def test_event_chain_click(event_chain, driver, button_id, exp_event_order):
+    """Click the button, assert that the events are handled in the correct order.
+
+    Args:
+        event_chain: AppHarness for the event_chain app
+        driver: selenium WebDriver open to the app
+        button_id: the ID of the button to click
+        exp_event_order: the expected events recorded in the State
+    """
+    token_input = driver.find_element(By.ID, "token")
+    btn = driver.find_element(By.ID, button_id)
+    assert token_input
+    assert btn
+
+    token = event_chain.poll_for_value(token_input)
+
+    btn.click()
+    if "redirect" in button_id:
+        # wait a bit longer if we're redirecting
+        time.sleep(0.5)
+    if "many_events" in button_id:
+        # wait a bit longer if we have loads of events
+        time.sleep(0.5)
+    time.sleep(0.2)
+    backend_state = event_chain.app_instance.state_manager.states[token]
+    assert backend_state.event_order == exp_event_order
+
+
+@pytest.mark.parametrize(
+    ("uri", "exp_event_order"),
+    [
+        (
+            "/on-load-return-chain",
+            [
+                "on_load_return_chain",
+                "event_arg:1",
+                "event_arg:2",
+                "event_arg:3",
+            ],
+        ),
+        (
+            "/on-load-yield-chain",
+            [
+                "on_load_yield_chain",
+                "event_arg:4",
+                "event_arg:5",
+                "event_arg:6",
+            ],
+        ),
+    ],
+)
+def test_event_chain_on_load(event_chain, driver, uri, exp_event_order):
+    """Load the URI, assert that the events are handled in the correct order.
+
+    Args:
+        event_chain: AppHarness for the event_chain app
+        driver: selenium WebDriver open to the app
+        uri: the page to load
+        exp_event_order: the expected events recorded in the State
+    """
+    driver.get(event_chain.frontend_url + uri)
+    token_input = driver.find_element(By.ID, "token")
+    assert token_input
+
+    token = event_chain.poll_for_value(token_input)
+
+    time.sleep(0.2)
+    backend_state = event_chain.app_instance.state_manager.states[token]
+    assert backend_state.event_order == exp_event_order

--- a/integration/test_input.py
+++ b/integration/test_input.py
@@ -78,6 +78,7 @@ async def test_fully_controlled_input(fully_controlled_input: AppHarness):
     # move cursor to home, then to the right and type characters
     debounce_input.send_keys(Keys.HOME, Keys.ARROW_RIGHT)
     debounce_input.send_keys("foo")
+    time.sleep(0.5)
     assert debounce_input.get_attribute("value") == "ifoonitial"
     assert backend_state.text == "ifoonitial"
     assert fully_controlled_input.poll_for_value(value_input) == "ifoonitial"
@@ -96,21 +97,21 @@ async def test_fully_controlled_input(fully_controlled_input: AppHarness):
 
     # type more characters
     debounce_input.send_keys("getting testing done")
-    time.sleep(0.2)
+    time.sleep(0.5)
     assert debounce_input.get_attribute("value") == "getting testing done"
     assert backend_state.text == "getting testing done"
     assert fully_controlled_input.poll_for_value(value_input) == "getting testing done"
 
     # type into the on_change input
     on_change_input.send_keys("overwrite the state")
-    time.sleep(0.2)
+    time.sleep(0.5)
     assert debounce_input.get_attribute("value") == "overwrite the state"
     assert on_change_input.get_attribute("value") == "overwrite the state"
     assert backend_state.text == "overwrite the state"
     assert fully_controlled_input.poll_for_value(value_input) == "overwrite the state"
 
     clear_button.click()
-    time.sleep(0.2)
+    time.sleep(0.5)
     assert on_change_input.get_attribute("value") == ""
     # potential bug: clearing the on_change field doesn't itself trigger on_change
     # assert backend_state.text == ""

--- a/reflex/.templates/jinja/web/pages/index.js.jinja2
+++ b/reflex/.templates/jinja/web/pages/index.js.jinja2
@@ -10,25 +10,10 @@
 
 export default function Component() {
   const [{{state_name}}, {{state_name|react_setter}}] = useState({{initial_state|json_dumps}})
-  const [queueNotifyCounter, setQueueNotifyCounter] = useState(0)
-  const [notConnected, setNotConnected] = useState(false)
   const {{const.router}} = useRouter()
   const {{const.socket}} = useRef(null)
-  const { isReady } = {{const.router}}
   const { {{const.color_mode}}, {{const.toggle_color_mode}} } = {{const.use_color_mode}}()
   const focusRef = useRef();
-
-  // Function to trigger re-render when event queue is updated by websocket or event handler
-  const queueNotify = () => {
-    setQueueNotifyCounter(count => (count + 1))
-  }
-  
-  // Function to add new events to the event queue.
-  const Event = (events, _e) => {
-      preventDefault(_e);
-      pending_events.push(...events)
-      queueNotify()
-  }
 
   // Function to add new files to be uploaded.
   const File = files => {{state_name|react_setter}}(state => ({
@@ -37,38 +22,12 @@ export default function Component() {
   }))
 
   // Main event loop.
-  useEffect(()=> {
-    // Skip if the router is not ready.
-    if (!isReady) {
-      return;
-    }
-
-    // Initialize the websocket connection.
-    if (!{{const.socket}}.current) {
-      connect({{const.socket}}, queueNotify, {{const.router}}, {{transports}}, setNotConnected)
-      // perform hydration when websocket connects
-      Event([E('{{state_name}}.{{const.hydrate}}', {})])
-    }
-
-    (async () => {
-      // Process all outstanding events
-      while (pending_events.length > 0 && !event_status.processing) {
-        await processEvent({{const.router}}, {{const.socket}}.current)
-      }
-      // Update the state based on deltas from the websocket connection
-      if (pending_updates.length > 0) {
-        {{state_name|react_setter}}(currentState => {
-          pending_updates.forEach((update) => {
-            applyDelta(currentState, update.delta)
-            event_status.{{const.processing}} = !update.{{const.final}}
-          })
-          pending_updates.length = 0  // all updates processed
-          queueNotify()
-          return currentState
-        })
-      }
-    })()
-  })
+  const [Event, notConnected] = useEventLoop(
+    {{const.socket}},
+    {{const.router}},
+    {{state_name|react_setter}},
+    [E('{{state_name}}.{{const.hydrate}}', {})],
+  )
 
   // Set focus to the specified element.
   useEffect(() => {

--- a/reflex/.templates/jinja/web/pages/index.js.jinja2
+++ b/reflex/.templates/jinja/web/pages/index.js.jinja2
@@ -7,23 +7,27 @@
 {% endblock %}
 
 {% block export %}
+
 export default function Component() {
   const [{{state_name}}, {{state_name|react_setter}}] = useState({{initial_state|json_dumps}})
-  const [{{const.result}}, {{const.result|react_setter}}] = useState({{const.initial_result|json_dumps}})
+  const [queueNotifyCounter, setQueueNotifyCounter] = useState(0)
   const [notConnected, setNotConnected] = useState(false)
   const {{const.router}} = useRouter()
   const {{const.socket}} = useRef(null)
   const { isReady } = {{const.router}}
   const { {{const.color_mode}}, {{const.toggle_color_mode}} } = {{const.use_color_mode}}()
   const focusRef = useRef();
+
+  // Function to trigger re-render when event queue is updated by websocket or event handler
+  const queueNotify = () => {
+    setQueueNotifyCounter(count => (count + 1))
+  }
   
   // Function to add new events to the event queue.
   const Event = (events, _e) => {
       preventDefault(_e);
-      {{state_name|react_setter}}(state => ({
-        ...state,
-        events: [...state.events, ...events],
-      }))
+      pending_events.push(...events)
+      queueNotify()
   }
 
   // Function to add new files to be uploaded.
@@ -41,37 +45,29 @@ export default function Component() {
 
     // Initialize the websocket connection.
     if (!{{const.socket}}.current) {
-      connect({{const.socket}}, {{state_name}}, {{state_name|react_setter}}, {{const.result}}, {{const.result|react_setter}}, {{const.router}}, {{transports}}, setNotConnected)
+      connect({{const.socket}}, queueNotify, {{const.router}}, {{transports}}, setNotConnected)
+      // perform hydration when websocket connects
+      Event([E('{{state_name}}.{{const.hydrate}}', {})])
     }
 
-    // If we are not processing an event, process the next event.
-    if (!{{const.result}}.{{const.processing}}) {
-      processEvent({{state_name}}, {{state_name|react_setter}}, {{const.result}}, {{const.result|react_setter}}, {{const.router}}, {{const.socket}}.current)
-    }
-
-    // Reset the result.
-    {{const.result|react_setter}}(result => {
-      // If there is a new result, update the state.
-      if ({{const.result}}.{{const.state}} != null) {
-        // Apply the new result to the state and the new events to the queue.
-        {{state_name|react_setter}}(state => {
-          return {
-            ...{{const.result}}.{{const.state}},
-            events: [...state.{{const.events}}, ...{{const.result}}.{{const.events}}],
-          } 
-        })
-        return {
-          {{const.state}}: null,
-          {{const.events}}: [],
-          {{const.final}}: true,
-          {{const.processing}}: !{{const.result}}.{{const.final}},
-        }
+    (async () => {
+      // Process all outstanding events
+      while (pending_events.length > 0 && !event_status.processing) {
+        await processEvent({{const.router}}, {{const.socket}}.current)
       }
-      return result;
-    })
-
-    // Process the next event.
-    processEvent({{state_name}}, {{state_name|react_setter}}, {{const.result}}, {{const.result|react_setter}}, {{const.router}}, {{const.socket}}.current)
+      // Update the state based on deltas from the websocket connection
+      if (pending_updates.length > 0) {
+        {{state_name|react_setter}}(currentState => {
+          pending_updates.forEach((update) => {
+            applyDelta(currentState, update.delta)
+            event_status.{{const.processing}} = !update.{{const.final}}
+          })
+          pending_updates.length = 0  // all updates processed
+          queueNotify()
+          return currentState
+        })
+      }
+    })()
   })
 
   // Set focus to the specified element.
@@ -80,15 +76,6 @@ export default function Component() {
       focusRef.current.focus();
     }
   })
-
-  // Route after the initial page hydration.
-  useEffect(() => {
-    const change_complete = () => Event([E('{{state_name}}.{{const.hydrate}}', {})])
-    {{const.router}}.events.on('routeChangeComplete', change_complete)
-    return () => {
-      {{const.router}}.events.off('routeChangeComplete', change_complete)
-    }
-  }, [{{const.router}}])
 
   {% for hook in hooks %}
   {{ hook }}

--- a/reflex/compiler/compiler.py
+++ b/reflex/compiler/compiler.py
@@ -29,6 +29,10 @@ DEFAULT_IMPORTS: imports.ImportDict = {
         ImportVar(tag="refs"),
         ImportVar(tag="getRefValue"),
         ImportVar(tag="getAllLocalStorageItems"),
+        ImportVar(tag="pending_updates"),
+        ImportVar(tag="event_status"),
+        ImportVar(tag="pending_events"),
+        ImportVar(tag="applyDelta"),
     },
     "": {ImportVar(tag="focus-visible/dist/focus-visible")},
     "@chakra-ui/react": {

--- a/reflex/compiler/compiler.py
+++ b/reflex/compiler/compiler.py
@@ -20,8 +20,6 @@ DEFAULT_IMPORTS: imports.ImportDict = {
     },
     "next/router": {ImportVar(tag="useRouter")},
     f"/{constants.STATE_PATH}": {
-        ImportVar(tag="connect"),
-        ImportVar(tag="processEvent"),
         ImportVar(tag="uploadFiles"),
         ImportVar(tag="E"),
         ImportVar(tag="isTrue"),
@@ -29,10 +27,7 @@ DEFAULT_IMPORTS: imports.ImportDict = {
         ImportVar(tag="refs"),
         ImportVar(tag="getRefValue"),
         ImportVar(tag="getAllLocalStorageItems"),
-        ImportVar(tag="pending_updates"),
-        ImportVar(tag="event_status"),
-        ImportVar(tag="pending_events"),
-        ImportVar(tag="applyDelta"),
+        ImportVar(tag="useEventLoop"),
     },
     "": {ImportVar(tag="focus-visible/dist/focus-visible")},
     "@chakra-ui/react": {

--- a/reflex/compiler/utils.py
+++ b/reflex/compiler/utils.py
@@ -19,7 +19,6 @@ from reflex.components.base import (
     Title,
 )
 from reflex.components.component import Component, ComponentStyle, CustomComponent
-from reflex.event import get_hydrate_event
 from reflex.state import State
 from reflex.style import Style
 from reflex.utils import format, imports, path_ops
@@ -129,7 +128,6 @@ def compile_state(state: Type[State]) -> Dict:
         initial_state = state().dict(include_computed=False)
     initial_state.update(
         {
-            "events": [{"name": get_hydrate_event(state)}],
             "files": [],
         }
     )


### PR DESCRIPTION
Do not manage incoming websocket events via React's state system.

Reactive state should never have side effects, and by definition the incoming websocket event handler and event queuing is a side effect outside of react, which introduces subtle incorrect data races.

Instead, manage the event queue completely outside of the state, and only interact with it during useEffect hook, which allows side effects since it occurs after render time.

# Testing

Some tests for yielding and returning State and client-side events have been added, but unfortunately these tests still do not reliably fail without the proposed changes (although they will fail eventually). I'd like some more deterministic test cases that really bring out the dropped events behavior that we see in #1422 