### PR TITLE
StateProxy rebinds functools.partial and methods that are bound to the proxied State

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1177,6 +1177,14 @@ class StateProxy(wrapt.ObjectProxy):
                 state=self,  # type: ignore
                 field_name=value._self_field_name,
             )
+        if isinstance(value, functools.partial) and value.args[0] is self.__wrapped__:
+            # Rebind event handler to the proxy instance
+            value = functools.partial(
+                value.func,
+                self,
+                *value.args[1:],
+                **value.keywords,
+            )
         return value
 
     def __setattr__(self, name: str, value: Any) -> None:

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -12,7 +12,7 @@ import urllib.parse
 import uuid
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from types import FunctionType
+from types import FunctionType, MethodType
 from typing import (
     Any,
     AsyncIterator,
@@ -1185,6 +1185,9 @@ class StateProxy(wrapt.ObjectProxy):
                 *value.args[1:],
                 **value.keywords,
             )
+        if isinstance(value, MethodType) and value.__self__ is self.__wrapped__:
+            # Rebind methods to the proxy instance
+            value = type(value)(value.__func__, self)  # type: ignore
         return value
 
     def __setattr__(self, name: str, value: Any) -> None:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1714,6 +1714,20 @@ class BackgroundTaskState(State):
             self.other()  # direct calling event handlers works in context
 
     @rx.background
+    async def background_task_reset(self):
+        """A background task that resets the state."""
+        with pytest.raises(ImmutableStateError):
+            # Resetting the state should be explicitly blocked.
+            self.reset()
+
+        async with self:
+            self.order.append("foo")
+            self.reset()
+        assert not self.order
+        async with self:
+            self.order.append("reset")
+
+    @rx.background
     async def background_task_generator(self):
         """A background task generator that does nothing.
 
@@ -1760,7 +1774,6 @@ async def test_background_task_no_block(mock_app: rx.App, token: str):
     ):
         # background task returns empty update immediately
         assert update == StateUpdate()
-    assert len(mock_app.background_tasks) == 1
 
     # wait for the coroutine to start
     await asyncio.sleep(0.5 if CI else 0.1)
@@ -1801,6 +1814,41 @@ async def test_background_task_no_block(mock_app: rx.App, token: str):
         "other",
         "background_task:stop",
         "other",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_background_task_reset(mock_app: rx.App, token: str):
+    """Test that a background task calling reset is protected by the state proxy.
+
+    Args:
+        mock_app: An app that will be returned by `get_app()`
+        token: A token.
+    """
+    router_data = {"query": {}}
+    mock_app.state_manager.state = mock_app.state = BackgroundTaskState
+    async for update in rx.app.process(  # type: ignore
+        mock_app,
+        Event(
+            token=token,
+            name=f"{BackgroundTaskState.get_name()}.background_task_reset",
+            router_data=router_data,
+            payload={},
+        ),
+        sid="",
+        headers={},
+        client_ip="",
+    ):
+        # background task returns empty update immediately
+        assert update == StateUpdate()
+
+    # Explicit wait for background tasks
+    for task in tuple(mock_app.background_tasks):
+        await task
+    assert not mock_app.background_tasks
+
+    assert (await mock_app.state_manager.get_state(token)).order == [
+        "reset",
     ]
 
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1699,6 +1699,10 @@ class BackgroundTaskState(State):
             # Even nested access to mutables raises an exception.
             self.dict_list["foo"].append(42)
 
+        with pytest.raises(ImmutableStateError):
+            # Direct calling another handler that modifies state raises an exception.
+            self.other()
+
         # wait for some other event to happen
         while len(self.order) == 1:
             await asyncio.sleep(0.01)
@@ -1707,6 +1711,7 @@ class BackgroundTaskState(State):
 
         async with self:
             self.order.append("background_task:stop")
+            self.other()  # direct calling event handlers works in context
 
     @rx.background
     async def background_task_generator(self):
@@ -1795,6 +1800,7 @@ async def test_background_task_no_block(mock_app: rx.App, token: str):
         "background_task:start",
         "other",
         "background_task:stop",
+        "other",
     ]
 
 


### PR DESCRIPTION
Ensure that calling other event handlers directly or regular methods defined on the state cannot bypass the immutability protections of the StateProxy.

Add test cases to prevent regressions in this area.