### PR TITLE
Warn when computed vars raise an exception

### DIFF
--- a/reflex/compiler/utils.py
+++ b/reflex/compiler/utils.py
@@ -24,7 +24,7 @@ from reflex.components.base import (
 from reflex.components.component import Component, ComponentStyle, CustomComponent
 from reflex.state import Cookie, LocalStorage, State
 from reflex.style import Style
-from reflex.utils import format, imports, path_ops
+from reflex.utils import console, format, imports, path_ops
 from reflex.vars import ImportVar
 
 # To re-export this function.
@@ -139,7 +139,10 @@ def compile_state(state: Type[State]) -> dict:
     """
     try:
         initial_state = state().dict()
-    except Exception:
+    except Exception as e:
+        console.warn(
+            f"Failed to compile initial state with computed vars, excluding them: {e}"
+        )
         initial_state = state().dict(include_computed=False)
     return format.format_state(initial_state)
 


### PR DESCRIPTION
This will help users understand why their computed vars are not iterable or are causing frontend errors.

Often this comes up when querying a database or making an API call, but missing some parameters when the app isn't actually running. Usually causes an issue, for example, when a computed var is expected to be iterable (`list[str]`), but gets excluded from the state and thus is actually `undefined` on the frontend.