### PR TITLE
CLI improvements

### DIFF
--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -442,7 +442,7 @@ def deploy(
     envs: List[str] = typer.Option(
         list(),
         "--env",
-        help="The environment variables to set: <key>=<value>. For multiple envs, repeat this option followed by the env name.",
+        help="The environment variables to set: <key>=<value>. For multiple envs, repeat this option, e.g. --env k1=v2 --env k2=v2.",
     ),
     cpus: Optional[int] = typer.Option(
         None, help="The number of CPUs to allocate.", hidden=True

--- a/reflex/utils/build.py
+++ b/reflex/utils/build.py
@@ -60,7 +60,7 @@ def _zip(
     target: str,
     root_dir: str,
     exclude_venv_dirs: bool,
-    exclude_sqlite_db_files: bool = True,
+    upload_db_file: bool = False,
     dirs_to_exclude: set[str] | None = None,
     files_to_exclude: set[str] | None = None,
 ) -> None:
@@ -71,7 +71,7 @@ def _zip(
         target: The target zip file.
         root_dir: The root directory to zip.
         exclude_venv_dirs: Whether to exclude venv directories.
-        exclude_sqlite_db_files: Whether to exclude sqlite db files.
+        upload_db_file: Whether to include local sqlite db files.
         dirs_to_exclude: The directories to exclude.
         files_to_exclude: The files to exclude.
 
@@ -97,8 +97,7 @@ def _zip(
         files[:] = [
             f
             for f in files
-            if not f.startswith(".")
-            and (not exclude_sqlite_db_files or not f.endswith(".db"))
+            if not f.startswith(".") and (upload_db_file or not f.endswith(".db"))
         ]
         files_to_zip += [
             os.path.join(root, file) for file in files if file not in files_to_exclude
@@ -127,7 +126,7 @@ def export(
     zip: bool = False,
     zip_dest_dir: str = os.getcwd(),
     deploy_url: str | None = None,
-    backend_exclude_sqlite_db_files: bool = True,
+    upload_db_file: bool = False,
 ):
     """Export the app for deployment.
 
@@ -137,7 +136,7 @@ def export(
         zip: Whether to zip the app.
         zip_dest_dir: The destination directory for created zip files (if any)
         deploy_url: The URL of the deployed app.
-        backend_exclude_sqlite_db_files: Whether to exclude sqlite db files from the backend zip.
+        upload_db_file: Whether to include local sqlite db files from the backend zip.
     """
     # Remove the static folder.
     path_ops.rm(constants.Dirs.WEB_STATIC)
@@ -196,7 +195,7 @@ def export(
                 dirs_to_exclude={"assets", "__pycache__"},
                 files_to_exclude=files_to_exclude,
                 exclude_venv_dirs=True,
-                exclude_sqlite_db_files=backend_exclude_sqlite_db_files,
+                upload_db_file=upload_db_file,
             )
 
 


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.
- Implements REF-996, REF-997.
- Do not show on `--help` the options not meant for public users for all hosting related commands.
```
>>>>> reflex deploy --help                                                                                                                                                                                                                                              
Usage: reflex deploy [OPTIONS]

  Deploy the app to the Reflex hosting service.

Options:
  -k, --deployment-key TEXT       The name of the deployment.
  -r, --region TEXT               The regions to deploy to.
  --env TEXT                      The environment variables to set:
                                  <key>=<value>. For multiple envs, repeat
                                  this option, e.g. --env k1=v2 --env k2=v2.
  --interactive / --no-interactive
                                  Whether to list configuration options and
                                  ask for confirmation.  [default:
                                  interactive]
  --loglevel [debug|info|warning|error|critical]
                                  The log level to use.  [default:
                                  LogLevel.INFO]
  --help                          Show this message and exit.
```
- Bug fix: the deploy command cleans up in a finally clause right after zip, causing the actual post to upload code to fail.
- Keep only `reflex deployments logs` command to show user logs.
- For file related errors, currently it resulted in internal errors for deploy command. Now changed to reraise OSError back to the user.