### PR TITLE
Reinstate bun path

### DIFF
--- a/reflex/config.py
+++ b/reflex/config.py
@@ -169,7 +169,7 @@ class Config(Base):
     frontend_packages: List[str] = []
 
     # The bun path
-    bun_path: Optional[str] = constants.BUN_PATH
+    bun_path: str = constants.BUN_PATH
 
     # The Admin Dash.
     admin_dash: Optional[AdminDash] = None

--- a/reflex/config.py
+++ b/reflex/config.py
@@ -168,6 +168,9 @@ class Config(Base):
     # Additional frontend packages to install.
     frontend_packages: List[str] = []
 
+    # The bun path
+    bun_path: Optional[str] = constants.BUN_PATH
+
     # The Admin Dash.
     admin_dash: Optional[AdminDash] = None
 

--- a/reflex/constants.py
+++ b/reflex/constants.py
@@ -65,6 +65,8 @@ JINJA_TEMPLATE_DIR = os.path.join(TEMPLATE_DIR, "jinja")
 # Bun config.
 # The Bun version.
 BUN_VERSION = "0.7.0"
+# Min Bun Version
+MIN_BUN_VERSION = "0.7.0"
 # The directory to store the bun.
 BUN_ROOT_PATH = os.path.join(REFLEX_DIR, ".bun")
 # Default bun path.

--- a/reflex/constants.py
+++ b/reflex/constants.py
@@ -67,8 +67,10 @@ JINJA_TEMPLATE_DIR = os.path.join(TEMPLATE_DIR, "jinja")
 BUN_VERSION = "0.7.0"
 # The directory to store the bun.
 BUN_ROOT_PATH = os.path.join(REFLEX_DIR, ".bun")
+# Default bun path.
+DEFAULT_BUN_PATH = os.path.join(BUN_ROOT_PATH, "bin", "bun")
 # The bun path.
-BUN_PATH = os.path.join(BUN_ROOT_PATH, "bin", "bun")
+BUN_PATH = get_value("BUN_PATH", DEFAULT_BUN_PATH)
 # URL to bun install script.
 BUN_INSTALL_URL = "https://bun.sh/install"
 

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -453,10 +453,11 @@ def validate_bun():
             raise typer.Exit(1)
         elif bun_version < version.parse(constants.MIN_BUN_VERSION):
             console.error(
-                f"Reflex requires bun version {constants.BUN_VERSION}+ to run. If you specified a bun path in your "
-                f"config,"
-                f"make sure to specify one that meets the requirements."
+                f"Reflex requires bun version {constants.BUN_VERSION} or higher to run, but the detected version is "
+                f"{bun_version}. If you have specified a custom bun path in your config, make sure to provide one "
+                f"that satisfies the minimum version requirement."
             )
+
             raise typer.Exit(1)
 
 

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -436,7 +436,11 @@ def is_latest_template() -> bool:
 
 
 def validate_bun():
-    """Validate bun if a custom bun path is specified to ensure the bun version meets requirements."""
+    """Validate bun if a custom bun path is specified to ensure the bun version meets requirements.
+
+    Raises:
+        Exit: If custom specified bun does not exist or does not meet requirements.
+    """
     # if a custom bun path is provided, make sure its valid
     # This is specific to non-FHS OS
     bun_path = get_config().bun_path

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -447,9 +447,9 @@ def validate_bun():
                 f"Failed to obtain bun version. Make sure the specified bun path in your config is correct."
             )
             raise typer.Exit(1)
-        elif bun_version < version.parse(constants.BUN_VERSION):
+        elif bun_version < version.parse(constants.MIN_BUN_VERSION):
             console.error(
-                f"Reflex requires bun version {constants.BUN_VERSION} to run. If you specified a bun path in your "
+                f"Reflex requires bun version {constants.BUN_VERSION}+ to run. If you specified a bun path in your "
                 f"config,"
                 f"make sure to specify one that meets the requirements."
             )

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -245,34 +245,11 @@ def initialize_web_directory():
         json.dump(reflex_json, f, ensure_ascii=False)
 
 
-def initialize_bun():
-    """Check that bun requirements are met, and install if not."""
-    if IS_WINDOWS:
-        # Bun is not supported on Windows.
-        console.debug("Skipping bun installation on Windows.")
-        return
-
-    # Check the bun version.
-    bun_version = get_bun_version()
-    if bun_version != version.parse(constants.BUN_VERSION):
-        console.debug(
-            f"Current bun version ({bun_version}) does not match ({constants.BUN_VERSION})."
-        )
-        remove_existing_bun_installation()
-        install_bun()
-
-
 def remove_existing_bun_installation():
     """Remove existing bun installation."""
     console.debug("Removing existing bun installation.")
     if os.path.exists(get_config().bun_path):
         path_ops.rm(constants.BUN_ROOT_PATH)
-
-
-def initialize_node():
-    """Validate nodejs have install or not."""
-    if not check_node_version():
-        install_node()
 
 
 def download_and_run(url: str, *args, show_status: bool = False, **env):
@@ -448,7 +425,7 @@ def validate_bun():
         bun_version = get_bun_version()
         if not bun_version:
             console.error(
-                f"Failed to obtain bun version. Make sure the specified bun path in your config is correct."
+                "Failed to obtain bun version. Make sure the specified bun path in your config is correct."
             )
             raise typer.Exit(1)
         elif bun_version < version.parse(constants.MIN_BUN_VERSION):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -520,6 +520,7 @@ def test_node_install_windows(mocker):
         mocker: Pytest mocker object.
     """
     mocker.patch("reflex.utils.prerequisites.IS_WINDOWS", True)
+    mocker.patch("reflex.utils.prerequisites.check_node_version", return_value=False)
 
     with pytest.raises(typer.Exit):
         prerequisites.install_node()


### PR DESCRIPTION
We took out the bun_path config param in `v0.2.3` and this introduced regression in non-fhs systems. This PR reinstates the `bun_path` param allowing users with non-FHS systems to specify a custom path to a bun executable. It also adds validation checks to ensure the bun exec is compatible with reflex.

 **Note that this only applies to non-fhs systems, for all other OS, reflex handles installation of these dependencies under the hood**

closes #1470 