### PR TITLE
Fix CustomComponent rendering

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -123,7 +123,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: reflex-dev/reflex-web
-          ref: reflex-ci
+          ref: main
           path: reflex-web
 
       - name: Install Requirements for reflex-web

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -384,6 +384,8 @@ class Component(Base, ABC):
             ref = self.get_ref()
             if ref is not None:
                 props["ref"] = Var.create(ref, _var_is_local=False)
+        else:
+            props = props.copy()
 
         props.update(
             self.event_triggers,


### PR DESCRIPTION
Copy `props` passed to `Component._render` before mutation to avoid modifying the callers' value (which could be reused).

Update integration-tests.yml to always test against reflex-dev/reflex-web#main branch, even if it might introduce instability from time to time.