### PR TITLE
Proper serialization for chained Event payloads

### DIFF
--- a/integration/test_event_chain.py
+++ b/integration/test_event_chain.py
@@ -31,6 +31,9 @@ def EventChain():
         def event_arg(self, arg):
             self.event_order.append(f"event_arg:{arg}")
 
+        def event_arg_repr_type(self, arg):
+            self.event_order.append(f"event_arg_repr:{arg!r}_{type(arg).__name__}")
+
         def event_nested_1(self):
             self.event_order.append("event_nested_1")
             yield State.event_nested_2
@@ -100,6 +103,14 @@ def EventChain():
             self.event_order.append("redirect_yield_chain")
             yield rx.redirect("/on-load-yield-chain")
 
+        def click_return_int_type(self):
+            self.event_order.append("click_return_int_type")
+            return State.event_arg_repr_type(1)  # type: ignore
+
+        def click_return_dict_type(self):
+            self.event_order.append("click_return_dict_type")
+            return State.event_arg_repr_type({"a": 1})  # type: ignore
+
     app = rx.App(state=State)
 
     @app.add_page
@@ -140,6 +151,16 @@ def EventChain():
                 "Redirect Return Chain",
                 id="redirect_return_chain",
                 on_click=State.redirect_return_chain,
+            ),
+            rx.button(
+                "Return Chain Int Type",
+                id="return_int_type",
+                on_click=State.click_return_int_type,
+            ),
+            rx.button(
+                "Return Chain Dict Type",
+                id="return_dict_type",
+                on_click=State.click_return_dict_type,
             ),
         )
 
@@ -285,6 +306,14 @@ def driver(event_chain: AppHarness):
                 "event_arg:5",
                 "event_arg:6",
             ],
+        ),
+        (
+            "return_int_type",
+            ["click_return_int_type", "event_arg_repr:1_int"],
+        ),
+        (
+            "return_dict_type",
+            ["click_return_dict_type", "event_arg_repr:{'a': 1}_dict"],
         ),
     ],
 )

--- a/integration/test_event_chain.py
+++ b/integration/test_event_chain.py
@@ -403,6 +403,7 @@ def test_event_chain_on_load(event_chain, driver, uri, exp_event_order):
 
     time.sleep(0.5)
     backend_state = event_chain.app_instance.state_manager.states[token]
+    assert backend_state.is_hydrated is True
     assert backend_state.event_order == exp_event_order
 
 

--- a/integration/test_event_chain.py
+++ b/integration/test_event_chain.py
@@ -153,6 +153,16 @@ def EventChain():
                 on_click=State.redirect_return_chain,
             ),
             rx.button(
+                "Click Int Type",
+                id="click_int_type",
+                on_click=lambda: State.event_arg_repr_type(1),  # type: ignore
+            ),
+            rx.button(
+                "Click Dict Type",
+                id="click_dict_type",
+                on_click=lambda: State.event_arg_repr_type({"a": 1}),  # type: ignore
+            ),
+            rx.button(
                 "Return Chain Int Type",
                 id="return_int_type",
                 on_click=State.click_return_int_type,
@@ -306,6 +316,14 @@ def driver(event_chain: AppHarness):
                 "event_arg:5",
                 "event_arg:6",
             ],
+        ),
+        (
+            "click_int_type",
+            ["event_arg_repr:1_int"],
+        ),
+        (
+            "click_dict_type",
+            ["event_arg_repr:{'a': 1}_dict"],
         ),
         (
             "return_int_type",

--- a/reflex/event.py
+++ b/reflex/event.py
@@ -479,7 +479,7 @@ def fix_events(
             e = e()
         assert isinstance(e, EventSpec), f"Unexpected event type, {type(e)}."
         name = format.format_event_handler(e.handler)
-        payload = {k.name: v.name for k, v in e.args}
+        payload = {k.name: v._decode() for k, v in e.args}
 
         # Create an event and append it to the list.
         out.append(

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -144,6 +144,24 @@ class Var(ABC):
         """
         return _GenericAlias(cls, type_)
 
+    def _decode(self) -> Any:
+        """Decode Var as a python value.
+
+        Note that Var with state set cannot be decoded python-side and will be
+        returned as full_name.
+
+        Returns:
+            The decoded value or the Var name.
+        """
+        if self.state:
+            return self.full_name
+        if self.is_string or self.type_ is Figure:
+            return self.name
+        try:
+            return json.loads(self.name)
+        except ValueError:
+            return self.name
+
     def equals(self, other: Var) -> bool:
         """Check if two vars are equal.
 

--- a/tests/middleware/test_hydrate_middleware.py
+++ b/tests/middleware/test_hydrate_middleware.py
@@ -17,7 +17,7 @@ def exp_is_hydrated(state: State) -> Dict[str, Any]:
     Returns:
         dict similar to that returned by `State.get_delta` with IS_HYDRATED: True
     """
-    return {state.get_name(): {IS_HYDRATED: "true"}}
+    return {state.get_name(): {IS_HYDRATED: True}}
 
 
 class TestState(State):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -833,7 +833,7 @@ async def test_dynamic_route_var_route_change_completed_on_load(
                 _dynamic_state_event(name="on_load", val=exp_val, router_data={}),
                 _dynamic_state_event(
                     name="set_is_hydrated",
-                    payload={"value": "true"},
+                    payload={"value": True},
                     val=exp_val,
                     router_data={},
                 ),


### PR DESCRIPTION
Calling an `EventHandler` returns an `EventSpec` with the function call arguments encoded as `Var`.

This works fine when formatting the `Var` into an event via `format.format_event`, however when directly creating a payload and serializing the entire `Event` to send to the client to be queued, the `fix_events` function was just taking the "name" of the `Var`, which is a json-encoded value.

In order to properly serialize the event payload, these `Var` args need to be decoded back into their python values, so that the payload as a whole can be re-serialized properly.

Implement a `Var._decode` operation, which operates (mostly) as the inverse of `Var.create`. This is an underscore method, because it actually doesn't return another `Var`, but instead the real python value that the `Var` is created from.

Fix #1722

---------------

Add/update unit and integration test cases in this area.