### PR TITLE
Fix rx.link href prop and Var.to_string type

### DIFF
--- a/integration/test_dynamic_routes.py
+++ b/integration/test_dynamic_routes.py
@@ -36,8 +36,8 @@ def DynamicRoute():
         return rx.fragment(
             rx.input(value=DynamicState.token, is_read_only=True, id="token"),
             rx.input(value=DynamicState.page_id, is_read_only=True, id="page_id"),
-            rx.link("index", href="/", id="link_index"),  # type: ignore
-            rx.link("page_X", href="/static/x", id="link_page_x"),  # type: ignore
+            rx.link("index", href="/", id="link_index"),
+            rx.link("page_X", href="/static/x", id="link_page_x"),
             rx.link(
                 "next", href="/page/" + DynamicState.next_page, id="link_page_next"  # type: ignore
             ),

--- a/reflex/components/navigation/link.py
+++ b/reflex/components/navigation/link.py
@@ -1,6 +1,5 @@
 """A link component."""
 
-from typing import Optional
 
 from reflex.components.component import Component
 from reflex.components.libs.chakra import ChakraComponent
@@ -33,12 +32,11 @@ class Link(ChakraComponent):
         return {**super()._get_imports(), **NextLink.create()._get_imports()}
 
     @classmethod
-    def create(cls, *children, href: Optional[Var] = None, **props) -> Component:
+    def create(cls, *children, **props) -> Component:
         """Create a Link component.
 
         Args:
             *children: The children of the component.
-            href: The href attribute of the link.
             **props: The props of the component.
 
         Raises:
@@ -47,11 +45,10 @@ class Link(ChakraComponent):
         Returns:
             Component: The link component
         """
-        if href and not len(children):
-            raise ValueError("Link without a child will not display")
-        elif href is None and len(children):
+        if props["href"]:
+            if not len(children):
+                raise ValueError("Link without a child will not display")
+        else:
             # Don't use a NextLink if there is no href.
             props["as_"] = ""
-        if href:
-            props["href"] = href
         return super().create(*children, **props)

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -166,7 +166,7 @@ class Var(ABC):
         Returns:
             The stringified var.
         """
-        return self.operation(fn="JSON.stringify")
+        return self.operation(fn="JSON.stringify", type_=str)
 
     def __hash__(self) -> int:
         """Define a hash function for a var.
@@ -661,7 +661,7 @@ class Var(ABC):
         Returns:
             A var representing the logical and.
         """
-        return self.operation("&&", other, flip=True)
+        return self.operation("&&", other, type_=bool, flip=True)
 
     def __or__(self, other: Var) -> Var:
         """Perform a logical or.
@@ -672,7 +672,7 @@ class Var(ABC):
         Returns:
             A var representing the logical or.
         """
-        return self.operation("||", other)
+        return self.operation("||", other, type_=bool)
 
     def __ror__(self, other: Var) -> Var:
         """Perform a logical or.

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -650,7 +650,7 @@ class Var(ABC):
         Returns:
             A var representing the logical and.
         """
-        return self.operation("&&", other)
+        return self.operation("&&", other, type_=bool)
 
     def __rand__(self, other: Var) -> Var:
         """Perform a logical and.
@@ -683,7 +683,7 @@ class Var(ABC):
         Returns:
             A var representing the logical or.
         """
-        return self.operation("||", other, flip=True)
+        return self.operation("||", other, type_=bool, flip=True)
 
     def foreach(self, fn: Callable) -> Var:
         """Return a list of components. after doing a foreach on this var.


### PR DESCRIPTION
1. Update rx.link to read the `href` prop from the `**props` kwarg. Before we were hitting some type checking issues because we specified the type had to be `Var[str]`.
2. Update the type for var operations `to_string` as well as the bool operators