### PR TITLE
Do not stop prop is there is no prop to stop

### DIFF
--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -488,10 +488,10 @@ export const useEventLoop = (
 
   // Function to add new events to the event queue.
   const addEvents = (events, _e, event_actions) => {
-    if (event_actions?.preventDefault && _e) {
+    if (event_actions?.preventDefault && _e?.preventDefault) {
       _e.preventDefault();
     }
-    if (event_actions?.stopPropagation && _e) {
+    if (event_actions?.stopPropagation && _e?.stopPropagation) {
       _e.stopPropagation();
     }
     queueEvents(events, socket)


### PR DESCRIPTION
Check that desired event actions are defined on the object passed as the DOM event before calling them to avoid frontend errors.