### PR TITLE
Flex props to support Lists

### DIFF
--- a/reflex/components/layout/flex.py
+++ b/reflex/components/layout/flex.py
@@ -1,6 +1,6 @@
 """A reflexive container component."""
 
-from typing import Union
+from typing import List, Union
 
 from reflex.components.libs.chakra import ChakraComponent
 from reflex.vars import Var
@@ -18,7 +18,7 @@ class Flex(ChakraComponent):
     basis: Var[str]
 
     # Shorthand for flexDirection style prop
-    direction: Var[Union[str, list]]
+    direction: Var[Union[str, List[str]]]
 
     # Shorthand for flexGrow style prop
     grow: Var[str]
@@ -27,7 +27,7 @@ class Flex(ChakraComponent):
     justify: Var[str]
 
     # Shorthand for flexWrap style prop
-    wrap: Var[Union[str, list]]
+    wrap: Var[Union[str, List[str]]]
 
     # Shorthand for flexShrink style prop
     shrink: Var[str]

--- a/reflex/components/layout/flex.py
+++ b/reflex/components/layout/flex.py
@@ -2,6 +2,7 @@
 
 from reflex.components.libs.chakra import ChakraComponent
 from reflex.vars import Var
+from typing import Union
 
 
 class Flex(ChakraComponent):
@@ -16,7 +17,7 @@ class Flex(ChakraComponent):
     basis: Var[str]
 
     # Shorthand for flexDirection style prop
-    direction: Var[str]
+    direction: Var[Union[str, list]]
 
     # Shorthand for flexGrow style prop
     grow: Var[str]
@@ -25,7 +26,7 @@ class Flex(ChakraComponent):
     justify: Var[str]
 
     # Shorthand for flexWrap style prop
-    wrap: Var[str]
+    wrap: Var[Union[str, list]]
 
     # Shorthand for flexShrink style prop
     shrink: Var[str]

--- a/reflex/components/layout/flex.py
+++ b/reflex/components/layout/flex.py
@@ -1,8 +1,9 @@
 """A reflexive container component."""
 
+from typing import Union
+
 from reflex.components.libs.chakra import ChakraComponent
 from reflex.vars import Var
-from typing import Union
 
 
 class Flex(ChakraComponent):


### PR DESCRIPTION
closes #1494 
closes #1495 

with this PR, `rx.flex` props: `direction` and `wraps` should support list values

eg:
```python
rx.flex(
        ...
        direction=["row", "row", "column", "column", "column"],
        wrap=["wrap", "wrap", "nowrap", "nowrap", "nowrap"],
        )
```