### PR TITLE
supply default for rx.Model PK for both DB and python to work

### DIFF
--- a/reflex/model.py
+++ b/reflex/model.py
@@ -54,7 +54,7 @@ class Model(Base, sqlmodel.SQLModel):
     """Base class to define a table in the database."""
 
     # The primary key for the table.
-    id: Optional[int] = sqlmodel.Field(primary_key=True)
+    id: Optional[int] = sqlmodel.Field(default=None, primary_key=True)
 
     def __init_subclass__(cls):
         """Drop the default primary key field if any primary key field is defined."""

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from unittest import mock
 
 import pytest
@@ -20,7 +21,7 @@ def model_default_primary() -> Model:
     class ChildModel(Model):
         name: str
 
-    return ChildModel(name="name")  # type: ignore
+    return ChildModel(name="name")
 
 
 @pytest.fixture
@@ -32,10 +33,10 @@ def model_custom_primary() -> Model:
     """
 
     class ChildModel(Model):
-        custom_id: int = sqlmodel.Field(default=None, primary_key=True)
+        custom_id: Optional[int] = sqlmodel.Field(default=None, primary_key=True)
         name: str
 
-    return ChildModel(name="name")  # type: ignore
+    return ChildModel(name="name")
 
 
 def test_default_primary_key(model_default_primary):


### PR DESCRIPTION
Summary
- According to https://sqlmodel.tiangolo.com/tutorial/automatic-id-none-refresh/, the primary key should be defined as Optional with default None for python to work (static type checker complains) while DB works.

Tests
- Updated UTs. They should still pass.