### PR TITLE
[fixup] _valid_children and _invalid_children pyi_generator and graphing components

### DIFF
--- a/reflex/components/graphing/recharts/cartesian.py
+++ b/reflex/components/graphing/recharts/cartesian.py
@@ -278,7 +278,7 @@ class Bar(Cartesian):
     max_bar_size: Var[int]
 
     # Valid children components
-    valid_children: List[str] = ["Cell", "LabelList", "ErrorBar"]
+    _valid_children: List[str] = ["Cell", "LabelList", "ErrorBar"]
 
 
 class Line(Cartesian):
@@ -313,7 +313,7 @@ class Line(Cartesian):
     connect_nulls: Var[bool]
 
     # Valid children components
-    valid_children: List[str] = ["LabelList", "ErrorBar"]
+    _valid_children: List[str] = ["LabelList", "ErrorBar"]
 
 
 class Scatter(Cartesian):
@@ -345,7 +345,7 @@ class Scatter(Cartesian):
     name: Var[Union[str, int]]
 
     # Valid children components.
-    valid_children: List[str] = ["LabelList", "ErrorBar"]
+    _valid_children: List[str] = ["LabelList", "ErrorBar"]
 
 
 class Funnel(Cartesian):
@@ -368,7 +368,7 @@ class Funnel(Cartesian):
     animation_easing: Var[LiteralAnimationEasing]
 
     # Valid children components
-    valid_children: List[str] = ["LabelList", "Cell"]
+    _valid_children: List[str] = ["LabelList", "Cell"]
 
 
 class ErrorBar(Recharts):
@@ -427,7 +427,7 @@ class ReferenceLine(Reference):
     stroke_width: Var[int]
 
     # Valid children components
-    valid_children: List[str] = ["Label"]
+    _valid_children: List[str] = ["Label"]
 
 
 class ReferenceDot(Reference):
@@ -438,7 +438,7 @@ class ReferenceDot(Reference):
     alias = "RechartsReferenceDot"
 
     # Valid children components
-    valid_children: List[str] = ["Label"]
+    _valid_children: List[str] = ["Label"]
 
     def get_event_triggers(self) -> dict[str, Union[Var, Any]]:
         """Get the event triggers that pass the component's value to the handler.
@@ -497,7 +497,7 @@ class ReferenceArea(Recharts):
     is_front: Var[bool]
 
     # Valid children components
-    valid_children: List[str] = ["Label"]
+    _valid_children: List[str] = ["Label"]
 
 
 class Grid(Recharts):

--- a/reflex/components/graphing/recharts/charts.py
+++ b/reflex/components/graphing/recharts/charts.py
@@ -130,7 +130,7 @@ class AreaChart(ChartBase):
     stack_offset: Var[LiteralStackOffset]
 
     # Valid children components
-    valid_children: List[str] = [
+    _valid_children: List[str] = [
         "XAxis",
         "YAxis",
         "ReferenceArea",
@@ -170,7 +170,7 @@ class BarChart(ChartBase):
     reverse_stack_order: Var[bool]
 
     # Valid children components
-    valid_children: List[str] = [
+    _valid_children: List[str] = [
         "XAxis",
         "YAxis",
         "ReferenceArea",
@@ -192,7 +192,7 @@ class LineChart(ChartBase):
     alias = "RechartsLineChart"
 
     # Valid children components
-    valid_children: List[str] = [
+    _valid_children: List[str] = [
         "XAxis",
         "YAxis",
         "ReferenceArea",
@@ -229,7 +229,7 @@ class ComposedChart(ChartBase):
     reverse_stack_order: Var[bool]
 
     # Valid children components
-    valid_children: List[str] = [
+    _valid_children: List[str] = [
         "XAxis",
         "YAxis",
         "ReferenceArea",
@@ -253,7 +253,7 @@ class PieChart(ChartBase):
     alias = "RechartsPieChart"
 
     # Valid children components
-    valid_children: List[str] = [
+    _valid_children: List[str] = [
         "PolarAngleAxis",
         "PolarRadiusAxis",
         "PolarGrid",
@@ -301,7 +301,7 @@ class RadarChart(ChartBase):
     outer_radius: Var[Union[int, str]]
 
     # Valid children components
-    valid_children: List[str] = [
+    _valid_children: List[str] = [
         "PolarAngleAxis",
         "PolarRadiusAxis",
         "PolarGrid",
@@ -359,7 +359,7 @@ class RadialBarChart(ChartBase):
     bar_size: Var[int]
 
     # Valid children components
-    valid_children: List[str] = [
+    _valid_children: List[str] = [
         "PolarAngleAxis",
         "PolarRadiusAxis",
         "PolarGrid",
@@ -390,7 +390,7 @@ class ScatterChart(ChartBase):
     alias = "RechartsScatterChart"
 
     # Valid children components
-    valid_children: List[str] = [
+    _valid_children: List[str] = [
         "XAxis",
         "YAxis",
         "ZAxis",
@@ -455,7 +455,7 @@ class FunnelChart(RechartsCharts):
     layout: Var[str]
 
     # Valid children components
-    valid_children: List[str] = ["Legend", "GraphingTooltip", "Funnel"]
+    _valid_children: List[str] = ["Legend", "GraphingTooltip", "Funnel"]
 
     def get_event_triggers(self) -> dict[str, Union[Var, Any]]:
         """Get the event triggers that pass the component's value to the handler.

--- a/reflex/components/graphing/recharts/general.py
+++ b/reflex/components/graphing/recharts/general.py
@@ -42,7 +42,7 @@ class ResponsiveContainer(Recharts):
     debounce: Var[int]
 
     # Valid children components
-    valid_children: List[str] = [
+    _valid_children: List[str] = [
         "AreaChart",
         "BarChart",
         "LineChart",

--- a/reflex/components/graphing/recharts/polar.py
+++ b/reflex/components/graphing/recharts/polar.py
@@ -65,7 +65,7 @@ class Pie(Recharts):
     label_line: Var[bool]
 
     # Valid children components
-    valid_children: List[str] = ["Cell", "LabelList"]
+    _valid_children: List[str] = ["Cell", "LabelList"]
 
     # fill color
     fill: Var[str]
@@ -130,7 +130,7 @@ class Radar(Recharts):
     animation_easing: Var[LiteralAnimationEasing]
 
     # Valid children components
-    valid_children: List[str] = ["LabelList"]
+    _valid_children: List[str] = ["LabelList"]
 
 
 class RadialBar(Recharts):
@@ -156,7 +156,7 @@ class RadialBar(Recharts):
     background: Var[bool]
 
     # Valid children components
-    valid_children: List[str] = ["LabelList"]
+    _valid_children: List[str] = ["LabelList"]
 
     def get_event_triggers(self) -> dict[str, Union[Var, Any]]:
         """Get the event triggers that pass the component's value to the handler.
@@ -215,7 +215,7 @@ class PolarAngleAxis(Recharts):
     allow_duplicated_category: Var[bool]
 
     # Valid children components
-    valid_children: List[str] = ["Label"]
+    _valid_children: List[str] = ["Label"]
 
     def get_event_triggers(self) -> dict[str, Union[Var, Any]]:
         """Get the event triggers that pass the component's value to the handler.
@@ -262,7 +262,7 @@ class PolarGrid(Recharts):
     grid_type: Var[LiteralGridType]
 
     # Valid children components
-    valid_children: List[str] = ["RadarChart", "RadiarBarChart"]
+    _valid_children: List[str] = ["RadarChart", "RadiarBarChart"]
 
 
 class PolarRadiusAxis(Recharts):
@@ -306,7 +306,7 @@ class PolarRadiusAxis(Recharts):
     scale: Var[LiteralScale]
 
     # Valid children components
-    valid_children: List[str] = ["Label"]
+    _valid_children: List[str] = ["Label"]
 
     def get_event_triggers(self) -> dict[str, Union[Var, Any]]:
         """Get the event triggers that pass the component's value to the handler.

--- a/scripts/pyi_generator.py
+++ b/scripts/pyi_generator.py
@@ -38,13 +38,13 @@ EXCLUDED_PROPS = [
     "alias",
     "children",
     "event_triggers",
-    "invalid_children",
     "library",
     "lib_dependencies",
     "tag",
     "is_default",
     "special_props",
-    "valid_children",
+    "_invalid_children",
+    "_valid_children",
 ]
 
 DEFAULT_TYPING_IMPORTS = {


### PR DESCRIPTION
While merging latest changes from `main` into #2029, i noticed a few discrepancies