### PR TITLE
Remove need for User to call `rx.App.compile()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cd my_app_name
 reflex init
 ```
 
-This command initializes a template app in your new directory. 
+This command initializes a template app in your new directory.
 
 You can run this app in development mode:
 
@@ -89,7 +89,7 @@ class State(rx.State):
         response = openai.Image.create(prompt=self.prompt, n=1, size="1024x1024")
         self.image_url = response["data"][0]["url"]
         self.processing, self.complete = False, True
-        
+
 
 def index():
     return rx.center(
@@ -121,7 +121,6 @@ def index():
 # Add state and page to the app.
 app = rx.App()
 app.add_page(index, title="reflex:DALL·E")
-app.compile()
 ```
 
 ## Let's break this down.
@@ -192,7 +191,6 @@ We add a page from the root of the app to the index component. We also add a tit
 
 ```python
 app.add_page(index, title="DALL-E")
-app.compile()
 ```
 
 You can create a multi-page app by adding more pages.
@@ -201,7 +199,7 @@ You can create a multi-page app by adding more pages.
 
 <div align="center">
 
-📑 [Docs](https://reflex.dev/docs/getting-started/introduction) &nbsp; |  &nbsp; 🗞️ [Blog](https://reflex.dev/blog) &nbsp; |  &nbsp; 📱 [Component Library](https://reflex.dev/docs/library) &nbsp; |  &nbsp; 🖼️ [Gallery](https://reflex.dev/docs/gallery) &nbsp; |  &nbsp; 🛸 [Deployment](https://reflex.dev/docs/hosting/deploy)  &nbsp;   
+📑 [Docs](https://reflex.dev/docs/getting-started/introduction) &nbsp; |  &nbsp; 🗞️ [Blog](https://reflex.dev/blog) &nbsp; |  &nbsp; 📱 [Component Library](https://reflex.dev/docs/library) &nbsp; |  &nbsp; 🖼️ [Gallery](https://reflex.dev/docs/gallery) &nbsp; |  &nbsp; 🛸 [Deployment](https://reflex.dev/docs/hosting/deploy)  &nbsp;
 
 </div>
 

--- a/docs/zh/zh_cn/README.md
+++ b/docs/zh/zh_cn/README.md
@@ -136,7 +136,6 @@ def index():
 # 把状态跟页面添加到应用程序。
 app = rx.App(state=State)
 app.add_page(index, title="Reflex:DALL·E")
-app.compile()
 ```
 
 ### **Reflex 中的图形用户接口**
@@ -207,7 +206,6 @@ app = rx.App(state=State)
 
 ```python
 app.add_page(index, title="Reflex:DALL-E")
-app.compile()
 ```
 
 你可以借由通过添加路由来增加更多页面。

--- a/docs/zh/zh_tw/README.md
+++ b/docs/zh/zh_tw/README.md
@@ -8,7 +8,7 @@
 
 <hr>
 
-**✨ 使用 Python 建立高效且可自訂的網頁應用程式，幾秒鐘內即可部署。✨**  
+**✨ 使用 Python 建立高效且可自訂的網頁應用程式，幾秒鐘內即可部署。✨**
 
 [![PyPI version](https://badge.fury.io/py/reflex.svg)](https://badge.fury.io/py/reflex)
 ![tests](https://github.com/pynecone-io/pynecone/actions/workflows/integration.yml/badge.svg)
@@ -89,7 +89,7 @@ class State(rx.State):
         response = openai.Image.create(prompt=self.prompt, n=1, size="1024x1024")
         self.image_url = response["data"][0]["url"]
         self.processing, self.complete = False, True
-        
+
 
 def index():
     return rx.center(
@@ -121,7 +121,6 @@ def index():
 # 把狀態跟頁面添加到應用程式。
 app = rx.App()
 app.add_page(index, title="reflex:DALL·E")
-app.compile()
 ```
 
 ## 讓我們來拆解一下。
@@ -192,7 +191,6 @@ app = rx.App()
 
 ```python
 app.add_page(index, title="DALL-E")
-app.compile()
 ```
 
 你可以添加更多頁面至路由藉此來建立多頁面應用程式(multi-page app)
@@ -201,7 +199,7 @@ app.compile()
 
 <div align="center">
 
-📑 [Docs](https://reflex.dev/docs/getting-started/introduction) &nbsp; |  &nbsp; 🗞️ [Blog](https://reflex.dev/blog) &nbsp; |  &nbsp; 📱 [Component Library](https://reflex.dev/docs/library) &nbsp; |  &nbsp; 🖼️ [Gallery](https://reflex.dev/docs/gallery) &nbsp; |  &nbsp; 🛸 [Deployment](https://reflex.dev/docs/hosting/deploy)  &nbsp;   
+📑 [Docs](https://reflex.dev/docs/getting-started/introduction) &nbsp; |  &nbsp; 🗞️ [Blog](https://reflex.dev/blog) &nbsp; |  &nbsp; 📱 [Component Library](https://reflex.dev/docs/library) &nbsp; |  &nbsp; 🖼️ [Gallery](https://reflex.dev/docs/gallery) &nbsp; |  &nbsp; 🛸 [Deployment](https://reflex.dev/docs/hosting/deploy)  &nbsp;
 
 </div>
 

--- a/integration/test_dynamic_routes.py
+++ b/integration/test_dynamic_routes.py
@@ -50,7 +50,6 @@ def DynamicRoute():
     app.add_page(index)
     app.add_page(index, route="/page/[page_id]", on_load=DynamicState.on_load)  # type: ignore
     app.add_page(index, route="/static/x", on_load=DynamicState.on_load)  # type: ignore
-    app.compile()
 
 
 @pytest.fixture(scope="session")

--- a/integration/test_event_chain.py
+++ b/integration/test_event_chain.py
@@ -158,8 +158,6 @@ def EventChain():
     app.add_page(on_load_return_chain, on_load=State.on_load_return_chain)  # type: ignore
     app.add_page(on_load_yield_chain, on_load=State.on_load_yield_chain)  # type: ignore
 
-    app.compile()
-
 
 @pytest.fixture(scope="session")
 def event_chain(tmp_path_factory) -> Generator[AppHarness, None, None]:

--- a/integration/test_form_submit.py
+++ b/integration/test_form_submit.py
@@ -44,8 +44,6 @@ def FormSubmit():
             height="100vh",
         )
 
-    app.compile()
-
 
 @pytest.fixture(scope="session")
 def form_submit(tmp_path_factory) -> Generator[AppHarness, None, None]:

--- a/integration/test_input.py
+++ b/integration/test_input.py
@@ -31,8 +31,6 @@ def FullyControlledInput():
             rx.button("CLEAR", on_click=rx.set_value("on_change_input", "")),
         )
 
-    app.compile()
-
 
 @pytest.fixture()
 def fully_controlled_input(tmp_path) -> Generator[AppHarness, None, None]:

--- a/integration/test_server_side_event.py
+++ b/integration/test_server_side_event.py
@@ -72,8 +72,6 @@ def ServerSideEvent():
             ),
         )
 
-    app.compile()
-
 
 @pytest.fixture(scope="session")
 def server_side_event(tmp_path_factory) -> Generator[AppHarness, None, None]:

--- a/integration/test_upload.py
+++ b/integration/test_upload.py
@@ -51,7 +51,6 @@ def UploadFile():
 
     app = rx.App(state=UploadState)
     app.add_page(index)
-    app.compile()
 
 
 @pytest.fixture(scope="session")

--- a/reflex/.templates/apps/counter/counter.py
+++ b/reflex/.templates/apps/counter/counter.py
@@ -50,4 +50,3 @@ def index() -> rx.Component:
 # Add state and page to the app.
 app = rx.App()
 app.add_page(index, title="Counter")
-app.compile()

--- a/reflex/.templates/apps/default/default.py
+++ b/reflex/.templates/apps/default/default.py
@@ -42,4 +42,3 @@ def index() -> rx.Component:
 # Add state and page to the app.
 app = rx.App()
 app.add_page(index)
-app.compile()

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -460,6 +460,13 @@ class App(Base):
             admin.mount_to(self.api)
 
     def compile(self):
+        """Deprecated: Compile the app. Now no-op."""
+        # To be deprecated
+        console.deprecate(
+            "@rx.App.compile is being deprecated. User no longer needs to call this function in their code."
+        )
+
+    def _compile(self):
         """Compile the app and output it to the pages folder."""
         # Create a progress bar.
         progress = Progress(

--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -9,6 +9,7 @@ import typer
 from alembic.util.exc import CommandError
 
 from reflex import constants, model
+from reflex.app import App
 from reflex.config import get_config
 from reflex.utils import build, console, exec, prerequisites, processes, telemetry
 
@@ -140,6 +141,10 @@ def run(
     # Get the app module.
     console.rule("[bold]Starting Reflex App")
     app = prerequisites.get_app()
+    # Find the attribute of the imported app that is rx.App to run compilation.
+    for app_local in vars(app).values():
+        if isinstance(app_local, App):
+            app_local._compile()
 
     # Warn if schema is not up to date.
     prerequisites.check_schema_up_to_date()

--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -251,7 +251,7 @@ def export(
     console.rule("[bold]Compiling production app and preparing for export.")
 
     if frontend:
-        # Ensure module can be imported and app.compile() is called.
+        # Ensure module can be imported and app._compile() is called.
         app = prerequisites.get_app()
         # Find the attribute of the imported app that is rx.App to run compilation.
         for app_local in vars(app).values():

--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -252,7 +252,11 @@ def export(
 
     if frontend:
         # Ensure module can be imported and app.compile() is called.
-        prerequisites.get_app()
+        app = prerequisites.get_app()
+        # Find the attribute of the imported app that is rx.App to run compilation.
+        for app_local in vars(app).values():
+            if isinstance(app_local, App):
+                app_local._compile()
         # Set up .web directory and install frontend dependencies.
         build.setup_frontend(Path.cwd())
 

--- a/reflex/testing.py
+++ b/reflex/testing.py
@@ -158,8 +158,8 @@ class AppHarness:
             # ensure config is reloaded when testing different app
             reflex.config.get_config(reload=True)
             self.app_module = reflex.utils.prerequisites.get_app()
+            self.app_module.app._compile()
         self.app_instance = self.app_module.app
-        self.app_instance._compile()
 
     def _start_backend(self):
         if self.app_instance is None:

--- a/reflex/testing.py
+++ b/reflex/testing.py
@@ -159,6 +159,7 @@ class AppHarness:
             reflex.config.get_config(reload=True)
             self.app_module = reflex.utils.prerequisites.get_app()
         self.app_instance = self.app_module.app
+        self.app_instance._compile()
 
     def _start_backend(self):
         if self.app_instance is None:

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -18,7 +18,6 @@ def test_app_harness(tmp_path):
 
         app = rx.App()
         app.add_page(lambda: rx.text("Basic App"), route="/", title="index")
-        app.compile()
 
     with AppHarness.create(
         root=tmp_path,


### PR DESCRIPTION
## Summary
- Rename `App.compile` to `App._compile` to indicate private methods
- Call the new `App._compile` after importing the app in the run_frontend. Do this for both reflex CLI and AppHarness.
- Remove the use of `App.compile` from code examples and tests.
- Add back `App.compile` which only prints deprecation warning, the method is no-op.
## Tests
- [ ] CI green