### PR TITLE
Hosting CLI: remove requirements generation when init, add back timeout for deploy command, remove deploy legacy command

### DIFF
--- a/reflex/config.py
+++ b/reflex/config.py
@@ -185,7 +185,6 @@ class Config(Base):
     # Additional frontend packages to install.
     frontend_packages: List[str] = []
 
-    
     # The hosting service backend URL.
     cp_backend_url: str = constants.Hosting.CP_BACKEND_URL
     # The hosting service frontend URL.

--- a/reflex/config.py
+++ b/reflex/config.py
@@ -185,18 +185,11 @@ class Config(Base):
     # Additional frontend packages to install.
     frontend_packages: List[str] = []
 
-    # Params to remove eventually.
-    # For rest are for deploy only.
-    # The rxdeploy url.
-    rxdeploy_url: Optional[str] = None
-
+    
     # The hosting service backend URL.
     cp_backend_url: str = constants.Hosting.CP_BACKEND_URL
     # The hosting service frontend URL.
     cp_web_url: str = constants.Hosting.CP_WEB_URL
-
-    # The username.
-    username: Optional[str] = None
 
     # The worker class used in production mode
     gunicorn_worker_class: str = "uvicorn.workers.UvicornH11Worker"

--- a/reflex/constants/config.py
+++ b/reflex/constants/config.py
@@ -47,7 +47,7 @@ class RequirementsTxt(SimpleNamespace):
     # The requirements.txt file.
     FILE = "requirements.txt"
     # The partial text used to form requirement that pins a reflex version
-    DEFAULTS_STUB = f"{Reflex.MODULE_NAME}=="
+    DEFAULTS_STUB = f"{Reflex.MODULE_NAME}>="
 
 
 # The deployment URL.

--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -14,7 +14,6 @@ from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
 
-import httpx
 import typer
 import typer.core
 from alembic.util.exc import CommandError
@@ -256,47 +255,6 @@ def run(
 ):
     """Run the app in the current directory."""
     _run(env, frontend, backend, frontend_port, backend_port, backend_host, loglevel)
-
-
-@cli.command()
-def deploy_legacy(
-    dry_run: bool = typer.Option(False, help="Whether to run a dry run."),
-    loglevel: constants.LogLevel = typer.Option(
-        console._LOG_LEVEL, help="The log level to use."
-    ),
-):
-    """Deploy the app to the Reflex hosting service."""
-    # Set the log level.
-    console.set_log_level(loglevel)
-
-    # Show system info
-    exec.output_system_info()
-
-    # Check if the deploy url is set.
-    if config.rxdeploy_url is None:
-        console.info("This feature is coming soon!")
-        return
-
-    # Compile the app in production mode.
-    export(loglevel=loglevel)
-
-    # Exit early if this is a dry run.
-    if dry_run:
-        return
-
-    # Deploy the app.
-    data = {"userId": config.username, "projectId": config.app_name}
-    original_response = httpx.get(config.rxdeploy_url, params=data)
-    response = original_response.json()
-    frontend = response["frontend_resources_url"]
-    backend = response["backend_resources_url"]
-
-    # Upload the frontend and backend.
-    with open(constants.ComponentName.FRONTEND.zip(), "rb") as f:
-        httpx.put(frontend, data=f)  # type: ignore
-
-    with open(constants.ComponentName.BACKEND.zip(), "rb") as f:
-        httpx.put(backend, data=f)  # type: ignore
 
 
 @cli.command()

--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -527,7 +527,7 @@ def deploy(
             enabled_regions = pre_deploy_response.enabled_regions
 
     except Exception as ex:
-        console.error(f"Unable to prepare deployment")
+        console.error(f"Unable to prepare deployment due to: {ex}")
         raise typer.Exit(1) from ex
 
     # The app prefix should not change during the time of preparation

--- a/reflex/utils/hosting.py
+++ b/reflex/utils/hosting.py
@@ -324,22 +324,22 @@ def prepare_deploy(
             enabled_regions=response_json.get("enabled_regions"),
         )
     except httpx.RequestError as re:
-        console.error(f"Unable to prepare launch due to {re}.")
+        console.debug(f"Unable to prepare launch due to {re}.")
         raise Exception(str(re)) from re
     except httpx.HTTPError as he:
-        console.error(f"Unable to prepare deploy due to {he}.")
+        console.debug(f"Unable to prepare deploy due to {he}.")
         raise Exception(f"{he}") from he
     except json.JSONDecodeError as jde:
-        console.error(f"Server did not respond with valid json: {jde}")
+        console.debug(f"Server did not respond with valid json: {jde}")
         raise Exception("internal errors") from jde
     except (KeyError, ValidationError) as kve:
-        console.error(f"The server response format is unexpected {kve}")
+        console.debug(f"The server response format is unexpected {kve}")
         raise Exception("internal errors") from kve
     except ValueError as ve:
         # This is a recognized client error, currently indicates forbidden
         raise Exception(f"{ve}") from ve
     except Exception as ex:
-        console.error(f"Unexpected error: {ex}.")
+        console.debug(f"Unexpected error: {ex}.")
         raise Exception("internal errors") from ex
 
 

--- a/reflex/utils/hosting.py
+++ b/reflex/utils/hosting.py
@@ -467,6 +467,7 @@ def deploy(
                 headers=authorization_header(token),
                 data=params.dict(exclude_none=True),
                 files=files,
+                timeout=HTTP_REQUEST_TIMEOUT,
             )
         # If the server explicitly states bad request,
         # display a different error

--- a/reflex/utils/hosting.py
+++ b/reflex/utils/hosting.py
@@ -142,6 +142,8 @@ def save_token_to_config(token: str, code: str | None = None):
     if code:
         hosting_config["code"] = code
     try:
+        if not os.path.exists(constants.Reflex.DIR):
+            os.makedirs(constants.Reflex.DIR)
         with open(constants.Hosting.HOSTING_JSON, "w") as config_file:
             json.dump(hosting_config, config_file)
     except Exception as ex:

--- a/tests/test_reflex.py
+++ b/tests/test_reflex.py
@@ -61,6 +61,7 @@ def test_deploy_required_args_missing(args):
 @pytest.fixture
 def setup_env_authentication(mocker):
     mocker.patch("reflex.utils.prerequisites.check_initialized")
+    mocker.patch("reflex.utils.dependency.check_requirements")
     mocker.patch("reflex.utils.hosting.authenticated_token", return_value="fake-token")
     mocker.patch("time.sleep")
 


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.

    a. Hosting CLI: requirements txt when reflex init uses >= instead of ==.
    b. add back timeout for deploy command, default timeout is 5 seconds, occasionally not enough for large zips.
    c. remove deploy legacy command, replaced by CI pipeline
    d. remove unused username, rxdeploy_url from config
    e. reflex login: add support folder if not exist before trying to save token