### PR TITLE
Skip frontend packages install if previously done

### DIFF
--- a/reflex/app.py
+++ b/reflex/app.py
@@ -595,7 +595,7 @@ class App(Base):
                 continue
             _frontend_packages.append(package)
         page_imports.update(_frontend_packages)
-        prerequisites.install_frontend_packages(page_imports)
+        prerequisites.install_frontend_packages(page_imports, get_config())
 
     def _app_root(self, app_wrappers: dict[tuple[int, str], Component]) -> Component:
         for component in tuple(app_wrappers.values()):

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -643,7 +643,7 @@ def cached_procedure(cache_file: str, payload_fn: Callable[..., str]):
 
     Args:
         cache_file: The file to store the cache payload in.
-        payload_fn: The function to cache.
+        payload_fn: Function that computes cache payload from function args
 
     Returns:
         The decorated function.

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -637,7 +637,7 @@ def _clear_cached_procedure_file(cache_file: str):
         os.remove(cache_file)
 
 
-def cached_procedure(cache_file, payload_fn: Callable[..., str]):
+def cached_procedure(cache_file: str, payload_fn: Callable[..., str]):
     """Decorator to cache the runs of a procedure on disk. Procedures should not have
        a return value.
 

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -16,6 +16,7 @@ import zipfile
 from fileinput import FileInput
 from pathlib import Path
 from types import ModuleType
+from typing import Callable
 
 import httpx
 import pkg_resources
@@ -26,7 +27,7 @@ from redis.asyncio import Redis
 
 from reflex import constants, model
 from reflex.compiler import templates
-from reflex.config import get_config
+from reflex.config import Config, get_config
 from reflex.utils import console, path_ops, processes
 
 
@@ -619,14 +620,64 @@ def install_bun():
     )
 
 
-def install_frontend_packages(packages: set[str]):
+def _write_cached_procedure_file(payload: str, cache_file: str):
+    with open(cache_file, "w") as f:
+        f.write(payload)
+
+
+def _read_cached_procedure_file(cache_file: str) -> str | None:
+    if os.path.exists(cache_file):
+        with open(cache_file, "r") as f:
+            return f.read()
+    return None
+
+
+def _clear_cached_procedure_file(cache_file: str):
+    if os.path.exists(cache_file):
+        os.remove(cache_file)
+
+
+def cached_procedure(cache_file, payload_fn: Callable[..., str]):
+    """Decorator to cache the runs of a procedure on disk. Procedures should not have
+       a return value.
+
+    Args:
+        cache_file: The file to store the cache payload in.
+        payload_fn: The function to cache.
+
+    Returns:
+        The decorated function.
+    """
+
+    def _inner_decorator(func):
+        def _inner(*args, **kwargs):
+            payload = _read_cached_procedure_file(cache_file)
+            new_payload = payload_fn(*args, **kwargs)
+            if payload != new_payload:
+                _clear_cached_procedure_file(cache_file)
+                func(*args, **kwargs)
+                _write_cached_procedure_file(new_payload, cache_file)
+
+        return _inner
+
+    return _inner_decorator
+
+
+@cached_procedure(
+    cache_file=os.path.join(
+        constants.Dirs.WEB, "reflex.install_frontend_packages.cached"
+    ),
+    payload_fn=lambda p, c: f"{repr(sorted(list(p)))},{c.json()}",
+)
+def install_frontend_packages(packages: set[str], config: Config):
     """Installs the base and custom frontend packages.
 
     Args:
         packages: A list of package names to be installed.
+        config: The config object.
 
     Example:
-        >>> install_frontend_packages(["react", "react-dom"])
+        >>> install_frontend_packages(["react", "react-dom"], get_config())
     """
     # Install the base packages.
     process = processes.new_process(
@@ -637,7 +688,6 @@ def install_frontend_packages(packages: set[str]):
 
     processes.show_status("Installing base frontend packages", process)
 
-    config = get_config()
     if config.tailwind is not None:
         # install tailwind and tailwind plugins as dev dependencies.
         process = processes.new_process(

--- a/tests/test_prerequisites.py
+++ b/tests/test_prerequisites.py
@@ -147,7 +147,7 @@ def test_requirements_txt_other_encoding(mocker):
 
 
 def test_cached_procedure():
-    call_count = 1
+    call_count = 0
 
     @cached_procedure(tempfile.mktemp(), payload_fn=lambda: "constant")
     def _function_with_no_args():


### PR DESCRIPTION
We introduce a decorator `@cached_procedure` for this functionality.  "Procedure" because we are not caching any results, only the inputs to a previous call.  It is up to the decoratee to ensure its args capture the unique call under cache sufficiently.