### PR TITLE
allow external link for redirect

### DIFF
--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -114,7 +114,10 @@ export const getAllLocalStorageItems = () => {
 export const applyEvent = async (event, socket) => {
   // Handle special events
   if (event.name == "_redirect") {
-    Router.push(event.payload.path);
+    if (event.payload.external)
+      window.open(event.payload.path, "_blank");
+    else
+      Router.push(event.payload.path);
     return false;
   }
 
@@ -185,7 +188,7 @@ export const applyEvent = async (event, socket) => {
   if (event.name == "_call_script") {
     try {
       eval(event.payload.javascript_code);
-    } catch(e) {
+    } catch (e) {
       console.log("_call_script", e);
     }
     return false;

--- a/reflex/event.py
+++ b/reflex/event.py
@@ -247,16 +247,19 @@ def server_side(name: str, sig: inspect.Signature, **kwargs) -> EventSpec:
     )
 
 
-def redirect(path: str | Var[str]) -> EventSpec:
+def redirect(path: str | Var[str], external: Optional[bool] = False) -> EventSpec:
     """Redirect to a new path.
 
     Args:
         path: The path to redirect to.
+        external: Whether to open in new tab or not.
 
     Returns:
         An event to redirect to the path.
     """
-    return server_side("_redirect", get_fn_signature(redirect), path=path)
+    return server_side(
+        "_redirect", get_fn_signature(redirect), path=path, external=external
+    )
 
 
 def console_log(message: str | Var[str]) -> EventSpec:


### PR DESCRIPTION
Add external optional parameter in `rx.redirect` to handle opening external link in new tab.