### PR TITLE
Resolve correct python path on windows

### DIFF
--- a/reflex/utils/path_ops.py
+++ b/reflex/utils/path_ops.py
@@ -121,8 +121,8 @@ def get_node_bin_path() -> str | None:
     """
     if not os.path.exists(constants.Node.BIN_PATH):
         str_path = which("node")
-        return str(Path(str_path).parent) if str_path else str_path
-    return constants.Node.BIN_PATH
+        return str(Path(str_path).parent.resolve()) if str_path else str_path
+    return str(Path(constants.Node.BIN_PATH).resolve())
 
 
 def get_node_path() -> str | None:


### PR DESCRIPTION
This PR sets/resolves the correct python path when running the frontend via node using a python version installed from microsoft store. Previously, a fresh install of reflex on a windows machine without preinstalled node raised a `node command not recognized ` error.