### PR TITLE
add download event

### DIFF
--- a/reflex/__init__.py
+++ b/reflex/__init__.py
@@ -23,6 +23,7 @@ from .event import EventChain as EventChain
 from .event import FileUpload as upload_files
 from .event import clear_local_storage as clear_local_storage
 from .event import console_log as console_log
+from .event import download as download
 from .event import redirect as redirect
 from .event import remove_cookie as remove_cookie
 from .event import remove_local_storage as remove_local_storage

--- a/reflex/event.py
+++ b/reflex/event.py
@@ -330,6 +330,29 @@ def set_clipboard(content: str) -> EventSpec:
     )
 
 
+def download(url: str, filename: str) -> EventSpec:
+    """Download the file at a given path.
+
+    Args:
+        url : The URL to the file to download.
+        filename : The name that the file should be saved as after download.
+
+    Raises:
+        ValueError: If the URL provided is invalid.
+
+    Returns:
+        EventSpec: An event to download the associated file.
+    """
+    if not url.startswith("/"):
+        raise ValueError("The URL argument should start with a /")
+    return server_side(
+        "_download",
+        get_fn_signature(download),
+        url=url,
+        filename=filename,
+    )
+
+
 def get_event(state, event):
     """Get the event from the given state.
 


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Description

Add an API for easily downloading files.

Usage is as follow:
```python
rx.button("Download file", on_click=rx.download("/uri/for/file.extension", "target_file.extension")
```

or 
```python
def export_data(self):
    ...
    # do export logic here and write to filepath
    # then
    yield rx.download(filepath, filename)
```
