### PR TITLE
Handle VarData roundtrip when encoded value contains newline

### DIFF
--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -209,7 +209,11 @@ def _decode_var(value: str) -> tuple[VarData | None, str]:
     var_datas = []
     if isinstance(value, str):
         # Extract the state name from a formatted var
-        while m := re.match(r"(.*)<reflex.Var>(.*)</reflex.Var>(.*)", value):
+        while m := re.match(
+            pattern=r"(.*)<reflex.Var>(.*)</reflex.Var>(.*)",
+            string=value,
+            flags=re.DOTALL,  # Ensure . matches newline characters.
+        ):
             value = m.group(1) + m.group(3)
             try:
                 var_datas.append(VarData.parse_raw(m.group(2)))

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -638,9 +638,20 @@ def test_extract_state_from_container(value, expect_state):
     assert Var.create_safe(value)._var_state == expect_state
 
 
-def test_fstring_roundtrip():
-    """Test that f-string roundtrip carries state."""
-    var = BaseVar.create_safe("var")._var_set_state("state")
+@pytest.mark.parametrize(
+    "value",
+    [
+        "var",
+        "\nvar",
+    ],
+)
+def test_fstring_roundtrip(value):
+    """Test that f-string roundtrip carries state.
+
+    Args:
+        value: The value to create a Var from.
+    """
+    var = BaseVar.create_safe(value)._var_set_state("state")
     rt_var = Var.create_safe(f"{var}")
     assert var._var_state == rt_var._var_state
     assert var._var_full_name_needs_state_prefix


### PR DESCRIPTION
Encoded VarData (created when formatting a Var via f-string) should be treated as a stream of characters, where a newline supplied by the user should not be handled differently than any other character.

Fix #2349