### PR TITLE
Add a placeholder timeout to GitHub Actions unit tests

### DIFF
--- a/.github/workflows/check_generated_pyi.yml
+++ b/.github/workflows/check_generated_pyi.yml
@@ -15,6 +15,7 @@ on:
 
 jobs:
   check-generated-pyi-components:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/integration_app_harness.yml
+++ b/.github/workflows/integration_app_harness.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   integration-app-harness:
+    timeout-minutes: 30
     strategy:
       matrix:
         state_manager: [ "redis", "memory" ]

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -28,6 +28,7 @@ env:
 
 jobs:
   example-counter:
+    timeout-minutes: 30
     strategy:
       # Prioritize getting more information out of the workflow (even if something fails)
       fail-fast: false

--- a/.github/workflows/integration_tests_wsl.yml
+++ b/.github/workflows/integration_tests_wsl.yml
@@ -18,6 +18,7 @@ env:
 
 jobs:
   example-counter-wsl:
+    timeout-minutes: 30
     # 2019 is more stable with WSL in GH actions
     # https://github.com/actions/runner-images/issues/5151
     # Confirmed through trial and error. 2022 has >80% failure rate (probably BSOD)

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   pre-commit:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/reflex_init_in_docker_test.yml
+++ b/.github/workflows/reflex_init_in_docker_test.yml
@@ -15,6 +15,7 @@ jobs:
   # TODO we can extend to various starting points (e.g. Ubuntu with node, without node, with unzip, without unzip, etc.)
   # Currently starting point is: Ubuntu + unzip, xz-utils, Python suite.  No node.
   reflex-install-and-init:
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -19,6 +19,7 @@ defaults:
 
 jobs:
   unit-tests:
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### All Submissions:

- [ x ] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [ x ] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?


### Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)


### Change Description

This PR is in response to #1893 . I have added a placeholder timeout of 30 minutes for the `unit-tests` job in [`unit_tests.yml`](https://github.com/reflex-dev/reflex/blob/main/.github/workflows/unit_tests.yml). 

This placeholder may need to be revised to a lower timeout value (i.e. 10 or 15 mins). I looked through the last few weeks of unit tests, with successful tests finishing around 5 minutes or less, but unsuccessful tests exceeding past 10 min. 

There are however [outliers](https://github.com/reflex-dev/reflex/actions/runs/5718350316/job/15493965383) where the unit test ran for over an hour and was still successful.

Edit: Placeholder timeout values were added to all workflows as requested. See [comment](https://github.com/reflex-dev/reflex/pull/1897#pullrequestreview-1651931042).

closes #1893 