### PR TITLE
Resolve npm path and fnm path on Windows

### DIFF
--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -83,7 +83,7 @@ def get_install_package_manager() -> str | None:
     """
     # On Windows, we use npm instead of bun.
     if constants.IS_WINDOWS:
-        return path_ops.get_npm_path()
+        return get_package_manager()
 
     # On other platforms, we use bun.
     return get_config().bun_path
@@ -96,7 +96,10 @@ def get_package_manager() -> str | None:
     Returns:
         The path to the package manager.
     """
-    return path_ops.get_npm_path()
+    npm_path = path_ops.get_npm_path()
+    if npm_path is not None:
+        npm_path = str(Path(npm_path).resolve())
+    return npm_path
 
 
 def get_app(reload: bool = False) -> ModuleType:
@@ -411,11 +414,13 @@ def install_node():
 
     if constants.IS_WINDOWS:
         # Install node
+        fnm_exe = Path(constants.Fnm.EXE).resolve()
+        fnm_dir = Path(constants.Fnm.DIR).resolve()
         process = processes.new_process(
             [
                 "powershell",
                 "-Command",
-                f'& "{constants.Fnm.EXE}" install {constants.Node.VERSION} --fnm-dir "{constants.Fnm.DIR}"',
+                f'& "{fnm_exe}" install {constants.Node.VERSION} --fnm-dir "{fnm_dir}"',
             ],
         )
     else:  # All other platforms (Linux, MacOS).


### PR DESCRIPTION
Microsoft App Store versions of python use a sandboxing technique that causes AppData to point to a per-app location via link. However shelling out to powershell or cmd does not seem to respect the sandbox links, so to access the actual files that were installed, we must explicitly `.resolve()` the paths before formatting them into command lines.

From https://discord.com/channels/1029853095527727165/1164954271737970769/1164954280483115028

## Test it out

```
pip install git+https://github.com/reflex-dev/reflex@masenf/microsoft-store-python
```