### PR TITLE
fix rx.image src not working with state

### DIFF
--- a/reflex/components/media/image.py
+++ b/reflex/components/media/image.py
@@ -76,7 +76,7 @@ class Image(ChakraComponent):
             The Image component.
         """
         src = props.get("src", None)
-        if src is not None and isinstance(src, str):
+        if src is not None and not isinstance(src, (Var)):
             props["src"] = Var.create(value=src, is_string=True)
         return super().create(*children, **props)
 

--- a/reflex/components/media/image.py
+++ b/reflex/components/media/image.py
@@ -7,7 +7,6 @@ from typing import Any, Optional, Union
 
 from reflex.components.component import Component
 from reflex.components.libs.chakra import ChakraComponent
-from reflex.components.tags import Tag
 from reflex.utils.serializers import serializer
 from reflex.vars import Var
 
@@ -65,11 +64,21 @@ class Image(ChakraComponent):
             "on_load": lambda: [],
         }
 
-    def _render(self) -> Tag:
-        self.src.is_string = True
+    @classmethod
+    def create(cls, *children, **props) -> Component:
+        """Create an Image component.
 
-        # Render the table.
-        return super()._render()
+        Args:
+            *children: The children of the image.
+            **props: The props of the image.
+
+        Returns:
+            The Image component.
+        """
+        src = props.get("src", None)
+        if src is not None and isinstance(src, str):
+            props["src"] = Var.create(value=src, is_string=True)
+        return super().create(*children, **props)
 
 
 try:

--- a/tests/components/media/test_image.py
+++ b/tests/components/media/test_image.py
@@ -34,7 +34,7 @@ try:
     def test_set_src_str():
         """Test that setting the src works."""
         image = rx.image(src="pic2.jpeg")
-        assert str(image.src) == "pic2.jpeg"  # type: ignore
+        assert str(image.src) == "{`pic2.jpeg`}"  # type: ignore
 
     def test_set_src_img(pil_image: Img):
         """Test that setting the src works.
@@ -43,7 +43,7 @@ try:
             pil_image: The image to serialize.
         """
         image = Image.create(src=pil_image)
-        assert str(image.src) == serialize_image(pil_image)  # type: ignore
+        assert str(image.src.name) == serialize_image(pil_image)  # type: ignore
 
     def test_render(pil_image: Img):
         """Test that rendering an image works.
@@ -52,8 +52,6 @@ try:
             pil_image: The image to serialize.
         """
         image = Image.create(src=pil_image)
-        assert not image.src.is_string  # type: ignore
-        image._render()
         assert image.src.is_string  # type: ignore
 
 except ImportError:


### PR DESCRIPTION
Serialization update may have broken the `src` parameter of `rx.image` working with State var. (haven't checked if it worked before)

Now work with State var (PIL, absolute link or relative link) or raw values

Closes #1914 
