### PR TITLE
Prevent Substate class shadowing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -584,3 +584,23 @@ def mutable_state():
             self.test_set = {1, 2, 3, 4, "five"}
 
     return MutableTestState()
+
+
+@pytest.fixture
+def duplicate_substate():
+    """Create a Test state that has duplicate child substates.
+
+    Returns:
+        The test state.
+    """
+
+    class TestState(rx.State):
+        pass
+
+    class ChildTestState(TestState):  # type: ignore # noqa
+        pass
+
+    class ChildTestState(TestState):  # type: ignore # noqa
+        pass
+
+    return TestState

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1583,3 +1583,8 @@ def test_mutable_backend(mutable_state):
     assert_custom_dirty()
     mutable_state._be_custom.custom.bar = "baz"
     assert_custom_dirty()
+
+
+def test_duplicate_substate_class(duplicate_substate):
+    with pytest.raises(ValueError):
+        duplicate_substate()


### PR DESCRIPTION
This PR aims to prevent shadowing children substate which inherently leads to unexpected behaviors since they're not exactly shadowed. With this PR the following example will throw an error:

```python
import reflex as rx

class State(rx.State):
       ...

class ChildState(State):
       ...

class ChildState(State):
      ... 
```