### PR TITLE
Add event_url attribute rx.Config

### DIFF
--- a/reflex/config.py
+++ b/reflex/config.py
@@ -152,6 +152,9 @@ class Config(Base):
     # The url the frontend will be hosted on.
     deploy_url: Optional[str] = f"http://localhost:{frontend_port}"
 
+    # The url the frontend will send / receive websockets messages.
+    event_url: Optional[str] = None
+
     # The url the backend will be hosted on.
     backend_host: str = "0.0.0.0"
 
@@ -317,6 +320,9 @@ class Config(Base):
                     f"https://{codespace_name}-{kwargs.get('backend_port', self.backend_port)}"
                     f".{GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}"
                 )
+
+        if "event_url" in kwargs:
+            self.event_url = kwargs["event_url"]
 
     def _set_persistent(self, **kwargs):
         """Set values in this config and in the environment so they persist into subprocess.

--- a/reflex/config.pyi
+++ b/reflex/config.pyi
@@ -54,6 +54,7 @@ class Config(Base):
     backend_port: int
     api_url: str
     deploy_url: Optional[str]
+    event_url: Optional[str]
     backend_host: str
     db_url: Optional[str]
     redis_url: Optional[str]
@@ -81,6 +82,7 @@ class Config(Base):
         backend_port: Optional[int] = None,
         api_url: Optional[str] = None,
         deploy_url: Optional[str] = None,
+        event_url: Optional[str] = None,
         backend_host: Optional[str] = None,
         db_url: Optional[str] = None,
         redis_url: Optional[str] = None,

--- a/reflex/constants/event.py
+++ b/reflex/constants/event.py
@@ -33,6 +33,9 @@ class Endpoint(Enum):
 
         # The event endpoint is a websocket.
         if self == Endpoint.EVENT:
+            # Get the EVENT URL from the config if is set.
+            if config.event_url:
+                url = "".join([config.event_url, str(self)])
             # Replace the protocol with ws.
             url = url.replace("https://", "wss://").replace("http://", "ws://")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -86,6 +86,23 @@ def test_update_from_env(base_config_values, monkeypatch, env_var, value):
             {"app_name": "test_app", "api_url": "http://example.com/api"},
             f"/api{Endpoint.EVENT}",
         ),
+        (
+            {
+                "app_name": "test_app",
+                "api_url": "http://example.com/api",
+                "event_url": "http://example.com/",
+            },
+            f"/{Endpoint.EVENT}",
+        ),
+        (
+            {
+                "app_name": "test_app",
+                "api_url": "http://example.com/api",
+                "event_url": "http://example.com/",
+                "event_namespace": "/event_",
+            },
+            "/event_",
+        ),
         ({"app_name": "test_app", "event_namespace": "/event"}, f"/event"),
         ({"app_name": "test_app", "event_namespace": "event"}, f"/event"),
         ({"app_name": "test_app", "event_namespace": "event/"}, f"/event"),
@@ -125,6 +142,7 @@ DEFAULT_CONFIG = rx.Config(app_name="a")
                 "backend_port": DEFAULT_CONFIG.backend_port,
                 "deploy_url": DEFAULT_CONFIG.deploy_url,
                 "frontend_port": DEFAULT_CONFIG.frontend_port,
+                "event_url": DEFAULT_CONFIG.event_url,
             },
         ),
         # Ports set in config kwargs
@@ -137,6 +155,7 @@ DEFAULT_CONFIG = rx.Config(app_name="a")
                 "backend_port": 8001,
                 "deploy_url": "http://localhost:3001",
                 "frontend_port": 3001,
+                "event_url": None,
             },
         ),
         # Ports set in environment take precedence
@@ -149,6 +168,7 @@ DEFAULT_CONFIG = rx.Config(app_name="a")
                 "backend_port": 8002,
                 "deploy_url": "http://localhost:3001",
                 "frontend_port": 3001,
+                "event_url": None,
             },
         ),
         # Ports set on the command line take precedence
@@ -161,6 +181,7 @@ DEFAULT_CONFIG = rx.Config(app_name="a")
                 "backend_port": 8002,
                 "deploy_url": "http://localhost:3005",
                 "frontend_port": 3005,
+                "event_url": None,
             },
         ),
         # api_url / deploy_url already set should not be overridden
@@ -173,6 +194,46 @@ DEFAULT_CONFIG = rx.Config(app_name="a")
                 "backend_port": 8002,
                 "deploy_url": "http://foo.bar:3001",
                 "frontend_port": 3005,
+                "event_url": None,
+            },
+        ),
+        # event_url set via environment var should be set
+        (
+            {"api_url": "http://localhost:9000"},
+            {"EVENT_URL": "http://localhost:8004"},
+            {},
+            {
+                "api_url": "http://localhost:9000",
+                "backend_port": 8000,
+                "deploy_url": "http://localhost:3000",
+                "frontend_port": 3000,
+                "event_url": "http://localhost:8004",
+            },
+        ),
+        # event_url already set should not be overridden
+        (
+            {"event_url": "http://localhost:8000"},
+            {"EVENT_URL": "http://localhost:8004"},
+            {},
+            {
+                "api_url": "http://localhost:8000",
+                "backend_port": 8000,
+                "deploy_url": "http://localhost:3000",
+                "frontend_port": 3000,
+                "event_url": "http://localhost:8004",
+            },
+        ),
+        # event_url already set should not be overridden by persistent_vars
+        (
+            {"event_url": "http://localhost:8000"},
+            {"EVENT_URL": "http://localhost:8004"},
+            {"event_url": "http://localhost:9000"},
+            {
+                "api_url": "http://localhost:8000",
+                "backend_port": 8000,
+                "deploy_url": "http://localhost:3000",
+                "frontend_port": 3000,
+                "event_url": "http://localhost:9000",
             },
         ),
     ],


### PR DESCRIPTION
This PR add an `event_url` attribute to rx.Config and allow users to set their event endpoints to reflex when using another backend api url.

This change add to the rx.Config a new attribute called `event_url`, with this new attribute users can define a different endpoint for sending/receiving events on the websocket events endpoint. This will help users in case they need to use different types of backend apis.

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.

    a. Give a descriptive title to your PR.

    b. Describe your changes.

    c. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

