### PR TITLE
remove oxbow file upload code

### DIFF
--- a/reflex/.templates/jinja/web/pages/index.js.jinja2
+++ b/reflex/.templates/jinja/web/pages/index.js.jinja2
@@ -13,12 +13,6 @@ export default function Component() {
   const { {{const.color_mode}}, {{const.toggle_color_mode}} } = {{const.use_color_mode}}()
   const focusRef = useRef();
   
-  // Function to add new files to be uploaded.
-  const File = files => {{state_name|react_setter}}(state => ({
-    ...state,
-    files,
-  }))
-
   // Main event loop.
   const [Event, notConnected] = useContext(EventLoopContext)
 

--- a/reflex/compiler/utils.py
+++ b/reflex/compiler/utils.py
@@ -126,11 +126,6 @@ def compile_state(state: Type[State]) -> Dict:
         initial_state = state().dict()
     except Exception:
         initial_state = state().dict(include_computed=False)
-    initial_state.update(
-        {
-            "files": [],
-        }
-    )
     return format.format_state(initial_state)
 
 


### PR DESCRIPTION
this code is no longer used, since file uploads are handled via state/hooks provided in the upload component itself.

noticed this bit was still in here while inspecting compiled output from discord/discussions examples