### PR TITLE
be more specific with python versions - so caching can be safe

### DIFF
--- a/.github/workflows/integration_app_harness.yml
+++ b/.github/workflows/integration_app_harness.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/setup_build_env
       with:
-          python-version: "3.11.4"
+          python-version: "3.11.5"
           run-poetry-install: true
           create-venv-at-path: .venv
     - run: poetry run pip install pyvirtualdisplay pillow

--- a/.github/workflows/integration_app_harness.yml
+++ b/.github/workflows/integration_app_harness.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/setup_build_env
       with:
-          python-version: "3.11"
+          python-version: "3.11.5"
           run-poetry-install: true
           create-venv-at-path: .venv
     - run: poetry run pip install pyvirtualdisplay pillow

--- a/.github/workflows/integration_app_harness.yml
+++ b/.github/workflows/integration_app_harness.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/setup_build_env
       with:
-          python-version: "3.11.5"
+          python-version: "3.11.4"
           run-poetry-install: true
           create-venv-at-path: .venv
     - run: poetry run pip install pyvirtualdisplay pillow

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         # Show OS combos first in GUI
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ "3.8.18", "3.9.18", "3.10.13", "3.11.5" ]
+        python-version: [ "3.8.17", "3.9.17", "3.10.12", "3.11.4" ]
         node-version: [ "16.x" ]
 
     runs-on: ${{ matrix.os }}
@@ -86,7 +86,7 @@ jobs:
       matrix:
         # Show OS combos first in GUI
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ "3.10.13", "3.11.5" ]
+        python-version: [ "3.10.12", "3.11.4" ]
         node-version: [ "16.x" ]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -35,6 +35,12 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
         python-version: [ "3.8.10", "3.9.13", "3.10.11", "3.11.4" ]
         node-version: [ "16.x" ]
+        exclude:
+          - os: ubuntu-latest
+            python-version: "3.8.10" # windows wants 3.8.10
+        include:
+          - os: ubuntu-latest
+            python-version: "3.8.12" # but ubuntu 22.04 needs >=3.8.12
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         # Show OS combos first in GUI
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ "3.8.17", "3.9.17", "3.10.12", "3.11.4" ]
+        python-version: [ "3.8.10", "3.9.13", "3.10.11", "3.11.4" ]
         node-version: [ "16.x" ]
 
     runs-on: ${{ matrix.os }}
@@ -86,7 +86,7 @@ jobs:
       matrix:
         # Show OS combos first in GUI
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ "3.10.12", "3.11.4" ]
+        python-version: [ "3.10.10", "3.11.4" ]
         node-version: [ "16.x" ]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -33,14 +33,22 @@ jobs:
       matrix:
         # Show OS combos first in GUI
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ "3.8.10", "3.9.13", "3.10.11", "3.11.4" ]
         node-version: [ "16.x" ]
+        python-version: ["3.8.18", "3.9.18", "3.10.13", "3.11.5"]
         exclude:
-          - os: ubuntu-latest
-            python-version: "3.8.10" # windows wants 3.8.10
+          - os: windows-latest
+            python-version: "3.10.13"
+          - os: windows-latest
+            python-version: "3.9.18"
+          - os: windows-latest
+            python-version: "3.8.18"
         include:
-          - os: ubuntu-latest
-            python-version: "3.8.12" # but ubuntu 22.04 needs >=3.8.12
+          - os: windows-latest
+            python-version: "3.10.11"
+          - os: windows-latest
+            python-version: "3.9.13"
+          - os: windows-latest
+            python-version: "3.8.10"
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         # Show OS combos first in GUI
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.8.18", "3.9.18", "3.10.13", "3.11.5" ]
         node-version: [ "16.x" ]
 
     runs-on: ${{ matrix.os }}
@@ -86,7 +86,7 @@ jobs:
       matrix:
         # Show OS combos first in GUI
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ "3.10", "3.11" ]
+        python-version: [ "3.10.13", "3.11.5" ]
         node-version: [ "16.x" ]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           # running vs. one version of Python is OK
           # i.e. ruff, black, etc.
-          python-version: 3.11
+          python-version: 3.11.5
           run-poetry-install: true
           shell: bash
           create-venv-at-path: .venv

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -23,17 +23,21 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8.10", "3.9.18", "3.10.13", "3.11.5"]
+        python-version: ["3.8.18", "3.9.18", "3.10.13", "3.11.5"]
         exclude:
           - os: windows-latest
             python-version: "3.10.13"
           - os: windows-latest
             python-version: "3.9.18"
+          - os: windows-latest
+            python-version: "3.8.18"
         include:
           - os: windows-latest
             python-version: "3.10.11"
           - os: windows-latest
             python-version: "3.9.13"
+          - os: windows-latest
+            python-version: "3.8.10"
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,6 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.8.18", "3.9.18", "3.10.13", "3.11.5"]
+        # Windows is a bit behind on Python version availability in Github
         exclude:
           - os: windows-latest
             python-version: "3.10.13"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -23,8 +23,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        # TODO consider bringing back 3.7. Note Windows x 3.7 fails from some sqlalchemy related problem
         python-version: ["3.8.10", "3.9.13", "3.10.11", "3.11.4"]
+        exclude:
+          - os: ubuntu-latest
+            python-version: "3.8.10" # windows wants 3.8.10
+        include:
+          - os: ubuntu-latest
+            python-version: "3.8.12" # but ubuntu 22.04 needs >=3.8.12
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         # TODO consider bringing back 3.7. Note Windows x 3.7 fails from some sqlalchemy related problem
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8.18", "3.9.18", "3.10.13", "3.11.5"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         # TODO consider bringing back 3.7. Note Windows x 3.7 fails from some sqlalchemy related problem
-        python-version: ["3.8.18", "3.9.18", "3.10.13", "3.11.5"]
+        python-version: ["3.8.17", "3.9.17", "3.10.12", "3.11.4"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -23,13 +23,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8.10", "3.9.13", "3.10.11", "3.11.4"]
+        python-version: ["3.8.10", "3.9.18", "3.10.13", "3.11.5"]
         exclude:
-          - os: ubuntu-latest
-            python-version: "3.8.10" # windows wants 3.8.10
+          - os: windows-latest
+            python-version: "3.10.13"
+          - os: windows-latest
+            python-version: "3.9.18"
         include:
-          - os: ubuntu-latest
-            python-version: "3.8.12" # but ubuntu 22.04 needs >=3.8.12
+          - os: windows-latest
+            python-version: "3.10.11"
+          - os: windows-latest
+            python-version: "3.9.13"
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         # TODO consider bringing back 3.7. Note Windows x 3.7 fails from some sqlalchemy related problem
-        python-version: ["3.8.17", "3.9.17", "3.10.12", "3.11.4"]
+        python-version: ["3.8.10", "3.9.13", "3.10.11", "3.11.4"]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Python published minor releases 1-2 weeks ago.  Our cached python artifacts started becoming unusable sometimes.   CI logs hint at minor versions being off (cached with 3.11.5, but we use the cache on a runner with another minor version).  Theory is if we pin versions more precisely we won't get cache misalignment any more.

Litmus test is to rerun all CI jobs with this PR, multiple times, and look for lack of any flakes.