### PR TITLE
fix missing on_load parameter in custom_404

### DIFF
--- a/reflex/app.py
+++ b/reflex/app.py
@@ -404,14 +404,14 @@ class App(Base):
 
     def add_custom_404_page(
         self,
-        component=None,
-        title=None,
-        image=None,
-        description=None,
+        component: Optional[Union[Component, ComponentCallable]],
+        title: str = constants.TITLE_404,
+        image: str = constants.FAVICON_404,
+        description: str = constants.DESCRIPTION_404,
         on_load: Optional[
             Union[EventHandler, EventSpec, List[Union[EventHandler, EventSpec]]]
         ] = None,
-        meta=constants.DEFAULT_META_LIST,
+        meta: List[Dict] = constants.DEFAULT_META_LIST,
     ):
         """Define a custom 404 page for any url having no match.
 

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -427,11 +427,7 @@ class App(Base):
             meta: The metadata of the page.
         """
         self.add_page(
-            component=(
-                component
-                if isinstance(component, Component)
-                else (component() if component else Fragment.create())
-            ),
+            component=component if component else Fragment.create(),
             route=constants.SLUG_404,
             title=title or constants.TITLE_404,
             image=image or constants.FAVICON_404,

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -404,7 +404,7 @@ class App(Base):
 
     def add_custom_404_page(
         self,
-        component: Optional[Union[Component, ComponentCallable]],
+        component: Optional[Union[Component, ComponentCallable]] = None,
         title: str = constants.TITLE_404,
         image: str = constants.FAVICON_404,
         description: str = constants.DESCRIPTION_404,

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -426,35 +426,19 @@ class App(Base):
             on_load: The event handler(s) that will be called each time the page load.
             meta: The metadata of the page.
         """
-        title = title or constants.TITLE_404
-        image = image or constants.FAVICON_404
-        description = description or constants.DESCRIPTION_404
-
-        component = (
-            component
-            if isinstance(component, Component)
-            else (component() if component else Fragment.create())
-        )
-
-        compiler_utils.add_meta(
-            component,
-            title=title,
-            image=image,
-            description=description,
+        self.add_page(
+            component=(
+                component
+                if isinstance(component, Component)
+                else (component() if component else Fragment.create())
+            ),
+            route=constants.SLUG_404,
+            title=title or constants.TITLE_404,
+            image=image or constants.FAVICON_404,
+            description=description or constants.DESCRIPTION_404,
+            on_load=on_load,
             meta=meta,
         )
-
-        # format 404 route
-        route = format.format_route(constants.SLUG_404)
-
-        # add the page
-        self.pages[route] = component
-
-        # Add the load events.
-        if on_load:
-            if not isinstance(on_load, list):
-                on_load = [on_load]
-            self.load_events[route] = on_load
 
     def setup_admin_dash(self):
         """Setup the admin dash."""


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran tests with your changes locally?

### Description

Add the missing on_load kwargs to the custom 404 method, allowing a default redirect when a page is unknown.

Also make component optional (default to a rx.fragment()) since defining one is not needed for redirects.

