### PR TITLE
[WIP] add search support to data_editor

### DIFF
--- a/reflex/components/datadisplay/dataeditor.py
+++ b/reflex/components/datadisplay/dataeditor.py
@@ -197,6 +197,15 @@ class DataEditor(NoSSRComponent):
     # Initial scroll offset on the vertical axis.
     scroll_offset_y: Var[int]
 
+    # Enable the built-in search of the data editor.
+    show_search: Var[bool]
+
+    # The search value.
+    search_value: Var[str]
+
+    # The results of the search as a list of cells positions to highlight.
+    search_results: Var[list[list[int]]]
+
     # global theme
     theme: Var[Union[DataEditorTheme, Dict]]
 
@@ -229,6 +238,7 @@ class DataEditor(NoSSRComponent):
             return [pos, data]
 
         return {
+            **super().get_event_triggers(),
             "on_cell_activated": lambda pos: [pos],
             "on_cell_clicked": lambda pos: [pos],
             "on_cell_context_menu": lambda pos: [pos],
@@ -244,6 +254,8 @@ class DataEditor(NoSSRComponent):
             "on_finished_editing": lambda new_value, movement: [new_value, movement],
             "on_row_appended": lambda: [],
             "on_selection_cleared": lambda: [],
+            "on_search_value_change": lambda val: [val],
+            "on_search_close": lambda: [],
         }
 
     def _get_hooks(self) -> str | None:


### PR DESCRIPTION
Implement search props and event triggers for data_editor.

State and data:
```python
data_ = {
    "Column1": [1, 2, 3, 4, 5],
    "Column2": ["A", "B", "C", "D", "E"],
    "Column3": [0.1, 0.2, 0.3, 0.4, 0.5],
}

class State(rx.State):
    search_in_grid: bool = False
    search_value: str = ""
    search_results: list = [[0, 0], [2, 0], [2, 2]]
    columns: list = [
        {"title": "Column1", "id": "column1", "type": "int"},
        {"title": "Column2", "id": "column2", "type": "str"},
        {"title": "Column3", "id": "column3", "type": "float"},
    ]
    data: list = [
        dict((key.lower(), value) for key, value in zip(data_.keys(), values))
        for values in zip(*data_.values())
    ]
    
    def toggle_search(self):
        self.search_in_grid = not self.search_in_grid

    def search_for(self, val):
        self.search_value = val
        if val:
            self.search_results = [[0, 0], [1, 1], [2, 2]]
```

Render:
```python
    rx.data_editor(
        columns=State.columns,
        data=State.data,
        rows=5,
        show_search=State.search_in_grid,
        search_value=State.search_value,
        on_search_value_change=State.search_for,
        on_search_close=State.toggle_search,
         search_results=State.search_results,
    )
```