### PR TITLE
Format var better in error message

### DIFF
--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -266,8 +266,9 @@ class Component(BaseComponent, ABC):
                     passed_type = type(value)
                     expected_type = fields[key].outer_type_
                 if not types._issubclass(passed_type, expected_type):
+                    value_name = value._var_name if isinstance(value, Var) else value
                     raise TypeError(
-                        f"Invalid var passed for prop {key}, expected type {expected_type}, got value {value} of type {passed_type}."
+                        f"Invalid var passed for prop {key}, expected type {expected_type}, got value {value_name} of type {passed_type}."
                     )
 
             # Check if the key is an event trigger.


### PR DESCRIPTION
Before we were printing the entire var_data due to the f-string of the var class, which made the error messages hard to read.

```
TypeError: Invalid var passed for prop value, expected type <class 'int'>, got value $<reflex.Var>{"state": "state.state", "imports": {"/utils/context": [{"tag": "StateContexts", "is_default": false, "alias": null, "install": true, "render": tru
e}], "react": [{"tag": "useContext", "is_default": false, "alias": null, "install": true, "render": true}]}, "hooks": ["const state__state = useContext(StateContexts.state__state)"]}</reflex.Var>{state__state.array.at(0)} of type typing.Any.
```

The new error message is

```
TypeError: Invalid var passed for prop value, expected type <class 'int'>, got value array.at(0) of type typing.Any.
```