### PR TITLE
format_dict: only unescape quotes when removing outer quotes

### DIFF
--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -473,10 +473,12 @@ def format_dict(prop: ComponentStyle) -> str:
     # Dump the dict to a string.
     fprop = json_dumps(prop)
 
+    def unescape_double_quotes_in_var(m: re.Match) -> str:
+        # Since the outer quotes are removed, the inner escaped quotes must be unescaped.
+        return re.sub('\\\\"', '"', m.group(1))
+
     # This substitution is necessary to unwrap var values.
-    fprop = re.sub('"{', "", fprop)
-    fprop = re.sub('}"', "", fprop)
-    fprop = re.sub('\\\\"', '"', fprop)
+    fprop = re.sub(r'"{([^}]*)}"', unescape_double_quotes_in_var, fprop)
 
     # Return the formatted dict.
     return fprop

--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -479,15 +479,16 @@ def format_dict(prop: ComponentStyle) -> str:
 
     # This substitution is necessary to unwrap var values.
     fprop = re.sub(
-        pattern=r'''
+        pattern=r"""
             (?<!\\)      # must NOT start with a backslash
             "            # match opening double quote of JSON value
             {(.*?)}      # extract the value between curly braces (non-greedy)
             "            # match must end with an unescaped double quote
-        ''',
+        """,
         repl=unescape_double_quotes_in_var,
         string=fprop,
-        flags=re.VERBOSE)
+        flags=re.VERBOSE,
+    )
 
     # Return the formatted dict.
     return fprop

--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -478,7 +478,16 @@ def format_dict(prop: ComponentStyle) -> str:
         return re.sub('\\\\"', '"', m.group(1))
 
     # This substitution is necessary to unwrap var values.
-    fprop = re.sub(r'"{([^}]*)}"', unescape_double_quotes_in_var, fprop)
+    fprop = re.sub(
+        pattern=r'''
+            (?<!\\)      # must NOT start with a backslash
+            "            # match opening double quote of JSON value
+            {(.*?)}      # extract the value between curly braces (non-greedy)
+            "            # match must end with an unescaped double quote
+        ''',
+        repl=unescape_double_quotes_in_var,
+        string=fprop,
+        flags=re.VERBOSE)
 
     # Return the formatted dict.
     return fprop

--- a/tests/components/test_tag.py
+++ b/tests/components/test_tag.py
@@ -23,6 +23,14 @@ def mock_event(arg):
         ([1, 2, 3], "{[1, 2, 3]}"),
         (["a", "b", "c"], '{["a", "b", "c"]}'),
         ({"a": 1, "b": 2, "c": 3}, '{{"a": 1, "b": 2, "c": 3}}'),
+        ({"a": 'foo "bar" baz'}, r'{{"a": "foo \"bar\" baz"}}'),
+        (
+            {
+                "a": 'foo "{ "bar" }" baz',
+                "b": BaseVar(name="val", type_="str"),
+            },
+            r'{{"a": "foo \"{ \"bar\" }\" baz", "b": val}}',
+        ),
         (
             EventChain(events=[EventSpec(handler=EventHandler(fn=mock_event))]),
             '{_e => Event([E("mock_event", {})], _e)}',

--- a/tests/components/test_tag.py
+++ b/tests/components/test_tag.py
@@ -4,6 +4,7 @@ import pytest
 
 from reflex.components.tags import CondTag, Tag, tagless
 from reflex.event import EVENT_ARG, EventChain, EventHandler, EventSpec
+from reflex.style import Style
 from reflex.vars import BaseVar, Var
 
 
@@ -64,6 +65,13 @@ def mock_event(arg):
         (
             {"a": BaseVar(name='state.colors["val"]', type_="str")},
             '{{"a": state.colors["val"]}}',
+        ),
+        # tricky real-world case from markdown component
+        (
+            {
+                "h1": f"{{({{node, ...props}}) => <Heading {{...props}} {''.join(Tag(name='', props=Style({'as_': 'h1'})).format_props())} />}}"
+            },
+            '{{"h1": ({node, ...props}) => <Heading {...props} as={`h1`} />}}',
         ),
     ],
 )


### PR DESCRIPTION
If the outer quotes are removed, then it's safe and necessary to remove the escapes on the inner quotes. Otherwise they should be left alone or they will break the double-quote terminated string.

Only remove double quote escapes if we are for sure removing outer quotes with a curly brace; a string containing the pattern `}"` will _never_ match this regex because the quote following the curly will always be escaped by the JSON encoder as `}\"`. So our regex here will only ever match a curly followed by JSON encoder's closing double quote (which is always unescaped).

This allows `rx.html` strings to contain double quotes and generally fixes weird quoting issue described in REF-226.