### PR TITLE
state: implement __copy__ and __deepcopy__ for MutableProxy

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1313,3 +1313,22 @@ class MutableProxy(wrapt.ObjectProxy):
             super().__setattr__(name, value)
             return
         self._mark_dirty(super().__setattr__, args=(name, value))
+
+    def __copy__(self) -> Any:
+        """Return a copy of the proxy.
+
+        Returns:
+            A copy of the wrapped object, unconnected to the proxy.
+        """
+        return copy.copy(self.__wrapped__)
+
+    def __deepcopy__(self, memo=None) -> Any:
+        """Return a deepcopy of the proxy.
+
+        Args:
+            memo: The memo dict to use for the deepcopy.
+
+        Returns:
+            A deepcopy of the wrapped object, unconnected to the proxy.
+        """
+        return copy.deepcopy(self.__wrapped__, memo=memo)


### PR DESCRIPTION
[state: implement __copy__ and __deepcopy__ for MutableProxy](https://github.com/reflex-dev/reflex/commit/5478b1fc86a00073d3a20d1f72426107dc188610)

Allow state vars accessed through MutableProxy to be copied and unconnected from the proxy. Copied objects that are modified will not mark the associated field on the state as dirty.

Fix https://github.com/reflex-dev/reflex/issues/1841
Fix REF-647