### PR TITLE
Allow underscores in routes

### DIFF
--- a/integration/test_dynamic_routes.py
+++ b/integration/test_dynamic_routes.py
@@ -69,7 +69,7 @@ def DynamicRoute():
 
 @pytest.fixture(scope="session")
 def dynamic_route(
-    app_harness_env: Type[AppHarness], tmp_path_factory
+        app_harness_env: Type[AppHarness], tmp_path_factory
 ) -> Generator[AppHarness, None, None]:
     """Start DynamicRoute app at tmp_path via AppHarness.
 
@@ -81,8 +81,8 @@ def dynamic_route(
         running AppHarness instance
     """
     with app_harness_env.create(
-        root=tmp_path_factory.mktemp(f"dynamic_route"),
-        app_source=DynamicRoute,  # type: ignore
+            root=tmp_path_factory.mktemp(f"dynamic_route"),
+            app_source=DynamicRoute,  # type: ignore
     ) as harness:
         yield harness
 
@@ -131,7 +131,7 @@ def backend_state(dynamic_route: AppHarness, driver: WebDriver) -> State:
 
 @pytest.fixture()
 def poll_for_order(
-    dynamic_route: AppHarness, backend_state: State
+        dynamic_route: AppHarness, backend_state: State
 ) -> Callable[[list[str]], None]:
     """Poll for the order list to match the expected order.
 
@@ -151,10 +151,10 @@ def poll_for_order(
 
 
 def test_on_load_navigate(
-    dynamic_route: AppHarness,
-    driver: WebDriver,
-    backend_state: State,
-    poll_for_order: Callable[[list[str]], None],
+        dynamic_route: AppHarness,
+        driver: WebDriver,
+        backend_state: State,
+        poll_for_order: Callable[[list[str]], None],
 ):
     """Click links to navigate between dynamic pages with on_load event.
 
@@ -169,8 +169,7 @@ def test_on_load_navigate(
     link = driver.find_element(By.ID, "link_page_next")
     assert link
 
-    exp_order = [f"/page/[page-id]-{ix}" for ix in range(10)]
-
+    exp_order = [f"/page/[page_id]-{ix}" for ix in range(10)]
     # click the link a few times
     for ix in range(10):
         # wait for navigation, then assert on url
@@ -190,13 +189,13 @@ def test_on_load_navigate(
     # manually load the next page to trigger client side routing in prod mode
     if is_prod:
         exp_order += ["/404-no page id"]
-    exp_order += ["/page/[page-id]-10"]
+    exp_order += ["/page/[page_id]-10"]
     with poll_for_navigation(driver):
         driver.get(f"{dynamic_route.frontend_url}/page/10/")
     poll_for_order(exp_order)
 
     # make sure internal nav still hydrates after redirect
-    exp_order += ["/page/[page-id]-11"]
+    exp_order += ["/page/[page_id]-11"]
     link = driver.find_element(By.ID, "link_page_next")
     with poll_for_navigation(driver):
         link.click()
@@ -205,7 +204,7 @@ def test_on_load_navigate(
     # load same page with a query param and make sure it passes through
     if is_prod:
         exp_order += ["/404-no page id"]
-    exp_order += ["/page/[page-id]-11"]
+    exp_order += ["/page/[page_id]-11"]
     with poll_for_navigation(driver):
         driver.get(f"{driver.current_url}?foo=bar")
     poll_for_order(exp_order)
@@ -220,7 +219,7 @@ def test_on_load_navigate(
     # browser nav should still trigger hydration
     if is_prod:
         exp_order += ["/404-no page id"]
-    exp_order += ["/page/[page-id]-11"]
+    exp_order += ["/page/[page_id]-11"]
     with poll_for_navigation(driver):
         driver.back()
     poll_for_order(exp_order)
@@ -235,7 +234,7 @@ def test_on_load_navigate(
     # hit a page that redirects back to dynamic page
     if is_prod:
         exp_order += ["/404-no page id"]
-    exp_order += ["on_load_redir-{'foo': 'bar', 'page_id': '0'}", "/page/[page-id]-0"]
+    exp_order += ["on_load_redir-{'foo': 'bar', 'page_id': '0'}", "/page/[page_id]-0"]
     with poll_for_navigation(driver):
         driver.get(f"{dynamic_route.frontend_url}/redirect-page/0/?foo=bar")
     poll_for_order(exp_order)
@@ -244,9 +243,9 @@ def test_on_load_navigate(
 
 
 def test_on_load_navigate_non_dynamic(
-    dynamic_route: AppHarness,
-    driver: WebDriver,
-    poll_for_order: Callable[[list[str]], None],
+        dynamic_route: AppHarness,
+        driver: WebDriver,
+        poll_for_order: Callable[[list[str]], None],
 ):
     """Click links to navigate between static pages with on_load event.
 

--- a/integration/test_dynamic_routes.py
+++ b/integration/test_dynamic_routes.py
@@ -69,7 +69,7 @@ def DynamicRoute():
 
 @pytest.fixture(scope="session")
 def dynamic_route(
-        app_harness_env: Type[AppHarness], tmp_path_factory
+    app_harness_env: Type[AppHarness], tmp_path_factory
 ) -> Generator[AppHarness, None, None]:
     """Start DynamicRoute app at tmp_path via AppHarness.
 
@@ -81,8 +81,8 @@ def dynamic_route(
         running AppHarness instance
     """
     with app_harness_env.create(
-            root=tmp_path_factory.mktemp(f"dynamic_route"),
-            app_source=DynamicRoute,  # type: ignore
+        root=tmp_path_factory.mktemp(f"dynamic_route"),
+        app_source=DynamicRoute,  # type: ignore
     ) as harness:
         yield harness
 
@@ -131,7 +131,7 @@ def backend_state(dynamic_route: AppHarness, driver: WebDriver) -> State:
 
 @pytest.fixture()
 def poll_for_order(
-        dynamic_route: AppHarness, backend_state: State
+    dynamic_route: AppHarness, backend_state: State
 ) -> Callable[[list[str]], None]:
     """Poll for the order list to match the expected order.
 
@@ -151,10 +151,10 @@ def poll_for_order(
 
 
 def test_on_load_navigate(
-        dynamic_route: AppHarness,
-        driver: WebDriver,
-        backend_state: State,
-        poll_for_order: Callable[[list[str]], None],
+    dynamic_route: AppHarness,
+    driver: WebDriver,
+    backend_state: State,
+    poll_for_order: Callable[[list[str]], None],
 ):
     """Click links to navigate between dynamic pages with on_load event.
 
@@ -243,9 +243,9 @@ def test_on_load_navigate(
 
 
 def test_on_load_navigate_non_dynamic(
-        dynamic_route: AppHarness,
-        driver: WebDriver,
-        poll_for_order: Callable[[list[str]], None],
+    dynamic_route: AppHarness,
+    driver: WebDriver,
+    poll_for_order: Callable[[list[str]], None],
 ):
     """Click links to navigate between static pages with on_load event.
 

--- a/integration/test_event_chain.py
+++ b/integration/test_event_chain.py
@@ -97,11 +97,11 @@ def EventChain():
 
         def redirect_return_chain(self):
             self.event_order.append("redirect_return_chain")
-            yield rx.redirect("/on_load_return_chain")
+            yield rx.redirect("/on-load-return-chain")
 
         def redirect_yield_chain(self):
             self.event_order.append("redirect_yield_chain")
-            yield rx.redirect("/on_load_yield_chain")
+            yield rx.redirect("/on-load-yield-chain")
 
         def click_return_int_type(self):
             self.event_order.append("click_return_int_type")
@@ -367,7 +367,7 @@ def test_event_chain_click(event_chain, driver, button_id, exp_event_order):
     ("uri", "exp_event_order"),
     [
         (
-            "/on_load_return_chain",
+            "/on-load-return-chain",
             [
                 "on_load_return_chain",
                 "event_arg:1",
@@ -376,7 +376,7 @@ def test_event_chain_click(event_chain, driver, button_id, exp_event_order):
             ],
         ),
         (
-            "/on_load_yield_chain",
+            "/on-load-yield-chain",
             [
                 "on_load_yield_chain",
                 "event_arg:4",
@@ -411,7 +411,7 @@ def test_event_chain_on_load(event_chain, driver, uri, exp_event_order):
     ("uri", "exp_event_order"),
     [
         (
-            "/on_mount_return_chain",
+            "/on-mount-return-chain",
             [
                 "on_load_return_chain",
                 "event_arg:unmount",
@@ -426,7 +426,7 @@ def test_event_chain_on_load(event_chain, driver, uri, exp_event_order):
             ],
         ),
         (
-            "/on_mount_yield_chain",
+            "/on-mount-yield-chain",
             [
                 "on_load_yield_chain",
                 "event_arg:mount",

--- a/integration/test_event_chain.py
+++ b/integration/test_event_chain.py
@@ -411,7 +411,7 @@ def test_event_chain_on_load(event_chain, driver, uri, exp_event_order):
     ("uri", "exp_event_order"),
     [
         (
-            "/on-mount-return-chain",
+            "/on_mount_return_chain",
             [
                 "on_load_return_chain",
                 "event_arg:unmount",
@@ -426,7 +426,7 @@ def test_event_chain_on_load(event_chain, driver, uri, exp_event_order):
             ],
         ),
         (
-            "/on-mount-yield-chain",
+            "/on_mount_yield_chain",
             [
                 "on_load_yield_chain",
                 "event_arg:mount",

--- a/integration/test_event_chain.py
+++ b/integration/test_event_chain.py
@@ -97,11 +97,11 @@ def EventChain():
 
         def redirect_return_chain(self):
             self.event_order.append("redirect_return_chain")
-            yield rx.redirect("/on-load-return-chain")
+            yield rx.redirect("/on_load_return_chain")
 
         def redirect_yield_chain(self):
             self.event_order.append("redirect_yield_chain")
-            yield rx.redirect("/on-load-yield-chain")
+            yield rx.redirect("/on_load_yield_chain")
 
         def click_return_int_type(self):
             self.event_order.append("click_return_int_type")
@@ -367,7 +367,7 @@ def test_event_chain_click(event_chain, driver, button_id, exp_event_order):
     ("uri", "exp_event_order"),
     [
         (
-            "/on-load-return-chain",
+            "/on_load_return_chain",
             [
                 "on_load_return_chain",
                 "event_arg:1",
@@ -376,7 +376,7 @@ def test_event_chain_click(event_chain, driver, button_id, exp_event_order):
             ],
         ),
         (
-            "/on-load-yield-chain",
+            "/on_load_yield_chain",
             [
                 "on_load_yield_chain",
                 "event_arg:4",

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -356,6 +356,8 @@ class App(Base):
                 component, Callable
             ), "Route must be set if component is not a callable."
             route = component.__name__
+            # Format the route.
+            route = format.format_route(route)
 
         # Check if the route given is valid
         verify_route_validity(route)
@@ -388,8 +390,6 @@ class App(Base):
         if script_tags:
             component.children.extend(script_tags)
 
-        # Format the route.
-        route = format.format_route(route)
 
         # Add the page.
         self._check_routes_conflict(route)

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -355,9 +355,10 @@ class App(Base):
             assert isinstance(
                 component, Callable
             ), "Route must be set if component is not a callable."
-            route = component.__name__
             # Format the route.
-            route = format.format_route(route)
+            route = format.format_route(component.__name__)
+        else:
+            route = format.format_route(route, format_case=False)
 
         # Check if the route given is valid
         verify_route_validity(route)
@@ -389,7 +390,6 @@ class App(Base):
         # Add script tags if given
         if script_tags:
             component.children.extend(script_tags)
-
 
         # Add the page.
         self._check_routes_conflict(route)

--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -164,6 +164,21 @@ def to_title_case(text: str) -> str:
     return "".join(word.capitalize() for word in text.split("_"))
 
 
+def to_kebab_case(text: str) -> str:
+    """Convert a string to kebab case.
+
+    The words in the text are converted to lowercase and
+    separated by hyphens.
+
+    Args:
+        text: The string to convert.
+
+    Returns:
+        The title case string.
+    """
+    return to_snake_case(text).replace("_", "-")
+
+
 def format_string(string: str) -> str:
     """Format the given string as a JS string literal..
 
@@ -207,6 +222,7 @@ def format_route(route: str, format_case=True) -> str:
 
     Args:
         route: The route to format.
+        format_case: whether to format case to kebab case.
 
     Returns:
         The formatted route.
@@ -214,7 +230,7 @@ def format_route(route: str, format_case=True) -> str:
     route = route.strip("/")
     # Strip the route and format casing.
     if format_case:
-        route = to_snake_case(route)
+        route = to_kebab_case(route)
 
     # If the route is empty, return the index route.
     if route == "":

--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -213,7 +213,7 @@ def format_route(route: str) -> str:
     """
     # Strip the route.
     route = route.strip("/")
-    route = to_snake_case(route).replace("_", "-")
+    route = to_snake_case(route)
 
     # If the route is empty, return the index route.
     if route == "":

--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -211,9 +211,8 @@ def format_route(route: str) -> str:
     Returns:
         The formatted route.
     """
-    # Strip the route.
-    route = route.strip("/")
-    route = to_snake_case(route)
+    # Strip the route and format casing.
+    route = to_snake_case(route.strip("/"))
 
     # If the route is empty, return the index route.
     if route == "":

--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -202,7 +202,7 @@ def format_var(var: Var) -> str:
     return json_dumps(var.full_name)
 
 
-def format_route(route: str) -> str:
+def format_route(route: str, format_case=True) -> str:
     """Format the given route.
 
     Args:
@@ -211,8 +211,10 @@ def format_route(route: str) -> str:
     Returns:
         The formatted route.
     """
+    route = route.strip("/")
     # Strip the route and format casing.
-    route = to_snake_case(route.strip("/"))
+    if format_case:
+        route = to_snake_case(route)
 
     # If the route is empty, return the index route.
     if route == "":

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -1,0 +1,30 @@
+import pytest
+
+from reflex.route import get_route_args
+from reflex import constants
+
+
+@pytest.mark.parametrize(
+    "route_name, expected",
+    [
+        ("/users/[id]", {"id": constants.RouteArgType.SINGLE}),
+        ("/posts/[postId]/comments/[commentId]",
+         {"postId": constants.RouteArgType.SINGLE, "commentId": constants.RouteArgType.SINGLE}),
+        ("/products/...", {"": constants.RouteArgType.LIST}),
+        ("/products/[...]", {"": constants.RouteArgType.LIST})
+    ]
+)
+def test_route_args(route_name, expected):
+    assert get_route_args(route_name) == expected
+
+
+@pytest.mark.parametrize(
+    "route_name", [
+        "/products/[id]/[id]",
+        "/posts/[postId]/comments/[postId]",
+
+    ]
+)
+def test_invalid_route_args(route_name):
+    with pytest.raises(ValueError):
+        get_route_args(route_name)

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -1,6 +1,6 @@
 import pytest
 
-from reflex.route import get_route_args
+from reflex.route import get_route_args, catchall_in_route
 from reflex import constants
 
 
@@ -28,3 +28,17 @@ def test_route_args(route_name, expected):
 def test_invalid_route_args(route_name):
     with pytest.raises(ValueError):
         get_route_args(route_name)
+
+
+@pytest.mark.parametrize(
+    "route_name,expected",
+    [
+        ("/events/[year]/[month]/[...slug]", "[...slug]"),
+        ("pages/shop/[[...slug]]", "[[...slug]]")
+
+    ]
+)
+def test_catchall_in_route(route_name, expected):
+    assert catchall_in_route(route_name) == expected
+
+

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -1,29 +1,34 @@
 import pytest
 
-from reflex.route import get_route_args, catchall_in_route
 from reflex import constants
+from reflex.route import catchall_in_route, get_route_args, verify_route_validity
 
 
 @pytest.mark.parametrize(
     "route_name, expected",
     [
         ("/users/[id]", {"id": constants.RouteArgType.SINGLE}),
-        ("/posts/[postId]/comments/[commentId]",
-         {"postId": constants.RouteArgType.SINGLE, "commentId": constants.RouteArgType.SINGLE}),
+        (
+            "/posts/[postId]/comments/[commentId]",
+            {
+                "postId": constants.RouteArgType.SINGLE,
+                "commentId": constants.RouteArgType.SINGLE,
+            },
+        ),
         ("/products/...", {"": constants.RouteArgType.LIST}),
-        ("/products/[...]", {"": constants.RouteArgType.LIST})
-    ]
+        ("/products/[...]", {"": constants.RouteArgType.LIST}),
+    ],
 )
 def test_route_args(route_name, expected):
     assert get_route_args(route_name) == expected
 
 
 @pytest.mark.parametrize(
-    "route_name", [
+    "route_name",
+    [
         "/products/[id]/[id]",
         "/posts/[postId]/comments/[postId]",
-
-    ]
+    ],
 )
 def test_invalid_route_args(route_name):
     with pytest.raises(ValueError):
@@ -34,11 +39,35 @@ def test_invalid_route_args(route_name):
     "route_name,expected",
     [
         ("/events/[year]/[month]/[...slug]", "[...slug]"),
-        ("pages/shop/[[...slug]]", "[[...slug]]")
-
-    ]
+        ("pages/shop/[[...slug]]", "[[...slug]]"),
+    ],
 )
 def test_catchall_in_route(route_name, expected):
     assert catchall_in_route(route_name) == expected
 
 
+@pytest.mark.parametrize(
+    "route_name",
+    [
+        "/products",
+        "/products/[category]/[...]/details/[version]",
+        "[...]",
+        "/products/details",
+    ],
+)
+def test_verify_valid_routes(route_name):
+    verify_route_validity(route_name)
+
+
+@pytest.mark.parametrize(
+    "route_name",
+    [
+        "/products/[...]/details/[category]/latest",
+        "/blog/[...]/post/[year]/latest",
+        "/products/[...]/details/[...]/[category]/[...]/latest",
+        "/products/[...]/details/category",
+    ],
+)
+def test_verify_invalid_routes(route_name):
+    with pytest.raises(ValueError):
+        verify_route_validity(route_name)

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -15,8 +15,6 @@ from reflex.route import catchall_in_route, get_route_args, verify_route_validit
                 "commentId": constants.RouteArgType.SINGLE,
             },
         ),
-        ("/products/...", {"": constants.RouteArgType.LIST}),
-        ("/products/[...]", {"": constants.RouteArgType.LIST}),
     ],
 )
 def test_route_args(route_name, expected):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -258,6 +258,7 @@ def test_is_generic_alias(cls: type, expected: bool):
         ("custom-route/", "custom-route"),
         ("/custom-route", "custom-route"),
         ("/custom_route", "custom_route"),
+        ("/CUSTOM_route", "CUSTOM_route"),
     ],
 )
 def test_format_route(route: str, expected: bool):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -250,25 +250,31 @@ def test_is_generic_alias(cls: type, expected: bool):
 
 
 @pytest.mark.parametrize(
-    "route,expected",
+    "route,format_case,expected",
     [
-        ("", "index"),
-        ("/", "index"),
-        ("custom-route", "custom-route"),
-        ("custom-route/", "custom-route"),
-        ("/custom-route", "custom-route"),
-        ("/custom_route", "custom_route"),
-        ("/CUSTOM_route", "CUSTOM_route"),
+        ("", True, "index"),
+        ("/", True, "index"),
+        ("custom-route", True, "custom-route"),
+        ("custom-route", False, "custom-route"),
+        ("custom-route/", True, "custom-route"),
+        ("custom-route/", False, "custom-route"),
+        ("/custom-route", True, "custom-route"),
+        ("/custom-route", False, "custom-route"),
+        ("/custom_route", True, "custom_route"),
+        ("/custom_route", False, "custom_route"),
+        ("/CUSTOM_route", True, "custom_route"),
+        ("/CUSTOM_route", False, "CUSTOM_route"),
     ],
 )
-def test_format_route(route: str, expected: bool):
+def test_format_route(route: str, format_case: bool, expected: bool):
     """Test formatting a route.
 
     Args:
         route: The route to format.
+        format_case: Whether to change casing to snake_case.
         expected: The expected formatted route.
     """
-    assert format.format_route(route) == expected
+    assert format.format_route(route, format_case=format_case) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -257,6 +257,7 @@ def test_is_generic_alias(cls: type, expected: bool):
         ("custom-route", "custom-route"),
         ("custom-route/", "custom-route"),
         ("/custom-route", "custom-route"),
+        ("/custom_route", "custom_route"),
     ],
 )
 def test_format_route(route: str, expected: bool):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -260,9 +260,9 @@ def test_is_generic_alias(cls: type, expected: bool):
         ("custom-route/", False, "custom-route"),
         ("/custom-route", True, "custom-route"),
         ("/custom-route", False, "custom-route"),
-        ("/custom_route", True, "custom_route"),
+        ("/custom_route", True, "custom-route"),
         ("/custom_route", False, "custom_route"),
-        ("/CUSTOM_route", True, "custom_route"),
+        ("/CUSTOM_route", True, "custom-route"),
         ("/CUSTOM_route", False, "CUSTOM_route"),
     ],
 )


### PR DESCRIPTION
### Description
This pull request addresses the need for converting underscores to hyphens in routes, which was previously implemented. The goal of this change is to enhance the flexibility of route naming by allowing both underscores and hyphens to coexist without the need for any conversions. This PR proposes to remove the underscore-to-hyphen conversion logic, allowing developers to freely choose between these two naming conventions for routes.

### Changes Made
* Removed the underscore-to-hyphen conversion logic from route handling, enabling route names to support both underscores and hyphens directly.

### Motivation
* Allowing both underscore-separated and hyphen-separated route names provides developers with greater flexibility in choosing naming conventions that align with their preferences and practices.
* By removing the conversion, we empower developers to use the naming convention that best suits their needs, contributing to a more adaptable and user-friendly codebase.

### Impact
With this change, developers are free to use both underscores and hyphens as they see fit in route names.
The removal of the underscore-to-hyphen conversion ensures that developers can choose their preferred naming convention without the need for special handling.
Existing routes with either underscores or hyphens in their names will continue to function as expected.