### PR TITLE
Serialize PIL Image in its format

### DIFF
--- a/reflex/components/media/image.py
+++ b/reflex/components/media/image.py
@@ -95,10 +95,11 @@ try:
             The serialized image.
         """
         buff = io.BytesIO()
-        image.save(buff, format="PNG")
+        image.save(buff, format=getattr(image, "format", "PNG"))
         image_bytes = buff.getvalue()
         base64_image = base64.b64encode(image_bytes).decode("utf-8")
-        return f"data:image/png;base64,{base64_image}"
+        mime_type = getattr(image, "get_format_mimetype", lambda: "image/png")()
+        return f"data:{mime_type};base64,{base64_image}"
 
 except ImportError:
     pass

--- a/reflex/components/media/image.py
+++ b/reflex/components/media/image.py
@@ -95,7 +95,7 @@ try:
             The serialized image.
         """
         buff = io.BytesIO()
-        image.save(buff, format=getattr(image, "format", "PNG"))
+        image.save(buff, format=getattr(image, "format", None) or "PNG")
         image_bytes = buff.getvalue()
         base64_image = base64.b64encode(image_bytes).decode("utf-8")
         mime_type = getattr(image, "get_format_mimetype", lambda: "image/png")()


### PR DESCRIPTION
Instead of serializing everything as PNG, if the image already has a `format` associated with it, then use that.