### PR TITLE
Set is_hydrated var explicitly on rx.State

### DIFF
--- a/reflex/middleware/hydrate_middleware.py
+++ b/reflex/middleware/hydrate_middleware.py
@@ -13,9 +13,6 @@ if TYPE_CHECKING:
     from reflex.app import App
 
 
-State.add_var(constants.CompileVars.IS_HYDRATED, type_=bool, default_value=False)
-
-
 class HydrateMiddleware(Middleware):
     """Middleware to handle initial app hydration."""
 
@@ -57,9 +54,10 @@ class HydrateMiddleware(Middleware):
 
         # Get the route for on_load events.
         route = event.router_data.get(constants.RouteVar.PATH, "")
-
+        load_events = app.get_load_events(route)
+        sh = type(state).set_is_hydrated(True)
         # Add the on_load events and set is_hydrated to True.
-        events = [*app.get_load_events(route), type(state).set_is_hydrated(True)]  # type: ignore
+        events = [*load_events, sh]  # type: ignore
         events = fix_events(events, event.token, router_data=event.router_data)
 
         # Return the state update.

--- a/reflex/middleware/hydrate_middleware.py
+++ b/reflex/middleware/hydrate_middleware.py
@@ -54,10 +54,8 @@ class HydrateMiddleware(Middleware):
 
         # Get the route for on_load events.
         route = event.router_data.get(constants.RouteVar.PATH, "")
-        load_events = app.get_load_events(route)
-        sh = type(state).set_is_hydrated(True)
         # Add the on_load events and set is_hydrated to True.
-        events = [*load_events, sh]  # type: ignore
+        events = [*app.get_load_events(route), type(state).set_is_hydrated(True)]  # type: ignore
         events = fix_events(events, event.token, router_data=event.router_data)
 
         # Return the state update.

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -194,6 +194,9 @@ class State(Base, ABC, extra=pydantic.Extra.allow):
     # The router data for the current page
     router: RouterData = RouterData()
 
+    # The hydrated bool.
+    is_hydrated: bool = False
+
     def __init__(self, *args, parent_state: State | None = None, **kwargs):
         """Initialize the state.
 


### PR DESCRIPTION
Define an explicit `is_hydrated` var on the state so it is converted properly when doing `State._init_vars` on base vars in the base state 