### PR TITLE
base template: read README as utf-8

### DIFF
--- a/reflex/.templates/apps/base/code/pages/index.py
+++ b/reflex/.templates/apps/base/code/pages/index.py
@@ -13,6 +13,6 @@ def index() -> rx.Component:
     Returns:
         The UI for the home page.
     """
-    with open("README.md") as readme:
+    with open("README.md", encoding="utf-8") as readme:
         content = readme.read()
     return rx.markdown(content, component_map=styles.markdown_style)


### PR DESCRIPTION
On windows, the default encoding is something else and it ends up rendering the page with ugly characters on it.

Reported on discord: https://discord.com/channels/1029853095527727165/1061874061250150441/1167586252736966777