### PR TITLE
Fix non-default imports for NoSSRComponent

### DIFF
--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -788,4 +788,10 @@ class NoSSRComponent(Component):
     def _get_custom_code(self) -> str:
         opts_fragment = ", { ssr: false });"
         library_import = f"const {self.tag} = dynamic(() => import('{self.library}')"
-        return "".join((library_import, opts_fragment))
+        mod_import = (
+            # https://nextjs.org/docs/pages/building-your-application/optimizing/lazy-loading#with-named-exports
+            f".then((mod) => mod.{self.tag})"
+            if not self.is_default
+            else ""
+        )
+        return "".join((library_import, mod_import, opts_fragment))

--- a/reflex/components/graphing/plotly.py
+++ b/reflex/components/graphing/plotly.py
@@ -20,6 +20,8 @@ class Plotly(PlotlyLib):
 
     tag = "Plot"
 
+    is_default = True
+
     # The figure to display. This can be a plotly figure or a plotly data json.
     data: Var[Figure]
 

--- a/reflex/components/libs/react_player.py
+++ b/reflex/components/libs/react_player.py
@@ -15,6 +15,8 @@ class ReactPlayerComponent(NoSSRComponent):
 
     tag = "ReactPlayer"
 
+    is_default = True
+
     # The url of a video or song to play
     url: Var[str]
 


### PR DESCRIPTION
Bring back support for `is_default = False` imports in NoSSRComponent #1533 

Ensure `Plot` and `ReactPlayer` are set with `is_default = True` such that they generate the same import code as before. (`is_default = False` is the default, so #1533 introduced regression)

Tested with audio/video sample app

```python
import reflex as rx


class State(rx.State):
    pass


def index() -> rx.Component:
    return rx.fragment(
        rx.color_mode_button(rx.color_mode_icon(), float="right"),
        rx.vstack(
            rx.video(
                url="https://youtu.be/E45fogGN_Y8",
            ),
            rx.video(
                url="/tea.mp4",
            ),
            rx.audio(
                url="/tech-house-vibes.mp3",
            ),
            spacing="1.5em",
            font_size="2em",
            padding_top="10%",
        ),
    )


# Add state and page to the app.
app = rx.App()
app.add_page(index)
app.compile()
```
[assets.zip](https://github.com/reflex-dev/reflex/files/12297666/assets.zip)

![image](https://github.com/reflex-dev/reflex/assets/1524005/b8783f09-08aa-4e3b-b864-61697458bdc0)

Also confirmed that plotly plots on `reflex-web` are working with this change!

![image](https://github.com/reflex-dev/reflex/assets/1524005/a6aa0ab7-3c2f-406d-a9f5-3f0b20f40885)