### PR TITLE
Send updated client-side storage values when hydrating

### DIFF
--- a/reflex/.templates/jinja/web/pages/index.js.jinja2
+++ b/reflex/.templates/jinja/web/pages/index.js.jinja2
@@ -25,7 +25,7 @@ export default function Component() {
 
   // Route after the initial page hydration.
   useEffect(() => {
-    const change_complete = () => Event([E('{{state_name}}.{{const.hydrate}}', {})])
+    const change_complete = () => Event(initialEvents.map((e) => ({...e})))
     {{const.router}}.events.on('routeChangeComplete', change_complete)
     return () => {
       {{const.router}}.events.off('routeChangeComplete', change_complete)

--- a/reflex/compiler/compiler.py
+++ b/reflex/compiler/compiler.py
@@ -33,6 +33,7 @@ DEFAULT_IMPORTS: imports.ImportDict = {
     },
     "/utils/context.js": {
         ImportVar(tag="EventLoopContext"),
+        ImportVar(tag="initialEvents"),
         ImportVar(tag="StateContext"),
     },
     "": {ImportVar(tag="focus-visible/dist/focus-visible")},


### PR DESCRIPTION
Re-use the `initialEvents` list when hydrating on page navigation events.

Eventually, we will decouple hydrate from `on_load` and this problem will go away, but until then, since we're resetting the client storage values on the hydrate event, each hydrate event needs to include the updated client storage values, so just reuse the `initialEvents` from `context.js` when re-hydrating for page loads.