### PR TITLE
fix offset of data_editor input when page is scrolled

### DIFF
--- a/reflex/components/datadisplay/dataeditor.py
+++ b/reflex/components/datadisplay/dataeditor.py
@@ -345,7 +345,11 @@ class DataEditor(NoSSRComponent):
             def get_ref(self):
                 return None
 
-        return {(-1, "DataEditorPortal"): Portal.create(id="portal")}
+        return {
+            (-1, "DataEditorPortal"): Portal.create(
+                id="portal", style={"position": "fixed", "top": 0}
+            )
+        }
 
 
 # try:


### PR DESCRIPTION
Fix a small issue where the input of a cell in data_editor doesn't appear in the correct position if you are scrolling though the page where the data_editor is contained.