### PR TITLE
App harness use new_process

### DIFF
--- a/reflex/testing.py
+++ b/reflex/testing.py
@@ -241,10 +241,14 @@ class AppHarness:
                 os.killpg(pgrp, signal.SIGTERM)
             # kill any remaining child processes
             for child in frontend_children:
-                child.terminate()
+                # It's okay if the process is already gone.
+                with contextlib.suppress(psutil.NoSuchProcess):
+                    child.terminate()
             _, still_alive = psutil.wait_procs(frontend_children, timeout=3)
             for child in still_alive:
-                child.kill()
+                # It's okay if the process is already gone.
+                with contextlib.suppress(psutil.NoSuchProcess):
+                    child.kill()
             # wait for main process to exit
             self.frontend_process.communicate()
         if self.backend_thread is not None:

--- a/reflex/testing.py
+++ b/reflex/testing.py
@@ -174,20 +174,19 @@ class AppHarness:
         self.backend_thread.start()
 
     def _start_frontend(self):
+        # Set up the frontend.
         with chdir(self.app_path):
             config = reflex.config.get_config()
             config.api_url = "http://{0}:{1}".format(
                 *self._poll_for_servers().getsockname(),
             )
             reflex.utils.build.setup_frontend(self.app_path)
-        frontend_env = os.environ.copy()
-        frontend_env["PORT"] = "0"
-        self.frontend_process = subprocess.Popen(
-            [reflex.utils.prerequisites.get_install_package_manager(), "run", "dev"],
-            stdout=subprocess.PIPE,
-            encoding="utf-8",
+
+        # Start the frontend.
+        self.frontend_process = reflex.utils.processes.new_process(
+            [reflex.utils.prerequisites.get_package_manager(), "run", "dev"],
             cwd=self.app_path / reflex.constants.WEB_DIR,
-            env=frontend_env,
+            env={"PORT": "0"},
             **FRONTEND_POPEN_ARGS,
         )
 

--- a/reflex/utils/processes.py
+++ b/reflex/utils/processes.py
@@ -145,6 +145,7 @@ def new_process(args, run: bool = False, show_logs: bool = False, **kwargs):
     env = {
         **os.environ,
         "PATH": os.pathsep.join([constants.NODE_BIN_PATH, os.environ["PATH"]]),
+        **kwargs.pop("env", {}),
     }
     kwargs = {
         "env": env,


### PR DESCRIPTION
Use the unifying `new_process` command to launch processes in the test harness.