### PR TITLE
Hosting CLI: use http endpoint to return deploy milestones

### DIFF
--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -669,9 +669,10 @@ def deploy(
 
     console.print("Waiting for server to report progress ...")
     # Display the key events such as build, deploy, etc
-    server_report_deploy_success = asyncio.get_event_loop().run_until_complete(
-        hosting.display_deploy_milestones(key, from_iso_timestamp=deploy_requested_at)
+    server_report_deploy_success = hosting.poll_deploy_milestones(
+        key, from_iso_timestamp=deploy_requested_at
     )
+
     if not server_report_deploy_success:
         console.error("Hosting server reports failure.")
         console.error(
@@ -797,7 +798,7 @@ def get_deployment_status(
         status = hosting.get_deployment_status(key)
 
         # TODO: refactor all these tabulate calls
-        status.backend.updated_at = hosting.convert_to_local_time(
+        status.backend.updated_at = hosting.convert_to_local_time_str(
             status.backend.updated_at or "N/A"
         )
         backend_status = status.backend.dict(exclude_none=True)
@@ -806,7 +807,7 @@ def get_deployment_status(
         console.print(tabulate([table], headers=headers))
         # Add a new line in console
         console.print("\n")
-        status.frontend.updated_at = hosting.convert_to_local_time(
+        status.frontend.updated_at = hosting.convert_to_local_time_str(
             status.frontend.updated_at or "N/A"
         )
         frontend_status = status.frontend.dict(exclude_none=True)

--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -673,7 +673,10 @@ def deploy(
         key, from_iso_timestamp=deploy_requested_at
     )
 
-    if not server_report_deploy_success:
+    if server_report_deploy_success is None:
+        console.warn("Hosting server timed out.")
+        console.warn("The deployment may still be in progress. Proceeding ...")
+    elif not server_report_deploy_success:
         console.error("Hosting server reports failure.")
         console.error(
             f"Check the server logs using `reflex deployments build-logs {key}`"

--- a/reflex/utils/hosting.py
+++ b/reflex/utils/hosting.py
@@ -1025,7 +1025,7 @@ def log_out_on_browser():
         )
 
 
-def poll_deploy_milestones(key: str, from_iso_timestamp: datetime) -> bool:
+def poll_deploy_milestones(key: str, from_iso_timestamp: datetime) -> bool | None:
     """Periodically poll the hosting server for deploy milestones.
 
     Args:
@@ -1037,7 +1037,7 @@ def poll_deploy_milestones(key: str, from_iso_timestamp: datetime) -> bool:
         Exception: If the user is not authenticated.
 
     Returns:
-        False if server reports back failure, True otherwise.
+        False if server reports back failure, True otherwise. None if do not receive the end of deployment message.
     """
     if not key:
         raise ValueError("Non-empty key is required for querying deploy status.")
@@ -1096,8 +1096,6 @@ def poll_deploy_milestones(key: str, from_iso_timestamp: datetime) -> bool:
             console.debug(f"Unable to get more deployment events due to {he}.")
         except Exception as ex:
             console.warn(f"Unable to parse server response due to {ex}.")
-
-    return False
 
 
 async def display_deploy_milestones(key: str, from_iso_timestamp: datetime) -> bool:

--- a/reflex/utils/hosting.py
+++ b/reflex/utils/hosting.py
@@ -48,7 +48,7 @@ DEPLOYMENT_PICKUP_DELAY = 30
 # End of deployment workflow message. Used to determine if it is the last message from server.
 END_OF_DEPLOYMENT_MESSAGES = ["deploy success"]
 # How many iterations to try and print the deployment event messages from server during deployment.
-DEPLOYMENT_EVENT_MESSAGES_RETRIES = 90
+DEPLOYMENT_EVENT_MESSAGES_RETRIES = 120
 # Timeout limit for http requests
 HTTP_REQUEST_TIMEOUT = 60  # seconds
 

--- a/tests/test_reflex.py
+++ b/tests/test_reflex.py
@@ -118,7 +118,7 @@ def test_deploy_non_interactive_success(
         ),
     )
     mocker.patch("reflex.utils.hosting.wait_for_server_to_pick_up_request")
-    mocker.patch("reflex.utils.hosting.display_deploy_milestones")
+    mocker.patch("reflex.utils.hosting.poll_deploy_milestones")
     mocker.patch("reflex.utils.hosting.poll_backend", return_value=True)
     mocker.patch("reflex.utils.hosting.poll_frontend", return_value=True)
     # TODO: typer option default not working in test for app name
@@ -351,7 +351,7 @@ def test_deploy_interactive(
         ),
     )
     mocker.patch("reflex.utils.hosting.wait_for_server_to_pick_up_request")
-    mocker.patch("reflex.utils.hosting.display_deploy_milestones")
+    mocker.patch("reflex.utils.hosting.poll_deploy_milestones")
     mocker.patch("reflex.utils.hosting.poll_backend", return_value=True)
     mocker.patch("reflex.utils.hosting.poll_frontend", return_value=True)
 


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.
- For users with less ideal internet conditions, it's possible the websocket streaming deploy milestones get disconnected. There was no retry mechanism. Instead, hosting service adds an equivalent endpoint to query these events once. CLI can query this endpoint peridiocally.