### PR TITLE
chore: ignore all files with .db extensions in .gitignore

### DIFF
--- a/reflex/constants.py
+++ b/reflex/constants.py
@@ -214,7 +214,7 @@ DEFAULT_META_LIST = []
 # The gitignore file.
 GITIGNORE_FILE = ".gitignore"
 # Files to gitignore.
-DEFAULT_GITIGNORE = {WEB_DIR, DB_NAME, "__pycache__/", "*.py[cod]"}
+DEFAULT_GITIGNORE = {WEB_DIR, "*.db", "__pycache__/", "*.py[cod]"}
 # The name of the reflex config module.
 CONFIG_MODULE = "rxconfig"
 # The python config file.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -481,7 +481,7 @@ def test_initialize_non_existent_gitignore(tmp_path, mocker, gitignore_exists):
     if gitignore_exists:
         gitignore_file.touch()
         gitignore_file.write_text(
-            """reflex.db
+            """*.db
         __pycache__/
         """
         )


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

This PR changes default .gitignore file to ignore all .db files, not only reflex.db

