### PR TITLE
[Experimental] component as props for IconButton

### DIFF
--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -20,6 +20,7 @@ from reflex.event import (
 )
 from reflex.style import Style
 from reflex.utils import console, format, imports, types
+from reflex.utils.serializers import serializer
 from reflex.vars import BaseVar, ImportVar, Var
 
 
@@ -966,3 +967,17 @@ class NoSSRComponent(Component):
             else ""
         )
         return "".join((library_import, mod_import, opts_fragment))
+
+
+# We need to define it here instead of inside serializers.py to avoid circular import.
+@serializer
+def serialize_component(comp: Component):
+    """Serialize a component.
+
+    Args:
+        comp: The component to serialize.
+
+    Returns:
+        The serialized component.
+    """
+    return str(comp)

--- a/reflex/components/forms/iconbutton.py
+++ b/reflex/components/forms/iconbutton.py
@@ -1,6 +1,8 @@
 """An icon button component."""
 
+from reflex.components.component import Component
 from reflex.components.typography.text import Text
+from reflex.utils import imports
 from reflex.vars import Var
 
 
@@ -16,7 +18,7 @@ class IconButton(Text):
     aria_label: Var[str]
 
     # The icon to be used in the button.
-    icon: Var[str]
+    icon: Var[Component]
 
     # If true, the button will be styled in its active state.
     is_active: Var[bool]
@@ -32,3 +34,36 @@ class IconButton(Text):
 
     # Replace the spinner component when isLoading is set to true
     spinner: Var[str]
+
+    _props_import = {}
+
+    def _get_imports(self) -> imports.ImportDict:
+        return imports.merge_imports(
+            super()._get_imports(),
+            self._props_import,
+        )
+
+    @classmethod
+    def create(cls, *children, **props):
+        """Create an IconButton component.
+
+        Args:
+            *children: The children of the component.
+            **props: The props of the component.
+
+        Raises:
+            ValueError: Raise an error if invalid value is provided.
+
+        Returns:
+            The IconButton component.
+        """
+        comp = super().create(*children, **props)
+        if "icon" in props:
+            icon = props.get("icon")
+            if isinstance(icon, Component):
+                comp._props_import = icon._get_imports()
+            else:
+                raise ValueError(
+                    "The `icon` props only accept statically defined Components, not State vars."
+                )
+        return comp


### PR DESCRIPTION
Only accept static component because we still need to define the imports during compilation time.

```python
rx.icon_button(icon=rx.icon(tag="add"))
```