### PR TITLE
Remove special case for reflex.page in lazy import machinery

### DIFF
--- a/reflex/__init__.py
+++ b/reflex/__init__.py
@@ -7,6 +7,7 @@ we use the Flask "import name as name" syntax.
 import importlib
 from typing import Type
 
+from reflex.page import page as page
 from reflex.utils.format import to_snake_case
 
 _ALL_COMPONENTS = [
@@ -307,11 +308,6 @@ def __getattr__(name: str) -> Type:
 
         # Import the module.
         module = importlib.import_module(_MAPPING[name])
-
-        # Special case for page.
-        if name == "page":
-            globals()["page"] = module.page
-            return module.page
 
         # Get the attribute from the module if the name is not the module itself.
         return (

--- a/reflex/page.py
+++ b/reflex/page.py
@@ -2,8 +2,7 @@
 
 from __future__ import annotations
 
-from reflex.components.component import Component
-from reflex.event import EventHandler
+from typing import Any
 
 DECORATED_PAGES = []
 
@@ -14,8 +13,8 @@ def page(
     image: str | None = None,
     description: str | None = None,
     meta: str | None = None,
-    script_tags: list[Component] | None = None,
-    on_load: EventHandler | list[EventHandler] | None = None,
+    script_tags: list[Any] | None = None,
+    on_load: Any | list[Any] | None = None,
 ):
     """Decorate a function as a page.
 

--- a/reflex/page.pyi
+++ b/reflex/page.pyi
@@ -1,0 +1,17 @@
+"""The page decorator and associated variables and functions."""
+
+from reflex.components.component import Component
+from reflex.event import EventHandler
+
+DECORATED_PAGES: list
+
+def page(
+    route: str | None = None,
+    title: str | None = None,
+    image: str | None = None,
+    description: str | None = None,
+    meta: str | None = None,
+    script_tags: list[Component] | None = None,
+    on_load: EventHandler | list[EventHandler] | None = None,
+): ...
+def get_decorated_pages() -> list[dict]: ...


### PR DESCRIPTION
Instead remove all deep reflex imports, and just eager import reflex.page, since it is a simple module.