### PR TITLE
ReflexList: reassign field on `insert`

### DIFF
--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -1006,6 +1006,16 @@ class ReflexList(list):
         super().append(*args, **kwargs)
         self._reassign_field()
 
+    def insert(self, *args, **kwargs):
+        """Insert.
+
+        Args:
+            args: The args passed.
+            kwargs: The kwargs passed.
+        """
+        super().insert(*args, **kwargs)
+        self._reassign_field()
+
     def __setitem__(self, *args, **kwargs):
         """Set item.
 


### PR DESCRIPTION
Seems this operation was just missing, cannot think of a good reason why it was not included.