### PR TITLE
base: expand template content to right edge of screen

### DIFF
--- a/reflex/.templates/apps/base/code/styles.py
+++ b/reflex/.templates/apps/base/code/styles.py
@@ -13,10 +13,9 @@ hover_accent_bg = {"_hover": {"bg": accent_color}}
 content_width_vw = "90vw"
 sidebar_width = "20em"
 
-template_page_style = {"padding_top": "5em", "padding_x": ["auto", "2em"]}
+template_page_style = {"padding_top": "5em", "padding_x": ["auto", "2em"], "flex": "1"}
 
 template_content_style = {
-    "width": "100%",
     "align_items": "flex-start",
     "box_shadow": box_shadow,
     "border_radius": border_radius,

--- a/reflex/.templates/apps/base/code/templates/template.py
+++ b/reflex/.templates/apps/base/code/templates/template.py
@@ -116,7 +116,6 @@ def template(
                     ),
                     **styles.template_page_style,
                 ),
-                rx.spacer(),
                 menu_button(),
                 align_items="flex-start",
                 transition="left 0.5s, width 0.5s",


### PR DESCRIPTION
remove the rx.spacer which restricts the template page to its minimal width

add flex grow to the template_page_style to let it fill the remaining width

remove width=100% from template_content_style; that's already the default

## Before
![Screenshot 2023-10-31 at 4 09 13 PM](https://github.com/reflex-dev/reflex/assets/1524005/aa5d1149-7fc5-440e-87dc-2424b7c3db27)

## After
![Screenshot 2023-10-31 at 4 09 49 PM](https://github.com/reflex-dev/reflex/assets/1524005/ca0e6a41-38ae-45e0-bbcb-1de72117ad3a)
