### PR TITLE
fix serialization as a whole for list/dict/Base containing custom items to serialize

### DIFF
--- a/reflex/base.py
+++ b/reflex/base.py
@@ -30,7 +30,9 @@ class Base(pydantic.BaseModel):
         Returns:
             The object as a json string.
         """
-        return self.__config__.json_dumps(self.dict(), default=list)
+        from reflex.utils.serializers import serialize
+
+        return self.__config__.json_dumps(self.dict(), default=serialize)
 
     def set(self, **kwargs):
         """Set multiple fields and return the object.

--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -588,7 +588,7 @@ def json_dumps(obj: Any) -> str:
     Returns:
         A string
     """
-    return json.dumps(obj, ensure_ascii=False, default=list)
+    return json.dumps(obj, ensure_ascii=False, default=serialize)
 
 
 def unwrap_vars(value: str) -> str:

--- a/reflex/utils/serializers.py
+++ b/reflex/utils/serializers.py
@@ -93,7 +93,7 @@ def get_serializer(type_: Type) -> Serializer | None:
         return serializer
 
     # If the type is not registered, check if it is a subclass of a registered type.
-    for registered_type, serializer in SERIALIZERS.items():
+    for registered_type, serializer in reversed(SERIALIZERS.items()):
         if types._issubclass(type_, registered_type):
             return serializer
 
@@ -127,16 +127,29 @@ def serialize_str(value: str) -> str:
 
 
 @serializer
-def serialize_primitive(value: Union[bool, int, float, Base, None]) -> str:
+def serialize_primitive(value: Union[bool, int, float, None]) -> str:
     """Serialize a primitive type.
 
     Args:
-        value: The number to serialize.
+        value: The number/bool/None to serialize.
 
     Returns:
-        The serialized number.
+        The serialized number/bool/None.
     """
     return format.json_dumps(value)
+
+
+@serializer
+def serialize_base(value: Base) -> str:
+    """Serialize a Base instance.
+
+    Args:
+        value : The Base to serialize.
+
+    Returns:
+        The serialized Base.
+    """
+    return value.json()
 
 
 @serializer

--- a/tests/utils/test_format.py
+++ b/tests/utils/test_format.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import Any
 
 import pytest
@@ -572,6 +573,14 @@ def test_format_library_name(input: str, output: str):
         ([1, 2, 3], "[1, 2, 3]"),
         ({}, "{}"),
         ({"k1": False, "k2": True}, '{"k1": false, "k2": true}'),
+        (
+            [datetime.timedelta(1, 1, 1), datetime.timedelta(1, 1, 2)],
+            '["1 day, 0:00:01.000001", "1 day, 0:00:01.000002"]',
+        ),
+        (
+            {"key1": datetime.timedelta(1, 1, 1), "key2": datetime.timedelta(1, 1, 2)},
+            '{"key1": "1 day, 0:00:01.000001", "key2": "1 day, 0:00:01.000002"}',
+        ),
     ],
 )
 def test_json_dumps(input, output):

--- a/tests/utils/test_serializers.py
+++ b/tests/utils/test_serializers.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Type
 
 import pytest
 
+from reflex.base import Base
 from reflex.utils import serializers
 from reflex.vars import Var
 
@@ -101,7 +102,7 @@ class TestEnum(str, Enum):
     BAR = "bar"
 
 
-class TestEnum2(str, Enum):
+class TestEnum2(Enum):
     """TestEnum2."""
 
     FOO = "foo"
@@ -111,6 +112,12 @@ class TestEnum2(str, Enum):
 @serializers.serializer
 def serialize_TestEnum2(enum: TestEnum2) -> str:
     return "prefix_" + enum.value
+
+
+class TestBase(Base):
+    """A class inheriting from Base for testing."""
+
+    ts: datetime.timedelta = datetime.timedelta(1, 1, 1)
 
 
 @pytest.mark.parametrize(
@@ -137,6 +144,7 @@ def serialize_TestEnum2(enum: TestEnum2) -> str:
             {"key1": TestEnum2.FOO, "key2": TestEnum2.BAR},
             '{"key1": "prefix_foo", "key2": "prefix_bar"}',
         ),
+        (TestBase(ts=datetime.timedelta(1, 1, 1)), '{"ts": "1 day, 0:00:01.000001"}'),
         (
             [1, Var.create_safe("hi"), Var.create_safe("bye", is_local=False)],
             '[1, "hi", bye]',
@@ -154,6 +162,10 @@ def serialize_TestEnum2(enum: TestEnum2) -> str:
         (datetime.date(2021, 1, 1), "2021-01-01"),
         (datetime.time(1, 1, 1, 1), "01:01:01.000001"),
         (datetime.timedelta(1, 1, 1), "1 day, 0:00:01.000001"),
+        (
+            [datetime.timedelta(1, 1, 1), datetime.timedelta(1, 1, 2)],
+            '["1 day, 0:00:01.000001", "1 day, 0:00:01.000002"]',
+        ),
     ],
 )
 def test_serialize(value: Any, expected: str):

--- a/tests/utils/test_serializers.py
+++ b/tests/utils/test_serializers.py
@@ -95,26 +95,26 @@ def test_add_serializer():
     assert not serializers.has_serializer(Foo)
 
 
-class TestEnum(str, Enum):
-    """TestEnum."""
+class StrEnum(str, Enum):
+    """An enum also inheriting from str."""
 
     FOO = "foo"
     BAR = "bar"
 
 
-class TestEnum2(Enum):
-    """TestEnum2."""
+class EnumWithPrefix(Enum):
+    """An enum with a serializer adding a prefix."""
 
     FOO = "foo"
     BAR = "bar"
 
 
 @serializers.serializer
-def serialize_TestEnum2(enum: TestEnum2) -> str:
+def serialize_EnumWithPrefix(enum: EnumWithPrefix) -> str:
     return "prefix_" + enum.value
 
 
-class TestBase(Base):
+class BaseSubclass(Base):
     """A class inheriting from Base for testing."""
 
     ts: datetime.timedelta = datetime.timedelta(1, 1, 1)
@@ -132,19 +132,22 @@ class TestBase(Base):
         ([1, 2, 3], "[1, 2, 3]"),
         ([1, "2", 3.0], '[1, "2", 3.0]'),
         ([{"key": 1}, {"key": 2}], '[{"key": 1}, {"key": 2}]'),
-        (TestEnum.FOO, "foo"),
-        ([TestEnum.FOO, TestEnum.BAR], '["foo", "bar"]'),
+        (StrEnum.FOO, "foo"),
+        ([StrEnum.FOO, StrEnum.BAR], '["foo", "bar"]'),
         (
-            {"key1": [1, 2, 3], "key2": [TestEnum.FOO, TestEnum.BAR]},
+            {"key1": [1, 2, 3], "key2": [StrEnum.FOO, StrEnum.BAR]},
             '{"key1": [1, 2, 3], "key2": ["foo", "bar"]}',
         ),
-        (TestEnum2.FOO, "prefix_foo"),
-        ([TestEnum2.FOO, TestEnum2.BAR], '["prefix_foo", "prefix_bar"]'),
+        (EnumWithPrefix.FOO, "prefix_foo"),
+        ([EnumWithPrefix.FOO, EnumWithPrefix.BAR], '["prefix_foo", "prefix_bar"]'),
         (
-            {"key1": TestEnum2.FOO, "key2": TestEnum2.BAR},
+            {"key1": EnumWithPrefix.FOO, "key2": EnumWithPrefix.BAR},
             '{"key1": "prefix_foo", "key2": "prefix_bar"}',
         ),
-        (TestBase(ts=datetime.timedelta(1, 1, 1)), '{"ts": "1 day, 0:00:01.000001"}'),
+        (
+            BaseSubclass(ts=datetime.timedelta(1, 1, 1)),
+            '{"ts": "1 day, 0:00:01.000001"}',
+        ),
         (
             [1, Var.create_safe("hi"), Var.create_safe("bye", is_local=False)],
             '[1, "hi", bye]',


### PR DESCRIPTION
Improve the serialization logic to handle the case where we want to serialize a list of custom objects.

Before PR, a datetime can be serialized,  but not a list of datetime or a dict containing datetime as value.
After PR, they can all be serialized.

Include the changes suggested by @ElijahAhianyo in #1977.

Closes #1976 