### PR TITLE
Remove .pyc and __pycache__ from template dir

### DIFF
--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -251,10 +251,17 @@ def initialize_app_directory(app_name: str, template: constants.Templates.Kind):
     console.log("Initializing the app directory.")
 
     # Copy the template to the current directory.
-    template_dir = os.path.join(constants.Templates.Dirs.BASE, "apps", template.value)
-    for file in os.listdir(template_dir):
-        # Copy the file but keep the name the same.
-        path_ops.cp(os.path.join(template_dir, file), file)
+    template_dir = Path(constants.Templates.Dirs.BASE, "apps", template.value)
+
+    # Remove all pyc and __pycache__ dirs in template directory.
+    for pyc_file in template_dir.glob("**/*.pyc"):
+        pyc_file.unlink()
+    for pycache_dir in template_dir.glob("**/__pycache__"):
+        pycache_dir.rmdir()
+
+    for file in template_dir.iterdir():
+        # Copy the file to current directory but keep the name the same.
+        path_ops.cp(str(file), file.name)
 
     # Rename the template app to the app name.
     path_ops.mv(constants.Templates.Dirs.CODE, app_name)
@@ -262,12 +269,6 @@ def initialize_app_directory(app_name: str, template: constants.Templates.Kind):
         os.path.join(app_name, template.value + constants.Ext.PY),
         os.path.join(app_name, app_name + constants.Ext.PY),
     )
-
-    # Remove all pyc and __pycache__ dirs in current directory.
-    for pyc_file in glob.glob("**/*.pyc", recursive=True):
-        os.remove(pyc_file)
-    for pycache_dir in glob.glob("**/__pycache__", recursive=True):
-        os.rmdir(pycache_dir)
 
     # Fix up the imports.
     path_ops.find_replace(

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -263,6 +263,12 @@ def initialize_app_directory(app_name: str, template: constants.Templates.Kind):
         os.path.join(app_name, app_name + constants.Ext.PY),
     )
 
+    # Remove all pyc and __pycache__ dirs in current directory.
+    for pyc_file in glob.glob("**/*.pyc", recursive=True):
+        os.remove(pyc_file)
+    for pycache_dir in glob.glob("**/__pycache__", recursive=True):
+        os.rmdir(pycache_dir)
+
     # Fix up the imports.
     path_ops.find_replace(
         app_name,


### PR DESCRIPTION
Since the .py files are having imports rewritten anyway, these bytecode cache files are not helpful and will have to be regenerated. Explicitly deleting them avoids hitting an exception attempting to read them as utf-8 text.