### PR TITLE
Bug fix: Export should only excludes assets folder if it's in the top level

### DIFF
--- a/reflex/utils/build.py
+++ b/reflex/utils/build.py
@@ -67,6 +67,7 @@ def _zip(
     upload_db_file: bool = False,
     dirs_to_exclude: set[str] | None = None,
     files_to_exclude: set[str] | None = None,
+    top_level_dirs_to_exclude: set[str] | None = None,
 ) -> None:
     """Zip utility function.
 
@@ -78,6 +79,7 @@ def _zip(
         upload_db_file: Whether to include local sqlite db files.
         dirs_to_exclude: The directories to exclude.
         files_to_exclude: The files to exclude.
+        top_level_dirs_to_exclude: The top level directory names immediately under root_dir to exclude. Do not exclude folders by these names further in the sub-directories.
 
     """
     dirs_to_exclude = dirs_to_exclude or set()
@@ -97,6 +99,9 @@ def _zip(
                 not exclude_venv_dirs or not _looks_like_venv_dir(os.path.join(root, d))
             )
         ]
+        # If we are at the top level with root_dir, exclude the top level dirs.
+        if top_level_dirs_to_exclude and root == root_dir:
+            dirs[:] = [d for d in dirs if d not in top_level_dirs_to_exclude]
         # Modify the files in-place so the hidden files and db files are excluded.
         files[:] = [
             f
@@ -197,8 +202,9 @@ def export(
                     zip_dest_dir, constants.ComponentName.BACKEND.zip()
                 ),
                 root_dir=".",
-                dirs_to_exclude={"assets", "__pycache__"},
+                dirs_to_exclude={"__pycache__"},
                 files_to_exclude=files_to_exclude,
+                top_level_dirs_to_exclude={"assets"},
                 exclude_venv_dirs=True,
                 upload_db_file=upload_db_file,
             )


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### New Feature Submission:

- [ ] Does your submission pass the tests? 
- [ ] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.
- Previously, the export command excludes folders named `assets` at all levels. We should only exclude it if it is at the top level within the project directory (root_dir).
[x] Run `reflex export` with PR change and verify assets further within subdirectories are included in the zip.
