### PR TITLE
state: subclass of MutableState must return _mark_dirty return value

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1853,7 +1853,7 @@ class ImmutableMutableProxy(MutableProxy):
     to modify the wrapped object when the StateProxy is immutable.
     """
 
-    def _mark_dirty(self, wrapped=None, instance=None, args=tuple(), kwargs=None):
+    def _mark_dirty(self, wrapped=None, instance=None, args=tuple(), kwargs=None) -> Any:
         """Raise an exception when an attempt is made to modify the object.
 
         Intended for use with `FunctionWrapper` from the `wrapt` library.
@@ -1864,6 +1864,9 @@ class ImmutableMutableProxy(MutableProxy):
             args: The args for the wrapped function.
             kwargs: The kwargs for the wrapped function.
 
+        Returns:
+            The result of the wrapped function.
+
         Raises:
             ImmutableStateError: if the StateProxy is not mutable.
         """
@@ -1872,6 +1875,6 @@ class ImmutableMutableProxy(MutableProxy):
                 "Background task StateProxy is immutable outside of a context "
                 "manager. Use `async with self` to modify state."
             )
-        super()._mark_dirty(
+        return super()._mark_dirty(
             wrapped=wrapped, instance=instance, args=args, kwargs=kwargs
         )

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1624,7 +1624,7 @@ class BackgroundTaskState(State):
     """A state with a background task."""
 
     order: List[str] = []
-    dict_list: Dict[str, List[int]] = {"foo": []}
+    dict_list: Dict[str, List[int]] = {"foo": [1, 2, 3]}
 
     @rx.background
     async def background_task(self):
@@ -1656,6 +1656,9 @@ class BackgroundTaskState(State):
                 pass  # update proxy instance
 
         async with self:
+            # Methods on ImmutableMutableProxy should return their wrapped return value.
+            assert self.dict_list.pop("foo") is not None
+
             self.order.append("background_task:stop")
             self.other()  # direct calling event handlers works in context
             self._private_method()


### PR DESCRIPTION
Some of the methods actually return useful values, like `pop`, so the return value must be passed through after marking dirty.

Previous fix https://github.com/reflex-dev/reflex/pull/1876 corrected this issue for normal event handlers using MutableProxy. This fix is needed for background tasks that use ImmutableMutableProxy.