### PR TITLE
Improve Event handler Error message

### DIFF
--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -268,8 +268,8 @@ class Component(Base, ABC):
                         event = call_event_handler(v, arg_spec)  # type: ignore
                     except ValueError as err:
                         raise ValueError(
-                            str(err) + f" defined in the `{type(self).__name__}` component"
-                        )
+                            f" {str(err)} defined in the `{type(self).__name__}` component"
+                        ) from err
 
                     # Add the event to the chain.
                     events.append(event)

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -268,7 +268,7 @@ class Component(Base, ABC):
                         event = call_event_handler(v, arg_spec)  # type: ignore
                     except ValueError as err:
                         raise ValueError(
-                            f" {str(err)} defined in the `{type(self).__name__}` component"
+                            f" {err} defined in the `{type(self).__name__}` component"
                         ) from err
 
                     # Add the event to the chain.

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -264,7 +264,12 @@ class Component(Base, ABC):
             for v in value:
                 if isinstance(v, EventHandler):
                     # Call the event handler to get the event.
-                    event = call_event_handler(v, arg_spec)  # type: ignore
+                    try:
+                        event = call_event_handler(v, arg_spec)  # type: ignore
+                    except ValueError as err:
+                        raise ValueError(
+                            str(err) + f" defined in the `{type(self).__name__}` component"
+                        )
 
                     # Add the event to the chain.
                     events.append(event)

--- a/reflex/event.py
+++ b/reflex/event.py
@@ -479,8 +479,8 @@ def call_event_handler(
         else:
             source = inspect.getsource(arg_spec)  # type: ignore
             raise ValueError(
-                f"number of arguments in {event_handler.fn.__name__} "
-                f"doesn't match the definition '{source.strip().strip(',')}'"
+                f"number of arguments in {event_handler.fn.__qualname__} "
+                f"doesn't match the definition of the event trigger '{source.strip().strip(',')}'"
             )
     else:
         console.deprecate(


### PR DESCRIPTION
When the number of arguments of an event handler is not the same as that of when its been invoked, we throw an error which doesn't easily tell where the issue is from. We can use `__qualname__` to get a more accurate path and propagate the error to the component class level to tell what component has triggered the said error