### PR TITLE
circular_progress cleanup: size, thickness, label

### DIFF
--- a/reflex/components/feedback/circularprogress.py
+++ b/reflex/components/feedback/circularprogress.py
@@ -23,7 +23,7 @@ class CircularProgress(ChakraComponent):
     min_: Var[int]
 
     # This defines the stroke width of the svg circle.
-    thickness: Var[int]
+    thickness: Var[str]
 
     # The color name of the progress track. Use a color key in the theme object
     track_color: Var[str]
@@ -36,6 +36,9 @@ class CircularProgress(ChakraComponent):
 
     # The color name of the progress bar
     color: Var[str]
+
+    # The size of the circular progress
+    size: Var[str]
 
     @classmethod
     def create(cls, *children, label=None, **props) -> Component:
@@ -52,7 +55,7 @@ class CircularProgress(ChakraComponent):
         if len(children) == 0:
             children = []
 
-            if label:
+            if label is not None:
                 children.append(CircularProgressLabel.create(label))
         return super().create(*children, **props)
 


### PR DESCRIPTION
found some issues while trying to actually use the `rx.circular_progress` component

* allow label to be specified as a var
* add size prop
* change thickness prop to str (matching the chakra docs)