### PR TITLE
Stop double compiles in dev mode

### DIFF
--- a/reflex/app.py
+++ b/reflex/app.py
@@ -594,9 +594,9 @@ class App(Base):
             return False
 
         # Check the nocompile file.
-        if os.path.exists(constants.compiler.NOCOMPILE_FILE):
+        if os.path.exists(constants.NOCOMPILE_FILE):
             # Delete the nocompile file
-            os.remove(constants.compiler.NOCOMPILE_FILE)
+            os.remove(constants.NOCOMPILE_FILE)
             return False
 
         # By default, compile the app.

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -583,10 +583,30 @@ class App(Base):
             parent = child
         return root
 
+    def _should_compile(self) -> bool:
+        """Check if the app should be compiled.
+
+        Returns:
+            Whether the app should be compiled.
+        """
+        # Check the environment variable.
+        if os.environ.get(constants.SKIP_COMPILE_ENV_VAR) == "yes":
+            return False
+
+        # Check the nocompile file.
+        if os.path.exists(constants.compiler.NOCOMPILE_FILE):
+            # Delete the nocompile file
+            os.remove(constants.compiler.NOCOMPILE_FILE)
+            return False
+
+        # By default, compile the app.
+        return True
+
     def compile(self):
         """Compile the app and output it to the pages folder."""
-        if os.environ.get(constants.SKIP_COMPILE_ENV_VAR) == "yes":
+        if not self._should_compile():
             return
+
         # Create a progress bar.
         progress = Progress(
             *Progress.get_default_columns()[:-1],

--- a/reflex/constants/__init__.py
+++ b/reflex/constants/__init__.py
@@ -17,6 +17,7 @@ from .base import (
     Templates,
 )
 from .compiler import (
+    NOCOMPILE_FILE,
     SETTER_PREFIX,
     CompileVars,
     ComponentName,
@@ -70,6 +71,7 @@ __ALL__ = [
     LogLevel,
     Next,
     Node,
+    NOCOMPILE_FILE,
     PackageJson,
     PageNames,
     Page404,

--- a/reflex/constants/compiler.py
+++ b/reflex/constants/compiler.py
@@ -5,6 +5,9 @@ from types import SimpleNamespace
 # The prefix used to create setters for state vars.
 SETTER_PREFIX = "set_"
 
+# The file used to specify no compilation.
+NOCOMPILE_FILE = ".web/nocompile"
+
 
 class Ext(SimpleNamespace):
     """Extension used in Reflex."""

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -156,8 +156,8 @@ def run_backend(
     app_module = f"{config.app_name}.{config.app_name}:{constants.CompileVars.APP}"
 
     # Create a .nocompile file to skip compile for backend.
-    if os.path.exists(constants.base.Dirs.WEB):
-        with open(constants.compiler.NOCOMPILE_FILE, "w"):
+    if os.path.exists(constants.Dirs.WEB):
+        with open(constants.NOCOMPILE_FILE, "w"):
             pass
 
     # Run the backend in development mode.

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -154,6 +154,13 @@ def run_backend(
     """
     config = get_config()
     app_module = f"{config.app_name}.{config.app_name}:{constants.CompileVars.APP}"
+
+    # Create a .nocompile file to skip compile for backend.
+    if os.path.exists(constants.base.Dirs.WEB):
+        with open(constants.compiler.NOCOMPILE_FILE, "w"):
+            pass
+
+    # Run the backend in development mode.
     uvicorn.run(
         app=f"{app_module}.{constants.CompileVars.API}",
         host=host,


### PR DESCRIPTION
Create a `.web/.nocompile` function that stops the first initial compile on the backend process in dev mode. After the first skip, the file is deleted, enabling hot reload to keep working.