### PR TITLE
add option to disable Tailwind

### DIFF
--- a/reflex/.templates/web/package.json
+++ b/reflex/.templates/web/package.json
@@ -24,7 +24,6 @@
   },
   "devDependencies": {
     "autoprefixer": "^10.4.14",
-    "postcss": "^8.4.24",
-    "tailwindcss": "^3.3.2"
+    "postcss": "^8.4.24"
   }
 }

--- a/reflex/compiler/compiler.py
+++ b/reflex/compiler/compiler.py
@@ -151,9 +151,9 @@ def _compile_root_stylesheet(stylesheets: List[str]) -> str:
     """
     tailwind_config = get_config().tailwind
     sheets = (
-        [constants.TAILWIND_ROOT_STYLE_PATH]
-        if tailwind_config and tailwind_config.get("disable") is not True
-        else []
+        []
+        if tailwind_config and tailwind_config.get("disable") is True
+        else [constants.TAILWIND_ROOT_STYLE_PATH]
     )
     for stylesheet in stylesheets:
         if not utils.is_valid_url(stylesheet):

--- a/reflex/compiler/compiler.py
+++ b/reflex/compiler/compiler.py
@@ -8,6 +8,7 @@ from typing import List, Set, Tuple, Type
 from reflex import constants
 from reflex.compiler import templates, utils
 from reflex.components.component import Component, ComponentStyle, CustomComponent
+from reflex.config import get_config
 from reflex.state import State
 from reflex.utils import imports
 from reflex.vars import ImportVar
@@ -148,7 +149,12 @@ def _compile_root_stylesheet(stylesheets: List[str]) -> str:
     Raises:
         FileNotFoundError: If a specified stylesheet in assets directory does not exist.
     """
-    sheets = [constants.TAILWIND_ROOT_STYLE_PATH]
+    tailwind_config = get_config().tailwind
+    sheets = (
+        [constants.TAILWIND_ROOT_STYLE_PATH]
+        if tailwind_config and tailwind_config.get("disable") is not True
+        else []
+    )
     for stylesheet in stylesheets:
         if not utils.is_valid_url(stylesheet):
             # check if stylesheet provided exists.

--- a/reflex/compiler/compiler.py
+++ b/reflex/compiler/compiler.py
@@ -149,11 +149,11 @@ def _compile_root_stylesheet(stylesheets: List[str]) -> str:
     Raises:
         FileNotFoundError: If a specified stylesheet in assets directory does not exist.
     """
-    tailwind_config = get_config().tailwind
+    # Add tailwind css if enabled.
     sheets = (
-        []
-        if tailwind_config and tailwind_config.get("disable") is True
-        else [constants.TAILWIND_ROOT_STYLE_PATH]
+        [constants.TAILWIND_ROOT_STYLE_PATH]
+        if get_config().tailwind is not None
+        else []
     )
     for stylesheet in stylesheets:
         if not utils.is_valid_url(stylesheet):

--- a/reflex/config.py
+++ b/reflex/config.py
@@ -169,7 +169,7 @@ class Config(Base):
     cors_allowed_origins: List[str] = ["*"]
 
     # Tailwind config.
-    tailwind: Optional[Dict[str, Any]] = None
+    tailwind: Optional[Dict[str, Any]] = {}
 
     # Timeout when launching the gunicorn server. TODO(rename this to backend_timeout?)
     timeout: int = 120

--- a/reflex/constants.py
+++ b/reflex/constants.py
@@ -134,6 +134,8 @@ TAILWIND_CONFIG = os.path.join(WEB_DIR, "tailwind.config.js")
 TAILWIND_CONTENT = ["./pages/**/*.{js,ts,jsx,tsx}"]
 # Relative tailwind style path to root stylesheet in STYLES_DIR.
 TAILWIND_ROOT_STYLE_PATH = "./tailwind.css"
+# The Tailwindcss version
+TAILWIND_VERSION = "tailwindcss@^3.3.2"
 # The NextJS config file
 NEXT_CONFIG_FILE = "next.config.js"
 # The sitemap config file.

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -434,18 +434,13 @@ def install_frontend_packages(packages: set[str]):
     config = get_config()
     if config.tailwind is not None:
         # install tailwind and tailwind plugins as dev dependencies.
-        plugins = [
-            plugin
-            for plugin in config.tailwind["plugins"]
-            if config.tailwind and "plugins" in config.tailwind
-        ]
         process = processes.new_process(
             [
                 get_install_package_manager(),
                 "add",
                 "-d",
                 constants.TAILWIND_VERSION,
-                *plugins,
+                *((config.tailwind or {}).get("plugins", [])),
             ],
             cwd=constants.WEB_DIR,
             shell=constants.IS_WINDOWS,

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -433,22 +433,19 @@ def install_frontend_packages(packages: set[str]):
 
     config = get_config()
     if config.tailwind is not None:
-        # install tailwind
+        # install tailwind and tailwind plugins as dev dependencies.
         process = processes.new_process(
-            [get_install_package_manager(), "add", constants.TAILWIND_VERSION, "-d"],
+            [
+                get_install_package_manager(),
+                "add",
+                "-d",
+                constants.TAILWIND_VERSION,
+                *config.tailwind["plugins"],
+            ],
             cwd=constants.WEB_DIR,
             shell=constants.IS_WINDOWS,
         )
         processes.show_status("Installing tailwind", process)
-
-        # install tailwind plugins
-        if "plugins" in config.tailwind:
-            process = processes.new_process(
-                [get_install_package_manager(), "add", *config.tailwind["plugins"]],
-                cwd=constants.WEB_DIR,
-                shell=constants.IS_WINDOWS,
-            )
-            processes.show_status("Installing tailwind packages", process)
 
     # Install custom packages defined in frontend_packages
     if len(packages) > 0:

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -434,13 +434,18 @@ def install_frontend_packages(packages: set[str]):
     config = get_config()
     if config.tailwind is not None:
         # install tailwind and tailwind plugins as dev dependencies.
+        plugins = [
+            plugin
+            for plugin in config.tailwind["plugins"]
+            if config.tailwind and "plugins" in config.tailwind
+        ]
         process = processes.new_process(
             [
                 get_install_package_manager(),
                 "add",
                 "-d",
                 constants.TAILWIND_VERSION,
-                *config.tailwind["plugins"],
+                *plugins,
             ],
             cwd=constants.WEB_DIR,
             shell=constants.IS_WINDOWS,

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -432,13 +432,23 @@ def install_frontend_packages(packages: set[str]):
     processes.show_status("Installing base frontend packages", process)
 
     config = get_config()
-    if config.tailwind is not None and "plugins" in config.tailwind:
+    if config.tailwind is not None:
+        # install tailwind
         process = processes.new_process(
-            [get_install_package_manager(), "add", *config.tailwind["plugins"]],
+            [get_install_package_manager(), "add", constants.TAILWIND_VERSION, "-d"],
             cwd=constants.WEB_DIR,
             shell=constants.IS_WINDOWS,
         )
-        processes.show_status("Installing tailwind packages", process)
+        processes.show_status("Installing tailwind", process)
+
+        # install tailwind plugins
+        if "plugins" in config.tailwind:
+            process = processes.new_process(
+                [get_install_package_manager(), "add", *config.tailwind["plugins"]],
+                cwd=constants.WEB_DIR,
+                shell=constants.IS_WINDOWS,
+            )
+            processes.show_status("Installing tailwind packages", process)
 
     # Install custom packages defined in frontend_packages
     if len(packages) > 0:

--- a/tests/compiler/test_compiler.py
+++ b/tests/compiler/test_compiler.py
@@ -12,28 +12,28 @@ from reflex.vars import ImportVar
     "fields,test_default,test_rest",
     [
         (
-                {ImportVar(tag="axios", is_default=True)},
-                "axios",
-                set(),
+            {ImportVar(tag="axios", is_default=True)},
+            "axios",
+            set(),
         ),
         (
-                {ImportVar(tag="foo"), ImportVar(tag="bar")},
-                "",
-                {"foo", "bar"},
+            {ImportVar(tag="foo"), ImportVar(tag="bar")},
+            "",
+            {"foo", "bar"},
         ),
         (
-                {
-                    ImportVar(tag="axios", is_default=True),
-                    ImportVar(tag="foo"),
-                    ImportVar(tag="bar"),
-                },
-                "axios",
-                {"foo", "bar"},
+            {
+                ImportVar(tag="axios", is_default=True),
+                ImportVar(tag="foo"),
+                ImportVar(tag="bar"),
+            },
+            "axios",
+            {"foo", "bar"},
         ),
     ],
 )
 def test_compile_import_statement(
-        fields: Set[ImportVar], test_default: str, test_rest: str
+    fields: Set[ImportVar], test_default: str, test_rest: str
 ):
     """Test the compile_import_statement function.
 
@@ -52,44 +52,44 @@ def test_compile_import_statement(
     [
         ({}, []),
         (
-                {"axios": {ImportVar(tag="axios", is_default=True)}},
-                [{"lib": "axios", "default": "axios", "rest": set()}],
+            {"axios": {ImportVar(tag="axios", is_default=True)}},
+            [{"lib": "axios", "default": "axios", "rest": set()}],
         ),
         (
-                {"axios": {ImportVar(tag="foo"), ImportVar(tag="bar")}},
-                [{"lib": "axios", "default": "", "rest": {"foo", "bar"}}],
+            {"axios": {ImportVar(tag="foo"), ImportVar(tag="bar")}},
+            [{"lib": "axios", "default": "", "rest": {"foo", "bar"}}],
         ),
         (
-                {
-                    "axios": {
-                        ImportVar(tag="axios", is_default=True),
-                        ImportVar(tag="foo"),
-                        ImportVar(tag="bar"),
-                    },
-                    "react": {ImportVar(tag="react", is_default=True)},
+            {
+                "axios": {
+                    ImportVar(tag="axios", is_default=True),
+                    ImportVar(tag="foo"),
+                    ImportVar(tag="bar"),
                 },
-                [
-                    {"lib": "axios", "default": "axios", "rest": {"foo", "bar"}},
-                    {"lib": "react", "default": "react", "rest": set()},
-                ],
+                "react": {ImportVar(tag="react", is_default=True)},
+            },
+            [
+                {"lib": "axios", "default": "axios", "rest": {"foo", "bar"}},
+                {"lib": "react", "default": "react", "rest": set()},
+            ],
         ),
         (
-                {"": {ImportVar(tag="lib1.js"), ImportVar(tag="lib2.js")}},
-                [
-                    {"lib": "lib1.js", "default": "", "rest": set()},
-                    {"lib": "lib2.js", "default": "", "rest": set()},
-                ],
+            {"": {ImportVar(tag="lib1.js"), ImportVar(tag="lib2.js")}},
+            [
+                {"lib": "lib1.js", "default": "", "rest": set()},
+                {"lib": "lib2.js", "default": "", "rest": set()},
+            ],
         ),
         (
-                {
-                    "": {ImportVar(tag="lib1.js"), ImportVar(tag="lib2.js")},
-                    "axios": {ImportVar(tag="axios", is_default=True)},
-                },
-                [
-                    {"lib": "lib1.js", "default": "", "rest": set()},
-                    {"lib": "lib2.js", "default": "", "rest": set()},
-                    {"lib": "axios", "default": "axios", "rest": set()},
-                ],
+            {
+                "": {ImportVar(tag="lib1.js"), ImportVar(tag="lib2.js")},
+                "axios": {ImportVar(tag="axios", is_default=True)},
+            },
+            [
+                {"lib": "lib1.js", "default": "", "rest": set()},
+                {"lib": "lib2.js", "default": "", "rest": set()},
+                {"lib": "axios", "default": "axios", "rest": set()},
+            ],
         ),
     ],
 )
@@ -166,7 +166,7 @@ def test_compile_stylesheets_exclude_tailwind(tmp_path, mocker):
 
     assert compiler.compile_root_stylesheet(stylesheets) == (
         os.path.join(".web", "styles", "styles.css"),
-        "@import url('@/styles.css'); \n"
+        "@import url('@/styles.css'); \n",
     )
 
 

--- a/tests/compiler/test_compiler.py
+++ b/tests/compiler/test_compiler.py
@@ -121,7 +121,6 @@ def test_compile_stylesheets(tmp_path, mocker):
     assets_dir.mkdir()
 
     (assets_dir / "styles.css").touch()
-
     mocker.patch("reflex.compiler.compiler.Path.cwd", return_value=project)
 
     stylesheets = [

--- a/tests/compiler/test_compiler.py
+++ b/tests/compiler/test_compiler.py
@@ -12,28 +12,28 @@ from reflex.vars import ImportVar
     "fields,test_default,test_rest",
     [
         (
-            {ImportVar(tag="axios", is_default=True)},
-            "axios",
-            set(),
+                {ImportVar(tag="axios", is_default=True)},
+                "axios",
+                set(),
         ),
         (
-            {ImportVar(tag="foo"), ImportVar(tag="bar")},
-            "",
-            {"foo", "bar"},
+                {ImportVar(tag="foo"), ImportVar(tag="bar")},
+                "",
+                {"foo", "bar"},
         ),
         (
-            {
-                ImportVar(tag="axios", is_default=True),
-                ImportVar(tag="foo"),
-                ImportVar(tag="bar"),
-            },
-            "axios",
-            {"foo", "bar"},
+                {
+                    ImportVar(tag="axios", is_default=True),
+                    ImportVar(tag="foo"),
+                    ImportVar(tag="bar"),
+                },
+                "axios",
+                {"foo", "bar"},
         ),
     ],
 )
 def test_compile_import_statement(
-    fields: Set[ImportVar], test_default: str, test_rest: str
+        fields: Set[ImportVar], test_default: str, test_rest: str
 ):
     """Test the compile_import_statement function.
 
@@ -52,44 +52,44 @@ def test_compile_import_statement(
     [
         ({}, []),
         (
-            {"axios": {ImportVar(tag="axios", is_default=True)}},
-            [{"lib": "axios", "default": "axios", "rest": set()}],
+                {"axios": {ImportVar(tag="axios", is_default=True)}},
+                [{"lib": "axios", "default": "axios", "rest": set()}],
         ),
         (
-            {"axios": {ImportVar(tag="foo"), ImportVar(tag="bar")}},
-            [{"lib": "axios", "default": "", "rest": {"foo", "bar"}}],
+                {"axios": {ImportVar(tag="foo"), ImportVar(tag="bar")}},
+                [{"lib": "axios", "default": "", "rest": {"foo", "bar"}}],
         ),
         (
-            {
-                "axios": {
-                    ImportVar(tag="axios", is_default=True),
-                    ImportVar(tag="foo"),
-                    ImportVar(tag="bar"),
+                {
+                    "axios": {
+                        ImportVar(tag="axios", is_default=True),
+                        ImportVar(tag="foo"),
+                        ImportVar(tag="bar"),
+                    },
+                    "react": {ImportVar(tag="react", is_default=True)},
                 },
-                "react": {ImportVar(tag="react", is_default=True)},
-            },
-            [
-                {"lib": "axios", "default": "axios", "rest": {"foo", "bar"}},
-                {"lib": "react", "default": "react", "rest": set()},
-            ],
+                [
+                    {"lib": "axios", "default": "axios", "rest": {"foo", "bar"}},
+                    {"lib": "react", "default": "react", "rest": set()},
+                ],
         ),
         (
-            {"": {ImportVar(tag="lib1.js"), ImportVar(tag="lib2.js")}},
-            [
-                {"lib": "lib1.js", "default": "", "rest": set()},
-                {"lib": "lib2.js", "default": "", "rest": set()},
-            ],
+                {"": {ImportVar(tag="lib1.js"), ImportVar(tag="lib2.js")}},
+                [
+                    {"lib": "lib1.js", "default": "", "rest": set()},
+                    {"lib": "lib2.js", "default": "", "rest": set()},
+                ],
         ),
         (
-            {
-                "": {ImportVar(tag="lib1.js"), ImportVar(tag="lib2.js")},
-                "axios": {ImportVar(tag="axios", is_default=True)},
-            },
-            [
-                {"lib": "lib1.js", "default": "", "rest": set()},
-                {"lib": "lib2.js", "default": "", "rest": set()},
-                {"lib": "axios", "default": "axios", "rest": set()},
-            ],
+                {
+                    "": {ImportVar(tag="lib1.js"), ImportVar(tag="lib2.js")},
+                    "axios": {ImportVar(tag="axios", is_default=True)},
+                },
+                [
+                    {"lib": "lib1.js", "default": "", "rest": set()},
+                    {"lib": "lib2.js", "default": "", "rest": set()},
+                    {"lib": "axios", "default": "axios", "rest": set()},
+                ],
         ),
     ],
 )
@@ -137,6 +137,36 @@ def test_compile_stylesheets(tmp_path, mocker):
         f"@import url('https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/css/bootstrap.min.css'); \n"
         f"@import url('@/styles.css'); \n"
         f"@import url('https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/css/bootstrap-theme.min.css'); \n",
+    )
+
+
+def test_compile_stylesheets_exclude_tailwind(tmp_path, mocker):
+    """Test that Tailwind is excluded if tailwind config is explicitly set to None.
+
+    Args:
+        tmp_path: The test directory.
+        mocker: Pytest mocker object.
+    """
+    project = tmp_path / "test_project"
+    project.mkdir()
+
+    assets_dir = project / "assets"
+    assets_dir.mkdir()
+    mock = mocker.Mock()
+
+    mocker.patch.object(mock, "tailwind", None)
+    mocker.patch("reflex.compiler.compiler.get_config", return_value=mock)
+
+    (assets_dir / "styles.css").touch()
+    mocker.patch("reflex.compiler.compiler.Path.cwd", return_value=project)
+
+    stylesheets = [
+        "/styles.css",
+    ]
+
+    assert compiler.compile_root_stylesheet(stylesheets) == (
+        os.path.join(".web", "styles", "styles.css"),
+        "@import url('@/styles.css'); \n"
     )
 
 


### PR DESCRIPTION
This PR provides an option to disable the out-of-the-box supported Tailwind. To do that, simply set the `tailwind` config to `None` :

`rxconfig.py`
---------------------------------
```python
import reflex as rx

config = ExampleConfig(
    app_name="example",
    tailwind= None
)
```

fixes #1829 

Docs: https://github.com/reflex-dev/reflex-web/pull/205