### PR TITLE
test_state: assert popped value is the actual value

### DIFF
--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1658,7 +1658,7 @@ class BackgroundTaskState(State):
 
         async with self:
             # Methods on ImmutableMutableProxy should return their wrapped return value.
-            assert self.dict_list.pop("foo") is not None
+            assert self.dict_list.pop("foo") == [1, 2, 3]
 
             self.order.append("background_task:stop")
             self.other()  # direct calling event handlers works in context


### PR DESCRIPTION
improve the assertion from `is not None` to `== [1, 2, 3]` to catch any other potential issues

Follow up to #1898 -- test fix only