### PR TITLE
test_app: copy the on_load_internal function to DynamicState

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1330,7 +1330,7 @@ class State(BaseState):
                 self.router.session.client_token,
                 router_data=self.router_data,
             ),
-            State.set_is_hydrated(True),  # type: ignore
+            type(self).set_is_hydrated(True),  # type: ignore
         ]
 
 


### PR DESCRIPTION
Actually test the real on_load_internal logic in case it changes, but test it via a separate class to avoid polluting the rx.State namespace with extra dynamic vars.