### PR TITLE
components as props

### DIFF
--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -613,7 +613,11 @@ class Component(Base, ABC):
 
     def _get_props_imports(self) -> imports.ImportDict:
         return imports.merge_imports(
-            *[getattr(self, prop).get_imports() for prop in self.get_component_props()]
+            *[
+                getattr(self, prop).get_imports()
+                for prop in self.get_component_props()
+                if getattr(self, prop) is not None
+            ]
         )
 
     def _get_dependencies_imports(self) -> imports.ImportDict:

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -626,14 +626,15 @@ class Component(Base, ABC):
         )
 
     def _get_imports(self) -> imports.ImportDict:
-        imports = {}
+        _imports = {}
         if self.library is not None and self.tag is not None:
-            imports[self.library] = {self.import_var}
-        return {
-            **self._get_props_imports(),
-            **self._get_dependencies_imports(),
-            **imports,
-        }
+            _imports[self.library] = {self.import_var}
+
+        return imports.merge_imports(
+            self._get_props_imports(),
+            self._get_dependencies_imports(),
+            _imports,
+        )
 
     def get_imports(self) -> imports.ImportDict:
         """Get all the libraries and fields that are used by the component.

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -612,6 +612,11 @@ class Component(Base, ABC):
         return dynamic_imports
 
     def _get_props_imports(self) -> imports.ImportDict:
+        """Get the imports needed for components props.
+
+        Returns:
+            The  imports for the components props of the component.
+        """
         return imports.merge_imports(
             *[
                 getattr(self, prop).get_imports()
@@ -621,11 +626,21 @@ class Component(Base, ABC):
         )
 
     def _get_dependencies_imports(self) -> imports.ImportDict:
+        """Get the imports from lib_dependencies for installing.
+
+        Returns:
+            The dependencies imports of the component.
+        """
         return imports.merge_imports(
             {dep: {ImportVar(tag=None, render=False)} for dep in self.lib_dependencies}
         )
 
     def _get_imports(self) -> imports.ImportDict:
+        """Get all the libraries and fields that are used by the component.
+
+        Returns:
+            The imports needed by the component.
+        """
         _imports = {}
         if self.library is not None and self.tag is not None:
             _imports[self.library] = {self.import_var}
@@ -637,7 +652,7 @@ class Component(Base, ABC):
         )
 
     def get_imports(self) -> imports.ImportDict:
-        """Get all the libraries and fields that are used by the component.
+        """Get all the libraries and fields that are used by the component and its children.
 
         Returns:
             The import dict with the required imports.

--- a/reflex/components/forms/iconbutton.py
+++ b/reflex/components/forms/iconbutton.py
@@ -1,5 +1,8 @@
 """An icon button component."""
 
+from typing import Optional
+
+from reflex.components.component import Component
 from reflex.components.typography.text import Text
 from reflex.vars import Var
 
@@ -16,7 +19,7 @@ class IconButton(Text):
     aria_label: Var[str]
 
     # The icon to be used in the button.
-    icon: Var[str]
+    icon: Optional[Component]
 
     # If true, the button will be styled in its active state.
     is_active: Var[bool]


### PR DESCRIPTION
Proper feature to use components as props based on #2017 

Auto detect props annotated with type Optional[Component]

Automatically add the imports required for the component prop to work.

Does NOT work with state Var, only compilation time component props are valid.

As example, see the changes in `iconbutton.py` :  This is all that is needed to have components as props.