### PR TITLE
support parsing type args of DeclarativeBase subclasses

### DIFF
--- a/reflex/utils/types.py
+++ b/reflex/utils/types.py
@@ -19,7 +19,7 @@ from typing import (
 )
 
 from pydantic.fields import ModelField
-from sqlalchemy.orm import Mapped, DeclarativeBase
+from sqlalchemy.orm import DeclarativeBase, Mapped
 
 from reflex.base import Base
 from reflex.utils import serializers

--- a/reflex/utils/types.py
+++ b/reflex/utils/types.py
@@ -19,7 +19,7 @@ from typing import (
 )
 
 from pydantic.fields import ModelField
-from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import Mapped, DeclarativeBase
 
 from reflex.base import Base
 from reflex.utils import serializers
@@ -128,7 +128,7 @@ def get_attribute_access_type(cls: GenericType, name: str) -> GenericType | None
             # Ensure frontend uses null coalescing when accessing.
             type_ = Optional[type_]
         return type_
-    elif isinstance(cls, type) and issubclass(cls, Model):
+    elif isinstance(cls, type) and issubclass(cls, (Model, DeclarativeBase)):
         # Check in the annotations directly (for sqlmodel.Relationship)
         hints = get_type_hints(cls)
         if name in hints:


### PR DESCRIPTION
Related Issue: #2340  
This PR only adds support for computed vars with return values which are annotated with sqlalchemy models inheriting from DeclarativeBase. It does not fix the other issues with bare sqlalchemy mentioned in #2340

### All Submissions:

- [X] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [X] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?


### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
