### PR TITLE
use process pool to compile faster

### DIFF
--- a/reflex/app.py
+++ b/reflex/app.py
@@ -752,7 +752,6 @@ class App(Base):
         return
 
     def compile_(self):
-        # TODO - "Compiling: " progress sometimes doesn't show!
         """Compile the app and output it to the pages folder.
 
         Raises:
@@ -777,7 +776,7 @@ class App(Base):
         )
 
         # try to be somewhat accurate - but still not 100%
-        adhoc_steps_without_executor = 7
+        adhoc_steps_without_executor = 6
         fixed_pages_within_executor = 7
         progress.start()
         task = progress.add_task(

--- a/reflex/compiler/compiler.py
+++ b/reflex/compiler/compiler.py
@@ -454,3 +454,113 @@ def remove_tailwind_from_postcss() -> tuple[str, str]:
 def purge_web_pages_dir():
     """Empty out .web directory."""
     utils.empty_dir(constants.Dirs.WEB_PAGES, keep_files=["_app.js"])
+
+
+class ExecutorSafeFunctions:
+    """Helper class to allow parallelisation of parts of the compilation process.
+
+    This class (and its class attributes) are available at global scope.
+
+    In a multiprocessing context (like when using a ProcessPoolExecutor), the content of this
+    global class is logically replicated to any FORKED process.
+
+    How it works:
+    * Before the child process is forked, ensure that we stash any input data required by any future
+      function call in the child process.
+    * After the child process is forked, the child process will have a copy of the global class, which
+      includes the previously stashed input data.
+    * Any task submitted to the child process simply needs a way to communicate which input data the
+      requested function call requires.
+
+    Why do we need this? Passing input data directly to child process often not possible because the input data is not picklable.
+    The mechanic described here removes the need to pickle the input data at all.
+
+    Limitations:
+    * This can never support returning unpicklable OUTPUT data.
+    * Any object mutations done by the child process will not propagate back to the parent process (fork goes one way!).
+
+    """
+
+    COMPILE_PAGE_ARGS_BY_ROUTE = {}
+    COMPILE_APP_APP_ROOT: Component | None = None
+    CUSTOM_COMPONENTS: set[CustomComponent] | None = None
+    HEAD_COMPONENTS: list[Component] | None = None
+    STYLE: ComponentStyle | None = None
+    STATE: type[BaseState] | None = None
+
+    @classmethod
+    def compile_page(cls, route: str):
+        """Compile a page.
+
+        Args:
+            route: The route of the page to compile.
+
+        Returns:
+            The path and code of the compiled page.
+        """
+        return compile_page(*cls.COMPILE_PAGE_ARGS_BY_ROUTE[route])
+
+    @classmethod
+    def compile_app(cls):
+        """Compile the app.
+
+        Returns:
+            The path and code of the compiled app.
+
+        Raises:
+            ValueError: If the app root is not set.
+        """
+        if cls.COMPILE_APP_APP_ROOT is None:
+            raise ValueError("COMPILE_APP_APP_ROOT should be set")
+        return compile_app(cls.COMPILE_APP_APP_ROOT)
+
+    @classmethod
+    def compile_custom_components(cls):
+        """Compile the custom components.
+
+        Returns:
+            The path and code of the compiled custom components.
+
+        Raises:
+            ValueError: If the custom components are not set.
+        """
+        if cls.CUSTOM_COMPONENTS is None:
+            raise ValueError("CUSTOM_COMPONENTS should be set")
+        return compile_components(cls.CUSTOM_COMPONENTS)
+
+    @classmethod
+    def compile_document_root(cls):
+        """Compile the document root.
+
+        Returns:
+            The path and code of the compiled document root.
+
+        Raises:
+            ValueError: If the head components are not set.
+        """
+        if cls.HEAD_COMPONENTS is None:
+            raise ValueError("HEAD_COMPONENTS should be set")
+        return compile_document_root(cls.HEAD_COMPONENTS)
+
+    @classmethod
+    def compile_theme(cls):
+        """Compile the theme.
+
+        Returns:
+            The path and code of the compiled theme.
+
+        Raises:
+            ValueError: If the style is not set.
+        """
+        if cls.STYLE is None:
+            raise ValueError("STYLE should be set")
+        return compile_theme(cls.STYLE)
+
+    @classmethod
+    def compile_contexts(cls):
+        """Compile the contexts.
+
+        Returns:
+            The path and code of the compiled contexts.
+        """
+        return compile_contexts(cls.STATE)


### PR DESCRIPTION
* On platforms that support it (Mac, Linux), use a forking ProcessPoolExecutor instead to leverage multiple CPU cores.  Compilation (especially for a site that has many pages) is CPU bound.  Python's faux threads don't help very much (for reflex-web, setting max threads to 1 results in same performance prior).
* Some gymnastics required to use processes, to workaround non-picklable task arguments (like components).  We make the strong assumption that we use these arguments in a read only manner, and return strings (path + compiled output text).

We also do some general cleanup - for steps that are not being parallelized, it should run outside of the executor context manager.

As an aside, we stop using multi-threading to write out final compilation output to file system.  Even for a large project like reflex-web, that part takes about 200ms on my laptop (Macs are fancy, but pretty much everyone has SSDs).

Before (reflex-web):
![image](https://github.com/reflex-dev/reflex/assets/136611113/6bbf6476-6b97-47e8-8433-ed7b8c0b7a08)

After (reflex-web):
![image](https://github.com/reflex-dev/reflex/assets/136611113/0839caf0-8d3e-49b2-966f-08dae893d661)
