### PR TITLE
state: _init_event_handlers recursively

### DIFF
--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -992,9 +992,17 @@ def test_event_handlers_call_other_handlers():
         def set_v2(self, v: int):
             self.set_v(v)
 
+    class SubState(MainState):
+        def set_v3(self, v: int):
+            self.set_v2(v)
+
     ms = MainState()
     ms.set_v2(1)
     assert ms.v == 1
+
+    # ensure handler can be called from substate
+    ms.substates[SubState.get_name()].set_v3(2)
+    assert ms.v == 2
 
 
 def test_computed_var_cached():


### PR DESCRIPTION
Allow event handlers defined in parent states to be directly called from substates.

Previously, only event handlers defined on the substate could be called on the substate. A workaround for queueing event handlers defined in a parent state was to explicitly `return`/`yield` the event handler/spec (`return State.handlerA()`)

```python
import reflex as rx


class State(rx.State):
    def handlerA(self):
        print("handlerA")


class Substate(State):
    def handlerB(self):
        self.handlerA()  # does NOT work before this change
        print("handlerB")
        self.handlerC()
        return State.handlerA()  # does work

    def handlerC(self):
        print("handlerC")


def index() -> rx.Component:
    return rx.vstack(
        rx.button("click", on_click=Substate.handlerB),
        padding_top="10%",
    )


app = rx.App()
app.add_page(index)
app.compile()
```

Before this change, the output is

```console
handlerB
handlerC
handlerA
```

After this change, the output is

```console
handlerA
handlerB
handlerC
handlerA
```

Reported in [discord](https://discord.com/channels/1029853095527727165/1061874061250150441/1143022149657960509) by community member **Samsam**