### PR TITLE
Event Handlers should not shadow base state methods

### DIFF
--- a/reflex/middleware/hydrate_middleware.py
+++ b/reflex/middleware/hydrate_middleware.py
@@ -40,7 +40,7 @@ class HydrateMiddleware(Middleware):
         setattr(state, constants.IS_HYDRATED, False)
         delta = format.format_state({state.get_name(): state.dict()})
         # since a full dict was captured, clean any dirtiness
-        state.clean()
+        state._clean()
 
         # Get the route for on_load events.
         route = event.router_data.get(constants.RouteVar.PATH, "")

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -237,7 +237,7 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
         events = {
             name: fn
             for name, fn in cls.__dict__.items()
-            if not name.startswith("__")
+            if not name.startswith("_")
             and isinstance(fn, Callable)
             and not isinstance(fn, EventHandler)
         }

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -473,7 +473,7 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
         """Get all functions of the state class excluding dunder methods.
 
         Returns:
-            The function names of rx.State class as a dict.
+            The functions of rx.State class as a dict.
         """
         return {
             func[0]: func[1]
@@ -658,7 +658,7 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
             for substate in self.substates.values():
                 setattr(substate, name, value)
 
-    def _reset(self):
+    def reset(self):
         """Reset all the base vars to their default values."""
         # Reset the base vars.
         fields = self.get_fields()
@@ -667,7 +667,7 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
 
         # Recursively reset the substates.
         for substate in self.substates.values():
-            substate._reset()
+            substate.reset()
 
     def get_substate(self, path: Sequence[str]) -> Optional[State]:
         """Get the substate.

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -451,7 +451,7 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
 
     @staticmethod
     def get_base_functions() -> List[str]:
-        """Get all functions of the state class excluding dunder functions."""
+        """Get all functions of the state class excluding dunder methods."""
         return [
             methods[0]
             for methods in inspect.getmembers(State, predicate=inspect.isfunction)

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -621,7 +621,7 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
             for substate in self.substates.values():
                 setattr(substate, name, value)
 
-    def reset(self):
+    def _reset(self):
         """Reset all the base vars to their default values."""
         # Reset the base vars.
         fields = self.get_fields()
@@ -630,7 +630,7 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
 
         # Recursively reset the substates.
         for substate in self.substates.values():
-            substate.reset()
+            substate._reset()
 
     def get_substate(self, path: Sequence[str]) -> Optional[State]:
         """Get the substate.

--- a/reflex/testing.py
+++ b/reflex/testing.py
@@ -365,7 +365,7 @@ class AppHarness:
             delta = state.get_delta()
             if delta:
                 update = reflex.state.StateUpdate(delta=delta, events=[], final=True)
-                state.clean()
+                state._clean()
                 # Emit the event.
                 pending.append(
                     event_ns.emit(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -573,3 +573,16 @@ def mutable_state():
             self.test_set = {1, 2, 3, 4, "five"}
 
     return MutableTestState()
+
+
+@pytest.fixture
+def state_with_invalid_event_handler():
+    """A test state with an event handler that shadows a
+    builtin state method.
+    """
+
+    class InvalidTest(rx.State):
+        def _reset(self):
+            pass
+
+    return InvalidTest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -579,6 +579,9 @@ def mutable_state():
 def state_with_invalid_event_handler():
     """A test state with an event handler that shadows a
     builtin state method.
+
+    Returns:
+        A test state.
     """
 
     class InvalidTest(rx.State):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -573,19 +573,3 @@ def mutable_state():
             self.test_set = {1, 2, 3, 4, "five"}
 
     return MutableTestState()
-
-
-@pytest.fixture
-def state_with_invalid_event_handler():
-    """A test state with an event handler that shadows a
-    builtin state method.
-
-    Returns:
-        A test state.
-    """
-
-    class InvalidTest(rx.State):
-        def _reset(self):
-            pass
-
-    return InvalidTest

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -553,7 +553,7 @@ def test_reset(test_state, child_state):
     child_state.value = "test"
 
     # Reset the state.
-    test_state._reset()
+    test_state.reset()
 
     # The values should be reset.
     assert test_state.num1 == 0
@@ -1198,7 +1198,7 @@ def test_error_on_state_method_shadow():
     with pytest.raises(NameError) as err:
 
         class InvalidTest(rx.State):
-            def _reset(self):
+            def reset(self):
                 pass
 
     assert (

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1193,14 +1193,14 @@ def test_setattr_of_mutable_types(mutable_state):
     assert isinstance(test_set, ReflexSet)
 
 
-def test_error_on_state_method_shadow(state_with_invalid_event_handler):
-    """Test that an error is thrown when an event handler shadows a state method.
-
-    Args:
-        state_with_invalid_event_handler: A test state.
-    """
+def test_error_on_state_method_shadow():
+    """Test that an error is thrown when an event handler shadows a state method."""
     with pytest.raises(NameError) as err:
-        state_with_invalid_event_handler()
+
+        class InvalidTest(rx.State):
+            def _reset(self):
+                pass
+
     assert (
         err.value.args[0]
         == f"The event handler name `_reset` shadows a builtin State method; use a different name instead"

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1191,3 +1191,13 @@ def test_setattr_of_mutable_types(mutable_state):
     assert isinstance(hashmap["mod_third_key"], ReflexDict)
 
     assert isinstance(test_set, ReflexSet)
+
+
+def test_error_on_state_method_shadow(state_with_invalid_event_handler):
+    """Test that an error is thrown when an event handler shadows a state method."""
+    with pytest.raises(NameError) as err:
+        state_with_invalid_event_handler()
+    assert (
+        err.value.args[0]
+        == f"The event handler name `_reset` shadows a builtin State method; use a different name instead"
+    )

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -553,7 +553,7 @@ def test_reset(test_state, child_state):
     child_state.value = "test"
 
     # Reset the state.
-    test_state.reset()
+    test_state._reset()
 
     # The values should be reset.
     assert test_state.num1 == 0

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1203,5 +1203,5 @@ def test_error_on_state_method_shadow():
 
     assert (
         err.value.args[0]
-        == f"The event handler name `_reset` shadows a builtin State method; use a different name instead"
+        == f"The event handler name `reset` shadows a builtin State method; use a different name instead"
     )

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -498,7 +498,7 @@ def test_set_dirty_var(test_state):
     assert test_state.dirty_vars == {"num1", "num2", "sum"}
 
     # Cleaning the state should remove all dirty vars.
-    test_state.clean()
+    test_state._clean()
     assert test_state.dirty_vars == set()
 
 
@@ -524,7 +524,7 @@ def test_set_dirty_substate(test_state, child_state, child_state2, grandchild_st
     assert child_state.dirty_substates == set()
 
     # Cleaning the parent state should remove the dirty substate.
-    test_state.clean()
+    test_state._clean()
     assert test_state.dirty_substates == set()
     assert child_state.dirty_vars == set()
 
@@ -534,7 +534,7 @@ def test_set_dirty_substate(test_state, child_state, child_state2, grandchild_st
     assert test_state.dirty_substates == {"child_state"}
 
     # Cleaning the middle state should keep the parent state dirty.
-    child_state.clean()
+    child_state._clean()
     assert test_state.dirty_substates == {"child_state"}
     assert child_state.dirty_substates == set()
     assert grandchild_state.dirty_vars == set()
@@ -626,7 +626,7 @@ async def test_process_event_substate(test_state, child_state, grandchild_state)
         "test_state": {"sum": 3.14, "upper": ""},
         "test_state.child_state": {"value": "HI", "count": 24},
     }
-    test_state.clean()
+    test_state._clean()
 
     # Test with the granchild state.
     assert grandchild_state.value2 == ""
@@ -1044,23 +1044,23 @@ def test_computed_var_cached_depends_on_non_cached():
     cs = ComputedState()
     assert cs.dirty_vars == set()
     assert cs.get_delta() == {cs.get_name(): {"no_cache_v": 0, "dep_v": 0}}
-    cs.clean()
+    cs._clean()
     assert cs.dirty_vars == set()
     assert cs.get_delta() == {cs.get_name(): {"no_cache_v": 0, "dep_v": 0}}
-    cs.clean()
+    cs._clean()
     assert cs.dirty_vars == set()
     cs.v = 1
     assert cs.dirty_vars == {"v", "comp_v", "dep_v", "no_cache_v"}
     assert cs.get_delta() == {
         cs.get_name(): {"v": 1, "no_cache_v": 1, "dep_v": 1, "comp_v": 1}
     }
-    cs.clean()
+    cs._clean()
     assert cs.dirty_vars == set()
     assert cs.get_delta() == {cs.get_name(): {"no_cache_v": 1, "dep_v": 1}}
-    cs.clean()
+    cs._clean()
     assert cs.dirty_vars == set()
     assert cs.get_delta() == {cs.get_name(): {"no_cache_v": 1, "dep_v": 1}}
-    cs.clean()
+    cs._clean()
     assert cs.dirty_vars == set()
 
 
@@ -1194,7 +1194,11 @@ def test_setattr_of_mutable_types(mutable_state):
 
 
 def test_error_on_state_method_shadow(state_with_invalid_event_handler):
-    """Test that an error is thrown when an event handler shadows a state method."""
+    """Test that an error is thrown when an event handler shadows a state method.
+
+    Args:
+        state_with_invalid_event_handler: A test state.
+    """
     with pytest.raises(NameError) as err:
         state_with_invalid_event_handler()
     assert (


### PR DESCRIPTION
With this PR an error is thrown when an event handler shadows a builtin state method. Also renames some builtin methods

closes #1424 