### PR TITLE
Caddyfile: reflex uses `/_event` and `/_upload` now

### DIFF
--- a/docker-example/Caddyfile
+++ b/docker-example/Caddyfile
@@ -2,7 +2,7 @@
 
 encode gzip
 
-@backend_routes path /event/* /upload /ping
+@backend_routes path /_event/* /_upload /ping
 handle @backend_routes {
 	reverse_proxy app:8000
 }


### PR DESCRIPTION
Fixup after #1542