### PR TITLE
Expose gunicorn_worker_class via Config

### DIFF
--- a/reflex/config.py
+++ b/reflex/config.py
@@ -198,6 +198,9 @@ class Config(Base):
     # The username.
     username: Optional[str] = None
 
+    # The worker class used in production mode
+    gunicorn_worker_class: str = "uvicorn.workers.UvicornH11Worker"
+
     # Attributes that were explicitly set by the user.
     _non_default_attributes: Set[str] = pydantic.PrivateAttr(set())
 

--- a/reflex/config.pyi
+++ b/reflex/config.pyi
@@ -69,6 +69,7 @@ class Config(Base):
     cp_backend_url: str
     cp_web_url: str
     username: Optional[str]
+    gunicorn_worker_class: str
 
     def __init__(
         self,
@@ -95,6 +96,7 @@ class Config(Base):
         cp_backend_url: Optional[str] = None,
         cp_web_url: Optional[str] = None,
         username: Optional[str] = None,
+        gunicorn_worker_class: Optional[str] = None,
         **kwargs
     ) -> None: ...
     @staticmethod

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -185,7 +185,7 @@ def run_backend_prod(
     """
     num_workers = processes.get_num_workers()
     config = get_config()
-    RUN_BACKEND_PROD = f"gunicorn --worker-class uvicorn.workers.UvicornH11Worker --preload --timeout {config.timeout} --log-level critical".split()
+    RUN_BACKEND_PROD = f"gunicorn --worker-class {config.gunicorn_worker_class} --preload --timeout {config.timeout} --log-level critical".split()
     RUN_BACKEND_PROD_WINDOWS = f"uvicorn --timeout-keep-alive {config.timeout}".split()
     app_module = f"{config.app_name}.{config.app_name}:{constants.CompileVars.APP}"
     command = (


### PR DESCRIPTION
Rather than plumbing through every possible uvicorn parameter that users might need in production, expose the gunicorn_worker_class in the config, which allows downstream code to completely control the worker configuration as needed.

Most users will not need to set this knob, but the moment one needs to tweak websocket protocol flags, timeout values, or the wealth of uvicorn config knobs for tweaking, then it's straightforward to override the worker class and apply these behavior changes.

Fix #2070