### PR TITLE
Radix Themes style notation fix

### DIFF
--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -456,6 +456,14 @@ class Component(Base, ABC):
             child.add_style(style)
         return self
 
+    def _get_style(self) -> dict:
+        """Get the style for the component.
+
+        Returns:
+            The dictionary of the component style as value and the style notation as key.
+        """
+        return {"sx": self.style}
+
     def render(self) -> Dict:
         """Render the component.
 
@@ -467,10 +475,10 @@ class Component(Base, ABC):
             tag.add_props(
                 **self.event_triggers,
                 key=self.key,
-                sx=self.style,
                 id=self.id,
                 class_name=self.class_name,
                 **self.custom_attrs,
+                **self._get_style(),
             ).set(
                 children=[child.render() for child in self.children],
                 contents=str(tag.contents),

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -477,8 +477,8 @@ class Component(Base, ABC):
                 key=self.key,
                 id=self.id,
                 class_name=self.class_name,
-                **self.custom_attrs,
                 **self._get_style(),
+                **self.custom_attrs,
             ).set(
                 children=[child.render() for child in self.children],
                 contents=str(tag.contents),

--- a/reflex/components/radix/themes/base.py
+++ b/reflex/components/radix/themes/base.py
@@ -65,6 +65,9 @@ class RadixThemesComponent(Component):
             (45, "RadixThemesColorModeProvider"): RadixThemesColorModeProvider.create(),
         }
 
+    def _get_style(self) -> dict:
+        return {"style": self.style}
+
 
 class Theme(RadixThemesComponent):
     """A theme provider for radix components.


### PR DESCRIPTION
Fix for a bug where `sx`  is used for radix style props instead of `style`