### PR TITLE
Don't show error logs on sigint

### DIFF
--- a/reflex/utils/processes.py
+++ b/reflex/utils/processes.py
@@ -217,7 +217,8 @@ def stream_logs(message: str, process: subprocess.Popen):
             logs.append(line)
             yield line
 
-    if process.returncode != 0:
+    # Check if the process failed (not printing the logs for SIGINT).
+    if process.returncode not in [0, 2]:
         console.error(f"{message} failed with exit code {process.returncode}")
         for line in logs:
             console.error(line, end="")

--- a/reflex/utils/processes.py
+++ b/reflex/utils/processes.py
@@ -218,7 +218,7 @@ def stream_logs(message: str, process: subprocess.Popen):
             yield line
 
     # Check if the process failed (not printing the logs for SIGINT).
-    if process.returncode not in [0, 2]:
+    if process.returncode not in [0, -2]:
         console.error(f"{message} failed with exit code {process.returncode}")
         for line in logs:
             console.error(line, end="")


### PR DESCRIPTION
Avoid showing logs when exiting the app in a Docker container