### PR TITLE
Validate component children

### DIFF
--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -456,26 +456,32 @@ class Component(Base, ABC):
         """
         if not self.invalid_children and not self.valid_children:
             return
+
         comp_name = type(self).__name__
 
-        # check that explicitly stated invalid components are not allowed.
-        for child in children:
-            if not self.invalid_children:
-                break
-            name = type(child).__name__
-            if name in self.invalid_children:
+        def validate_invalid_child(child_name):
+            if child_name in self.invalid_children:
                 raise ValueError(
-                    f"The component `{comp_name.lower()}` cannot have `{name.lower()}` as a child component"
+                    f"The component `{comp_name.lower()}` cannot have `{child_name.lower()}` as a child component"
                 )
-        # check that only explicitly stated valid components are allowed.
-        for child in children:
-            if not self.valid_children:
-                break
-            name = type(child).__name__
-            if name not in self.valid_children:
+
+        def validate_valid_child(child_name):
+            if child_name not in self.valid_children:
+                valid_child_list = ", ".join(
+                    [f"`{v_child}`" for v_child in self.valid_children]
+                )
                 raise ValueError(
-                    f"The component `{comp_name.lower()}` only allows the components: {','.join([f'`{v_child}`' for v_child in self.valid_children])} as children. Got `{name.lower()}` instead."
+                    f"The component `{comp_name.lower()}` only allows the components: {valid_child_list} as children. Got `{child_name.lower()}` instead."
                 )
+
+        for child in children:
+            name = type(child).__name__
+
+            if self.invalid_children:
+                validate_invalid_child(name)
+
+            if self.valid_children:
+                validate_valid_child(name)
 
     def _get_custom_code(self) -> Optional[str]:
         """Get custom code for the component.

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -451,8 +451,6 @@ class Component(Base, ABC):
         Args:
             children: The children of the component.
 
-        Raises:
-            ValueError: when an unsupported component is matched.
         """
         if not self.invalid_children and not self.valid_children:
             return

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -460,7 +460,7 @@ class Component(Base, ABC):
         def validate_invalid_child(child_name):
             if child_name in self.invalid_children:
                 raise ValueError(
-                    f"The component `{comp_name.lower()}` cannot have `{child_name.lower()}` as a child component"
+                    f"The component `{comp_name}` cannot have `{child_name}` as a child component"
                 )
 
         def validate_valid_child(child_name):
@@ -469,7 +469,7 @@ class Component(Base, ABC):
                     [f"`{v_child}`" for v_child in self.valid_children]
                 )
                 raise ValueError(
-                    f"The component `{comp_name.lower()}` only allows the components: {valid_child_list} as children. Got `{child_name.lower()}` instead."
+                    f"The component `{comp_name}` only allows the components: {valid_child_list} as children. Got `{child_name}` instead."
                 )
 
         for child in children:

--- a/reflex/components/forms/button.py
+++ b/reflex/components/forms/button.py
@@ -1,4 +1,5 @@
 """A button component."""
+from typing import List
 
 from reflex.components.libs.chakra import ChakraComponent
 from reflex.vars import Var
@@ -41,6 +42,9 @@ class Button(ChakraComponent):
 
     # The type of button.
     type_: Var[str]
+
+    # Components that are not allowed as children.
+    invalid_children: List[str] = ["Button", "MenuButton"]
 
 
 class ButtonGroup(ChakraComponent):

--- a/reflex/components/overlay/menu.py
+++ b/reflex/components/overlay/menu.py
@@ -1,6 +1,6 @@
 """Menu components."""
 
-from typing import Set
+from typing import List, Set
 
 from reflex.components.component import Component
 from reflex.components.libs.chakra import ChakraComponent
@@ -99,6 +99,9 @@ class MenuButton(ChakraComponent):
 
     # The variant of the menu button.
     variant: Var[str]
+
+    # Components that are not allowed as children.
+    invalid_children: List[str] = ["Button", "MenuButton"]
 
     # The tag to use for the menu button.
     as_: Var[str]

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -131,6 +131,38 @@ def component5() -> Type[Component]:
 
 
 @pytest.fixture
+def component6() -> Type[Component]:
+    """A test component.
+
+    Returns:
+        A test component.
+    """
+
+    class TestComponent6(Component):
+        tag = "RandomComponent"
+
+        invalid_children: List[str] = ["Text"]
+
+    return TestComponent6
+
+
+@pytest.fixture
+def component7() -> Type[Component]:
+    """A test component.
+
+    Returns:
+        A test component.
+    """
+
+    class TestComponent7(Component):
+        tag = "RandomComponent"
+
+        valid_children: List[str] = ["Text"]
+
+    return TestComponent7
+
+
+@pytest.fixture
 def on_click1() -> EventHandler:
     """A sample on click function.
 
@@ -463,34 +495,40 @@ def test_get_hooks_nested2(component3, component4):
     )
 
 
-def test_unsupported_child_components(component5):
+@pytest.mark.parametrize("fixture", ["component5", "component6"])
+def test_unsupported_child_components(fixture, request):
     """Test that a value error is raised when an unsupported component (a child component found in the
     component's invalid children list) is provided as a child.
 
     Args:
-        component5: the test component
+        fixture: the test component as a fixture.
+        request: Pytest request.
     """
+    component = request.getfixturevalue(fixture)
     with pytest.raises(ValueError) as err:
-        comp = component5.create(rx.text("testing component"))
+        comp = component.create(rx.text("testing component"))
         comp.render()
     assert (
         err.value.args[0]
-        == f"The component `testcomponent5` cannot have `text` as a child component"
+        == f"The component `{component.__name__}` cannot have `Text` as a child component"
     )
 
 
-def test_component_with_only_valid_children(component5):
+@pytest.mark.parametrize("fixture", ["component5", "component7"])
+def test_component_with_only_valid_children(fixture, request):
     """Test that a value error is raised when an unsupported component (a child component not found in the
     component's valid children list) is provided as a child.
 
     Args:
-        component5: the test component
+        fixture: the test component as a fixture.
+        request: Pytest request.
     """
+    component = request.getfixturevalue(fixture)
     with pytest.raises(ValueError) as err:
-        comp = component5.create(rx.box("testing component"))
+        comp = component.create(rx.box("testing component"))
         comp.render()
     assert (
         err.value.args[0]
-        == f"The component `testcomponent5` only allows the components: `Text` as children. "
-        f"Got `box` instead."
+        == f"The component `{component.__name__}` only allows the components: `Text` as children. "
+        f"Got `Box` instead."
     )

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -121,9 +121,11 @@ def component5() -> Type[Component]:
     """
 
     class TestComponent5(Component):
-        tag = "Tag"
+        tag = "RandomComponent"
 
         invalid_children: List[str] = ["Text"]
+
+        valid_children: List[str] = ["Text"]
 
     return TestComponent5
 
@@ -462,7 +464,8 @@ def test_get_hooks_nested2(component3, component4):
 
 
 def test_unsupported_child_components(component5):
-    """Test that a value error is raised when an unsupported component is provided as a child.
+    """Test that a value error is raised when an unsupported component (a child component found in the
+    component's invalid children list) is provided as a child.
 
     Args:
         component5: the test component
@@ -472,5 +475,22 @@ def test_unsupported_child_components(component5):
         comp.render()
     assert (
         err.value.args[0]
-        == f"The component `tag` cannot have `text` as a child component"
+        == f"The component `randomcomponent` cannot have `text` as a child component"
+    )
+
+
+def test_component_with_only_valid_children(component5):
+    """Test that a value error is raised when an unsupported component (a child component not found in the
+    component's valid children list) is provided as a child.
+
+    Args:
+        component5: the test component
+    """
+    with pytest.raises(ValueError) as err:
+        comp = component5.create(rx.box("testing component"))
+        comp.render()
+    assert (
+        err.value.args[0]
+        == f"The component `randomcomponent` only allows the components: `Text` as children. "
+        f"Got `box` instead."
     )

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -475,7 +475,7 @@ def test_unsupported_child_components(component5):
         comp.render()
     assert (
         err.value.args[0]
-        == f"The component `randomcomponent` cannot have `text` as a child component"
+        == f"The component `testcomponent5` cannot have `text` as a child component"
     )
 
 
@@ -491,6 +491,6 @@ def test_component_with_only_valid_children(component5):
         comp.render()
     assert (
         err.value.args[0]
-        == f"The component `randomcomponent` only allows the components: `Text` as children. "
+        == f"The component `testcomponent5` only allows the components: `Text` as children. "
         f"Got `box` instead."
     )


### PR DESCRIPTION
This PR allows a component to explicitly state only allowed child components

usage:
```python
         class TestComponent5(Component):
              tag = "RandomComponent"
      
              invalid_children: List[str] = ["Table"]
      
              valid_children: List[str] = ["Text", "Box"]

```

closes #1648 #1588 