### PR TITLE
[REF-1417] Convert underscore-prefixed style props to pseudo selector

### DIFF
--- a/integration/test_input.py
+++ b/integration/test_input.py
@@ -31,7 +31,12 @@ def FullyControlledInput():
             ),
             rx.input(value=State.text, id="value_input", is_read_only=True),
             rx.input(on_change=State.set_text, id="on_change_input"),  # type: ignore
-            rx.el.input(value=State.text, id="plain_value_input", disabled=True, _disabled={"background_color": "#EEE"}),
+            rx.el.input(
+                value=State.text,
+                id="plain_value_input",
+                disabled=True,
+                _disabled={"background_color": "#EEE"},
+            ),
             rx.button("CLEAR", on_click=rx.set_value("on_change_input", "")),
         )
 
@@ -82,7 +87,10 @@ async def test_fully_controlled_input(fully_controlled_input: AppHarness):
     assert fully_controlled_input.poll_for_value(debounce_input) == "initial"
     assert fully_controlled_input.poll_for_value(value_input) == "initial"
     assert fully_controlled_input.poll_for_value(plain_value_input) == "initial"
-    assert plain_value_input.value_of_css_property("background-color") == "rgba(238, 238, 238, 1)"
+    assert (
+        plain_value_input.value_of_css_property("background-color")
+        == "rgba(238, 238, 238, 1)"
+    )
 
     # move cursor to home, then to the right and type characters
     debounce_input.send_keys(Keys.HOME, Keys.ARROW_RIGHT)
@@ -114,7 +122,10 @@ async def test_fully_controlled_input(fully_controlled_input: AppHarness):
         "state"
     ].text == "getting testing done"
     assert fully_controlled_input.poll_for_value(value_input) == "getting testing done"
-    assert fully_controlled_input.poll_for_value(plain_value_input) == "getting testing done"
+    assert (
+        fully_controlled_input.poll_for_value(plain_value_input)
+        == "getting testing done"
+    )
 
     # type into the on_change input
     on_change_input.send_keys("overwrite the state")
@@ -125,7 +136,10 @@ async def test_fully_controlled_input(fully_controlled_input: AppHarness):
         "state"
     ].text == "overwrite the state"
     assert fully_controlled_input.poll_for_value(value_input) == "overwrite the state"
-    assert fully_controlled_input.poll_for_value(plain_value_input) == "overwrite the state"
+    assert (
+        fully_controlled_input.poll_for_value(plain_value_input)
+        == "overwrite the state"
+    )
 
     clear_button.click()
     time.sleep(0.5)

--- a/integration/test_input.py
+++ b/integration/test_input.py
@@ -31,6 +31,7 @@ def FullyControlledInput():
             ),
             rx.input(value=State.text, id="value_input", is_read_only=True),
             rx.input(on_change=State.set_text, id="on_change_input"),  # type: ignore
+            rx.el.input(value=State.text, id="plain_value_input", disabled=True, _disabled={"background_color": "#EEE"}),
             rx.button("CLEAR", on_click=rx.set_value("on_change_input", "")),
         )
 
@@ -76,9 +77,12 @@ async def test_fully_controlled_input(fully_controlled_input: AppHarness):
     debounce_input = driver.find_element(By.ID, "debounce_input_input")
     value_input = driver.find_element(By.ID, "value_input")
     on_change_input = driver.find_element(By.ID, "on_change_input")
+    plain_value_input = driver.find_element(By.ID, "plain_value_input")
     clear_button = driver.find_element(By.TAG_NAME, "button")
     assert fully_controlled_input.poll_for_value(debounce_input) == "initial"
     assert fully_controlled_input.poll_for_value(value_input) == "initial"
+    assert fully_controlled_input.poll_for_value(plain_value_input) == "initial"
+    assert plain_value_input.value_of_css_property("background-color") == "rgba(238, 238, 238, 1)"
 
     # move cursor to home, then to the right and type characters
     debounce_input.send_keys(Keys.HOME, Keys.ARROW_RIGHT)
@@ -89,6 +93,7 @@ async def test_fully_controlled_input(fully_controlled_input: AppHarness):
         "state"
     ].text == "ifoonitial"
     assert fully_controlled_input.poll_for_value(value_input) == "ifoonitial"
+    assert fully_controlled_input.poll_for_value(plain_value_input) == "ifoonitial"
 
     # clear the input on the backend
     async with fully_controlled_input.modify_state(token) as state:
@@ -109,6 +114,7 @@ async def test_fully_controlled_input(fully_controlled_input: AppHarness):
         "state"
     ].text == "getting testing done"
     assert fully_controlled_input.poll_for_value(value_input) == "getting testing done"
+    assert fully_controlled_input.poll_for_value(plain_value_input) == "getting testing done"
 
     # type into the on_change input
     on_change_input.send_keys("overwrite the state")
@@ -119,6 +125,7 @@ async def test_fully_controlled_input(fully_controlled_input: AppHarness):
         "state"
     ].text == "overwrite the state"
     assert fully_controlled_input.poll_for_value(value_input) == "overwrite the state"
+    assert fully_controlled_input.poll_for_value(plain_value_input) == "overwrite the state"
 
     clear_button.click()
     time.sleep(0.5)

--- a/integration/test_var_operations.py
+++ b/integration/test_var_operations.py
@@ -35,7 +35,7 @@ def VarOperations():
     @app.add_page
     def index():
         return rx.vstack(
-            rx.input(
+            rx.el.input(
                 id="token",
                 value=VarOperationState.router.session.client_token,
                 is_read_only=True,

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -624,7 +624,7 @@ class Component(BaseComponent, ABC):
         Returns:
             The dictionary of the component style as value and the style notation as key.
         """
-        return {"css": self.style.format_as_emotion()}
+        return {"css": Var.create_safe(self.style.format_as_emotion())}
 
     def render(self) -> Dict:
         """Render the component.

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -624,7 +624,7 @@ class Component(BaseComponent, ABC):
         Returns:
             The dictionary of the component style as value and the style notation as key.
         """
-        return {"css": Var.create_safe(self.style.format_as_emotion())}
+        return {"css": Var.create(self.style.format_as_emotion())}
 
     def render(self) -> Dict:
         """Render the component.

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -624,7 +624,7 @@ class Component(BaseComponent, ABC):
         Returns:
             The dictionary of the component style as value and the style notation as key.
         """
-        return {"css": self.style}
+        return {"css": self.style.format_as_emotion()}
 
     def render(self) -> Dict:
         """Render the component.

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -40,7 +40,7 @@ from reflex.event import (
     call_event_handler,
     get_handler_args,
 )
-from reflex.style import Style
+from reflex.style import Style, format_as_emotion
 from reflex.utils import console, format, imports, types
 from reflex.utils.imports import ImportVar
 from reflex.utils.serializers import serializer
@@ -624,7 +624,7 @@ class Component(BaseComponent, ABC):
         Returns:
             The dictionary of the component style as value and the style notation as key.
         """
-        return {"css": Var.create(self.style.format_as_emotion())}
+        return {"css": Var.create(format_as_emotion(self.style))}
 
     def render(self) -> Dict:
         """Render the component.

--- a/reflex/style.py
+++ b/reflex/style.py
@@ -175,7 +175,7 @@ class Style(dict):
             prefix = "&"
         return prefix + format.to_kebab_case(key)
 
-    def format_as_emotion(self) -> dict[str, Any]:
+    def format_as_emotion(self) -> dict[str, Any] | None:
         """Convert the style to an emotion-compatible CSS-in-JS dict.
 
         Returns:
@@ -197,4 +197,5 @@ class Style(dict):
                         emotion_style.setdefault(mq, {}).update(style_sub_dict)
             else:
                 emotion_style[key] = value
-        return emotion_style
+        if emotion_style:
+            return emotion_style

--- a/reflex/style.py
+++ b/reflex/style.py
@@ -75,6 +75,14 @@ def convert_item(style_item: str | Var) -> tuple[str, VarData | None]:
 def convert_list(
     responsive_list: list[str | dict | Var],
 ) -> tuple[list[str | dict], VarData | None]:
+    """Format a responsive value list.
+
+    Args:
+        responsive_list: The raw responsive value list (one value per breakpoint).
+
+    Returns:
+        The recursively converted responsive value list and any associated VarData.
+    """
     converted_value = []
     item_var_datas = []
     for responsive_item in responsive_list:
@@ -100,7 +108,7 @@ def convert(style_dict):
     var_data = None  # Track import/hook data from any Vars in the style dict.
     out = {}
     for key, value in style_dict.items():
-        key = format.to_camel_case(key, allow_hyphens=True)
+        key = format.to_camel_case(key)
         if isinstance(value, dict):
             # Recursively format nested style dictionaries.
             out[key], new_var_data = convert(value)
@@ -180,8 +188,11 @@ def _format_emotion_style_pseudo_selector(key: str) -> str:
     return key
 
 
-def format_as_emotion(style_dict) -> dict[str, Any] | None:
+def format_as_emotion(style_dict: dict[str, Any]) -> dict[str, Any] | None:
     """Convert the style to an emotion-compatible CSS-in-JS dict.
+
+    Args:
+        style_dict: The style dict to convert.
 
     Returns:
         The emotion dict.

--- a/reflex/style.py
+++ b/reflex/style.py
@@ -160,14 +160,20 @@ class Style(dict):
         """Format a pseudo selector for emotion CSS-in-JS.
 
         Args:
-            key: Underscore-prefixed pseudo selector key (_hover).
+            key: Underscore-prefixed or colon-prefixed pseudo selector key (_hover).
 
         Returns:
             A self-referential pseudo selector key (&:hover).
         """
+        prefix = ""
         if key.startswith("_"):
-            return f"&:{key[1:]}"
-        return key
+            # Handle pseudo selectors in chakra style format.
+            prefix = "&:"
+            key = key[1:]
+        if key.startswith(":"):
+            # Handle pseudo selectors and elements in native format.
+            prefix = "&"
+        return prefix + format.to_kebab_case(key)
 
     def format_as_emotion(self) -> dict[str, Any]:
         """Convert the style to an emotion-compatible CSS-in-JS dict.

--- a/reflex/style.py
+++ b/reflex/style.py
@@ -67,7 +67,7 @@ def convert_item(style_item: str | Var) -> tuple[str, VarData | None]:
     new_var = Var.create(style_item)
     if new_var is not None and new_var._var_data:
         # The wrapped backtick is used to identify the Var for interpolation.
-        return f"`{style_item}`", new_var._var_data
+        return f"`{str(new_var)}`", new_var._var_data
 
     return style_item, None
 

--- a/reflex/style.py
+++ b/reflex/style.py
@@ -110,3 +110,28 @@ class Style(dict):
             # Carry the imports/hooks when setting a Var as a value.
             self._var_data = VarData.merge(self._var_data, _var._var_data)
         super().__setitem__(key, value)
+
+    @staticmethod
+    def _format_emotion_style_pseudo_selector(key: str) -> str:
+        """Format a pseudo selector for emotion CSS-in-JS.
+
+        Args:
+            key: Underscore-prefixed pseudo selector key (_hover).
+
+        Returns:
+            A self-referential pseudo selector key (&:hover).
+        """
+        if key.startswith("_"):
+            return f"&:{key[1:]}"
+        return key
+
+    def format_as_emotion(self) -> dict[str, Any]:
+        """Convert the style to an emotion-compatible CSS-in-JS dict.
+
+        Returns:
+            The emotion dict.
+        """
+        return {
+            self._format_emotion_style_pseudo_selector(key): value
+            for key, value in self.items()
+        }

--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -625,18 +625,22 @@ def unwrap_vars(value: str) -> str:
         return prefix + re.sub('\\\\"', '"', m.group(2))
 
     # This substitution is necessary to unwrap var values.
-    return re.sub(
-        pattern=r"""
+    return (
+        re.sub(
+            pattern=r"""
             (?<!\\)      # must NOT start with a backslash
             "            # match opening double quote of JSON value
             (<reflex.Var>.*?</reflex.Var>)?  # Optional encoded VarData (non-greedy)
             {(.*?)}      # extract the value between curly braces (non-greedy)
             "            # match must end with an unescaped double quote
         """,
-        repl=unescape_double_quotes_in_var,
-        string=value,
-        flags=re.VERBOSE,
-    ).replace('"`', "`").replace('`"', "`")
+            repl=unescape_double_quotes_in_var,
+            string=value,
+            flags=re.VERBOSE,
+        )
+        .replace('"`', "`")
+        .replace('`"', "`")
+    )
 
 
 def collect_form_dict_names(form_dict: dict[str, Any]) -> dict[str, Any]:

--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -636,7 +636,7 @@ def unwrap_vars(value: str) -> str:
         repl=unescape_double_quotes_in_var,
         string=value,
         flags=re.VERBOSE,
-    )
+    ).replace('"`', "`").replace('`"', "`")
 
 
 def collect_form_dict_names(form_dict: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -17,7 +17,7 @@ test_style = [
     ({"::test_case": {"a": 1}}, {"::testCase": {"a": 1}}),
     (
         {"::-webkit-scrollbar": {"display": "none"}},
-        {"::WebkitScrollbar": {"display": "none"}},
+        {"::-webkit-scrollbar": {"display": "none"}},
     ),
 ]
 
@@ -309,7 +309,7 @@ class StyleState(rx.State):
         ),
         (
             {"color": f"dark{StyleState.color}"},
-            {"css": Var.create({"color": f"dark" + StyleState.color})},
+            {"css": Var.create(f'{{"color": `dark{StyleState.color}`}}').to(dict)},
         ),
         (
             {"color": StyleState.color, "_hover": {"color": StyleState.color2}},
@@ -318,6 +318,80 @@ class StyleState(rx.State):
                     {
                         "color": StyleState.color,
                         "&:hover": {"color": StyleState.color2},
+                    }
+                )
+            },
+        ),
+        (
+            {"color": [StyleState.color, "gray", StyleState.color2, "yellow", "blue"]},
+            {
+                "css": Var.create(
+                    {
+                        "@media screen and (min-width: 0)": {"color": StyleState.color},
+                        "@media screen and (min-width: 30em)": {"color": "gray"},
+                        "@media screen and (min-width: 48em)": {
+                            "color": StyleState.color2
+                        },
+                        "@media screen and (min-width: 62em)": {"color": "yellow"},
+                        "@media screen and (min-width: 80em)": {"color": "blue"},
+                    }
+                )
+            },
+        ),
+        (
+            {
+                "_hover": [
+                    {"color": StyleState.color},
+                    {"color": StyleState.color2},
+                    {"color": "#333"},
+                    {"color": "#444"},
+                    {"color": "#555"},
+                ]
+            },
+            {
+                "css": Var.create(
+                    {
+                        "&:hover": {
+                            "@media screen and (min-width: 0)": {
+                                "color": StyleState.color
+                            },
+                            "@media screen and (min-width: 30em)": {
+                                "color": StyleState.color2
+                            },
+                            "@media screen and (min-width: 48em)": {"color": "#333"},
+                            "@media screen and (min-width: 62em)": {"color": "#444"},
+                            "@media screen and (min-width: 80em)": {"color": "#555"},
+                        }
+                    }
+                )
+            },
+        ),
+        (
+            {
+                "_hover": {
+                    "color": [
+                        StyleState.color,
+                        StyleState.color2,
+                        "#333",
+                        "#444",
+                        "#555",
+                    ]
+                }
+            },
+            {
+                "css": Var.create(
+                    {
+                        "&:hover": {
+                            "@media screen and (min-width: 0)": {
+                                "color": StyleState.color
+                            },
+                            "@media screen and (min-width: 30em)": {
+                                "color": StyleState.color2
+                            },
+                            "@media screen and (min-width: 48em)": {"color": "#333"},
+                            "@media screen and (min-width: 62em)": {"color": "#444"},
+                            "@media screen and (min-width: 80em)": {"color": "#555"},
+                        }
                     }
                 )
             },

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -8,6 +8,9 @@ test_style = [
     ({"a": Var.create("abc")}, {"a": "abc"}),
     ({"test_case": 1}, {"testCase": 1}),
     ({"test_case": {"a": 1}}, {"testCase": {"a": 1}}),
+    ({":test_case": {"a": 1}}, {":testCase": {"a": 1}}),
+    ({"::test_case": {"a": 1}}, {"::testCase": {"a": 1}}),
+    ({"::-webkit-scrollbar": {"display": "none"}}, {"::WebkitScrollbar": {"display": "none"}}),
 ]
 
 

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -1,5 +1,10 @@
+from __future__ import annotations
+
+from typing import Any
+
 import pytest
 
+import reflex as rx
 from reflex import style
 from reflex.vars import Var
 
@@ -10,7 +15,10 @@ test_style = [
     ({"test_case": {"a": 1}}, {"testCase": {"a": 1}}),
     ({":test_case": {"a": 1}}, {":testCase": {"a": 1}}),
     ({"::test_case": {"a": 1}}, {"::testCase": {"a": 1}}),
-    ({"::-webkit-scrollbar": {"display": "none"}}, {"::WebkitScrollbar": {"display": "none"}}),
+    (
+        {"::-webkit-scrollbar": {"display": "none"}},
+        {"::WebkitScrollbar": {"display": "none"}},
+    ),
 ]
 
 
@@ -41,3 +49,298 @@ def test_create_style(style_dict, expected):
         expected: The expected formatted style.
     """
     assert style.Style(style_dict) == expected
+
+
+def compare_dict_of_var(d1: dict[str, Any], d2: dict[str, Any]):
+    """Compare two dictionaries of Var objects.
+
+    Args:
+        d1: The first dictionary.
+        d2: The second dictionary.
+    """
+    assert len(d1) == len(d2)
+    for key, value in d1.items():
+        assert key in d2
+        if isinstance(value, dict):
+            compare_dict_of_var(value, d2[key])
+        elif isinstance(value, Var):
+            assert value.equals(d2[key])
+        else:
+            assert value == d2[key]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "style_dict", "expected_get_style"),
+    [
+        ({}, {}, {"css": None}),
+        ({"color": "hotpink"}, {}, {"css": Var.create({"color": "hotpink"})}),
+        ({}, {"color": "red"}, {"css": Var.create({"color": "red"})}),
+        (
+            {"color": "hotpink"},
+            {"color": "red"},
+            {"css": Var.create({"color": "hotpink"})},
+        ),
+        (
+            {"_hover": {"color": "hotpink"}},
+            {},
+            {"css": Var.create({"&:hover": {"color": "hotpink"}})},
+        ),
+        (
+            {},
+            {"_hover": {"color": "red"}},
+            {"css": Var.create({"&:hover": {"color": "red"}})},
+        ),
+        (
+            {},
+            {":hover": {"color": "red"}},
+            {"css": Var.create({"&:hover": {"color": "red"}})},
+        ),
+        (
+            {},
+            {"::-webkit-scrollbar": {"display": "none"}},
+            {"css": Var.create({"&::-webkit-scrollbar": {"display": "none"}})},
+        ),
+        (
+            {},
+            {"::-moz-progress-bar": {"background_color": "red"}},
+            {"css": Var.create({"&::-moz-progress-bar": {"backgroundColor": "red"}})},
+        ),
+        (
+            {"color": ["#111", "#222", "#333", "#444", "#555"]},
+            {},
+            {
+                "css": Var.create(
+                    {
+                        "@media screen and (min-width: 0)": {"color": "#111"},
+                        "@media screen and (min-width: 30em)": {"color": "#222"},
+                        "@media screen and (min-width: 48em)": {"color": "#333"},
+                        "@media screen and (min-width: 62em)": {"color": "#444"},
+                        "@media screen and (min-width: 80em)": {"color": "#555"},
+                    }
+                )
+            },
+        ),
+        (
+            {
+                "color": ["#111", "#222", "#333", "#444", "#555"],
+                "background_color": "#FFF",
+            },
+            {},
+            {
+                "css": Var.create(
+                    {
+                        "@media screen and (min-width: 0)": {"color": "#111"},
+                        "@media screen and (min-width: 30em)": {"color": "#222"},
+                        "@media screen and (min-width: 48em)": {"color": "#333"},
+                        "@media screen and (min-width: 62em)": {"color": "#444"},
+                        "@media screen and (min-width: 80em)": {"color": "#555"},
+                        "backgroundColor": "#FFF",
+                    }
+                )
+            },
+        ),
+        (
+            {
+                "color": ["#111", "#222", "#333", "#444", "#555"],
+                "background_color": ["#FFF", "#EEE", "#DDD", "#CCC", "#BBB"],
+            },
+            {},
+            {
+                "css": Var.create(
+                    {
+                        "@media screen and (min-width: 0)": {
+                            "color": "#111",
+                            "backgroundColor": "#FFF",
+                        },
+                        "@media screen and (min-width: 30em)": {
+                            "color": "#222",
+                            "backgroundColor": "#EEE",
+                        },
+                        "@media screen and (min-width: 48em)": {
+                            "color": "#333",
+                            "backgroundColor": "#DDD",
+                        },
+                        "@media screen and (min-width: 62em)": {
+                            "color": "#444",
+                            "backgroundColor": "#CCC",
+                        },
+                        "@media screen and (min-width: 80em)": {
+                            "color": "#555",
+                            "backgroundColor": "#BBB",
+                        },
+                    }
+                )
+            },
+        ),
+        (
+            {
+                "_hover": [
+                    {"color": "#111"},
+                    {"color": "#222"},
+                    {"color": "#333"},
+                    {"color": "#444"},
+                    {"color": "#555"},
+                ]
+            },
+            {},
+            {
+                "css": Var.create(
+                    {
+                        "&:hover": {
+                            "@media screen and (min-width: 0)": {"color": "#111"},
+                            "@media screen and (min-width: 30em)": {"color": "#222"},
+                            "@media screen and (min-width: 48em)": {"color": "#333"},
+                            "@media screen and (min-width: 62em)": {"color": "#444"},
+                            "@media screen and (min-width: 80em)": {"color": "#555"},
+                        }
+                    }
+                )
+            },
+        ),
+        (
+            {"_hover": {"color": ["#111", "#222", "#333", "#444", "#555"]}},
+            {},
+            {
+                "css": Var.create(
+                    {
+                        "&:hover": {
+                            "@media screen and (min-width: 0)": {"color": "#111"},
+                            "@media screen and (min-width: 30em)": {"color": "#222"},
+                            "@media screen and (min-width: 48em)": {"color": "#333"},
+                            "@media screen and (min-width: 62em)": {"color": "#444"},
+                            "@media screen and (min-width: 80em)": {"color": "#555"},
+                        }
+                    }
+                )
+            },
+        ),
+        (
+            {
+                "_hover": {
+                    "color": ["#111", "#222", "#333", "#444", "#555"],
+                    "background_color": ["#FFF", "#EEE", "#DDD", "#CCC", "#BBB"],
+                }
+            },
+            {},
+            {
+                "css": Var.create(
+                    {
+                        "&:hover": {
+                            "@media screen and (min-width: 0)": {
+                                "color": "#111",
+                                "backgroundColor": "#FFF",
+                            },
+                            "@media screen and (min-width: 30em)": {
+                                "color": "#222",
+                                "backgroundColor": "#EEE",
+                            },
+                            "@media screen and (min-width: 48em)": {
+                                "color": "#333",
+                                "backgroundColor": "#DDD",
+                            },
+                            "@media screen and (min-width: 62em)": {
+                                "color": "#444",
+                                "backgroundColor": "#CCC",
+                            },
+                            "@media screen and (min-width: 80em)": {
+                                "color": "#555",
+                                "backgroundColor": "#BBB",
+                            },
+                        }
+                    }
+                )
+            },
+        ),
+        (
+            {
+                "_hover": {
+                    "color": ["#111", "#222", "#333", "#444", "#555"],
+                    "background_color": "#FFF",
+                }
+            },
+            {},
+            {
+                "css": Var.create(
+                    {
+                        "&:hover": {
+                            "@media screen and (min-width: 0)": {"color": "#111"},
+                            "@media screen and (min-width: 30em)": {"color": "#222"},
+                            "@media screen and (min-width: 48em)": {"color": "#333"},
+                            "@media screen and (min-width: 62em)": {"color": "#444"},
+                            "@media screen and (min-width: 80em)": {"color": "#555"},
+                            "backgroundColor": "#FFF",
+                        }
+                    }
+                )
+            },
+        ),
+    ],
+)
+def test_style_via_component(
+    kwargs: dict[str, Any],
+    style_dict: dict[str, Any],
+    expected_get_style: dict[str, Any],
+):
+    """Pass kwargs and style_dict to a component and assert the final, combined style dict.
+
+    Args:
+        kwargs: The kwargs to pass to the component.
+        style_dict: The style_dict to pass to the component.
+        expected_get_style: The expected style dict.
+    """
+
+    comp = rx.el.div(style=style_dict, **kwargs)
+    compare_dict_of_var(comp._get_style(), expected_get_style)
+
+
+class StyleState(rx.State):
+    """Style vars in a substate."""
+
+    color: str = "hotpink"
+    color2: str = "red"
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_get_style"),
+    [
+        (
+            {"color": StyleState.color},
+            {"css": Var.create({"color": StyleState.color})},
+        ),
+        (
+            {"color": f"dark{StyleState.color}"},
+            {"css": Var.create({"color": f"dark" + StyleState.color})},
+        ),
+        (
+            {"color": StyleState.color, "_hover": {"color": StyleState.color2}},
+            {
+                "css": Var.create(
+                    {
+                        "color": StyleState.color,
+                        "&:hover": {"color": StyleState.color2},
+                    }
+                )
+            },
+        ),
+    ],
+)
+def test_style_via_component_with_state(
+    kwargs: dict[str, Any],
+    expected_get_style: dict[str, Any],
+):
+    """Pass kwargs to a component with state vars and assert the final, combined style dict.
+
+    Args:
+        kwargs: The kwargs to pass to the component.
+        expected_get_style: The expected style dict.
+    """
+
+    comp = rx.el.div(**kwargs)
+
+    assert comp.style._var_data == expected_get_style["css"]._var_data
+    # Remove the _var_data from the expected style, since the emotion-formatted
+    # style dict won't actually have it.
+    expected_get_style["css"]._var_data = None
+
+    # Assert that style values are equal.
+    compare_dict_of_var(comp._get_style(), expected_get_style)

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -17,7 +17,7 @@ test_style = [
     ({"::test_case": {"a": 1}}, {"::testCase": {"a": 1}}),
     (
         {"::-webkit-scrollbar": {"display": "none"}},
-        {"::-webkit-scrollbar": {"display": "none"}},
+        {"::WebkitScrollbar": {"display": "none"}},
     ),
 ]
 
@@ -288,8 +288,7 @@ def test_style_via_component(
         style_dict: The style_dict to pass to the component.
         expected_get_style: The expected style dict.
     """
-
-    comp = rx.el.div(style=style_dict, **kwargs)
+    comp = rx.el.div(style=style_dict, **kwargs)  # type: ignore
     compare_dict_of_var(comp._get_style(), expected_get_style)
 
 
@@ -309,7 +308,7 @@ class StyleState(rx.State):
         ),
         (
             {"color": f"dark{StyleState.color}"},
-            {"css": Var.create(f'{{"color": `dark{StyleState.color}`}}').to(dict)},
+            {"css": Var.create_safe(f'{{"color": `dark{StyleState.color}`}}').to(dict)},
         ),
         (
             {"color": StyleState.color, "_hover": {"color": StyleState.color2}},
@@ -408,7 +407,6 @@ def test_style_via_component_with_state(
         kwargs: The kwargs to pass to the component.
         expected_get_style: The expected style dict.
     """
-
     comp = rx.el.div(**kwargs)
 
     assert comp.style._var_data == expected_get_style["css"]._var_data

--- a/tests/utils/test_format.py
+++ b/tests/utils/test_format.py
@@ -125,6 +125,8 @@ def test_indent(text: str, indent_level: int, expected: str, windows_platform: b
         ("__start_with_double_underscore", "__start_with_double_underscore"),
         ("kebab-case", "kebab_case"),
         ("double-kebab-case", "double_kebab_case"),
+        (":start-with-colon", ":start_with_colon"),
+        (":-start-with-colon-dash", ":_start_with_colon_dash"),
     ],
 )
 def test_to_snake_case(input: str, output: str):
@@ -153,6 +155,8 @@ def test_to_snake_case(input: str, output: str):
         ("--starts-with-double-hyphen", "--startsWithDoubleHyphen"),
         ("_starts_with_underscore", "_startsWithUnderscore"),
         ("__starts_with_double_underscore", "__startsWithDoubleUnderscore"),
+        (":start-with-colon", ":startWithColon"),
+        (":-start-with-colon-dash", ":StartWithColonDash"),
     ],
 )
 def test_to_camel_case(input: str, output: str):
@@ -193,6 +197,10 @@ def test_to_title_case(input: str, output: str):
         ("Hello", "hello"),
         ("snake_case", "snake-case"),
         ("snake_case_two", "snake-case-two"),
+        (":startWithColon", ":start-with-colon"),
+        (":StartWithColonDash", ":-start-with-colon-dash"),
+        (":start_with_colon", ":start-with-colon"),
+        (":_start_with_colon_dash", ":-start-with-colon-dash"),
     ],
 )
 def test_to_kebab_case(input: str, output: str):


### PR DESCRIPTION
Use emotion CSS-in-JS for default components.

Convert underscore-prefixed style props, like `_hover` and `_focus` to emotion compatible self-referential pseudo selectors like `&:hover` and `&:focus`.

## Test cases

### Keys

* Simple property
* webkit/moz property
* self-referential (underscore prefix, colon prefix)

### Values

* Each of the above with state vars / f-string
* Each of the above with responsive list

### Extension precedence

* Each of the above combined with `style={}`
* Each of the above combined with component styles from app

## Types of Test

* Unit: does the resulting style dict for a component (rx.el.div) look correct?
* Integration: for different types of components, get computed css property

## Sample Code

```python
import reflex as rx
import reflex.components.radix.themes as rdxt


class FooState(rx.State):
    """The app state."""
    counter: int = 0
    text: str = ""
    rcolor: str = "lime"

    def foo(self):
        print("foo")


def index() -> rx.Component:
    return rx.fragment(
        rx.color_mode_button(rx.color_mode_icon(), float="right"),
        rx.button("Foo", on_click=FooState.foo),
        rx.button("Increment", on_click=FooState.set_counter(FooState.counter + 1)),
        rx.text(FooState.counter, _hover={"color": "hotpink"}),
        rx.text(f"({FooState.counter})"),
        rx.button("Decrement", on_click=FooState.set_counter(FooState.counter - 1)),
        rx.input(placeholder="text", value=FooState.text, on_change=FooState.set_text, _placeholder={"text_decoration": "underline"}),
        rx.el.input(
            placeholder="text",
            value=FooState.text,
            _placeholder={"text_decoration": "underline", "padding-left": "10px"},
            _focus_visible={"outline": "2px solid crimson"},
        ),
        rx.text(FooState.text),
        rx.el.button(
            "Plain Button",
            background_color=f"var(--{FooState.rcolor}-3)",
            padding="4px",
            _hover=[
                {"background_color": f"var(--{FooState.rcolor}-4)"},
                {"background_color": "var(--plum-4)"},
                {"background_color": "var(--tomato-4)"},
                {"background_color": "var(--grass-4)"},
                {"background_color": "var(--accent-4)"},
            ],
            _active={"background_color": f"var(--{FooState.rcolor}-5)"},
        ),
        rdxt.box(
            rx.box("Foo", height="500px"),
            overflow_y="scroll",
            border="1px solid black",
            height="200px",
            width=["100px", "200px", "300px", "400px", "500px"],
            style={
                "::first-letter": {
                    "font_size": "1.5rem",
                    "font_weight": "bold",
                    "color": "brown",
                },
                "::-webkit-scrollbar": {"display": "none"},
                "::after": {"content": f"'{FooState.text}'"},
            }
        ),
    )


# Add state and page to the app.
app = rx.App(theme=rdxt.Theme(accent_color="plum"))
app.add_page(index)
app.add_page(index, route="/foo")
app.compile()
```