### PR TITLE
Added conditional rendering func to compile workflow

### DIFF
--- a/reflex/compiler/compiler.py
+++ b/reflex/compiler/compiler.py
@@ -133,7 +133,9 @@ def _compile_conditional_rendering(template_obj: str) -> str:
     Returns:
         The template after relevant modifications
     """
-    pattern = re.compile(r'(<DataTableGrid[^>]*\/>)')
+    pattern = re.compile(
+        r'(<DataTableGrid[^>]*\bdata\s*=\s*\{\s*\[\s*\]\s*\}[^>]*\/>)'
+    )
     replacement = r'{ state.is_hydrated ? \1 : null }'
 
     template_obj = re.sub(pattern, replacement, template_obj)

--- a/reflex/compiler/compiler.py
+++ b/reflex/compiler/compiler.py
@@ -123,7 +123,16 @@ def _compile_page(
     template_obj = _compile_conditional_rendering(template_obj)
     return template_obj
 
-def _compile_conditional_rendering(template_obj: str):
+def _compile_conditional_rendering(template_obj: str) -> str:
+    """Update generated template to add required conditional rendering
+       for elements in the template
+
+    Args:
+        template_obj: Template to be modified
+
+    Returns:
+        The template after relevant modifications
+    """
     pattern = re.compile(r'(<DataTableGrid[^>]*\/>)')
     replacement = r'{ state.is_hydrated ? \1 : null }'
 

--- a/reflex/compiler/compiler.py
+++ b/reflex/compiler/compiler.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 from typing import Type
 
@@ -111,7 +112,7 @@ def _compile_page(
     imports = utils.compile_imports(imports)
 
     # Compile the code to render the component.
-    return templates.PAGE.render(
+    template_obj = templates.PAGE.render(
         imports=imports,
         dynamic_imports=component.get_dynamic_imports(),
         custom_codes=component.get_custom_code(),
@@ -119,6 +120,15 @@ def _compile_page(
         hooks=component.get_hooks(),
         render=component.render(),
     )
+    template_obj = _compile_conditional_rendering(template_obj)
+    return template_obj
+
+def _compile_conditional_rendering(template_obj: str):
+    pattern = re.compile(r'(<DataTableGrid[^>]*\/>)')
+    replacement = r'{ state.is_hydrated ? \1 : null }'
+
+    template_obj = re.sub(pattern, replacement, template_obj)
+    return template_obj
 
 
 def compile_root_stylesheet(stylesheets: list[str]) -> tuple[str, str]:


### PR DESCRIPTION
### All Submissions:

- [ x ] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [ x ] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

### Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)


### New Feature Submission:

- [ x ] Does your submission pass the tests? 
- [ x ] Have you linted your code locally prior to submission?


### Change Description
Per #1830, there is an issue with empty data table behavior wherein the table is sometimes rendered without the expected "No matching records found" message. From my research, this appears to be due to multiple re-renders of the component. As of 4f6b3c0, these re-renders can clearly be seen on page load, even if the no data message is ultimately displayed. These re-renders are due to the contexts associated with the component state that are included in the compiled pages. Namely:
```
const state = useContext(StateContext)
/* some other code... */
const [addEvents, connectError] = useContext(EventLoopContext)
```

Specifically, the re-renders are due to the _is\_hydrated_ property in the state being updated from _false_ to _true_. As a first-time contributor to this repo, I do not feel comfortable manipulating the state without understanding fully how its used. Therefore, this PR includes a new method used in the compile workflow to solve #1830. The method uses regex to check the compilation template after its first generated and adds conditional rendering logic to elements as required. Currently, the conditional rendering is only added to DataTableGrid elements if they have no data.


closes #1830 

