### PR TITLE
Warning if newer reflex/reflex-hosting-cli available 

### DIFF
--- a/reflex/constants/__init__.py
+++ b/reflex/constants/__init__.py
@@ -15,6 +15,7 @@ from .base import (
     Next,
     Ping,
     Reflex,
+    ReflexHostingCLI,
     Templates,
 )
 from .compiler import (

--- a/reflex/constants/base.py
+++ b/reflex/constants/base.py
@@ -72,6 +72,13 @@ class Reflex(SimpleNamespace):
     )
 
 
+class ReflexHostingCLI(SimpleNamespace):
+    """Base constants concerning Reflex Hosting CLI."""
+
+    # The name of the Reflex Hosting CLI package.
+    MODULE_NAME = "reflex-hosting-cli"
+
+
 class Templates(SimpleNamespace):
     """Constants related to Templates."""
 

--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -15,7 +15,7 @@ from reflex_cli.utils import dependency
 
 from reflex import constants
 from reflex.config import get_config
-from reflex.utils import console, telemetry, prerequisites
+from reflex.utils import console, telemetry
 
 # Disable typer+rich integration for help panels
 typer.core.rich = False  # type: ignore
@@ -78,7 +78,7 @@ def _init(
     app_name = prerequisites.get_default_app_name() if name is None else name
     console.rule(f"[bold]Initializing {app_name}")
 
-    prerequisites.check_latest_package_version("reflex")    
+    prerequisites.check_latest_package_version("reflex")
 
     # Set up the web project.
     prerequisites.initialize_frontend_dependencies()
@@ -173,7 +173,7 @@ def _run(
 
     console.rule("[bold]Starting Reflex App")
 
-    prerequisites.check_latest_package_version("reflex")  
+    prerequisites.check_latest_package_version("reflex")
 
     if frontend:
         prerequisites.update_next_config()
@@ -493,7 +493,7 @@ def deploy(
 
     # Check if we are set up.
     prerequisites.check_initialized(frontend=True)
-    prerequisites.check_latest_package_version("reflex-hosting-cli")  
+    prerequisites.check_latest_package_version("reflex-hosting-cli")
 
     hosting_cli.deploy(
         app_name=app_name,

--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -15,7 +15,7 @@ from reflex_cli.utils import dependency
 
 from reflex import constants
 from reflex.config import get_config
-from reflex.utils import console, telemetry
+from reflex.utils import console, telemetry, prerequisites
 
 # Disable typer+rich integration for help panels
 typer.core.rich = False  # type: ignore
@@ -77,6 +77,8 @@ def _init(
     # Get the app name.
     app_name = prerequisites.get_default_app_name() if name is None else name
     console.rule(f"[bold]Initializing {app_name}")
+
+    prerequisites.check_latest_package_version("reflex")    
 
     # Set up the web project.
     prerequisites.initialize_frontend_dependencies()
@@ -170,6 +172,8 @@ def _run(
     get_config(reload=True)
 
     console.rule("[bold]Starting Reflex App")
+
+    prerequisites.check_latest_package_version("reflex")  
 
     if frontend:
         prerequisites.update_next_config()
@@ -489,6 +493,7 @@ def deploy(
 
     # Check if we are set up.
     prerequisites.check_initialized(frontend=True)
+    prerequisites.check_latest_package_version("reflex-hosting-cli")  
 
     hosting_cli.deploy(
         app_name=app_name,

--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -78,7 +78,7 @@ def _init(
     app_name = prerequisites.get_default_app_name() if name is None else name
     console.rule(f"[bold]Initializing {app_name}")
 
-    prerequisites.check_latest_package_version("reflex")
+    prerequisites.check_latest_package_version(constants.Reflex.MODULE_NAME)
 
     # Set up the web project.
     prerequisites.initialize_frontend_dependencies()
@@ -173,7 +173,7 @@ def _run(
 
     console.rule("[bold]Starting Reflex App")
 
-    prerequisites.check_latest_package_version("reflex")
+    prerequisites.check_latest_package_version(constants.Reflex.MODULE_NAME)
 
     if frontend:
         prerequisites.update_next_config()
@@ -493,7 +493,7 @@ def deploy(
 
     # Check if we are set up.
     prerequisites.check_initialized(frontend=True)
-    prerequisites.check_latest_package_version("reflex-hosting-cli")
+    prerequisites.check_latest_package_version(constants.ReflexHostingCLI.MODULE_NAME)
 
     hosting_cli.deploy(
         app_name=app_name,

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from types import ModuleType
 
 import httpx
+import pkg_resources
 import typer
 from alembic.util.exc import CommandError
 from packaging import version
@@ -36,15 +37,12 @@ def check_latest_package_version(package_name: str):
         package_name: The name of the package.
     """
     try:
+        # Get the latest version from PyPI
+        current_version = pkg_resources.get_distribution(package_name).version
         url = f"https://pypi.org/pypi/{package_name}/json"
-
         response = httpx.get(url)
-        data = response.json()
-
-        latest_version = data["info"]["version"]
-        current_version = version.parse(constants.Reflex.VERSION)
-
-        if current_version < version.parse(latest_version):
+        latest_version = response.json()["info"]["version"]
+        if version.parse(current_version) < version.parse(latest_version):
             console.warn(
                 f"Your version ({current_version}) of {package_name} is out of date. Upgrade to {latest_version} with 'pip install {package_name} --upgrade'"
             )

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -35,18 +35,21 @@ def check_latest_package_version(package_name: str):
     Args:
         package_name: The name of the package.
     """
-    url = f"https://pypi.org/pypi/{package_name}/json"
+    try:
+        url = f"https://pypi.org/pypi/{package_name}/json"
 
-    response = httpx.get(url)
-    data = response.json()
+        response = httpx.get(url)
+        data = response.json()
 
-    latest_version = data["info"]["version"]
-    current_version = version.parse(constants.Reflex.VERSION)
+        latest_version = data["info"]["version"]
+        current_version = version.parse(constants.Reflex.VERSION)
 
-    if current_version < version.parse(latest_version):
-        console.warn(
-            f"Your version ({current_version}) of {package_name} is out of date. Upgrade to {latest_version} with 'pip install {package_name} --upgrade'"
-        )
+        if current_version < version.parse(latest_version):
+            console.warn(
+                f"Your version ({current_version}) of {package_name} is out of date. Upgrade to {latest_version} with 'pip install {package_name} --upgrade'"
+            )
+    except Exception:
+        pass
 
 
 def check_node_version() -> bool:

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -16,6 +16,7 @@ import zipfile
 from fileinput import FileInput
 from pathlib import Path
 from types import ModuleType
+import requests
 
 import httpx
 import typer
@@ -27,6 +28,30 @@ from reflex import constants, model
 from reflex.compiler import templates
 from reflex.config import get_config
 from reflex.utils import console, path_ops, processes
+
+
+
+
+def check_latest_package_version(package_name) -> bool:
+    """Check if the latest version of the package is installed.
+
+    Returns:
+        Whether the latest version of the package is installed.
+    """
+    url = f"https://pypi.org/pypi/{package_name}/json"
+
+    response = requests.get(url)
+    data = response.json()
+
+    latest_version = data["info"]["version"]
+    current_version = version.parse(constants.Reflex.VERSION)
+
+    if current_version < version.parse(latest_version):
+        console.warn(
+            f"Your version ({current_version}) of {package_name} is out of date. Upgrade to {latest_version} with 'pip install {package_name} --upgrade'"
+        )
+        return False
+
 
 
 def check_node_version() -> bool:

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -18,7 +18,6 @@ from pathlib import Path
 from types import ModuleType
 
 import httpx
-import requests
 import typer
 from alembic.util.exc import CommandError
 from packaging import version
@@ -38,7 +37,7 @@ def check_latest_package_version(package_name: str):
     """
     url = f"https://pypi.org/pypi/{package_name}/json"
 
-    response = requests.get(url)
+    response = httpx.get(url)
     data = response.json()
 
     latest_version = data["info"]["version"]

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -16,9 +16,9 @@ import zipfile
 from fileinput import FileInput
 from pathlib import Path
 from types import ModuleType
-import requests
 
 import httpx
+import requests
 import typer
 from alembic.util.exc import CommandError
 from packaging import version
@@ -30,13 +30,11 @@ from reflex.config import get_config
 from reflex.utils import console, path_ops, processes
 
 
-
-
-def check_latest_package_version(package_name) -> bool:
+def check_latest_package_version(package_name: str):
     """Check if the latest version of the package is installed.
 
-    Returns:
-        Whether the latest version of the package is installed.
+    Args:
+        package_name: The name of the package.
     """
     url = f"https://pypi.org/pypi/{package_name}/json"
 
@@ -50,8 +48,6 @@ def check_latest_package_version(package_name) -> bool:
         console.warn(
             f"Your version ({current_version}) of {package_name} is out of date. Upgrade to {latest_version} with 'pip install {package_name} --upgrade'"
         )
-        return False
-
 
 
 def check_node_version() -> bool:


### PR DESCRIPTION
Add check_latest_package_version when given a package this checks if there is a newer python package and throws a warning to upgrades. Used in run and init to check for reflex and reflex-hosting-cli in deploy

![Screenshot 2023-12-06 at 5 53 13 PM](https://github.com/reflex-dev/reflex/assets/38776361/cd3b6e97-2b21-4dd8-9993-f1c2ea425992)
