### PR TITLE
Correct Radix Themes Slider props

### DIFF
--- a/reflex/components/radix/themes/components/slider.py
+++ b/reflex/components/radix/themes/components/slider.py
@@ -1,5 +1,5 @@
 """Interactive components provided by @radix-ui/themes."""
-from typing import Any, Dict, List, Literal
+from typing import Any, Dict, List, Literal, Union
 
 from reflex.vars import Var
 
@@ -35,22 +35,22 @@ class Slider(CommonMarginProps, RadixThemesComponent):
     radius: Var[LiteralRadius]
 
     # The value of the slider when initially rendered. Use when you do not need to control the state of the slider.
-    default_value: Var[List[float]]
+    default_value: Var[List[Union[float, int]]]
 
     # The controlled value of the slider. Must be used in conjunction with onValueChange.
-    value: Var[float]
+    value: Var[List[Union[float, int]]]
 
     # The name of the slider. Submitted with its owning form as part of a name/value pair.
     name: Var[str]
 
     # The minimum value of the slider.
-    min: Var[float, int]
+    min: Var[Union[float, int]]
 
     # The maximum value of the slider.
-    max: Var[float, int]
+    max: Var[Union[float, int]]
 
     # The step value of the slider.
-    step: Var[float, int]
+    step: Var[Union[float, int]]
 
     # Whether the slider is disabled
     disabled: Var[bool]

--- a/reflex/components/radix/themes/components/slider.pyi
+++ b/reflex/components/radix/themes/components/slider.pyi
@@ -7,7 +7,7 @@ from typing import Any, Dict, Literal, Optional, Union, overload
 from reflex.vars import Var, BaseVar, ComputedVar
 from reflex.event import EventChain, EventHandler, EventSpec
 from reflex.style import Style
-from typing import Any, Dict, List, Literal
+from typing import Any, Dict, List, Literal, Union
 from reflex.vars import Var
 from ..base import (
     CommonMarginProps,
@@ -103,12 +103,16 @@ class Slider(CommonMarginProps, RadixThemesComponent):
                 Literal["none", "small", "medium", "large", "full"],
             ]
         ] = None,
-        default_value: Optional[Union[Var[List[float]], List[float]]] = None,
-        value: Optional[Union[Var[float], float]] = None,
+        default_value: Optional[
+            Union[Var[List[Union[float, int]]], List[Union[float, int]]]
+        ] = None,
+        value: Optional[
+            Union[Var[List[Union[float, int]]], List[Union[float, int]]]
+        ] = None,
         name: Optional[Union[Var[str], str]] = None,
-        min: Optional[Union[Var[float, int], float, int]] = None,
-        max: Optional[Union[Var[float, int], float, int]] = None,
-        step: Optional[Union[Var[float, int], float, int]] = None,
+        min: Optional[Union[Var[Union[float, int]], Union[float, int]]] = None,
+        max: Optional[Union[Var[Union[float, int]], Union[float, int]]] = None,
+        step: Optional[Union[Var[Union[float, int]], Union[float, int]]] = None,
         disabled: Optional[Union[Var[bool], bool]] = None,
         orientation: Optional[
             Union[


### PR DESCRIPTION
All number-like props should accept either float or int types.

The `value` props must take a list of values.