### PR TITLE
Change fixture scope to be run per session rather than per function

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ def app() -> App:
     return App()
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="session")
 def windows_platform() -> Generator:
     """Check if system is windows.
 


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->


This PR only changes scope for pytest fixture `windows_platform()` from `function` to `session`. As far as I understand the tests it is could be checked only once per test session. This shaves tests time on cold start from 17s to 10s, and with cache from 8s to 6.5s (on my machine at least).
