### PR TITLE
CLI script to maintain Chakra backed components in rx namespace in older apps

### DIFF
--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -100,9 +100,8 @@ def _init(
     # Migrate Pynecone projects to Reflex.
     prerequisites.migrate_to_reflex()
 
-    # IF WE WANT TO PROMPT USER TO DO RUN AUTO-MIGRATION SCRIPT
-    # Migrate from rx to rx.chakra if not done before
-    # prerequisites.migrate_to_rx_chakra()
+    if prerequisites.should_show_rx_chakra_migration_instructions():
+        prerequisites.show_rx_chakra_migration_instructions()
 
     # Initialize the .gitignore.
     prerequisites.initialize_gitignore()
@@ -340,6 +339,7 @@ def logout(
 
 
 db_cli = typer.Typer()
+script_cli = typer.Typer()
 
 
 def _skip_compile():
@@ -416,6 +416,17 @@ def makemigrations(
             console.error(
                 f"{command_error} Run [bold]reflex db migrate[/bold] to update database."
             )
+
+
+@script_cli.command(
+    name="keep-chakra",
+    help="Change all rx.<component> references to rx.chakra.<component>, to preserve Chakra UI usage.",
+)
+def keep_chakra():
+    """Change all rx.<component> references to rx.chakra.<component>, to preserve Chakra UI usage."""
+    from reflex.utils import prerequisites
+
+    prerequisites.migrate_to_rx_chakra()
 
 
 @cli.command()
@@ -559,6 +570,7 @@ def demo(
 
 
 cli.add_typer(db_cli, name="db", help="Subcommands for managing the database schema.")
+cli.add_typer(script_cli, name="script", help="Subcommands running helper scripts.")
 cli.add_typer(
     deployments_cli,
     name="deployments",

--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -100,8 +100,9 @@ def _init(
     # Migrate Pynecone projects to Reflex.
     prerequisites.migrate_to_reflex()
 
+    # IF WE WANT TO PROMPT USER TO DO RUN AUTO-MIGRATION SCRIPT
     # Migrate from rx to rx.chakra if not done before
-    prerequisites.migrate_to_rx_chakra()
+    # prerequisites.migrate_to_rx_chakra()
 
     # Initialize the .gitignore.
     prerequisites.initialize_gitignore()

--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -100,6 +100,9 @@ def _init(
     # Migrate Pynecone projects to Reflex.
     prerequisites.migrate_to_reflex()
 
+    # Migrate from rx to rx.chakra if not done before
+    prerequisites.migrate_to_rx_chakra()
+
     # Initialize the .gitignore.
     prerequisites.initialize_gitignore()
 

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -29,7 +29,6 @@ from redis.asyncio import Redis
 import reflex
 from reflex import constants, model
 from reflex.compiler import templates
-from reflex.components import ChakraComponent
 from reflex.config import Config, get_config
 from reflex.utils import console, path_ops, processes
 
@@ -999,6 +998,8 @@ def migrate_to_rx_chakra():
 
 
 def _get_rx_chakra_component_to_migrate() -> set[str]:
+    from reflex.components import ChakraComponent
+
     rx_chakra_names = set(dir(reflex.chakra))
 
     names_to_migrate = set()

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -942,6 +942,12 @@ def prompt_for_template() -> constants.Templates.Kind:
 def migrate_to_rx_chakra():
     """Migrate rx.button => r.chakra.button, etc."""
     # Check to see if this migration question has been answered by user before
+    if (
+        os.getenv("REFLEX_ALLOW_MIGRATE_TO_RX_CHAKRA") != "yes"
+        and constants.Reflex.VERSION < "0.4"
+    ):
+        return
+
     with open(constants.Config.FILE, "r") as f:
         for line in f.readlines():
             m = re.search("^# reflex (\\S+)", line)

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -949,13 +949,19 @@ def migrate_to_rx_chakra():
         return
 
     # Check to see if this migration question has been answered by user before
-    with open(constants.Config.FILE, "r") as f:
-        for line in f.readlines():
-            m = re.search("^# reflex (\\S+)", line)
-            if m:
-                directive = m.group(1)
-                if directive == "rx_chakra_migration_processed":
-                    return
+    def _already_processed() -> bool:
+        with open(constants.Config.FILE, "r") as f:
+            for line in f.readlines():
+                m = re.search("^# reflex (\\S+)", line)
+                if m:
+                    directive = m.group(1)
+                    if directive == "rx_chakra_migration_processed":
+                        return True
+        return False
+
+    # FOR RXCONFIG BREADCRUMB BASED STATE TRACKING
+    # if _already_processed():
+    #    return
 
     def _add_processed_marker_to_config():
         new_line = "\n"
@@ -979,7 +985,8 @@ def migrate_to_rx_chakra():
 
     # No, and we will mark this project "processed" so we don't ask again
     if action == "n":
-        _add_processed_marker_to_config()
+        # FOR RXCONFIG BREADCRUMB BASED STATE TRACKING
+        # _add_processed_marker_to_config()
         return
 
     # Yes, proceed to migration
@@ -999,8 +1006,9 @@ def migrate_to_rx_chakra():
                     line = line.replace(old, new)
                 print(line, end="")
 
+    # FOR RXCONFIG BREADCRUMB BASED STATE TRACKING
     # If everything worked OK, mark this project "processed" so we don't ask again
-    _add_processed_marker_to_config()
+    # _add_processed_marker_to_config()
 
 
 def migrate_to_reflex():

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -969,12 +969,14 @@ def should_show_rx_chakra_migration_instructions() -> bool:
 def show_rx_chakra_migration_instructions():
     """Show the migration instructions for rx.chakra.* => rx.*."""
     console.log(
-        "Prior to reflex 0.4.0, rx.<component> are based on Chakra UI. rx.<component> are now based on Radix UI. To stick to Chakra UI, use rx.chakra.<component> ."
+        "Prior to reflex 0.4.0, rx.* components are based on Chakra UI. They are now based on Radix UI. To stick to Chakra UI, use rx.chakra.*."
     )
+    console.log("")
     console.log(
-        "[bold] Run `reflex migrate keep-chakra` to automatically update your app"
+        "[bold]Run `reflex migrate keep-chakra` to automatically update your app."
     )
-    console.log("For more details, please see TODO")  # TODO add link to docs
+    console.log("")
+    console.log("For more details, please see https://TODO")  # TODO add link to docs
 
 
 def migrate_to_rx_chakra():

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -955,8 +955,8 @@ def should_show_rx_chakra_migration_instructions() -> bool:
 
     if existing_init_reflex_version is None:
         # They clone a reflex app from git for the first time.
-        # If we don't ask... the reflex app would simply not work (if needed migration)
-        # If we ask... danger is only that they need to say "no". If they say "yes" by mistake, they can recover from git
+        # That app may or may not be 0.4 compatible.
+        # So let's just show these instructions THIS TIME.
         return True
 
     if constants.Reflex.VERSION < "0.4":

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -29,8 +29,8 @@ from redis.asyncio import Redis
 import reflex
 from reflex import constants, model
 from reflex.compiler import templates
-from reflex.config import Config, get_config
 from reflex.components import ChakraComponent
+from reflex.config import Config, get_config
 from reflex.utils import console, path_ops, processes
 
 

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -941,13 +941,14 @@ def prompt_for_template() -> constants.Templates.Kind:
 
 def migrate_to_rx_chakra():
     """Migrate rx.button => r.chakra.button, etc."""
-    # Check to see if this migration question has been answered by user before
+    # Only ask if: we are 0.4 or newer, or REFLEX_ALLOW_MIGRATE_TO_RX_CHAKRA=yes
     if (
         os.getenv("REFLEX_ALLOW_MIGRATE_TO_RX_CHAKRA") != "yes"
         and constants.Reflex.VERSION < "0.4"
     ):
         return
 
+    # Check to see if this migration question has been answered by user before
     with open(constants.Config.FILE, "r") as f:
         for line in f.readlines():
             m = re.search("^# reflex (\\S+)", line)

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -973,7 +973,7 @@ def show_rx_chakra_migration_instructions():
     )
     console.log("")
     console.log(
-        "[bold]Run `reflex migrate keep-chakra` to automatically update your app."
+        "[bold]Run `reflex script keep-chakra` to automatically update your app."
     )
     console.log("")
     console.log("For more details, please see https://TODO")  # TODO add link to docs

--- a/scripts/migrate_project_to_rx_chakra.py
+++ b/scripts/migrate_project_to_rx_chakra.py
@@ -1,0 +1,13 @@
+"""Migrate project to rx.chakra. I.e. switch usage of rx.<component> to rx.chakra.<component>."""
+
+import argparse
+
+if __name__ == "__main__":
+    # parse args just for the help message (-h, etc)
+    parser = argparse.ArgumentParser(
+        description="Migrate project to rx.chakra. I.e. switch usage of rx.<component> to rx.chakra.<component>."
+    )
+    args = parser.parse_args()
+    from reflex.utils.prerequisites import migrate_to_rx_chakra
+
+    migrate_to_rx_chakra()


### PR DESCRIPTION
On `reflex init` path, instructions to maintain Chakra component usage in an app will be provided in these scenarios:
* It's the very first `reflex init`.
* Previous `reflex init` was done with a pre-0.4 reflex, and the current reflex version is 0.4.

The instructions basically talks about `reflex script keep-chakra`. It will look for references to `rx.<component>` in the current app and change the reference to `rx.chakra.<component>`.  Whilst the actual transform is a simple string replace, there are safeguards in place, such as never transforming `rx.S` => `rx.chakra.T`, if S was not a `ChakraComponent` to begin with, or T is not a valid `ChakraComponent` under `rx.chakra`.
