### PR TITLE
Don't show app running message twice

### DIFF
--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -92,8 +92,9 @@ def run_process_and_launch_url(run_command: list[str]):
                         if get_config().frontend_path != "":
                             url = urljoin(url, get_config().frontend_path)
                         console.print(f"App running at: [bold green]{url}")
+                        first_run = False
                     else:
-                        console.print("New packages detected updating app...")
+                        console.print("New packages detected: Updating app...")
                 else:
                     console.debug(line)
                     new_hash = detect_package_change(json_file_path)


### PR DESCRIPTION
Update the `first_time` flag to avoid showing the message twice on startup.