### PR TITLE
pyproject.toml: add `packaging` to dep list

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2295,4 +2295,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "091bbeb36378731e9016db10ac0fcd19dda01947515fcfdc29303b2b3a2b37d6"
+content-hash = "8a9bdd4dee1d8701a966eece1cc94a0e395f514c6e8b4bf05ce295305bb7f4c5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ platformdirs = "^3.10.0"
 distro = {version = "^1.8.0", platform = "linux"}
 python-engineio = "!=4.6.0"
 wrapt = "^1.15.0"
+packaging = "^23.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.1.2"


### PR DESCRIPTION
This is used in prerequisites to compare node and bun versions.

Previously we were picking up this dep via `plotly`, which is no longer installed by default.