### PR TITLE
rx.background: make yield after async with self optional

### DIFF
--- a/reflex/event.py
+++ b/reflex/event.py
@@ -58,12 +58,19 @@ def background(
     Returns:
         The function with a marker set and optionally rewritten to include `yield`.
     """
+    locals = None
+    current_frame = inspect.currentframe()
+    if current_frame is not None and current_frame.f_back is not None:
+        locals = current_frame.f_back.f_locals
 
     def _decorator(fn: Callable) -> Callable:
         if not inspect.iscoroutinefunction(fn) and not inspect.isasyncgenfunction(fn):
             raise TypeError("Background task must be async function or generator.")
         if automatic_yield_after_modifications:
-            fn = rewrites.add_yield_after_async_with_self(fn)
+            fn = rewrites.add_yield_after_async_with_self(
+                fn,
+                locals=locals,
+            )
         setattr(fn, BACKGROUND_TASK_MARKER, True)
         return fn
 

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1288,7 +1288,7 @@ class StateProxy(wrapt.ObjectProxy):
         Returns:
             This StateProxy instance in mutable mode.
         """
-        self._self_actx = self._self_app.modify_state(
+        self._self_actx = self._self_app.state_manager.modify_state(
             self.__wrapped__.router.session.client_token
         )
         mutable_state = await self._self_actx.__aenter__()
@@ -1598,6 +1598,8 @@ class StateManagerRedis(StateManager):
         """
         async with self._lock(token) as lock_id:
             state = await self.get_state(token)
+            # no dirty vars for freshly loaded state
+            state._clean()
             yield state
             await self.set_state(token, state, lock_id)
 

--- a/reflex/utils/rewrites.py
+++ b/reflex/utils/rewrites.py
@@ -1,0 +1,124 @@
+"""Utilities for transforming and rewriting Reflex code.
+
+This module is used internally by Reflex to rewrite user code
+where needed to better support the Reflex programming model.
+
+Please watch out for Black Magic.
+"""
+from __future__ import annotations
+
+import ast
+import hashlib
+import inspect
+import linecache
+import textwrap
+from typing import Any, Callable
+
+
+def replace_function_code(
+    fn: Callable,
+    new_source_code: str,
+    filename_prefix: str = "reflex_rewrites",
+) -> Callable:
+    """Compile the new source code and replace the function's code object.
+
+    The source code will be inserted into `linecache` so that stack traces,
+    and other debugging tools will show the source correctly.
+
+    Args:
+        fn: The function to replace the code of.
+        new_source_code: The new source code to use.
+        filename_prefix: The prefix to use for the filename in `linecache`.
+
+    Returns:
+        The function with the new source code.
+    """
+    source_hash = hashlib.md5(new_source_code.encode()).hexdigest()
+    filename = f"<{filename_prefix}_{source_hash}>"
+    linecache.cache[filename] = (
+        len(new_source_code),
+        None,
+        new_source_code.splitlines(keepends=True),
+        filename,
+    )
+    gl = {}
+    exec(compile(new_source_code, filename, "exec"), gl)
+    fn.__code__ = gl[fn.__name__].__code__
+    return fn
+
+
+class AddYieldAfterAsyncWithSelf(ast.NodeTransformer):
+    """Transform the AST to add a `yield` statement after every `async with self:` block."""
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> Any:
+        """Remove the @rx.background decorator.
+
+        Because this transformation is applied from the @rx.background decorator, we
+        need to strip it off so that it's not applied multiple times.
+
+        Args:
+            node: The node to visit.
+
+        Returns:
+            The node with the decorator removed.
+        """
+        self.generic_visit(node)
+        # remove the background task decorator
+        for dec in node.decorator_list:
+            if isinstance(dec, ast.Attribute) and dec.attr == "background":
+                node.decorator_list.remove(dec)
+                return node
+
+    def generic_visit(self, node: ast.AST) -> ast.AST:
+        """Add a `yield` statement after every `async with self:` block.
+
+        Visit all nodes with a `body` and add a `yield` statement after every
+        `async with self:` block.
+
+        Args:
+            node: The node to visit.
+
+        Returns:
+            The node with the `yield` statements added.
+        """
+        super().generic_visit(node)
+        body: list[ast.stmt] | None = getattr(node, "body", None)
+        if body is None:
+            return node
+        insert_yield_at = []
+        for ix, child in enumerate(body):
+            if (
+                isinstance(child, ast.AsyncWith)
+                and child.items
+                and isinstance(child.items[0].context_expr, ast.Name)
+                and child.items[0].context_expr.id == "self"
+            ):
+                insert_yield_at.append((ix + 1))
+        for added_so_far, ix in enumerate(insert_yield_at):
+            next_ix = added_so_far + ix
+            if (
+                next_ix < len(body)
+                and isinstance(body[next_ix], ast.Expr)
+                and isinstance(body[next_ix].value, ast.Yield)
+            ):
+                continue  # already has a yield here
+            body.insert(next_ix, ast.Expr(value=ast.Yield()))
+        return node
+
+
+def add_yield_after_async_with_self(fn: Callable) -> Callable:
+    """Add a `yield` statement after every `async with self:` block.
+
+    Rewrite the source code of `fn` to append a `yield` statement after every
+    `async with self:` block.
+
+    Args:
+        fn: The function to rewrite.
+
+    Returns:
+        The function with the `yield` statements added.
+    """
+    orig_src = textwrap.dedent(inspect.getsource(fn))
+    magic_fn_tree = AddYieldAfterAsyncWithSelf().visit(ast.parse(orig_src))
+    magic_fn_source = ast.unparse(magic_fn_tree)
+    return replace_function_code(fn, magic_fn_source)

--- a/reflex/utils/rewrites.py
+++ b/reflex/utils/rewrites.py
@@ -51,6 +51,8 @@ def replace_function_code(
 class AddYieldAfterAsyncWithSelf(ast.NodeTransformer):
     """Transform the AST to add a `yield` statement after every `async with self:` block."""
 
+    _REMOVE_DECORATOR = "background"
+
     def __init__(self):
         """Initialize the transformer."""
         super().__init__()
@@ -71,10 +73,17 @@ class AddYieldAfterAsyncWithSelf(ast.NodeTransformer):
         """
         # remove the background task decorator
         for dec in node.decorator_list:
-            if isinstance(dec, ast.Attribute) and dec.attr == "background":
+            if isinstance(dec, ast.Attribute) and dec.attr == self._REMOVE_DECORATOR:
                 node.decorator_list.remove(dec)
                 break
-            if isinstance(dec, ast.Name) and dec.id == "background":
+            if isinstance(dec, ast.Name) and dec.id == self._REMOVE_DECORATOR:
+                node.decorator_list.remove(dec)
+                break
+            if (
+                isinstance(dec, ast.Call)
+                and isinstance(dec.func, ast.Name)
+                and dec.func.id == self._REMOVE_DECORATOR
+            ):
                 node.decorator_list.remove(dec)
                 break
         for arg in node.args.args:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1724,6 +1724,7 @@ class BackgroundTaskState(State):
         async with self:
             pass
 
+    @rx.background
     async def background_task_no_generator2(self):
         """A background task that does not yield."""
         pass
@@ -1918,6 +1919,8 @@ async def test_background_task_no_chain():
         await bts.bad_chain1()
     with pytest.raises(RuntimeError):
         await bts.bad_chain2()
+    with pytest.raises(RuntimeError):
+        await bts.bad_chain3()
 
 
 def test_mutable_list(mutable_state):

--- a/tests/utils/test_rewrites.py
+++ b/tests/utils/test_rewrites.py
@@ -149,3 +149,30 @@ def test_background_decorator_multiple():
     assert inspect.getsource(fn).count("background") == 2
     assert inspect.getsource(fn).count("yield") == 1
     assert getattr(fn, BACKGROUND_TASK_MARKER, None)
+
+
+@pytest.mark.parametrize(
+    "param_value",
+    [
+        True,
+        False,
+    ],
+    ids=["default", "disabled"],
+)
+def test_background_decorator_automatic_yield_after_modifications(param_value):
+    @background(automatic_yield_after_modifications=param_value)
+    async def fn(self):
+        async with self:
+            pass
+
+    if param_value:
+        assert inspect.isasyncgenfunction(fn)
+        assert "automatic_yield_after_modifications" not in inspect.getsource(fn)
+        assert inspect.getsource(fn).count("yield") == 1
+        assert "background" not in inspect.getsource(fn)
+    else:
+        assert not inspect.isasyncgenfunction(fn)
+        assert inspect.getsource(fn).count("background") == 1
+        assert "automatic_yield_after_modifications" in inspect.getsource(fn)
+        assert inspect.getsource(fn).count("yield") == 1
+    assert getattr(fn, BACKGROUND_TASK_MARKER, None)

--- a/tests/utils/test_rewrites.py
+++ b/tests/utils/test_rewrites.py
@@ -1,0 +1,151 @@
+"""Test cases for code rewriting utilities."""
+import inspect
+
+import pytest
+
+import reflex
+from reflex.event import BACKGROUND_TASK_MARKER, background
+from reflex.utils import rewrites
+
+
+def test_add_yield_after_async_with_self():
+    async def fn(self):
+        async with self:
+            pass
+
+    orig_code = fn.__code__
+
+    assert inspect.iscoroutinefunction(fn)
+    assert not inspect.isasyncgenfunction(fn)
+    new_fn = rewrites.add_yield_after_async_with_self(fn)
+    assert inspect.isasyncgenfunction(new_fn)
+    assert fn is new_fn
+    assert orig_code is not new_fn.__code__
+    assert inspect.getsource(new_fn).count("yield") == 1
+
+
+def test_add_yield_after_async_with_foo():
+    async def fn(foo):
+        async with foo:
+            pass
+
+    orig_code = fn.__code__
+
+    assert inspect.iscoroutinefunction(fn)
+    assert not inspect.isasyncgenfunction(fn)
+    new_fn = rewrites.add_yield_after_async_with_self(fn)
+    assert inspect.isasyncgenfunction(new_fn)
+    assert fn is new_fn
+    assert orig_code is not new_fn.__code__
+    assert inspect.getsource(new_fn).count("yield") == 1
+
+
+def test_add_yield_after_async_with_foo_not_self():
+    async def fn(foo, self):
+        async with self:
+            pass
+
+    orig_code = fn.__code__
+
+    assert inspect.iscoroutinefunction(fn)
+    assert not inspect.isasyncgenfunction(fn)
+    new_fn = rewrites.add_yield_after_async_with_self(fn)
+    assert not inspect.isasyncgenfunction(new_fn)
+    assert fn is new_fn
+    assert orig_code is new_fn.__code__
+    assert "yield" not in inspect.getsource(new_fn)
+
+
+def test_add_yield_after_async_with_self_no_mod():
+    async def fn(self):
+        async with self:
+            pass
+        yield
+
+    orig_code = fn.__code__
+
+    new_fn = rewrites.add_yield_after_async_with_self(fn)
+    assert fn is new_fn
+    assert orig_code is new_fn.__code__
+    assert inspect.getsource(new_fn).count("yield") == 1
+
+
+def test_add_yield_after_async_with_self_add_yield():
+    async def fn(self):
+        async with self:
+            pass
+        pass
+        yield
+
+    orig_code = fn.__code__
+
+    new_fn = rewrites.add_yield_after_async_with_self(fn)
+    assert fn is new_fn
+    assert orig_code is not new_fn.__code__
+    assert inspect.getsource(new_fn).count("yield") == 2
+
+
+def test_add_yield_after_async_with_self_dummy():
+    def fn(self):
+        pass
+
+    orig_code = fn.__code__
+
+    assert not inspect.iscoroutinefunction(fn)
+    assert not inspect.isasyncgenfunction(fn)
+    new_fn = rewrites.add_yield_after_async_with_self(fn)
+    assert not inspect.isasyncgenfunction(new_fn)
+    assert fn is new_fn
+    assert orig_code is new_fn.__code__
+    assert "yield" not in inspect.getsource(new_fn)
+
+
+@background
+async def _bg_fn1(self):
+    async with self:
+        pass
+
+
+@reflex.background
+async def _bg_fn2(self):
+    async with self:
+        pass
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [
+        _bg_fn1,
+        _bg_fn2,
+    ],
+)
+def test_background_decorator(fn):
+    assert inspect.isasyncgenfunction(fn)
+    assert "background" not in inspect.getsource(fn)
+    assert inspect.getsource(fn).count("yield") == 1
+    assert getattr(fn, BACKGROUND_TASK_MARKER, None)
+
+
+def test_background_decorator_no_apply():
+    @background
+    async def fn(self):
+        pass
+
+    assert not inspect.isasyncgenfunction(fn)
+    assert "yield" not in inspect.getsource(fn)
+    assert inspect.getsource(fn).count("background") == 1
+    assert getattr(fn, BACKGROUND_TASK_MARKER, None)
+
+
+def test_background_decorator_multiple():
+    @reflex.background
+    @background
+    @background
+    async def fn(self):
+        async with self:
+            pass
+
+    assert inspect.isasyncgenfunction(fn)
+    assert inspect.getsource(fn).count("background") == 2
+    assert inspect.getsource(fn).count("yield") == 1
+    assert getattr(fn, BACKGROUND_TASK_MARKER, None)


### PR DESCRIPTION
Previously, the StateProxy was responsible for emitting state updates after exiting the `async with self` block, using `app.modify_state` helper to actually do the heavy lifting. This created a redundant path where `async with self` updates were being handled in a different spot than normal `yield` from a background task.

With this change, the `@rx.background` decorator gets a new `automatic_yield_after_modifications` kwarg (default True), which controls this behavior. The StateProxy no longer uses `app.modify_state`, but instead `app.state_manager.modify_state` (which does NOT send the update automatically).

A new module, `reflex.utils.rewrite` has been added, which facilitates rewriting background event handlers to include a `yield` after `async with self` blocks. Since the yield is part of the function, the updates can be handled via the normal `_process_event` path and emitted from the background task coroutine. This arrangement also allows users to explicitly opt-out of automatic updates and function rewriting if they so choose.

Additionally, some event handlers, like upload, cannot rely on the websocket to send their deltas, so removing the out-of-band update path which relied on the websocket allows upload handlers to be implemented as background task, for example when processing large uploads.

In the future, I can see this mechanism being used to smooth out some syntactical difficulties around native `for` and `if`, by rewriting the AST of the render functions for the frontend?

TODO:
- [ ] use `astunparse` for py3.8 compatibility
- [ ] figure out what to do when source is not available (reflex-web)

Is this just too complicated? Is there a better way?

To support the upload case, we could just say you have to explicitly `yield` to send state updates... but `rx.background` is already weird enough without extra rules, hence trying to make it easier for users by retaining the automatic delta behavior.