### PR TITLE
Add reflex init app name validator, prevent import failure during reflex run

### DIFF
--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -74,8 +74,8 @@ def _init(
     # Show system info
     exec.output_system_info()
 
-    # Get the app name.
-    app_name = prerequisites.get_default_app_name() if name is None else name
+    # Validate the app name.
+    app_name = prerequisites.validate_app_name(name)
     console.rule(f"[bold]Initializing {app_name}")
 
     prerequisites.check_latest_package_version(constants.Reflex.MODULE_NAME)

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -215,23 +215,34 @@ def get_production_backend_url() -> str:
     )
 
 
-def get_default_app_name() -> str:
-    """Get the default app name.
+def validate_app_name(app_name: str | None = None) -> str:
+    """Validate the app name.
 
     The default app name is the name of the current directory.
 
+    Args:
+        app_name: the name passed by user during reflex init
+
     Returns:
-        The default app name.
+        The app name after validation.
 
     Raises:
-        Exit: if the app directory name is reflex.
+        Exit: if the app directory name is reflex or if the name is not standard for a python package name.
     """
-    app_name = os.getcwd().split(os.path.sep)[-1].replace("-", "_")
-
+    app_name = (
+        app_name if app_name else os.getcwd().split(os.path.sep)[-1].replace("-", "_")
+    )
     # Make sure the app is not named "reflex".
     if app_name == constants.Reflex.MODULE_NAME:
         console.error(
             f"The app directory cannot be named [bold]{constants.Reflex.MODULE_NAME}[/bold]."
+        )
+        raise typer.Exit(1)
+
+    # Make sure the app name is standard for a python package name.
+    if not re.match(r"^[a-zA-Z][a-zA-Z0-9_]*$", app_name):
+        console.error(
+            "The app directory name must start with a letter and can contain letters, numbers, and underscores."
         )
         raise typer.Exit(1)
 

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -306,8 +306,8 @@ def test_initialize_non_existent_gitignore(tmp_path, mocker, gitignore_exists):
     assert set(file_content) - expected == set()
 
 
-def test_app_default_name(tmp_path, mocker):
-    """Test that an error is raised if the app name is reflex.
+def test_validate_app_name(tmp_path, mocker):
+    """Test that an error is raised if the app name is reflex or if the name is not according to python package naming conventions.
 
     Args:
         tmp_path: Test working dir.
@@ -319,7 +319,10 @@ def test_app_default_name(tmp_path, mocker):
     mocker.patch("reflex.utils.prerequisites.os.getcwd", return_value=str(reflex))
 
     with pytest.raises(typer.Exit):
-        prerequisites.get_default_app_name()
+        prerequisites.validate_app_name()
+
+    with pytest.raises(typer.Exit):
+        prerequisites.validate_app_name(app_name="1_test")
 
 
 def test_node_install_windows(tmp_path, mocker):


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?


**Issue:** improper app directory name passed during reflex init will cause reflex run to fail, if the name is not according to python package naming conventions.

Run the below command to recreate the issue, 
`reflex init --name="123" --template="sidebar" `
and try running `reflex run`.

We get the following error.
```
from 123 import styles
         ^
SyntaxError: invalid syntax
```

This issue can also occur if `reflex init` is run inside a folder with similar improper app directory naming.

I've refactored get_default_app_name() of reflex init, and added a regex validator to check the app_name passed to the function, to ensure proper directory naming. Else it displays a console error, with proper message.

