### PR TITLE
docs: revise typo in korean README and common CONTRIBUTING readme

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Once you solve a current issue or improvement to Reflex, you can make a PR, and 
 Before submitting, a pull request, ensure the following steps are taken and test passing.
 
 In your `reflex` directory run make sure all the unit tests are still passing using the following command.
-This will fail if code coverage is below 80%.
+This will fail if code coverage is below 70%.
 ``` bash
 poetry run pytest tests --cov --no-cov-on-fail --cov-report= 
 ```

--- a/docs/kr/README.md
+++ b/docs/kr/README.md
@@ -47,7 +47,7 @@ reflex init
 reflex run
 ```
 
-http://localhost:3000에서 앱이 실행됩니다.
+http://localhost:3000 에서 앱이 실행 됩니다.
 
 이제 `my_app_name/my_app_name.py`에서 소스코드를 수정할 수 있습니다. Reflex는 빠른 새로고침을 지원하므로 코드를 저장할 때마다 즉시 변경 사항을 볼 수 있습니다.
 


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?


### Type of change

- [x] Documentation(korean) 
- [x] Documentation(`CONTRIBUTING.md`) 

### Description
- revise spacing typo in korean readme by (@starcat37 , [PR](https://github.com/reflex-dev/reflex/pull/2011))
- revise typo in CONTRIBUTING.md
    - I follow guideline for making PR but I found lower bound of unit-test 80%, but I found CLI log in my terminal following guideline(plz check attachment). please check it

![스크린샷 2023-11-12 오후 11 06 42](https://github.com/reflex-dev/reflex/assets/54783194/3463322f-699e-43b1-8bb6-a035637eb358)
