### PR TITLE
[REF-1584] investigate windows reload performance

### DIFF
--- a/reflex/config.py
+++ b/reflex/config.py
@@ -194,6 +194,9 @@ class Config(Base):
     # The worker class used in production mode
     gunicorn_worker_class: str = "uvicorn.workers.UvicornH11Worker"
 
+    # npm prefer-offline flag to prefer local cache.
+    npm_prefer_offline: bool = False
+
     # Attributes that were explicitly set by the user.
     _non_default_attributes: Set[str] = pydantic.PrivateAttr(set())
 

--- a/reflex/config.pyi
+++ b/reflex/config.pyi
@@ -68,6 +68,7 @@ class Config(Base):
     rxdeploy_url: Optional[str]
     cp_backend_url: str
     cp_web_url: str
+    npm_prefer_offline: bool
     username: Optional[str]
     gunicorn_worker_class: str
 
@@ -95,6 +96,7 @@ class Config(Base):
         rxdeploy_url: Optional[str] = None,
         cp_backend_url: Optional[str] = None,
         cp_web_url: Optional[str] = None,
+        npm_prefer_offline: bool = False,
         username: Optional[str] = None,
         gunicorn_worker_class: Optional[str] = None,
         **kwargs

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -623,37 +623,49 @@ def install_frontend_packages(packages: set[str]):
     Example:
         >>> install_frontend_packages(["react", "react-dom"])
     """
+    config = get_config()
+    package_manager = get_install_package_manager()
+
+    uses_npm = package_manager.endswith("npm") if package_manager else False
+
+    prefer_offline = (
+        ["--prefer-offline"] if config.npm_prefer_offline and uses_npm else []
+    )
+    # show logs for debug mode.
+    show_logs = config.loglevel >= constants.LogLevel.DEBUG
+
     # Install the base packages.
     process = processes.new_process(
-        [get_install_package_manager(), "install", "--loglevel", "silly"],
+        [package_manager, "install", "--loglevel", "silly", *prefer_offline],
         cwd=constants.Dirs.WEB,
         shell=constants.IS_WINDOWS,
+        show_logs=show_logs,
     )
 
     processes.show_status("Installing base frontend packages", process)
 
-    config = get_config()
     if config.tailwind is not None:
-        # install tailwind and tailwind plugins as dev dependencies.
         process = processes.new_process(
             [
-                get_install_package_manager(),
+                package_manager,
                 "add",
                 "-d",
+                *prefer_offline,
                 constants.Tailwind.VERSION,
-                *((config.tailwind or {}).get("plugins", [])),
+                *(config.tailwind or {}).get("plugins", []),
             ],
             cwd=constants.Dirs.WEB,
             shell=constants.IS_WINDOWS,
+            show_logs=show_logs,
         )
         processes.show_status("Installing tailwind", process)
 
-    # Install custom packages defined in frontend_packages
     if len(packages) > 0:
         process = processes.new_process(
-            [get_install_package_manager(), "add", *packages],
+            [package_manager, "add", *packages, *prefer_offline],
             cwd=constants.Dirs.WEB,
             shell=constants.IS_WINDOWS,
+            show_logs=show_logs,
         )
         processes.show_status(
             "Installing frontend packages from config and components", process


### PR DESCRIPTION
 introduces an `npm_prefer_offline` config(https://docs.npmjs.com/cli/v6/using-npm/config#prefer-offline) which allows npm to use local cache and only read from the registry when necessary. This is to help reduce the reload time on windows


## Performance Test on windows 11 (VM on Mac M2)
Below gives an overview of install times when `reflex.utils.prerequisites.install_frontend_packages` is called
In this function, We first install base packages using `npm install` and then add tailwind and its dependencies as development dependencies(`npm add -d`) then finally add all detected or installable packages (`npm add`). 

NB: Network connection speed may play a factor in the times but gives a general overview


| `npm install` | `npm add` (Tailwind) | `npm add`(All other packages) | Ran after `reflex init` | Ran after hot reload | with prefer-offline |
|:--------------|:---------------------|------------------------------:|-------------------------|----------------------|---------------------|
| 52s           | 18s                  |                            2m | Yes                     | No                   | No                  |
| 2s            | 5s                   |                           40s | No                      | Yes                  | No                  |                                                  |         |
| 3s            | 2s                   |                            2s | No                      | Yes                  | No                  |
| 2s            | 5s                   |                           45s | No                      | Yes                  | No                  |
| 2m            | 6s                   |                            1m | Yes                     | No                   | No                  |
| 3s            | 3s                   |                           36s | No                      | Yes                  | No                  |
| 2s            | 2s                   |                            3s | No                      | Yes                  | No                  |
| 3s            | 2s                   |                            2s | No                      | Yes                  | No                  |
| 2s            | 3s                   |                           23s | No                      | Yes                  | No                  |
| 2s            | 2s                   |                            2s | No                      | Yes                  | No                  |
| 2s            | 1s                   |                            2s | No                      | Yes                  | No                  |
| 14s           | 26s                  |                            2m | Yes                     | No                   | No                  |
| 2s            | 749ms                |                         961ms | No                      | Yes                  | Yes                 |
| 1s            | 2s                   |                            2s | No                      | Yes                  | Yes                 |
| 2s            | 2s                   |                            2s | No                      | Yes                  | Yes                 |
| 1s            | 1s                   |                            2s | No                      | Yes                  | Yes                 |
| 840ms         | 1s                   |                            1s | No                      | Yes                  | Yes                 |
| 2s            | 1s                   |                            3s | No                      | Yes                  | Yes                 |
| 1s            | 1s                   |                            1s | No                      | Yes                  | Yes                 |
|               |                      |                               |                         |                      |                     |



It can be seen that using `prefer-offline` flag produces consistent minimum start times.

