### PR TITLE
Use DebounceInput wrapper for fully controlled Editable

### DIFF
--- a/reflex/components/forms/editable.py
+++ b/reflex/components/forms/editable.py
@@ -56,10 +56,11 @@ class Editable(ChakraComponent):
             isinstance(props.get("value"), Var) and props.get("on_change")
         ) or "debounce_timeout" in props:
             # Create a debounced input if the user requests full control to avoid typing jank
+            # Currently default to 50ms, which appears to be a good balance
+            debounce_timeout = props.pop("debounce_timeout", 50)
             return DebounceInput.create(
                 super().create(*children, **props),
-                # Currently default to 50ms, which appears to be a good balance
-                debounce_timeout=props.pop("debounce_timeout", 50),
+                debounce_timeout=debounce_timeout,
             )
         return super().create(*children, **props)
 

--- a/reflex/components/forms/editable.py
+++ b/reflex/components/forms/editable.py
@@ -38,9 +38,6 @@ class Editable(ChakraComponent):
     # The initial value of the Editable in both edit and preview mode.
     default_value: Var[str]
 
-    # Time in milliseconds to wait between end of input and triggering on_change
-    debounce_timeout: Var[int]
-
     @classmethod
     def create(cls, *children, **props) -> Component:
         """Create an Editable component.

--- a/tests/components/forms/test_debounce.py
+++ b/tests/components/forms/test_debounce.py
@@ -89,7 +89,7 @@ def test_render_child_props_recursive():
     )
     assert tag.props["forceNotifyOnBlur"].name == "false"
     assert tag.props["forceNotifyByEnter"].name == "false"
-    assert tag.props["debounceTimeout"] == 42
+    assert tag.props["debounceTimeout"].name == "42"
     assert len(tag.props["onChange"].events) == 1
     assert tag.props["onChange"].events[0].handler == S.on_change
     assert tag.contents == ""
@@ -101,7 +101,7 @@ def test_full_control_implicit_debounce():
         value=S.value,
         on_change=S.on_change,
     )._render()
-    assert tag.props["debounceTimeout"] == 0
+    assert tag.props["debounceTimeout"].name == "50"
     assert len(tag.props["onChange"].events) == 1
     assert tag.props["onChange"].events[0].handler == S.on_change
     assert tag.contents == ""
@@ -113,7 +113,7 @@ def test_full_control_implicit_debounce_text_area():
         value=S.value,
         on_change=S.on_change,
     )._render()
-    assert tag.props["debounceTimeout"] == 0
+    assert tag.props["debounceTimeout"].name == "50"
     assert len(tag.props["onChange"].events) == 1
     assert tag.props["onChange"].events[0].handler == S.on_change
     assert tag.contents == ""

--- a/tests/components/forms/test_editable.py
+++ b/tests/components/forms/test_editable.py
@@ -1,0 +1,48 @@
+import reflex as rx
+
+
+class S(rx.State):
+    """Example state for debounce tests."""
+
+    value: str = ""
+
+    def on_change(self, v: str):
+        """Dummy on_change handler.
+
+        Args:
+            v: The changed value.
+        """
+        pass
+
+
+def test_full_control_implicit_debounce_editable():
+    """DebounceInput is used when value and on_change are used together."""
+    tag = rx.editable(
+        value=S.value,
+        on_change=S.on_change,
+    )._render()
+    assert tag.props["debounceTimeout"].name == "50"
+    assert len(tag.props["onChange"].events) == 1
+    assert tag.props["onChange"].events[0].handler == S.on_change
+    assert tag.contents == ""
+
+
+def test_full_control_explicit_debounce_editable():
+    """DebounceInput is used when user specifies `debounce_time`."""
+    tag = rx.editable(
+        on_change=S.on_change,
+        debounce_timeout=33,
+    )._render()
+    assert tag.props["debounceTimeout"].name == "33"
+    assert len(tag.props["onChange"].events) == 1
+    assert tag.props["onChange"].events[0].handler == S.on_change
+    assert tag.contents == ""
+
+
+def test_editable_no_debounce():
+    """DebounceInput is not used for regular editable."""
+    tag = rx.editable(
+        placeholder=S.value,
+    )._render()
+    assert "debounceTimeout" not in tag.props
+    assert tag.contents == ""

--- a/tests/components/forms/test_editable.py
+++ b/tests/components/forms/test_editable.py
@@ -28,7 +28,7 @@ def test_full_control_implicit_debounce_editable():
 
 
 def test_full_control_explicit_debounce_editable():
-    """DebounceInput is used when user specifies `debounce_time`."""
+    """DebounceInput is used when user specifies `debounce_timeout`."""
     tag = rx.editable(
         on_change=S.on_change,
         debounce_timeout=33,


### PR DESCRIPTION
## Summary
- When it is fully controlled or user specifies `debounce_time`, wrap Editable inside DebounceInput. Similar to Input and TextArea.
- Add UT for Editable.
## Tests
- [x] New UT for Editable pass.
- [x] CI green.