### PR TITLE
component: `imports` override `_get_dependencies_imports`

### DIFF
--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -603,7 +603,7 @@ class Component(Base, ABC):
         imports = {}
         if self.library is not None and self.tag is not None:
             imports[self.library] = {self.import_var}
-        return {**imports, **self._get_dependencies_imports()}
+        return {**self._get_dependencies_imports(), **imports}
 
     def get_imports(self) -> imports.ImportDict:
         """Get all the libraries and fields that are used by the component.


### PR DESCRIPTION
Ensure that the actual library import (with the tag) will override the same library named in `lib_dependencies`.

Fix #1858