### PR TITLE
[REF-1425] Always capitalize tag of StatefulComponent

### DIFF
--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -1476,7 +1476,9 @@ class StatefulComponent(BaseComponent):
         code_hash = md5(str(rendered_code).encode("utf-8")).hexdigest()
 
         # Format the tag name including the hash.
-        return format.format_state_name(f"{component.tag.capitalize() or 'Comp'}_{code_hash}")
+        return format.format_state_name(
+            f"{component.tag or 'Comp'}_{code_hash}"
+        ).capitalize()
 
     @classmethod
     def _render_stateful_code(


### PR DESCRIPTION
Lowercase tags in JSX are rendered as plain HTML, so the code hash suffix breaks the element.

```python
import reflex as rx


class State(rx.State):
    v: str = "foo"


def index() -> rx.Component:
    return rx.el.div(State.v)


app = rx.App()
app.add_page(index)
app.compile()
```

should show "foo"