### PR TITLE
state: _init_mutable_fields for backend vars as well

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -148,7 +148,7 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
                 setattr(self, field.name, value_in_rx_data)
 
         for field_name, value in self._backend_vars.items():
-            if isinstance(value, Union[List, Dict, Set]):
+            if isinstance(value, (list, dict, set)):
                 value_in_rx_data = _convert_mutable_datatypes(
                     value, self._reassign_field, field_name
                 )


### PR DESCRIPTION
ensure that backend var list, dict, and set are re-assigned as special reactive containers that can track modifications

fix #1727