### PR TITLE
rx.match component

### DIFF
--- a/reflex/.templates/jinja/web/pages/utils.js.jinja2
+++ b/reflex/.templates/jinja/web/pages/utils.js.jinja2
@@ -8,6 +8,8 @@
     {{- component }}
   {%- elif "iterable" in component %}
     {{- render_iterable_tag(component) }}
+  {%- elif component.name == "match"%}
+    {{- render_match_tag(component) }}
   {%- elif "cond" in component %}
     {{- render_condition_tag(component) }}
   {%- elif component.children|length %}
@@ -76,6 +78,30 @@
 {% macro render_props(props) %}
 {% if props|length %} {{ props|join(" ") }}{% endif %}
 {% endmacro %}
+
+{# Rendering Match component. #}
+{# Args: #}
+{#     component: component dictionary #}
+{% macro render_match_tag(component) %}
+{
+    (() => {
+        let codeToRender;
+        switch ({{ component.cond._var_full_name }}) {
+        {% for case in component.match_cases %}
+            {% for condition in case[:-1] %}
+                case {{ condition._var_full_name }}:
+            {% endfor %}
+                codeToRender = {{ case[-1] }};
+                break;
+        {% endfor %}
+            default:
+                codeToRender = {{ component.default }};
+                break;
+        }
+        return codeToRender;
+    })()
+  }
+{%- endmacro %}
 
 
 {# Rendering content with args. #}

--- a/reflex/.templates/jinja/web/pages/utils.js.jinja2
+++ b/reflex/.templates/jinja/web/pages/utils.js.jinja2
@@ -88,7 +88,7 @@
         switch (JSON.stringify({{ component.cond._var_full_name }})) {
         {% for case in component.match_cases %}
             {% for condition in case[:-1] %}
-                case JSON.stringify({{ condition._var_string_without_curly_braces }}):
+                case JSON.stringify({{ condition._var_name_unwrapped }}):
             {% endfor %}
                 return {{ case[-1] }};
                 break;

--- a/reflex/.templates/jinja/web/pages/utils.js.jinja2
+++ b/reflex/.templates/jinja/web/pages/utils.js.jinja2
@@ -88,7 +88,7 @@
         switch ({{ component.cond._var_full_name }}) {
         {% for case in component.match_cases %}
             {% for condition in case[:-1] %}
-                case {{ condition._var_full_name }}:
+                case {{ condition._var_string_without_curly_braces }}:
             {% endfor %}
                 return {{ case[-1] }};
                 break;

--- a/reflex/.templates/jinja/web/pages/utils.js.jinja2
+++ b/reflex/.templates/jinja/web/pages/utils.js.jinja2
@@ -85,20 +85,18 @@
 {% macro render_match_tag(component) %}
 {
     (() => {
-        let codeToRender;
         switch ({{ component.cond._var_full_name }}) {
         {% for case in component.match_cases %}
             {% for condition in case[:-1] %}
                 case {{ condition._var_full_name }}:
             {% endfor %}
-                codeToRender = {{ case[-1] }};
+                return {{ case[-1] }};
                 break;
         {% endfor %}
             default:
-                codeToRender = {{ component.default }};
+                return {{ component.default }};
                 break;
         }
-        return codeToRender;
     })()
   }
 {%- endmacro %}

--- a/reflex/.templates/jinja/web/pages/utils.js.jinja2
+++ b/reflex/.templates/jinja/web/pages/utils.js.jinja2
@@ -85,10 +85,10 @@
 {% macro render_match_tag(component) %}
 {
     (() => {
-        switch ({{ component.cond._var_full_name }}) {
+        switch (JSON.stringify({{ component.cond._var_full_name }})) {
         {% for case in component.match_cases %}
             {% for condition in case[:-1] %}
-                case {{ condition._var_string_without_curly_braces }}:
+                case JSON.stringify({{ condition._var_string_without_curly_braces }}):
             {% endfor %}
                 return {{ case[-1] }};
                 break;

--- a/reflex/__init__.py
+++ b/reflex/__init__.py
@@ -114,6 +114,7 @@ _ALL_COMPONENTS = [
     "List",
     "ListItem",
     "Markdown",
+    "Match",
     "Menu",
     "MenuButton",
     "MenuDivider",

--- a/reflex/__init__.pyi
+++ b/reflex/__init__.pyi
@@ -107,6 +107,7 @@ from reflex.components import LinkOverlay as LinkOverlay
 from reflex.components import List as List
 from reflex.components import ListItem as ListItem
 from reflex.components import Markdown as Markdown
+from reflex.components import Match as Match
 from reflex.components import Menu as Menu
 from reflex.components import MenuButton as MenuButton
 from reflex.components import MenuDivider as MenuDivider
@@ -317,6 +318,7 @@ from reflex.components import link_overlay as link_overlay
 from reflex.components import list as list
 from reflex.components import list_item as list_item
 from reflex.components import markdown as markdown
+from reflex.components import match as match
 from reflex.components import menu as menu
 from reflex.components import menu_button as menu_button
 from reflex.components import menu_divider as menu_divider

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -64,7 +64,7 @@ from reflex.state import (
     StateManager,
     StateUpdate,
 )
-from reflex.utils import console, format, prerequisites, types
+from reflex.utils import console, exceptions, format, prerequisites, types
 from reflex.utils.imports import ImportVar
 
 # Define custom types.
@@ -344,9 +344,12 @@ class App(Base):
 
         Raises:
             TypeError: When an invalid component function is passed.
+            MatchTypeError: If the return types of match cases in rx.match are different.
         """
         try:
             return component if isinstance(component, Component) else component()
+        except exceptions.MatchTypeError:
+            raise
         except TypeError as e:
             message = str(e)
             if "BaseVar" in message or "ComputedVar" in message:

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -344,7 +344,7 @@ class App(Base):
 
         Raises:
             TypeError: When an invalid component function is passed.
-            MatchTypeError: If the return types of match cases in rx.match are different.
+            exceptions.MatchTypeError: If the return types of match cases in rx.match are different.
         """
         try:
             return component if isinstance(component, Component) else component()

--- a/reflex/components/core/__init__.py
+++ b/reflex/components/core/__init__.py
@@ -4,6 +4,7 @@ from .banner import ConnectionBanner, ConnectionModal
 from .cond import Cond, cond
 from .debounce import DebounceInput
 from .foreach import Foreach
+from .match import Match
 from .responsive import (
     desktop_only,
     mobile_and_tablet,
@@ -17,4 +18,5 @@ connection_banner = ConnectionBanner.create
 connection_modal = ConnectionModal.create
 debounce_input = DebounceInput.create
 foreach = Foreach.create
+match = Match.create
 upload = Upload.create

--- a/reflex/components/core/match.py
+++ b/reflex/components/core/match.py
@@ -5,7 +5,7 @@ from reflex.components.base import Fragment
 from reflex.components.component import BaseComponent, Component, MemoizationLeaf
 from reflex.components.tags import MatchTag, Tag
 from reflex.utils import format, imports, types
-from reflex.vars import BaseVar, Var
+from reflex.vars import BaseVar, Var, VarData
 
 
 class Match(MemoizationLeaf):
@@ -201,6 +201,13 @@ class Match(MemoizationLeaf):
         ) or not types._isinstance(default, BaseVar):
             raise ValueError("Return types of match cases should be Vars.")
 
+        # match cases and default should all be Vars at this point.
+        # Retrieve var data of every var in the match cases and default.
+        var_data = [
+            *[el._var_data for case in match_cases for el in case],
+            default._var_data,  # type: ignore
+        ]
+
         return match_cond_var._replace(
             _var_name=format.format_match(
                 cond=match_cond_var._var_full_name,
@@ -210,6 +217,7 @@ class Match(MemoizationLeaf):
             _var_type=default._var_type,  # type: ignore
             _var_is_local=False,
             _var_full_name_needs_state_prefix=False,
+            merge_var_data=VarData.merge(*var_data),
         )
 
     def _render(self) -> Tag:

--- a/reflex/components/core/match.py
+++ b/reflex/components/core/match.py
@@ -91,7 +91,7 @@ class Match(MemoizationLeaf):
         if not isinstance(cases[-1], tuple):
             default = cases.pop()
             default = (
-                Var.create(default)
+                Var.create(default, _var_is_string=type(default) is str)
                 if not isinstance(default, BaseComponent)
                 else default
             )
@@ -127,7 +127,7 @@ class Match(MemoizationLeaf):
             for element in case:
                 # convert all non component element to vars.
                 el = (
-                    Var.create(element)
+                    Var.create(element, _var_is_string=type(element) is str)
                     if not isinstance(element, BaseComponent)
                     else element
                 )

--- a/reflex/components/core/match.py
+++ b/reflex/components/core/match.py
@@ -162,7 +162,9 @@ class Match(MemoizationLeaf):
         for index, case in enumerate(match_cases):
             if not types._issubclass(type(case[-1]), return_type):
                 raise MatchTypeError(
-                    f"Match cases should have the same return types. Case {index} with return value `{case[-1]._var_name if isinstance(case[-1], BaseVar) else textwrap.shorten(str(case[-1]), width=250)}` of type {type(case[-1])!r} is not {return_type}"
+                    f"Match cases should have the same return types. Case {index} with return "
+                    f"value `{case[-1]._var_name if isinstance(case[-1], BaseVar) else textwrap.shorten(str(case[-1]), width=250)}`"
+                    f" of type {type(case[-1])!r} is not {return_type}"
                 )
 
     @classmethod

--- a/reflex/components/core/match.py
+++ b/reflex/components/core/match.py
@@ -1,10 +1,12 @@
 """rx.match."""
+import textwrap
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from reflex.components.base import Fragment
 from reflex.components.component import BaseComponent, Component, MemoizationLeaf
 from reflex.components.tags import MatchTag, Tag
 from reflex.utils import format, imports, types
+from reflex.utils.exceptions import MatchTypeError
 from reflex.vars import BaseVar, Var, VarData
 
 
@@ -147,7 +149,7 @@ class Match(MemoizationLeaf):
             match_cases: The match cases.
 
         Raises:
-            TypeError: If the return types of cases are different.
+            MatchTypeError: If the return types of cases are different.
         """
         first_case_return = match_cases[0][-1]
         return_type = type(first_case_return)
@@ -157,9 +159,11 @@ class Match(MemoizationLeaf):
         elif types._isinstance(first_case_return, BaseVar):
             return_type = BaseVar
 
-        for case in match_cases:
+        for index, case in enumerate(match_cases):
             if not types._issubclass(type(case[-1]), return_type):
-                raise TypeError("match cases should have the same return types")
+                raise MatchTypeError(
+                    f"Match cases should have the same return types. Case {index} with return value `{case[-1]._var_name if isinstance(case[-1], BaseVar) else textwrap.shorten(str(case[-1]), width=250)}` of type {type(case[-1])!r} is not {return_type}"
+                )
 
     @classmethod
     def _create_match_cond_var_or_component(

--- a/reflex/components/core/match.py
+++ b/reflex/components/core/match.py
@@ -87,6 +87,7 @@ class Match(MemoizationLeaf):
         if len([case for case in cases if not isinstance(case, tuple)]) > 1:
             raise ValueError("rx.match can only have one default case.")
 
+        # Get the default case which should be the last non-tuple arg
         if not isinstance(cases[-1], tuple):
             default = cases.pop()
             default = (
@@ -116,6 +117,7 @@ class Match(MemoizationLeaf):
                 raise ValueError(
                     "rx.match should have tuples of cases and a default case as the last argument."
                 )
+            # There should be at least two elements in a case tuple(a condition and return value)
             if len(case) < 2:
                 raise ValueError(
                     "A case tuple should have at least a match case element and a return value."
@@ -123,6 +125,7 @@ class Match(MemoizationLeaf):
 
             case_list = []
             for element in case:
+                # convert all non component element to vars.
                 el = (
                     Var.create(element)
                     if not isinstance(element, BaseComponent)
@@ -192,7 +195,7 @@ class Match(MemoizationLeaf):
                 )
             )
 
-            # Validate the match cases (as well as the default case) to have Var return types.
+        # Validate the match cases (as well as the default case) to have Var return types.
         if any(
             case for case in match_cases if not types._isinstance(case[-1], BaseVar)
         ) or not types._isinstance(default, BaseVar):

--- a/reflex/components/core/match.py
+++ b/reflex/components/core/match.py
@@ -1,0 +1,103 @@
+"""rx.match"""
+from typing import Any, List, Dict, Optional, overload, Set
+
+from reflex.components.component import BaseComponent, Component, MemoizationLeaf
+from reflex.components.base import Fragment
+from reflex.vars import BaseVar, Var
+from reflex.components.tags import CondTag, Tag, MatchTag
+from reflex.utils import format, imports, types
+
+class Match(MemoizationLeaf):
+    cond: Var[Any]
+
+    match_cases: List[Any] = []
+
+    default: Any
+
+    @classmethod
+    def create(cls, cond: Var, *cases):
+        # Convert the condition to a Var.
+        cond_var = Var.create(cond)
+        assert cond_var is not None, "The condition must be set."
+
+        cases = list(cases)
+        default = None
+
+        # Can only have one default
+        if len([case for case in cases if not isinstance(case, tuple)]) > 1:
+            raise ValueError("rx.match can only have one default case.")
+
+        if not isinstance(cases[-1], tuple):
+            default = cases.pop()
+            default = Var.create(default) if not isinstance(default, BaseComponent) else default
+
+        match_cases = []
+        for case in cases:
+            if not isinstance(case, tuple):
+                # The default must be the last arg.
+                raise ValueError("rx.match should have tuples of cases and default case as the last argument ")
+            if len(case) < 2:
+                raise ValueError("a case tuple should have at least a match case element and a return value ")
+
+            case_list = []
+            for element in case:
+                el = Var.create(element) if not isinstance(element, BaseComponent) else element
+                assert isinstance(el, (BaseVar, BaseComponent)), "case element must be a var or component"
+                case_list.append(el)
+
+            match_cases.append(case_list)
+
+        return_type = BaseComponent if types._isinstance(match_cases[0][-1], BaseComponent) else BaseVar if types._isinstance(match_cases[0][-1], BaseVar) else type(match_cases[0][-1])
+
+        # types.get_base_class()
+        for case in match_cases:
+            if not types._issubclass(type(case[-1]), return_type):
+                raise TypeError("match cases should have the same return types")
+
+        if default is None and types._issubclass(return_type, BaseVar):
+            raise ValueError("For cases with return types as Vars, a default case must be provided")
+
+        if default is None and types._issubclass(return_type, BaseComponent):
+            default = Fragment.create()
+
+        if types._issubclass(return_type, BaseComponent) :
+            comp =  cls(
+                cond=cond_var,
+                match_cases=match_cases,
+                default=default,
+            )
+            return Fragment.create(comp)
+
+        return cond_var._replace(
+            _var_name=format.format_match(
+                cond = cond_var._var_full_name,
+                match_cases=match_cases,
+                default=default,
+
+            ),
+            _var_type=default._var_type,
+            _var_is_local=False,
+            _var_full_name_needs_state_prefix=False,
+        )
+    def _render(self) -> Tag:
+        return MatchTag(
+            cond = self.cond,
+            match_cases=self.match_cases,
+            default=self.default
+        )
+    def render(self) -> Dict:
+        tag = self._render()
+        tag.name = "match"
+        tag.set(props=tag.format_props())
+        a = dict(tag)
+        return a
+
+
+    def _get_imports(self):
+        merged_imports = super()._get_imports()
+        for case in self.match_cases:
+            if isinstance(case[-1], BaseComponent):
+                merged_imports = imports.merge_imports(merged_imports, case[-1].get_imports())
+        if isinstance(self.default, BaseComponent):
+            merged_imports = imports.merge_imports(merged_imports, self.default.get_imports())
+        return merged_imports

--- a/reflex/components/tags/__init__.py
+++ b/reflex/components/tags/__init__.py
@@ -2,5 +2,5 @@
 
 from .cond_tag import CondTag
 from .iter_tag import IterTag
-from .tag import Tag
 from .match_tag import MatchTag
+from .tag import Tag

--- a/reflex/components/tags/__init__.py
+++ b/reflex/components/tags/__init__.py
@@ -3,3 +3,4 @@
 from .cond_tag import CondTag
 from .iter_tag import IterTag
 from .tag import Tag
+from .match_tag import MatchTag

--- a/reflex/components/tags/match_tag.py
+++ b/reflex/components/tags/match_tag.py
@@ -1,9 +1,8 @@
 """Tag to conditionally render components."""
 
-from typing import Any, Dict, Optional, List
+from typing import Any, List
 
 from reflex.components.tags.tag import Tag
-from reflex.vars import Var
 
 
 class MatchTag(Tag):

--- a/reflex/components/tags/match_tag.py
+++ b/reflex/components/tags/match_tag.py
@@ -3,13 +3,14 @@
 from typing import Any, List
 
 from reflex.components.tags.tag import Tag
+from reflex.vars import Var
 
 
 class MatchTag(Tag):
     """A match tag."""
 
     # The condition to determine which case to match.
-    cond: Any
+    cond: Var[Any]
 
     # The list of match cases to be matched.
     match_cases: List[Any]

--- a/reflex/components/tags/match_tag.py
+++ b/reflex/components/tags/match_tag.py
@@ -1,0 +1,19 @@
+"""Tag to conditionally render components."""
+
+from typing import Any, Dict, Optional, List
+
+from reflex.components.tags.tag import Tag
+from reflex.vars import Var
+
+
+class MatchTag(Tag):
+    """A conditional tag."""
+
+    # The condition to determine which component to render.
+    cond: Any
+
+    # The code to render if the condition is true.
+    match_cases: List[Any]
+
+    # The code to render if the condition is false.
+    default: Any

--- a/reflex/components/tags/match_tag.py
+++ b/reflex/components/tags/match_tag.py
@@ -1,4 +1,4 @@
-"""Tag to conditionally render components."""
+"""Tag to conditionally match cases."""
 
 from typing import Any, List
 
@@ -6,13 +6,13 @@ from reflex.components.tags.tag import Tag
 
 
 class MatchTag(Tag):
-    """A conditional tag."""
+    """A match tag."""
 
-    # The condition to determine which component to render.
+    # The condition to determine which case to match.
     cond: Any
 
-    # The code to render if the condition is true.
+    # The list of match cases to be matched.
     match_cases: List[Any]
 
-    # The code to render if the condition is false.
+    # The catchall case to match.
     default: Any

--- a/reflex/utils/exceptions.py
+++ b/reflex/utils/exceptions.py
@@ -13,3 +13,9 @@ class ImmutableStateError(AttributeError):
 
 class LockExpiredError(Exception):
     """Raised when the state lock expires while an event is being processed."""
+
+
+class MatchTypeError(TypeError):
+    """Raised when the return types of match cases are different."""
+
+    pass

--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -272,7 +272,7 @@ def format_cond(
     return wrap(f"{cond} ? {true_value} : {false_value}", "{")
 
 
-def format_match(cond: str | Var, match_cases: List[Var], default: Var) -> str:
+def format_match(cond: str | Var, match_cases: List[BaseVar], default: Var) -> str:
     """Format a match expression whose return type is a Var.
 
     Args:

--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -284,7 +284,7 @@ def format_match(cond: str | Var, match_cases: List[BaseVar], default: Var) -> s
         The formatted match expression
 
     """
-    switch_code = f"(() => {{ switch ({cond}) {{"
+    switch_code = f"(() => {{ switch (JSON.stringify({cond})) {{"
 
     for case in match_cases:
         conditions = case[:-1]
@@ -292,7 +292,7 @@ def format_match(cond: str | Var, match_cases: List[BaseVar], default: Var) -> s
 
         case_conditions = " ".join(
             [
-                f"case {condition._var_string_without_curly_braces}:"
+                f"case JSON.stringify({condition._var_string_without_curly_braces}):"
                 for condition in conditions
             ]
         )

--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -292,15 +292,15 @@ def format_match(cond: str | Var, match_cases: List[BaseVar], default: Var) -> s
 
         case_conditions = " ".join(
             [
-                f"case JSON.stringify({condition._var_string_without_curly_braces}):"
+                f"case JSON.stringify({condition._var_name_unwrapped}):"
                 for condition in conditions
             ]
         )
-        case_code = f"{case_conditions}  return ({return_value._var_string_without_curly_braces});  break;"
+        case_code = f"{case_conditions}  return ({return_value._var_name_unwrapped});  break;"
         switch_code += case_code
 
     switch_code += (
-        f"default:  return ({default._var_string_without_curly_braces});  break;"
+        f"default:  return ({default._var_name_unwrapped});  break;"
     )
     switch_code += "};})()"
 

--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -296,12 +296,12 @@ def format_match(cond: str | Var, match_cases: List[BaseVar], default: Var) -> s
                 for condition in conditions
             ]
         )
-        case_code = f"{case_conditions}  return ({return_value._var_name_unwrapped});  break;"
+        case_code = (
+            f"{case_conditions}  return ({return_value._var_name_unwrapped});  break;"
+        )
         switch_code += case_code
 
-    switch_code += (
-        f"default:  return ({default._var_name_unwrapped});  break;"
-    )
+    switch_code += f"default:  return ({default._var_name_unwrapped});  break;"
     switch_code += "};})()"
 
     return switch_code

--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -291,12 +291,17 @@ def format_match(cond: str | Var, match_cases: List[BaseVar], default: Var) -> s
         return_value = case[-1]
 
         case_conditions = " ".join(
-            [f"case {condition._var_full_name}:" for condition in conditions]
+            [
+                f"case {condition._var_string_without_curly_braces}:"
+                for condition in conditions
+            ]
         )
-        case_code = f"{case_conditions}  return (`{return_value}`);  break;"
+        case_code = f"{case_conditions}  return ({return_value._var_string_without_curly_braces});  break;"
         switch_code += case_code
 
-    switch_code += f"default:  return (`{default._var_full_name}`);  break;"
+    switch_code += (
+        f"default:  return ({default._var_string_without_curly_braces});  break;"
+    )
     switch_code += "};})()"
 
     return switch_code

--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -7,7 +7,7 @@ import json
 import os
 import re
 import sys
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any, Union, List
 
 from reflex import constants
 from reflex.utils import exceptions, serializers, types
@@ -270,6 +270,24 @@ def format_cond(
 
     # Format component conds.
     return wrap(f"{cond} ? {true_value} : {false_value}", "{")
+
+
+def format_match(cond: Var, match_cases: List[Var], default: Var):
+    switch_code = f"(() => {{ let codeToRender; switch ({cond}) {{"
+
+    for case in match_cases:
+        conditions = case[:-1]
+        return_value = case[-1]
+
+        case_conditions = " ".join([f"case {condition}:" for condition in conditions])
+        case_code = f"{case_conditions}  codeToRender = (`{return_value}`);  break;"
+        switch_code += case_code
+
+    switch_code += f"default:  codeToRender = (`{default}`);  break;"
+    switch_code += "}; return codeToRender;})()"
+
+    return switch_code
+
 
 
 def format_prop(

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -1531,7 +1531,7 @@ class Var:
         return self._var_data.state if self._var_data else ""
 
     @property
-    def _var_string_without_curly_braces(self) -> str:
+    def _var_name_unwrapped(self) -> str:
         """Get the var str without wrapping in curly braces.
 
         Returns:

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -1530,6 +1530,26 @@ class Var:
         """
         return self._var_data.state if self._var_data else ""
 
+    @property
+    def _var_string_without_curly_braces(self) -> str:
+        """Get the var str without wrapping in curly braces.
+
+        Returns:
+            The str var without the wrapped curly braces
+        """
+        type_ = (
+            get_origin(self._var_type)
+            if types.is_generic_alias(self._var_type)
+            else self._var_type
+        )
+
+        wrapped_var = str(self)
+        return (
+            wrapped_var
+            if not self._var_state and issubclass(type_, dict)
+            else wrapped_var.strip("{}")
+        )
+
 
 # Allow automatic serialization of Var within JSON structures
 serializers.serializer(_encode_var)

--- a/scripts/pyi_generator.py
+++ b/scripts/pyi_generator.py
@@ -30,6 +30,7 @@ EXCLUDED_FILES = [
     "bare.py",
     "foreach.py",
     "cond.py",
+    "match.py",
     "multiselect.py",
     "literals.py",
 ]

--- a/tests/components/layout/test_match.py
+++ b/tests/components/layout/test_match.py
@@ -1,23 +1,28 @@
 import pytest
+
 import reflex as rx
-from reflex.state import BaseState
 from reflex.components.layout.match import Match
+from reflex.state import BaseState
+from reflex.vars import BaseVar
+
 
 class MatchState(BaseState):
+    """A test state."""
+
     value: int = 0
-    num : int = 5
+    num: int = 5
 
 
 def test_match_components():
     match_case_tuples = (
-                   (1, rx.text("first value")),
-                   (2, 3, rx.text("second value")),
-                   ([1,2], rx.text("third value")),
-                   ("random", rx.text("fourth value")),
-                   ({"foo":"bar"}, rx.text("fifth value")),
-                    (MatchState.num + 1, rx.text("sixth value")),
-                   rx.text("default value")
-           )
+        (1, rx.text("first value")),
+        (2, 3, rx.text("second value")),
+        ([1, 2], rx.text("third value")),
+        ("random", rx.text("fourth value")),
+        ({"foo": "bar"}, rx.text("fifth value")),
+        (MatchState.num + 1, rx.text("sixth value")),
+        rx.text("default value"),
+    )
     match_comp = Match.create(MatchState.value, *match_case_tuples)
     match_dict = match_comp.render()
     assert match_dict["name"] == "Fragment"
@@ -62,7 +67,7 @@ def test_match_components():
     assert fifth_return_value_render["name"] == "Text"
     assert fifth_return_value_render["children"][0]["contents"] == "{`fifth value`}"
 
-    assert match_cases[5][0]._var_name == '(match_state.num + 1)'
+    assert match_cases[5][0]._var_name == "(match_state.num + 1)"
     assert match_cases[5][0]._var_type == int
     fifth_return_value_render = match_cases[5][1].render()
     assert fifth_return_value_render["name"] == "Text"
@@ -76,15 +81,25 @@ def test_match_components():
 
 def test_match_vars():
     match_case_tuples = (
-        (1, rx.text("first value")),
-        (2, 3, rx.text("second value")),
-        ([1, 2], rx.text("third value")),
-        ("random", rx.text("fourth value")),
-        ({"foo": "bar"}, rx.text("fifth value")),
-        (MatchState.num + 1, rx.text("sixth value")),
-        rx.text("default value")
+        (1, "first"),
+        (2, 3, "second value"),
+        ([1, 2], "third-value"),
+        ("random", "fourth_value"),
+        ({"foo": "bar"}, "fifth value"),
+        (MatchState.num + 1, "sixth value"),
+        "default value",
     )
     match_comp = Match.create(MatchState.value, *match_case_tuples)
+    assert isinstance(match_comp, BaseVar)
+    assert (
+        match_comp._var_full_name
+        == "(() => { switch (match_state.value) {case 1:  return (`first`);  break;case 2: case 3:  return "
+        "(`second value`);  break;case [1, 2]:  return (`third-value`);  break;case random:  "
+        'return (`fourth_value`);  break;case {"foo": "bar"}:  return (`fifth value`);  '
+        "break;case (match_state.num + 1):  return (`sixth value`);  break;default:  "
+        "return (`default value`);  break;};})()"
+    )
+    pass
 
 
 def test_match_on_component_without_default():
@@ -98,6 +113,7 @@ def test_match_on_component_without_default():
 
     assert isinstance(default, rx.Fragment)
 
+
 def test_match_on_var_no_default():
     # should throw error
     match_case_tuples = (
@@ -106,8 +122,12 @@ def test_match_on_var_no_default():
         ([1, 2], "green"),
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="For cases with return types as Vars, a default case must be provided",
+    ):
         Match.create(MatchState.value, *match_case_tuples)
+
 
 @pytest.mark.parametrize(
     "match_case",
@@ -117,24 +137,26 @@ def test_match_on_var_no_default():
             (2, 3, "blue"),
             "black",
             ([1, 2], "green"),
-
         ),
         (
-                (1, rx.text("first value")),
-                (2, 3, rx.text("second value")),
-                ([1, 2], rx.text("third value")),
-                rx.text("default value"),
-                ("random", rx.text("fourth value")),
-                ({"foo": "bar"}, rx.text("fifth value")),
-                (MatchState.num + 1, rx.text("sixth value")),
-
-        )
-    ]
+            (1, rx.text("first value")),
+            (2, 3, rx.text("second value")),
+            ([1, 2], rx.text("third value")),
+            rx.text("default value"),
+            ("random", rx.text("fourth value")),
+            ({"foo": "bar"}, rx.text("fifth value")),
+            (MatchState.num + 1, rx.text("sixth value")),
+        ),
+    ],
 )
 def test_match_default_not_last_arg(match_case):
 
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="rx.match should have tuples of cases and default case as the last argument ",
+    ):
         Match.create(MatchState.value, *match_case)
+
 
 @pytest.mark.parametrize(
     "match_case",
@@ -144,21 +166,22 @@ def test_match_default_not_last_arg(match_case):
             (2, 3, "blue"),
             ("green",),
             "black",
-
-
         ),
         (
-                (1, rx.text("first value")),
-                (2, 3, rx.text("second value")),
-                ([1, 2],),
-                rx.text("default value"),
-
-        )
-    ]
+            (1, rx.text("first value")),
+            (2, 3, rx.text("second value")),
+            ([1, 2],),
+            rx.text("default value"),
+        ),
+    ],
 )
 def test_match_case_tuple_elements(match_case):
-    with pytest.raises(ValueError):
+    with pytest.raises(
+        ValueError,
+        match="a case tuple should have at least a match case element and a return value ",
+    ):
         Match.create(MatchState.value, *match_case)
+
 
 def test_match_different_return_types():
     match_case_tuples = (
@@ -168,10 +191,12 @@ def test_match_different_return_types():
         ("random", "red"),
         ({"foo": "bar"}, "green"),
         (MatchState.num + 1, "black"),
-        rx.text("default value")
+        rx.text("default value"),
     )
-    with pytest.raises(TypeError):
-        match_comp = Match.create(MatchState.value, *match_case_tuples)
+    with pytest.raises(
+        TypeError, match="match cases should have the same return types"
+    ):
+        Match.create(MatchState.value, *match_case_tuples)
 
 
 @pytest.mark.parametrize(
@@ -183,21 +208,19 @@ def test_match_different_return_types():
             ([1, 2], "green"),
             "black",
             "white",
-
         ),
         (
-                (1, rx.text("first value")),
-                (2, 3, rx.text("second value")),
-                ([1, 2], rx.text("third value")),
-                ("random", rx.text("fourth value")),
-                ({"foo": "bar"}, rx.text("fifth value")),
-                (MatchState.num + 1, rx.text("sixth value")),
-                rx.text("default value"),
-                rx.text("another default value"),
-
-        )
-    ]
+            (1, rx.text("first value")),
+            (2, 3, rx.text("second value")),
+            ([1, 2], rx.text("third value")),
+            ("random", rx.text("fourth value")),
+            ({"foo": "bar"}, rx.text("fifth value")),
+            (MatchState.num + 1, rx.text("sixth value")),
+            rx.text("default value"),
+            rx.text("another default value"),
+        ),
+    ],
 )
 def test_match_multiple_default_cases(match_case):
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="rx.match can only have one default case."):
         Match.create(MatchState.value, *match_case)

--- a/tests/components/layout/test_match.py
+++ b/tests/components/layout/test_match.py
@@ -99,11 +99,11 @@ def test_match_components():
                 (MatchState.string, f"{MatchState.value} - string"),
                 "default value",
             ),
-            "(() => { switch (match_state.value) {case 1:  return (`first`);  break;case 2: case 3:  return "
-            "(`second value`);  break;case [1, 2]:  return (`third-value`);  break;case `random`:  "
-            'return (`fourth_value`);  break;case {"foo": "bar"}:  return (`fifth value`);  '
-            "break;case (match_state.num + 1):  return (`sixth value`);  break;case `${match_state.value} - string`:  "
-            "return (match_state.string);  break;case match_state.string:  return (`${match_state.value} - string`);  break;default:  "
+            "(() => { switch (JSON.stringify(match_state.value)) {case JSON.stringify(1):  return (`first`);  break;case JSON.stringify(2): case JSON.stringify(3):  return "
+            "(`second value`);  break;case JSON.stringify([1, 2]):  return (`third-value`);  break;case JSON.stringify(`random`):  "
+            'return (`fourth_value`);  break;case JSON.stringify({"foo": "bar"}):  return (`fifth value`);  '
+            "break;case JSON.stringify((match_state.num + 1)):  return (`sixth value`);  break;case JSON.stringify(`${match_state.value} - string`):  "
+            "return (match_state.string);  break;case JSON.stringify(match_state.string):  return (`${match_state.value} - string`);  break;default:  "
             "return (`default value`);  break;};})()",
         ),
         (
@@ -118,11 +118,11 @@ def test_match_components():
                 (MatchState.string, f"{MatchState.value} - string"),
                 MatchState.string,
             ),
-            "(() => { switch (match_state.value) {case 1:  return (`first`);  break;case 2: case 3:  return "
-            "(`second value`);  break;case [1, 2]:  return (`third-value`);  break;case `random`:  "
-            'return (`fourth_value`);  break;case {"foo": "bar"}:  return (`fifth value`);  '
-            "break;case (match_state.num + 1):  return (`sixth value`);  break;case `${match_state.value} - string`:  "
-            "return (match_state.string);  break;case match_state.string:  return (`${match_state.value} - string`);  break;default:  "
+            "(() => { switch (JSON.stringify(match_state.value)) {case JSON.stringify(1):  return (`first`);  break;case JSON.stringify(2): case JSON.stringify(3):  return "
+            "(`second value`);  break;case JSON.stringify([1, 2]):  return (`third-value`);  break;case JSON.stringify(`random`):  "
+            'return (`fourth_value`);  break;case JSON.stringify({"foo": "bar"}):  return (`fifth value`);  '
+            "break;case JSON.stringify((match_state.num + 1)):  return (`sixth value`);  break;case JSON.stringify(`${match_state.value} - string`):  "
+            "return (match_state.string);  break;case JSON.stringify(match_state.string):  return (`${match_state.value} - string`);  break;default:  "
             "return (match_state.string);  break;};})()",
         ),
     ],

--- a/tests/components/layout/test_match.py
+++ b/tests/components/layout/test_match.py
@@ -25,7 +25,7 @@ def test_match_components():
         rx.text("default value"),
     )
     match_comp = Match.create(MatchState.value, *match_case_tuples)
-    match_dict = match_comp.render()
+    match_dict = match_comp.render()  # type: ignore
     assert match_dict["name"] == "Fragment"
 
     [match_child] = match_dict["children"]
@@ -113,7 +113,7 @@ def test_match_on_component_without_default():
     )
 
     match_comp = Match.create(MatchState.value, *match_case_tuples)
-    default = match_comp.render()["children"][0]["default"]
+    default = match_comp.render()["children"][0]["default"]  # type: ignore
 
     assert isinstance(default, rx.Fragment)
 

--- a/tests/components/layout/test_match.py
+++ b/tests/components/layout/test_match.py
@@ -101,7 +101,6 @@ def test_match_vars():
         "break;case (match_state.num + 1):  return (`sixth value`);  break;default:  "
         "return (`default value`);  break;};})()"
     )
-    pass
 
 
 def test_match_on_component_without_default():
@@ -162,7 +161,7 @@ def test_match_default_not_last_arg(match_case):
     """
     with pytest.raises(
         ValueError,
-        match="rx.match should have tuples of cases and default case as the last argument ",
+        match="rx.match should have tuples of cases and a default case as the last argument.",
     ):
         Match.create(MatchState.value, *match_case)
 
@@ -192,7 +191,7 @@ def test_match_case_tuple_elements(match_case):
     """
     with pytest.raises(
         ValueError,
-        match="a case tuple should have at least a match case element and a return value ",
+        match="A case tuple should have at least a match case element and a return value.",
     ):
         Match.create(MatchState.value, *match_case)
 

--- a/tests/components/layout/test_match.py
+++ b/tests/components/layout/test_match.py
@@ -1,7 +1,7 @@
 import pytest
 
 import reflex as rx
-from reflex.components.layout.match import Match
+from reflex.components.core.match import Match
 from reflex.state import BaseState
 from reflex.vars import BaseVar
 

--- a/tests/components/layout/test_match.py
+++ b/tests/components/layout/test_match.py
@@ -11,6 +11,7 @@ class MatchState(BaseState):
 
     value: int = 0
     num: int = 5
+    string: str = "random string"
 
 
 def test_match_components():
@@ -89,6 +90,8 @@ def test_match_vars():
         ("random", "fourth_value"),
         ({"foo": "bar"}, "fifth value"),
         (MatchState.num + 1, "sixth value"),
+        (f"{MatchState.value} - string", MatchState.string),
+        (MatchState.string, f"{MatchState.value} - string"),
         "default value",
     )
     match_comp = Match.create(MatchState.value, *match_case_tuples)
@@ -96,9 +99,10 @@ def test_match_vars():
     assert (
         match_comp._var_full_name
         == "(() => { switch (match_state.value) {case 1:  return (`first`);  break;case 2: case 3:  return "
-        "(`second value`);  break;case [1, 2]:  return (`third-value`);  break;case random:  "
+        "(`second value`);  break;case [1, 2]:  return (`third-value`);  break;case `random`:  "
         'return (`fourth_value`);  break;case {"foo": "bar"}:  return (`fifth value`);  '
-        "break;case (match_state.num + 1):  return (`sixth value`);  break;default:  "
+        "break;case (match_state.num + 1):  return (`sixth value`);  break;case `${match_state.value} - string`:  "
+        "return (match_state.string);  break;case match_state.string:  return (`${match_state.value} - string`);  break;default:  "
         "return (`default value`);  break;};})()"
     )
 

--- a/tests/components/layout/test_match.py
+++ b/tests/components/layout/test_match.py
@@ -14,6 +14,7 @@ class MatchState(BaseState):
 
 
 def test_match_components():
+    """Test matching cases with return values as components."""
     match_case_tuples = (
         (1, rx.text("first value")),
         (2, 3, rx.text("second value")),
@@ -80,6 +81,7 @@ def test_match_components():
 
 
 def test_match_vars():
+    """Test matching cases with return values as Vars."""
     match_case_tuples = (
         (1, "first"),
         (2, 3, "second value"),
@@ -103,6 +105,9 @@ def test_match_vars():
 
 
 def test_match_on_component_without_default():
+    """Test that matching cases with return values as components returns a Fragment
+    as the default case if not provided.
+    """
     match_case_tuples = (
         (1, rx.text("first value")),
         (2, 3, rx.text("second value")),
@@ -115,7 +120,7 @@ def test_match_on_component_without_default():
 
 
 def test_match_on_var_no_default():
-    # should throw error
+    """Test that an error is thrown when cases with return Values as Var do not have a default case."""
     match_case_tuples = (
         (1, "red"),
         (2, 3, "blue"),
@@ -150,7 +155,11 @@ def test_match_on_var_no_default():
     ],
 )
 def test_match_default_not_last_arg(match_case):
+    """Test that an error is thrown when the default case is not the last arg.
 
+    Args:
+        match_case: The cases to match.
+    """
     with pytest.raises(
         ValueError,
         match="rx.match should have tuples of cases and default case as the last argument ",
@@ -176,6 +185,11 @@ def test_match_default_not_last_arg(match_case):
     ],
 )
 def test_match_case_tuple_elements(match_case):
+    """Test that a match has at least 2 elements(a condition and a return value).
+
+    Args:
+        match_case: The cases to match.
+    """
     with pytest.raises(
         ValueError,
         match="a case tuple should have at least a match case element and a return value ",
@@ -184,6 +198,7 @@ def test_match_case_tuple_elements(match_case):
 
 
 def test_match_different_return_types():
+    """Test that an error is thrown when the return values are of different types."""
     match_case_tuples = (
         (1, rx.text("first value")),
         (2, 3, rx.text("second value")),
@@ -222,5 +237,10 @@ def test_match_different_return_types():
     ],
 )
 def test_match_multiple_default_cases(match_case):
+    """Test that there is only one default case.
+
+    Args:
+        match_case: the cases to match.
+    """
     with pytest.raises(ValueError, match="rx.match can only have one default case."):
         Match.create(MatchState.value, *match_case)

--- a/tests/components/layout/test_match.py
+++ b/tests/components/layout/test_match.py
@@ -1,0 +1,203 @@
+import pytest
+import reflex as rx
+from reflex.state import BaseState
+from reflex.components.layout.match import Match
+
+class MatchState(BaseState):
+    value: int = 0
+    num : int = 5
+
+
+def test_match_components():
+    match_case_tuples = (
+                   (1, rx.text("first value")),
+                   (2, 3, rx.text("second value")),
+                   ([1,2], rx.text("third value")),
+                   ("random", rx.text("fourth value")),
+                   ({"foo":"bar"}, rx.text("fifth value")),
+                    (MatchState.num + 1, rx.text("sixth value")),
+                   rx.text("default value")
+           )
+    match_comp = Match.create(MatchState.value, *match_case_tuples)
+    match_dict = match_comp.render()
+    assert match_dict["name"] == "Fragment"
+
+    [match_child] = match_dict["children"]
+
+    assert match_child["name"] == "match"
+    assert str(match_child["cond"]) == "{match_state.value}"
+
+    match_cases = match_child["match_cases"]
+    assert len(match_cases) == 6
+
+    assert match_cases[0][0]._var_name == "1"
+    assert match_cases[0][0]._var_type == int
+    first_return_value_render = match_cases[0][1].render()
+    assert first_return_value_render["name"] == "Text"
+    assert first_return_value_render["children"][0]["contents"] == "{`first value`}"
+
+    assert match_cases[1][0]._var_name == "2"
+    assert match_cases[1][0]._var_type == int
+    assert match_cases[1][1]._var_name == "3"
+    assert match_cases[1][1]._var_type == int
+    second_return_value_render = match_cases[1][2].render()
+    assert second_return_value_render["name"] == "Text"
+    assert second_return_value_render["children"][0]["contents"] == "{`second value`}"
+
+    assert match_cases[2][0]._var_name == "[1, 2]"
+    assert match_cases[2][0]._var_type == list
+    third_return_value_render = match_cases[2][1].render()
+    assert third_return_value_render["name"] == "Text"
+    assert third_return_value_render["children"][0]["contents"] == "{`third value`}"
+
+    assert match_cases[3][0]._var_name == "random"
+    assert match_cases[3][0]._var_type == str
+    fourth_return_value_render = match_cases[3][1].render()
+    assert fourth_return_value_render["name"] == "Text"
+    assert fourth_return_value_render["children"][0]["contents"] == "{`fourth value`}"
+
+    assert match_cases[4][0]._var_name == '{"foo": "bar"}'
+    assert match_cases[4][0]._var_type == dict
+    fifth_return_value_render = match_cases[4][1].render()
+    assert fifth_return_value_render["name"] == "Text"
+    assert fifth_return_value_render["children"][0]["contents"] == "{`fifth value`}"
+
+    assert match_cases[5][0]._var_name == '(match_state.num + 1)'
+    assert match_cases[5][0]._var_type == int
+    fifth_return_value_render = match_cases[5][1].render()
+    assert fifth_return_value_render["name"] == "Text"
+    assert fifth_return_value_render["children"][0]["contents"] == "{`sixth value`}"
+
+    default = match_child["default"].render()
+
+    assert default["name"] == "Text"
+    assert default["children"][0]["contents"] == "{`default value`}"
+
+
+def test_match_vars():
+    match_case_tuples = (
+        (1, rx.text("first value")),
+        (2, 3, rx.text("second value")),
+        ([1, 2], rx.text("third value")),
+        ("random", rx.text("fourth value")),
+        ({"foo": "bar"}, rx.text("fifth value")),
+        (MatchState.num + 1, rx.text("sixth value")),
+        rx.text("default value")
+    )
+    match_comp = Match.create(MatchState.value, *match_case_tuples)
+
+
+def test_match_on_component_without_default():
+    match_case_tuples = (
+        (1, rx.text("first value")),
+        (2, 3, rx.text("second value")),
+    )
+
+    match_comp = Match.create(MatchState.value, *match_case_tuples)
+    default = match_comp.render()["children"][0]["default"]
+
+    assert isinstance(default, rx.Fragment)
+
+def test_match_on_var_no_default():
+    # should throw error
+    match_case_tuples = (
+        (1, "red"),
+        (2, 3, "blue"),
+        ([1, 2], "green"),
+    )
+
+    with pytest.raises(ValueError):
+        Match.create(MatchState.value, *match_case_tuples)
+
+@pytest.mark.parametrize(
+    "match_case",
+    [
+        (
+            (1, "red"),
+            (2, 3, "blue"),
+            "black",
+            ([1, 2], "green"),
+
+        ),
+        (
+                (1, rx.text("first value")),
+                (2, 3, rx.text("second value")),
+                ([1, 2], rx.text("third value")),
+                rx.text("default value"),
+                ("random", rx.text("fourth value")),
+                ({"foo": "bar"}, rx.text("fifth value")),
+                (MatchState.num + 1, rx.text("sixth value")),
+
+        )
+    ]
+)
+def test_match_default_not_last_arg(match_case):
+
+    with pytest.raises(ValueError):
+        Match.create(MatchState.value, *match_case)
+
+@pytest.mark.parametrize(
+    "match_case",
+    [
+        (
+            (1, "red"),
+            (2, 3, "blue"),
+            ("green",),
+            "black",
+
+
+        ),
+        (
+                (1, rx.text("first value")),
+                (2, 3, rx.text("second value")),
+                ([1, 2],),
+                rx.text("default value"),
+
+        )
+    ]
+)
+def test_match_case_tuple_elements(match_case):
+    with pytest.raises(ValueError):
+        Match.create(MatchState.value, *match_case)
+
+def test_match_different_return_types():
+    match_case_tuples = (
+        (1, rx.text("first value")),
+        (2, 3, rx.text("second value")),
+        ([1, 2], rx.text("third value")),
+        ("random", "red"),
+        ({"foo": "bar"}, "green"),
+        (MatchState.num + 1, "black"),
+        rx.text("default value")
+    )
+    with pytest.raises(TypeError):
+        match_comp = Match.create(MatchState.value, *match_case_tuples)
+
+
+@pytest.mark.parametrize(
+    "match_case",
+    [
+        (
+            (1, "red"),
+            (2, 3, "blue"),
+            ([1, 2], "green"),
+            "black",
+            "white",
+
+        ),
+        (
+                (1, rx.text("first value")),
+                (2, 3, rx.text("second value")),
+                ([1, 2], rx.text("third value")),
+                ("random", rx.text("fourth value")),
+                ({"foo": "bar"}, rx.text("fifth value")),
+                (MatchState.num + 1, rx.text("sixth value")),
+                rx.text("default value"),
+                rx.text("another default value"),
+
+        )
+    ]
+)
+def test_match_multiple_default_cases(match_case):
+    with pytest.raises(ValueError):
+        Match.create(MatchState.value, *match_case)

--- a/tests/components/layout/test_match.py
+++ b/tests/components/layout/test_match.py
@@ -84,30 +84,59 @@ def test_match_components():
     assert default["children"][0]["contents"] == "{`default value`}"
 
 
-def test_match_vars():
-    """Test matching cases with return values as Vars."""
-    match_case_tuples = (
-        (1, "first"),
-        (2, 3, "second value"),
-        ([1, 2], "third-value"),
-        ("random", "fourth_value"),
-        ({"foo": "bar"}, "fifth value"),
-        (MatchState.num + 1, "sixth value"),
-        (f"{MatchState.value} - string", MatchState.string),
-        (MatchState.string, f"{MatchState.value} - string"),
-        "default value",
-    )
-    match_comp = Match.create(MatchState.value, *match_case_tuples)
+@pytest.mark.parametrize(
+    "cases, expected",
+    [
+        (
+            (
+                (1, "first"),
+                (2, 3, "second value"),
+                ([1, 2], "third-value"),
+                ("random", "fourth_value"),
+                ({"foo": "bar"}, "fifth value"),
+                (MatchState.num + 1, "sixth value"),
+                (f"{MatchState.value} - string", MatchState.string),
+                (MatchState.string, f"{MatchState.value} - string"),
+                "default value",
+            ),
+            "(() => { switch (match_state.value) {case 1:  return (`first`);  break;case 2: case 3:  return "
+            "(`second value`);  break;case [1, 2]:  return (`third-value`);  break;case `random`:  "
+            'return (`fourth_value`);  break;case {"foo": "bar"}:  return (`fifth value`);  '
+            "break;case (match_state.num + 1):  return (`sixth value`);  break;case `${match_state.value} - string`:  "
+            "return (match_state.string);  break;case match_state.string:  return (`${match_state.value} - string`);  break;default:  "
+            "return (`default value`);  break;};})()",
+        ),
+        (
+            (
+                (1, "first"),
+                (2, 3, "second value"),
+                ([1, 2], "third-value"),
+                ("random", "fourth_value"),
+                ({"foo": "bar"}, "fifth value"),
+                (MatchState.num + 1, "sixth value"),
+                (f"{MatchState.value} - string", MatchState.string),
+                (MatchState.string, f"{MatchState.value} - string"),
+                MatchState.string,
+            ),
+            "(() => { switch (match_state.value) {case 1:  return (`first`);  break;case 2: case 3:  return "
+            "(`second value`);  break;case [1, 2]:  return (`third-value`);  break;case `random`:  "
+            'return (`fourth_value`);  break;case {"foo": "bar"}:  return (`fifth value`);  '
+            "break;case (match_state.num + 1):  return (`sixth value`);  break;case `${match_state.value} - string`:  "
+            "return (match_state.string);  break;case match_state.string:  return (`${match_state.value} - string`);  break;default:  "
+            "return (match_state.string);  break;};})()",
+        ),
+    ],
+)
+def test_match_vars(cases, expected):
+    """Test matching cases with return values as Vars.
+
+    Args:
+        cases: The match cases.
+        expected: The expected var full name.
+    """
+    match_comp = Match.create(MatchState.value, *cases)
     assert isinstance(match_comp, BaseVar)
-    assert (
-        match_comp._var_full_name
-        == "(() => { switch (match_state.value) {case 1:  return (`first`);  break;case 2: case 3:  return "
-        "(`second value`);  break;case [1, 2]:  return (`third-value`);  break;case `random`:  "
-        'return (`fourth_value`);  break;case {"foo": "bar"}:  return (`fifth value`);  '
-        "break;case (match_state.num + 1):  return (`sixth value`);  break;case `${match_state.value} - string`:  "
-        "return (match_state.string);  break;case match_state.string:  return (`${match_state.value} - string`);  break;default:  "
-        "return (`default value`);  break;};})()"
-    )
+    assert match_comp._var_full_name == expected
 
 
 def test_match_on_component_without_default():

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -896,6 +896,7 @@ def test_instantiate_all_components():
         "FormControl",
         "Html",
         "Icon",
+        "Match",
         "Markdown",
         "MultiSelect",
         "Option",

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -24,6 +24,13 @@ test_vars = [
 ]
 
 
+class ATestState(BaseState):
+    """Test state."""
+
+    value: str
+    dict_val: Dict[str, List] = {}
+
+
 @pytest.fixture
 def TestObj():
     class TestObj(Base):
@@ -1126,3 +1133,22 @@ def test_invalid_var_operations(operand1_var: Var, operand2_var, operators: List
 
         with pytest.raises(TypeError):
             operand1_var.operation(op=operator, other=operand2_var, flip=True)
+
+
+@pytest.mark.parametrize(
+    "var, expected",
+    [
+        (Var.create("string_value", _var_is_string=True), "`string_value`"),
+        (Var.create(1), "1"),
+        (Var.create([1, 2, 3]), "[1, 2, 3]"),
+        (Var.create({"foo": "bar"}), '{"foo": "bar"}'),
+        (Var.create(ATestState.value, _var_is_string=True), "a_test_state.value"),
+        (
+            Var.create(f"{ATestState.value} string", _var_is_string=True),
+            "`${a_test_state.value} string`",
+        ),
+        (Var.create(ATestState.dict_val), "a_test_state.dict_val"),
+    ],
+)
+def test_var_string_without_curly_braces(var, expected):
+    assert var._var_string_without_curly_braces == expected

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -1150,5 +1150,5 @@ def test_invalid_var_operations(operand1_var: Var, operand2_var, operators: List
         (Var.create(ATestState.dict_val), "a_test_state.dict_val"),
     ],
 )
-def test_var_string_without_curly_braces(var, expected):
-    assert var._var_string_without_curly_braces == expected
+def test_var_name_unwrapped(var, expected):
+    assert var._var_name_unwrapped == expected

--- a/tests/utils/test_format.py
+++ b/tests/utils/test_format.py
@@ -309,9 +309,9 @@ def test_format_cond(condition: str, true_value: str, false_value: str, expected
                 ],
             ],
             Var.create("yellow", _var_is_string=True),
-            "(() => { switch (state__state.value) {case 1:  return (`red`);  break;case 2: case 3:  "
-            "return (`blue`);  break;case test_state.mapping:  return "
-            "(test_state.num1);  break;case `${test_state.map_key}-key`:  return (`return-key`);"
+            "(() => { switch (JSON.stringify(state__state.value)) {case JSON.stringify(1):  return (`red`);  break;case JSON.stringify(2): case JSON.stringify(3):  "
+            "return (`blue`);  break;case JSON.stringify(test_state.mapping):  return "
+            "(test_state.num1);  break;case JSON.stringify(`${test_state.map_key}-key`):  return (`return-key`);"
             "  break;default:  return (`yellow`);  break;};})()",
         )
     ],

--- a/tests/utils/test_format.py
+++ b/tests/utils/test_format.py
@@ -295,6 +295,26 @@ def test_format_cond(condition: str, true_value: str, false_value: str, expected
 
 
 @pytest.mark.parametrize(
+    "condition, match_cases, default,expected",
+    [
+        (
+            "state__state.value",
+            [
+                [Var.create(1), Var.create("red")],
+                [Var.create(2), Var.create(3), Var.create("blue")],
+            ],
+            Var.create("yellow"),
+            "(() => { switch (state__state.value) {case 1:  return (`red`);  break;case 2: case 3:  "
+            "return (`blue`);  break;default:  return (`yellow`);  break;};})()",
+        )
+    ],
+)
+def test_format_match(condition, match_cases, default, expected):
+
+    assert format.format_match(condition, match_cases, default) == expected
+
+
+@pytest.mark.parametrize(
     "prop,formatted",
     [
         ("string", '"string"'),

--- a/tests/utils/test_format.py
+++ b/tests/utils/test_format.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Any
+from typing import Any, List
 
 import pytest
 
@@ -309,8 +309,17 @@ def test_format_cond(condition: str, true_value: str, false_value: str, expected
         )
     ],
 )
-def test_format_match(condition, match_cases, default, expected):
+def test_format_match(
+    condition: str, match_cases: List[BaseVar], default: BaseVar, expected: str
+):
+    """Test formatting a match statement.
 
+    Args:
+        condition: The condition to match.
+        match_cases: List of match cases to be matched.
+        default: Catchall case for the match statement.
+        expected: The expected string output.
+    """
     assert format.format_match(condition, match_cases, default) == expected
 
 

--- a/tests/utils/test_format.py
+++ b/tests/utils/test_format.py
@@ -300,12 +300,19 @@ def test_format_cond(condition: str, true_value: str, false_value: str, expected
         (
             "state__state.value",
             [
-                [Var.create(1), Var.create("red")],
-                [Var.create(2), Var.create(3), Var.create("blue")],
+                [Var.create(1), Var.create("red", _var_is_string=True)],
+                [Var.create(2), Var.create(3), Var.create("blue", _var_is_string=True)],
+                [TestState.mapping, TestState.num1],
+                [
+                    Var.create(f"{TestState.map_key}-key", _var_is_string=True),
+                    Var.create("return-key", _var_is_string=True),
+                ],
             ],
-            Var.create("yellow"),
+            Var.create("yellow", _var_is_string=True),
             "(() => { switch (state__state.value) {case 1:  return (`red`);  break;case 2: case 3:  "
-            "return (`blue`);  break;default:  return (`yellow`);  break;};})()",
+            "return (`blue`);  break;case test_state.mapping:  return "
+            "(test_state.num1);  break;case `${test_state.map_key}-key`:  return (`return-key`);"
+            "  break;default:  return (`yellow`);  break;};})()",
         )
     ],
 )


### PR DESCRIPTION
nested `rx.cond` can get very intricate and messy. This PR introduces `rx.match` to fix this problem. 

`rx.match` takes in a condition which should be a var, match case tuples and a non tuple argument that will be treated as the default or catchall case.
 
```python
import reflex as rx

class State(rx.State):
    value: int = 0

def index():
    return rx.vstack(
        rx.match(
            State.value,
            (1, rx.vstack(rx.text('first value'))),
            (2, rx.text("second value")),
            rx.text("default value")
        )
    )
```
This renders as(formatted manually) :

```javascript

/** @jsxImportSource @emotion/react */import { Fragment, useContext } from "react"
import { Fragment_fd0e7cb8f9fb4669a6805377d925fba0 } from "/utils/stateful_components"
import { Text, VStack } from "@chakra-ui/react"
import { StateContexts } from "/utils/context"
import "focus-visible/dist/focus-visible"
import NextHead from "next/head"



export default function Component() {
  const state__state = useContext(StateContexts.state__state)

  return (
    <Fragment>
      <Fragment_fd0e7cb8f9fb4669a6805377d925fba0 />
      <VStack>
        <Fragment>
          {
            (() => {
              switch (state__state.value) {
                case 1:
                  return <VStack>
                    <Text>
                      {`first value`}
                    </Text>
                  </VStack>;
                  break;
                case 2:
                  return <Text>
                    {`second value`}
                  </Text>;
                  break;
                default:
                  return <Text>
                    {`default value`}
                  </Text>;
                  break;
              }
            })()
          }
        </Fragment>
      </VStack>
      <NextHead>
        <title>
          {`Reflex App`}
        </title>
        <meta content={`A Reflex app.`} name={`description`} />
        <meta content={`favicon.ico`} property={`og:image`} />
      </NextHead>
    </Fragment>
  )
}


```

## Match cases
These are tuples containing cases to be matched as well as their return values. The first `n-1` values are treated as the cases to be matched and the last value in the tuple is treated as the return value.
 Note that, a match case tuple MUST have a minimum of 2 elements (the condition and the return value).

## Default/catchall case
A default case is a non-tuple argument that is matched when none of the match cases are matched. Below are the caveats to know about the default case:
- The default case MUST be the last argument(the app will throw a `ValueError` if not)
(not accepted) ❌ 
```python
 rx.match(
            State.value,
            (1, rx.vstack(rx.text('first value'))),
            rx.text("default value"),
            (2, rx.text("second value")),
        )
```
(not accepted) ❌ 
```python
 rx.match(
            State.value,
            (1, 'first value'),
            "default value",
            (2, "second value"),
        )
```

- There can only be one default case.
(not accepted) ❌ 
```python
 rx.match(
            State.value,
            (1, rx.vstack(rx.text('first value'))),
            (2, rx.text("second value")),
            rx.text("default value"),
            rx.text("Another default value")
        )
```

(not accepted) ❌ 
```python
 rx.match(
            State.value,
            (1, 'first value'),
            (2, "second value"),
            "default value",
            "another default value",
        )
```
- The default case is optional when the type of the return value of the cases is a component (a default case `Fragment.create()` is implicitly created), however, when the return type is a Var (or when `rx.match` is used as a prop) a default case MUST be provided.

(accepted)✅ 
```python
rx.match(
            State.value,
            (1, rx.vstack(rx.text('first value'))),
            (2, rx.text("second value")),
        )
```

(not accepted) ❌ 
```python
 rx.match(
            State.value,
            (1, 'first value'),
            (2, "second value"),
        )
```

## `rx.match` as prop
```python
...
class State(rx.State):
    value: int = 0
    num: int = 1
...
rx.text(
            "Random text",
            color=rx.match(
                State.value,
                (1, "red"),
                (2, "blue"),
                (State.num + 1, "orange"),
                "yellow"
            ),
        ),

```

## support for multiple cases
```python
...
rx.match(
            State.value,
            (1, rx.text("first case")),
            (2, rx.text("second case")),
            (3, 4, 5, rx.text("third case")),
	    ((1,2,3), 6, 7, rx.text("fourth case")),
            ({"foo": "bar"}, [10, 11, 12], "random_case" ,rx.text("fifth case")),
             rx.text("default case"),
        ),
```

As mentioned above, the first `n-1` elements of the tuple are treated as cases to be matched and the last as the reurn value.

**Note** : Match cases must not have different return types:

(not accepted) ❌ 
```python
...
rx.match(
            State.value,
            (1, rx.text("first case")),
            (2, rx.text("second case")),
            (1, "red"),
            (2, "blue"),
             rx.text("default case"),
        ),

```