### PR TITLE
numberinput: check `_id is not None` to avoid Var truthiness warning

### DIFF
--- a/reflex/components/forms/numberinput.py
+++ b/reflex/components/forms/numberinput.py
@@ -90,7 +90,9 @@ class NumberInput(ChakraComponent):
         if len(children) == 0:
             _id = props.pop("id", None)
             children = [
-                NumberInputField.create(id=_id) if _id else NumberInputField.create(),
+                NumberInputField.create(id=_id)
+                if _id is not None
+                else NumberInputField.create(),
                 NumberInputStepper.create(
                     NumberIncrementStepper.create(),
                     NumberDecrementStepper.create(),


### PR DESCRIPTION
Partial fix for #1802

This doesn't let you actually use a dynamic ID in a form element, but it does avoid the confusing trace coming from reflex internal code:

```console
  File "/Users/masenf/code/reflex-dev/repro-1802/repro_1802/repro_1802.py", line 47, in fn
    rx.number_input(
  File "/Users/masenf/code/reflex-dev/reflex/reflex/components/forms/numberinput.py", line 93, in create
    NumberInputField.create(id=_id) if _id else NumberInputField.create(),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/masenf/code/reflex-dev/reflex/reflex/vars.py", line 214, in __bool__
    raise TypeError(
TypeError: Cannot convert Var '(("_" + _) + "_option")' to bool for use with `if`, `and`, `or`, and `not`. Instead use `rx.cond` and bitwise operators `&` (and), `|` (or), `~` (invert).
```