### PR TITLE
Fix Node Installation on ARM-based Macs with FNM

### DIFF
--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import glob
 import json
 import os
+import platform
 import re
 import stat
 import sys
@@ -330,10 +331,15 @@ def install_node():
             [
                 constants.FNM_EXE,
                 "install",
+                "--arch=arm64"
+                if platform.system() == "Darwin"
+                and platform.machine()
+                == "arm64"  # specify arm64 arch explicitly for M1/M2
+                else "",
                 constants.NODE_VERSION,
                 "--fnm-dir",
                 constants.FNM_DIR,
-            ]
+            ],
         )
     processes.show_status("Installing node", process)
 

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -327,15 +327,18 @@ def install_node():
         # Add execute permissions to fnm executable.
         os.chmod(constants.FNM_EXE, stat.S_IXUSR)
         # Install node.
+        # Specify arm64 arch explicitly for M1s and M2s.
+        architecture_arg = (
+            ["--arch=arm64"]
+            if platform.system() == "Darwin" and platform.machine() == "arm64"
+            else []
+        )
+
         process = processes.new_process(
             [
                 constants.FNM_EXE,
                 "install",
-                "--arch=arm64"
-                if platform.system() == "Darwin"
-                and platform.machine()
-                == "arm64"  # specify arm64 arch explicitly for M1/M2
-                else "",
+                *architecture_arg,
                 constants.NODE_VERSION,
                 "--fnm-dir",
                 constants.FNM_DIR,


### PR DESCRIPTION
## Issue
On ARM-based Macs (M1 and M2), FNM was installing the x64 binary of Node, leading to compatibility issues and flakiness in the application.

## Solution
 This PR addresses the problem by explicitly specifying the architecture (--arch=arm64) when installing Node using FNM on ARM-based Macs. Since there is currently no FNM ARM64 release binary available for macOS, FNM defaults to installing the x64 binary, causing compatibility issues when installing Node. By explicitly setting the architecture during Node installation, we ensure that the correct architecture is used, mitigating any compatibility problems.

## Changes

Introduces a conditional check to determine if the platform is an ARM-based Mac (M1/M2).
If the platform is ARM-based, the --arch=arm64 flag is included in the FNM installation command.
This change ensures that the ARM64 architecture is used for Node installation on ARM-based Macs, resolving the flakiness and compatibility issues.


Note: This fix is essential for maintaining consistent behavior and stability, especially for users on ARM-based Macs. The explicit architecture specification during Node installation resolves the root cause of the flakiness observed previously. This PR ensures that our application runs reliably across different Mac architectures.