### PR TITLE
Remove `app.compile()` from templates

### DIFF
--- a/reflex/.templates/apps/blank/code/blank.py
+++ b/reflex/.templates/apps/blank/code/blank.py
@@ -42,4 +42,3 @@ def index() -> rx.Component:
 # Add state and page to the app.
 app = rx.App()
 app.add_page(index)
-app.compile()

--- a/reflex/.templates/apps/demo/code/demo.py
+++ b/reflex/.templates/apps/demo/code/demo.py
@@ -120,4 +120,3 @@ def chatapp() -> rx.Component:
 
 # Add state and page to the app.
 app = rx.App(style=base_style)
-app.compile()

--- a/reflex/.templates/apps/sidebar/code/sidebar.py
+++ b/reflex/.templates/apps/sidebar/code/sidebar.py
@@ -9,4 +9,3 @@ import reflex as rx
 
 # Create the app and compile it.
 app = rx.App(style=styles.base_style)
-app.compile()


### PR DESCRIPTION
Now that the compile step is not required (and in fact throws a warning), we shouldn't be including this boilerplate in new apps created from the template.