### PR TITLE
[REF-669] Radix theme module

### DIFF
--- a/reflex/.templates/jinja/web/pages/index.js.jinja2
+++ b/reflex/.templates/jinja/web/pages/index.js.jinja2
@@ -11,6 +11,7 @@ export default function Component() {
   const {{state_name}} = useContext(StateContext)
   const {{const.router}} = useRouter()
   const [ {{const.color_mode}}, {{const.toggle_color_mode}} ] = useContext(ColorModeContext)
+  const {{const.theme_context}} = useThemeContext()
   const focusRef = useRef();
   
   // Main event loop.

--- a/reflex/__init__.py
+++ b/reflex/__init__.py
@@ -6,6 +6,7 @@ we use the Flask "import name as name" syntax.
 """
 
 from . import el as el
+from . import theme as theme
 from .admin import AdminDash as AdminDash
 from .app import App as App
 from .app import UploadFile as UploadFile

--- a/reflex/compiler/compiler.py
+++ b/reflex/compiler/compiler.py
@@ -47,6 +47,9 @@ DEFAULT_IMPORTS: imports.ImportDict = {
         #ImportVar(tag="Box"),
         #ImportVar(tag="Text"),
     },
+    "@radix-ui/themes": {
+        ImportVar(tag="useThemeContext"),
+    }
 }
 
 

--- a/reflex/compiler/templates.py
+++ b/reflex/compiler/templates.py
@@ -39,6 +39,7 @@ class ReflexJinjaEnvironment(Environment):
             "toggle_color_mode": constants.TOGGLE_COLOR_MODE,
             "use_color_mode": constants.USE_COLOR_MODE,
             "hydrate": constants.HYDRATE,
+            "theme_context": constants.THEME_CONTEXT,
         }
 
 

--- a/reflex/components/radix/themes/base.py
+++ b/reflex/components/radix/themes/base.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 from reflex.vars import Var
 
 from ...component import Component
@@ -10,3 +12,17 @@ class RadixThemeComponent(Component):
 
     variant: Var[str]
 
+    def render(self) -> Dict:
+        """Render the component.
+
+        Returns:
+            The dictionary for template of component.
+        """
+        rd = super().render()
+        # XXX: yucky hacks
+        for ix, prop in enumerate(rd.get("props", [])):
+            if prop.startswith("sx="):
+                rd["props"][ix] = rd["props"][ix].replace("sx=", "style=")
+                breakpoint()
+                break
+        return rd

--- a/reflex/components/radix/themes/base.py
+++ b/reflex/components/radix/themes/base.py
@@ -1,4 +1,5 @@
 from typing import Dict
+from reflex.components.tags import Tag
 
 from reflex.vars import Var
 
@@ -12,17 +13,8 @@ class RadixThemeComponent(Component):
 
     variant: Var[str]
 
-    def render(self) -> Dict:
-        """Render the component.
-
-        Returns:
-            The dictionary for template of component.
-        """
-        rd = super().render()
-        # XXX: yucky hacks
-        for ix, prop in enumerate(rd.get("props", [])):
-            if prop.startswith("sx="):
-                rd["props"][ix] = rd["props"][ix].replace("sx=", "style=")
-                breakpoint()
-                break
-        return rd
+    def _render(self) -> Tag:
+        # change sx prop to "style"
+        return super()._render().remove_props(
+            "sx",
+        ).add_props(style=self.style)

--- a/reflex/components/radix/themes/layout.py
+++ b/reflex/components/radix/themes/layout.py
@@ -5,8 +5,6 @@ from .base import RadixThemeComponent
 class Box(RadixThemeComponent):
     tag = "Box"
 
-    background_color: Var[str]
-
 
 class Flex(RadixThemeComponent):
     tag = "Flex"

--- a/reflex/components/radix/themes/layout.py
+++ b/reflex/components/radix/themes/layout.py
@@ -1,8 +1,11 @@
+from reflex.vars import Var
 from .base import RadixThemeComponent
 
 
 class Box(RadixThemeComponent):
     tag = "Box"
+
+    background_color: Var[str]
 
 
 class Flex(RadixThemeComponent):

--- a/reflex/constants.py
+++ b/reflex/constants.py
@@ -443,3 +443,5 @@ class EventTriggers(SimpleNamespace):
 
 # If this env var is set to "yes", App.compile will be a no-op
 SKIP_COMPILE_ENV_VAR = "__REFLEX_SKIP_COMPILE"
+
+THEME_CONTEXT = "theme_context"

--- a/reflex/style.py
+++ b/reflex/style.py
@@ -26,7 +26,7 @@ def convert(style_dict):
         if isinstance(value, dict):
             out[key] = convert(value)
         elif isinstance(value, Var):
-            out[key] = str(value)
+            out[key] = Var.create_safe(f"`{value}`", is_local=False, is_string=False)
         else:
             out[key] = value
     return out

--- a/reflex/theme.py
+++ b/reflex/theme.py
@@ -1,0 +1,61 @@
+import enum
+
+from reflex import constants
+from reflex.vars import BaseVar, Var
+
+
+class Scale(enum.Enum):
+    """The scale of the color.
+    
+    See https://www.radix-ui.com/colors/docs/palette-composition/understanding-the-scale
+    """
+    APP_BACKGROUND = 1
+    SUBTLE_BACKGROUND = 2
+    UI_ELEMENT_BACKGROUND = 3
+    HOVERED_UI_ELEMENT_BACKGROUND = 4
+    ACTIVE_SELECTED_UI_ELEMENT_BACKGROUND = 5
+    SUBTLE_BORDERS_AND_SEPARATORS = 6
+    UI_ELEMENT_BORDER_AND_FOCUS_RINGS = 7
+    HOVERED_UI_ELEMENT_BORDER = 8
+    SOLID_BACKGROUNDS = 9
+    HOVERED_SOLID_BACKGROUNDS = 10
+    LOW_CONTRAST_TEXT = 11
+    HIGH_CONTRAST_TEXT = 12
+
+
+def accent_color(scale: int | Scale) -> Var:
+    if isinstance(scale, Scale):
+        scale = scale.value
+    return BaseVar.create_safe(
+        f"var(--${{{constants.THEME_CONTEXT}?.accentColor}}-{scale})",
+    )
+
+
+def gray_color(scale: int | Scale) -> Var:
+    if isinstance(scale, Scale):
+        scale = scale.value
+    return BaseVar.create_safe(
+        f"var(--${{{constants.THEME_CONTEXT}?.grayColor}}-{scale})",
+    )
+
+panel_background = BaseVar.create_safe(
+    f"${{{constants.THEME_CONTEXT}?.panelBackground}}",
+)
+
+scaling = BaseVar.create_safe(
+    f"${{{constants.THEME_CONTEXT}?.scaling}}",
+)
+
+radius = BaseVar.create_safe(
+    f"${{{constants.THEME_CONTEXT}?.radius}}",
+)
+
+def size(value: int) -> dict[str, Var]:
+    return dict(
+        margin=f"var(--space-{value})",
+        padding=f"var(--space-{value})",
+        border_radius=f"max(var(--radius-{value}), var(--radius-full))",
+        custom_attrs={
+            "data-radius": radius,
+        },
+    )


### PR DESCRIPTION
* implement `rx.theme`
* move more Component prop construction to `_render` method, to make it easier to modify downstream

**TODO**

- [ ] expose more radix theme tokens as python names
- [ ] wrap real non-radix theme components and add missing helpers

**Sample Code**

```python
import reflex as rx
from reflex.utils import format
from reflex.vars import Var

import reflex.components.radix.themes as rdxt


class State(rx.State):
    pass


def index() -> rx.Component:
    return rdxt.box(
        rx.color_mode_switch(),
        rdxt.heading("Welcome to Reflex!"),
        rdxt.text(f"Radix-ui/themes edition!"),
        rx.list(
            rx.list_item(f"accentColor: {rx.theme.accent_color(4)}"),
            rx.list_item(f"grayColor: {rx.theme.gray_color(4)}"),
            rx.list_item(f"panelBackground: {rx.theme.panel_background}"),
            rx.list_item(f"scaling: {rx.theme.scaling}"),
            rx.list_item(f"radius: {rx.theme.radius}"),
        ),
        rdxt.button("Click me!", variant="soft"),
        rdxt.button("I'm Gray 🌈!", color="gray"),
        rdxt.text_field(),
        rdxt.box(
            "Foo",
            rdxt.box(
                "Bar",
                background_color="var(--color-panel)",
                **rx.theme.size(2),
            ),
            color=rx.theme.accent_color(rx.theme.Scale.HIGH_CONTRAST_TEXT),
            background_color=rx.theme.accent_color(rx.theme.Scale.SOLID_BACKGROUNDS),
            **rx.theme.size(3),
        ),
    )


# Add state and page to the app.
app = rx.App(radix_theme={"accentColor": "grass"}, overlay_component=None)
app.add_page(index)
app.compile()
```