### PR TITLE
Support custom styling for code in markdown

### DIFF
--- a/reflex/components/tags/tag.py
+++ b/reflex/components/tags/tag.py
@@ -51,6 +51,7 @@ class Tag(Base):
         Returns:
             The formatted props list.
         """
+        # return format.format_props({**self.props, **self.special_props})
         # If there are no props, return an empty string.
         if len(self.props) == 0:
             return []

--- a/reflex/components/tags/tag.py
+++ b/reflex/components/tags/tag.py
@@ -51,17 +51,7 @@ class Tag(Base):
         Returns:
             The formatted props list.
         """
-        # return format.format_props({**self.props, **self.special_props})
-        # If there are no props, return an empty string.
-        if len(self.props) == 0:
-            return []
-
-        # Format all the props.
-        return [
-            f"{name}={format.format_prop(prop)}"
-            for name, prop in sorted(self.props.items())
-            if prop is not None
-        ] + [str(prop) for prop in self.special_props]
+        return format.format_props(*self.special_props, **self.props)
 
     def add_props(self, **kwargs: Optional[Any]) -> Tag:
         """Add props to the tag.

--- a/reflex/components/typography/markdown.py
+++ b/reflex/components/typography/markdown.py
@@ -91,6 +91,7 @@ class Markdown(Component):
         return super().create(src, **props)
 
     def _get_imports(self):
+        # Import here to avoid circular imports.
         from reflex.components.datadisplay.code import Code, CodeBlock
 
         imports = super()._get_imports()
@@ -118,7 +119,9 @@ class Markdown(Component):
         return imports
 
     def _render(self):
+        # Import here to avoid circular imports.
         from reflex.components.tags.tag import Tag
+        from reflex.components.datadisplay.code import Code, CodeBlock
 
         components = {
             tag: f"{{({{node, ...props}}) => <{(component().tag)} {{...props}} {''.join(Tag(name='', props=Style(self.custom_styles.get(tag, {}))).format_props())} />}}"
@@ -126,22 +129,21 @@ class Markdown(Component):
         }
         components[
             "code"
-        ] = """{({node, inline, className, children, ...props}) =>
-                    {
-        const match = (className || '').match(/language-(?<lang>.*)/);
-        return !inline ? (
-          <Prism
-            children={String(children).replace(/\n$/, '')}
-            language={match ? match[1] : ''}
-            theme={light}
-            {...props}
-          />
-        ) : (
-          <Code {...props}>
-            {children}
-          </Code>
-        );
-      }}""".replace(
+        ] = f"""{{({{node, inline, className, children, ...props}}) => {{
+    const match = (className || '').match(/language-(?<lang>.*)/);
+    return !inline ? (
+        <{CodeBlock().tag}
+        children={{String(children).replace(/\n$/, '')}}
+        language={{match ? match[1] : ''}}
+        theme={{light}}
+        {{...props}}
+        />
+    ) : (
+        <{Code.create().tag} {{...props}}>
+        {{children}}
+        </{Code.create().tag}>
+    );
+      }}}}""".replace(
             "\n", " "
         )
 

--- a/reflex/components/typography/markdown.py
+++ b/reflex/components/typography/markdown.py
@@ -10,7 +10,7 @@ from reflex.components.navigation import Link
 from reflex.components.typography.heading import Heading
 from reflex.components.typography.text import Text
 from reflex.style import Style
-from reflex.utils import types
+from reflex.utils import format, types
 from reflex.vars import BaseVar, ImportVar, Var
 
 # Mapping from markdown tags to components.
@@ -135,7 +135,7 @@ class Markdown(Component):
         <{CodeBlock().tag}
         children={{String(children).replace(/\n$/, '')}}
         language={{match ? match[1] : ''}}
-        theme={{light}}
+        style={{light}}
         {{...props}}
         />
     ) : (

--- a/reflex/components/typography/markdown.py
+++ b/reflex/components/typography/markdown.py
@@ -10,7 +10,7 @@ from reflex.components.navigation import Link
 from reflex.components.typography.heading import Heading
 from reflex.components.typography.text import Text
 from reflex.style import Style
-from reflex.utils import format, types
+from reflex.utils import types
 from reflex.vars import BaseVar, ImportVar, Var
 
 # Mapping from markdown tags to components.
@@ -120,11 +120,18 @@ class Markdown(Component):
 
     def _render(self):
         # Import here to avoid circular imports.
-        from reflex.components.tags.tag import Tag
         from reflex.components.datadisplay.code import Code, CodeBlock
+        from reflex.components.tags.tag import Tag
+
+        def format_props(tag):
+            return "".join(
+                Tag(
+                    name="", props=Style(self.custom_styles.get(tag, {}))
+                ).format_props()
+            )
 
         components = {
-            tag: f"{{({{node, ...props}}) => <{(component().tag)} {{...props}} {''.join(Tag(name='', props=Style(self.custom_styles.get(tag, {}))).format_props())} />}}"
+            tag: f"{{({{node, ...props}}) => <{(component().tag)} {{...props}} {format_props(tag)} />}}"
             for tag, component in components_by_tag.items()
         }
         components[
@@ -137,9 +144,10 @@ class Markdown(Component):
         language={{match ? match[1] : ''}}
         style={{light}}
         {{...props}}
+        {format_props("pre")}
         />
     ) : (
-        <{Code.create().tag} {{...props}}>
+        <{Code.create().tag} {{...props}} {format_props("code")}>
         {{children}}
         </{Code.create().tag}>
     );

--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -326,25 +326,24 @@ def format_prop(
     assert isinstance(prop, str), "The prop must be a string."
     return wrap(prop, "{", check_first=False)
 
-def format_props(props: dict[str, Any]) -> list[str]:
+
+def format_props(*single_props, **key_value_props) -> list[str]:
     """Format the tag's props.
 
     Args:
-        props: The props to format.
+        single_props: Props that are not key-value pairs.
+        key_value_props: Props that are key-value pairs.
 
     Returns:
         The formatted props list.
     """
-    # If there are no props, return an empty list.
-    if len(props) == 0:
-        return []
-
     # Format all the props.
     return [
         f"{name}={format_prop(prop)}"
-        for name, prop in sorted(props.items())
+        for name, prop in sorted(key_value_props.items())
         if prop is not None
-    ]
+    ] + [str(prop) for prop in sorted(single_props)]
+
 
 def get_event_handler_parts(handler: EventHandler) -> tuple[str, str]:
     """Get the state and function name of an event handler.

--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -326,6 +326,25 @@ def format_prop(
     assert isinstance(prop, str), "The prop must be a string."
     return wrap(prop, "{", check_first=False)
 
+def format_props(props: dict[str, Any]) -> list[str]:
+    """Format the tag's props.
+
+    Args:
+        props: The props to format.
+
+    Returns:
+        The formatted props list.
+    """
+    # If there are no props, return an empty list.
+    if len(props) == 0:
+        return []
+
+    # Format all the props.
+    return [
+        f"{name}={format_prop(prop)}"
+        for name, prop in sorted(props.items())
+        if prop is not None
+    ]
 
 def get_event_handler_parts(handler: EventHandler) -> tuple[str, str]:
     """Get the state and function name of an event handler.


### PR DESCRIPTION
Extended Markdown support for inline code and code blocks. Inline code uses the `code` key, and code blocks use the `pre` key.

```python
custom_styles = {
        "h1": {
            "as_": "h1",
            "size": "xl",
            "color": styles.text_colors["docs"]["header"],
            "font_weight": styles.font_weights["heading"],
            "font_family": styles.SANS,
        },
        "h2": {
            "as_": "h2",
            "font_size": styles.H3_FONT_SIZE,
            "margin_top": "1em",
            "color": styles.text_colors["docs"]["header"],
            "font_weight": styles.font_weights["subheading"],
            "font_family": styles.SANS,
        },
        "a": styles.LINK_STYLE,
        "p": {
            "as_": "p",
            "margin_y": "1em",
            "font_family": styles.SANS,
        },
        "code": {
            "color": "#1F1944",
            "bg": "#EAE4FD",
        },
        "pre": {
            "border_radius": styles.DOC_BORDER_RADIUS,
            "background": "transparent",
            "code_tag_props": {
                "style": {
                    "fontFamily": "inherit"
                }
            }
        }
...
rx.markdown(
    source,
    custom_styles=custom_styles,
)
```