### PR TITLE
Upgrade Bun 0.7.0 to 0.7.3

### DIFF
--- a/reflex/constants.py
+++ b/reflex/constants.py
@@ -69,9 +69,9 @@ JINJA_TEMPLATE_DIR = os.path.join(TEMPLATE_DIR, "jinja")
 
 # Bun config.
 # The Bun version.
-BUN_VERSION = "0.7.0"
+BUN_VERSION = "0.7.3"
 # Min Bun Version
-MIN_BUN_VERSION = "0.7.0"
+MIN_BUN_VERSION = "0.7.3"
 # The directory to store the bun.
 BUN_ROOT_PATH = os.path.join(REFLEX_DIR, "bun")
 # Default bun path.

--- a/reflex/constants.py
+++ b/reflex/constants.py
@@ -71,7 +71,7 @@ JINJA_TEMPLATE_DIR = os.path.join(TEMPLATE_DIR, "jinja")
 # The Bun version.
 BUN_VERSION = "0.7.3"
 # Min Bun Version
-MIN_BUN_VERSION = "0.7.3"
+MIN_BUN_VERSION = "0.7.0"
 # The directory to store the bun.
 BUN_ROOT_PATH = os.path.join(REFLEX_DIR, "bun")
 # Default bun path.


### PR DESCRIPTION
The 0.7.0 version core dumps when using the bun-linux-x64-baseline binary. Upgrading to 0.7.3 fixes the issues. See https://github.com/reflex-dev/reflex/issues/1756 for more context on why I have to use the baseline build of Bun.

I have tested three reflex sites with Bun 0.7.3 and everything seems to work fine :tm:

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/pynecone-io/pynecone/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/pynecone-io/pynecone/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
