### PR TITLE
add type conversion for int,float in built-in setters

### DIFF
--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -839,6 +839,8 @@ class BaseVar(Var, Base):
                     console.warn(
                         f"{self.name}: Failed conversion of {value} to '{self.type_.__name__}'. Value not set.",
                     )
+            else:
+                setattr(state, self.name, value)
 
         setter.__qualname__ = self.get_setter_name()
 


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran tests with your changes locally?

### Description

Convert value to the expected type for built-in setter generated by Reflex.

If you have:
```
class State(rx.State):
    foo: int = 0

def index():
    return rx.number_input(value=State.foo, on_change=State.set_foo)
```

The value given to the setter `set_foo` is usually `str`, so the setter will attempt to cast to `int`

Closes #336 