### PR TITLE
state.js: fix prod mode! applyDelta must operate on new_state

### DIFF
--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -76,7 +76,7 @@ export const getToken = () => {
 export const applyDelta = (state, delta) => {
   const new_state = {...state}
   for (const substate in delta) {
-    let s = state;
+    let s = new_state;
     const path = substate.split(".").slice(1);
     while (path.length > 0) {
       s = s[path.shift()];


### PR DESCRIPTION
This was just a silly oversight, and honestly not clear at all how this was working on dev mode 🤔.

But shows that we need to add prod mode to our AppHarness matrix so we don't only test in dev mode.