### PR TITLE
radiogroup high level api

### DIFF
--- a/reflex/components/markdown/markdown.py
+++ b/reflex/components/markdown/markdown.py
@@ -41,6 +41,7 @@ _REHYPE_PLUGINS = Var.create_safe([_REHYPE_KATEX, _REHYPE_RAW])
 # These tags do NOT get props passed to them
 NO_PROPS_TAGS = ("ul", "ol", "li")
 
+
 # Component Mapping
 @lru_cache
 def get_base_component_map() -> dict[str, Callable]:

--- a/reflex/components/radix/themes/components/__init__.py
+++ b/reflex/components/radix/themes/components/__init__.py
@@ -49,7 +49,7 @@ from .iconbutton import IconButton
 from .icons import Icon
 from .inset import Inset
 from .popover import PopoverClose, PopoverContent, PopoverRoot, PopoverTrigger
-from .radiogroup import RadioGroupItem, RadioGroupRoot, radio_group
+from .radiogroup import HighLevelRadioGroup, RadioGroupItem, RadioGroupRoot
 from .scrollarea import ScrollArea
 from .select import (
     SelectContent,
@@ -161,6 +161,7 @@ popover_close = PopoverClose.create
 # Radio Group
 radio_group_root = RadioGroupRoot.create
 radio_group_item = RadioGroupItem.create
+radio_group = HighLevelRadioGroup.create
 
 # Scroll Area
 scroll_area = ScrollArea.create

--- a/reflex/components/radix/themes/components/__init__.py
+++ b/reflex/components/radix/themes/components/__init__.py
@@ -49,7 +49,7 @@ from .iconbutton import IconButton
 from .icons import Icon
 from .inset import Inset
 from .popover import PopoverClose, PopoverContent, PopoverRoot, PopoverTrigger
-from .radiogroup import RadioGroupItem, RadioGroupRoot
+from .radiogroup import RadioGroupItem, RadioGroupRoot, radio_group
 from .scrollarea import ScrollArea
 from .select import (
     SelectContent,

--- a/reflex/components/radix/themes/components/radiogroup.py
+++ b/reflex/components/radix/themes/components/radiogroup.py
@@ -89,13 +89,13 @@ class HighLevelRadioGroup(RadioGroupRoot):
     items: Var[List[str]]
 
     # The direction of the radio group.
-    direction: Var[LiteralFlexDirection] = "column"
+    direction: Var[LiteralFlexDirection] = Var.create_safe("column")
 
     # The gap between the items of the radio group.
-    gap: Var[LiteralSize] = "2"
+    gap: Var[LiteralSize] = Var.create_safe("2")
 
     # The size of the radio group.
-    size: Var[Literal["1", "2", "3"]] = "2"
+    size: Var[Literal["1", "2", "3"]] = Var.create_safe("2")
 
     @classmethod
     def create(cls, items: Var[List[str]], **props) -> Component:

--- a/reflex/components/radix/themes/components/radiogroup.py
+++ b/reflex/components/radix/themes/components/radiogroup.py
@@ -95,6 +95,7 @@ def radio_group(
         items: The items of the radio group.
         direction: The direction of the radio group.
         gap: The gap between the items of the radio group.
+        size: The size of the radio group.
         **props: Additional properties to apply to the accordion item.
 
     Returns:

--- a/reflex/components/radix/themes/components/radiogroup.py
+++ b/reflex/components/radix/themes/components/radiogroup.py
@@ -1,6 +1,7 @@
 """Interactive components provided by @radix-ui/themes."""
 from typing import Any, Dict, Literal
 
+import reflex as rx
 from reflex.components.component import Component
 from reflex.components.radix.themes.layout.flex import Flex
 from reflex.components.radix.themes.typography.text import Text
@@ -82,7 +83,7 @@ class RadioGroupItem(CommonMarginProps, RadixThemesComponent):
 
 
 def radio_group(
-    items: list[str],
+    items: Var[list[str]],
     direction: Var[LiteralFlexDirection] = "column",
     gap: Var[LiteralSize] = "2",
     **props
@@ -110,9 +111,14 @@ def radio_group(
             as_="label",
         )
 
+    if isinstance(items, Var):
+        child = [rx.foreach(items, radio_group_item)]
+    else:
+        child = [radio_group_item(value) for value in items]
+
     return RadioGroupRoot.create(
         Flex.create(
-            *[radio_group_item(value) for value in items],
+            *child,
             direction=direction,
             gap=gap,
         ),

--- a/reflex/components/radix/themes/components/radiogroup.py
+++ b/reflex/components/radix/themes/components/radiogroup.py
@@ -86,6 +86,7 @@ def radio_group(
     items: Var[List[str]],
     direction: Var[LiteralFlexDirection] = Var.create_safe("column"),
     gap: Var[LiteralSize] = Var.create_safe("2"),
+    size: Var[Literal["1", "2", "3"]] = Var.create_safe("2"),
     **props
 ) -> Component:
     """Create a radio group component.
@@ -107,7 +108,7 @@ def radio_group(
                 value,
                 gap="2",
             ),
-            size="2",
+            size=size,
             as_="label",
         )
 
@@ -122,5 +123,6 @@ def radio_group(
             direction=direction,
             gap=gap,
         ),
+        size=size,
         **props,
     )

--- a/reflex/components/radix/themes/components/radiogroup.py
+++ b/reflex/components/radix/themes/components/radiogroup.py
@@ -82,48 +82,58 @@ class RadioGroupItem(CommonMarginProps, RadixThemesComponent):
     required: Var[bool]
 
 
-def radio_group(
-    items: Var[List[str]],
-    direction: Var[LiteralFlexDirection] = Var.create_safe("column"),
-    gap: Var[LiteralSize] = Var.create_safe("2"),
-    size: Var[Literal["1", "2", "3"]] = Var.create_safe("2"),
-    **props
-) -> Component:
-    """Create a radio group component.
+class HighLevelRadioGroup(RadioGroupRoot):
+    """High level wrapper for the RadioGroup component."""
 
-    Args:
-        items: The items of the radio group.
-        direction: The direction of the radio group.
-        gap: The gap between the items of the radio group.
-        size: The size of the radio group.
-        **props: Additional properties to apply to the accordion item.
+    # The items of the radio group.
+    items: Var[List[str]]
 
-    Returns:
-        The created radio group component.
-    """
+    # The direction of the radio group.
+    direction: Var[LiteralFlexDirection] = "column"
 
-    def radio_group_item(value: str) -> Component:
-        return Text.create(
+    # The gap between the items of the radio group.
+    gap: Var[LiteralSize] = "2"
+
+    # The size of the radio group.
+    size: Var[Literal["1", "2", "3"]] = "2"
+
+    @classmethod
+    def create(cls, items: Var[List[str]], **props) -> Component:
+        """Create a radio group component.
+
+        Args:
+            items: The items of the radio group.
+            **props: Additional properties to apply to the accordion item.
+
+        Returns:
+            The created radio group component.
+        """
+        direction = props.pop("direction", "column")
+        gap = props.pop("gap", "2")
+        size = props.pop("size", "2")
+
+        def radio_group_item(value: str) -> Component:
+            return Text.create(
+                Flex.create(
+                    RadioGroupItem.create(value=value),
+                    value,
+                    gap="2",
+                ),
+                size=size,
+                as_="label",
+            )
+
+        if isinstance(items, Var):
+            child = [rx.foreach(items, radio_group_item)]
+        else:
+            child = [radio_group_item(value) for value in items]  #  type: ignore
+
+        return RadioGroupRoot.create(
             Flex.create(
-                RadioGroupItem.create(value=value),
-                value,
-                gap="2",
+                *child,
+                direction=direction,
+                gap=gap,
             ),
             size=size,
-            as_="label",
+            **props,
         )
-
-    if isinstance(items, Var):
-        child = [rx.foreach(items, radio_group_item)]
-    else:
-        child = [radio_group_item(value) for value in items]  #  type: ignore
-
-    return RadioGroupRoot.create(
-        Flex.create(
-            *child,
-            direction=direction,
-            gap=gap,
-        ),
-        size=size,
-        **props,
-    )

--- a/reflex/components/radix/themes/components/radiogroup.py
+++ b/reflex/components/radix/themes/components/radiogroup.py
@@ -83,9 +83,9 @@ class RadioGroupItem(CommonMarginProps, RadixThemesComponent):
 
 
 def radio_group(
-    items: Var[list[str]],
-    direction: Var[LiteralFlexDirection] = "column",
-    gap: Var[LiteralSize] = "2",
+    items: [list[str] | Var[list[str]]],
+    direction: [str | Var[LiteralFlexDirection]] = "column",
+    gap: [str | Var[LiteralSize]] = "2",
     **props
 ) -> Component:
     """Create a radio group component.

--- a/reflex/components/radix/themes/components/radiogroup.py
+++ b/reflex/components/radix/themes/components/radiogroup.py
@@ -1,5 +1,5 @@
 """Interactive components provided by @radix-ui/themes."""
-from typing import Any, Dict, Literal, Union
+from typing import Any, Dict, Literal
 
 import reflex as rx
 from reflex.components.component import Component
@@ -83,9 +83,9 @@ class RadioGroupItem(CommonMarginProps, RadixThemesComponent):
 
 
 def radio_group(
-    items: Union[list[str], Var[list[str]]],
-    direction: Union[str, Var[LiteralFlexDirection]] = "column",
-    gap: Union[str, Var[LiteralSize]] = "2",
+    items: Var[list[str]],
+    direction: Var[LiteralFlexDirection] = Var.create_safe("column"),  #  type: ignore
+    gap: Var[LiteralSize] = Var.create_safe("2"),  #  type: ignore
     **props
 ) -> Component:
     """Create a radio group component.
@@ -119,7 +119,7 @@ def radio_group(
     return RadioGroupRoot.create(
         Flex.create(
             *child,
-            direction=direction,
+            direction=direction,  #  type: ignore
             gap=gap,
         ),
         **props,

--- a/reflex/components/radix/themes/components/radiogroup.py
+++ b/reflex/components/radix/themes/components/radiogroup.py
@@ -84,8 +84,8 @@ class RadioGroupItem(CommonMarginProps, RadixThemesComponent):
 
 def radio_group(
     items: Var[list[str]],
-    direction: Var[LiteralFlexDirection] = Var.create_safe("column"),  #  type: ignore
-    gap: Var[LiteralSize] = Var.create_safe("2"),  #  type: ignore
+    direction: Var[LiteralFlexDirection] = Var.create_safe("column"),
+    gap: Var[LiteralSize] = Var.create_safe("2"),
     **props
 ) -> Component:
     """Create a radio group component.
@@ -114,12 +114,12 @@ def radio_group(
     if isinstance(items, Var):
         child = [rx.foreach(items, radio_group_item)]
     else:
-        child = [radio_group_item(value) for value in items]
+        child = [radio_group_item(value) for value in items]  #  type: ignore
 
     return RadioGroupRoot.create(
         Flex.create(
             *child,
-            direction=direction,  #  type: ignore
+            direction=direction,
             gap=gap,
         ),
         **props,

--- a/reflex/components/radix/themes/components/radiogroup.py
+++ b/reflex/components/radix/themes/components/radiogroup.py
@@ -1,5 +1,5 @@
 """Interactive components provided by @radix-ui/themes."""
-from typing import Any, Dict, Literal, List
+from typing import Any, Dict, List, Literal
 
 import reflex as rx
 from reflex.components.component import Component

--- a/reflex/components/radix/themes/components/radiogroup.py
+++ b/reflex/components/radix/themes/components/radiogroup.py
@@ -1,5 +1,5 @@
 """Interactive components provided by @radix-ui/themes."""
-from typing import Any, Dict, Literal
+from typing import Any, Dict, Literal, Union
 
 import reflex as rx
 from reflex.components.component import Component
@@ -83,9 +83,9 @@ class RadioGroupItem(CommonMarginProps, RadixThemesComponent):
 
 
 def radio_group(
-    items: [list[str] | Var[list[str]]],
-    direction: [str | Var[LiteralFlexDirection]] = "column",
-    gap: [str | Var[LiteralSize]] = "2",
+    items: Union[list[str], Var[list[str]]],
+    direction: Union[str, Var[LiteralFlexDirection]] = "column",
+    gap: Union[str, Var[LiteralSize]] = "2",
     **props
 ) -> Component:
     """Create a radio group component.

--- a/reflex/components/radix/themes/components/radiogroup.py
+++ b/reflex/components/radix/themes/components/radiogroup.py
@@ -1,13 +1,19 @@
 """Interactive components provided by @radix-ui/themes."""
 from typing import Any, Dict, Literal
 
+from reflex.components.component import Component
+from reflex.components.radix.themes.layout.flex import Flex
+from reflex.components.radix.themes.typography.text import Text
 from reflex.vars import Var
 
 from ..base import (
     CommonMarginProps,
     LiteralAccentColor,
+    LiteralSize,
     RadixThemesComponent,
 )
+
+LiteralFlexDirection = Literal["row", "column", "row-reverse", "column-reverse"]
 
 
 class RadioGroupRoot(CommonMarginProps, RadixThemesComponent):
@@ -73,3 +79,42 @@ class RadioGroupItem(CommonMarginProps, RadixThemesComponent):
 
     # When true, indicates that the user must check the radio item before the owning form can be submitted.
     required: Var[bool]
+
+
+def radio_group(
+    items: list[str],
+    direction: Var[LiteralFlexDirection] = "column",
+    gap: Var[LiteralSize] = "2",
+    **props
+) -> Component:
+    """Create a radio group component.
+
+    Args:
+        items: The items of the radio group.
+        direction: The direction of the radio group.
+        gap: The gap between the items of the radio group.
+        **props: Additional properties to apply to the accordion item.
+
+    Returns:
+        The created radio group component.
+    """
+
+    def radio_group_item(value: str) -> Component:
+        return Text.create(
+            Flex.create(
+                RadioGroupItem.create(value=value),
+                value,
+                gap="2",
+            ),
+            size="2",
+            as_="label",
+        )
+
+    return RadioGroupRoot.create(
+        Flex.create(
+            *[radio_group_item(value) for value in items],
+            direction=direction,
+            gap=gap,
+        ),
+        **props,
+    )

--- a/reflex/components/radix/themes/components/radiogroup.py
+++ b/reflex/components/radix/themes/components/radiogroup.py
@@ -1,5 +1,5 @@
 """Interactive components provided by @radix-ui/themes."""
-from typing import Any, Dict, Literal
+from typing import Any, Dict, Literal, List
 
 import reflex as rx
 from reflex.components.component import Component
@@ -83,7 +83,7 @@ class RadioGroupItem(CommonMarginProps, RadixThemesComponent):
 
 
 def radio_group(
-    items: Var[list[str]],
+    items: Var[List[str]],
     direction: Var[LiteralFlexDirection] = Var.create_safe("column"),
     gap: Var[LiteralSize] = Var.create_safe("2"),
     **props

--- a/reflex/components/radix/themes/components/radiogroup.pyi
+++ b/reflex/components/radix/themes/components/radiogroup.pyi
@@ -7,7 +7,7 @@ from typing import Any, Dict, Literal, Optional, Union, overload
 from reflex.vars import Var, BaseVar, ComputedVar
 from reflex.event import EventChain, EventHandler, EventSpec
 from reflex.style import Style
-from typing import Any, Dict, Literal
+from typing import Any, Dict, Literal, List
 import reflex as rx
 from reflex.components.component import Component
 from reflex.components.radix.themes.layout.flex import Flex
@@ -451,7 +451,7 @@ class RadioGroupItem(CommonMarginProps, RadixThemesComponent):
         ...
 
 def radio_group(
-    items: Var[list[str]],
+    items: Var[List[str]],
     direction: Var[LiteralFlexDirection] = Var.create_safe("column"),
     gap: Var[LiteralSize] = Var.create_safe("2"),
     **props

--- a/reflex/components/radix/themes/components/radiogroup.pyi
+++ b/reflex/components/radix/themes/components/radiogroup.pyi
@@ -7,7 +7,7 @@ from typing import Any, Dict, Literal, Optional, Union, overload
 from reflex.vars import Var, BaseVar, ComputedVar
 from reflex.event import EventChain, EventHandler, EventSpec
 from reflex.style import Style
-from typing import Any, Dict, Literal, List
+from typing import Any, Dict, List, Literal
 import reflex as rx
 from reflex.components.component import Component
 from reflex.components.radix.themes.layout.flex import Flex

--- a/reflex/components/radix/themes/components/radiogroup.pyi
+++ b/reflex/components/radix/themes/components/radiogroup.pyi
@@ -454,5 +454,6 @@ def radio_group(
     items: Var[List[str]],
     direction: Var[LiteralFlexDirection] = Var.create_safe("column"),
     gap: Var[LiteralSize] = Var.create_safe("2"),
+    size: Var[Literal["1", "2", "3"]] = Var.create_safe("2"),
     **props
 ) -> Component: ...

--- a/reflex/components/radix/themes/components/radiogroup.pyi
+++ b/reflex/components/radix/themes/components/radiogroup.pyi
@@ -7,7 +7,7 @@ from typing import Any, Dict, Literal, Optional, Union, overload
 from reflex.vars import Var, BaseVar, ComputedVar
 from reflex.event import EventChain, EventHandler, EventSpec
 from reflex.style import Style
-from typing import Any, Dict, Literal
+from typing import Any, Dict, Literal, Union
 import reflex as rx
 from reflex.components.component import Component
 from reflex.components.radix.themes.layout.flex import Flex
@@ -451,8 +451,8 @@ class RadioGroupItem(CommonMarginProps, RadixThemesComponent):
         ...
 
 def radio_group(
-    items: [list[str] | Var[list[str]]],
-    direction: [str | Var[LiteralFlexDirection]] = "column",
-    gap: [str | Var[LiteralSize]] = "2",
+    items: Union[list[str], Var[list[str]]],
+    direction: Union[str, Var[LiteralFlexDirection]] = "column",
+    gap: Union[str, Var[LiteralSize]] = "2",
     **props
 ) -> Component: ...

--- a/reflex/components/radix/themes/components/radiogroup.pyi
+++ b/reflex/components/radix/themes/components/radiogroup.pyi
@@ -8,8 +8,19 @@ from reflex.vars import Var, BaseVar, ComputedVar
 from reflex.event import EventChain, EventHandler, EventSpec
 from reflex.style import Style
 from typing import Any, Dict, Literal
+import reflex as rx
+from reflex.components.component import Component
+from reflex.components.radix.themes.layout.flex import Flex
+from reflex.components.radix.themes.typography.text import Text
 from reflex.vars import Var
-from ..base import CommonMarginProps, LiteralAccentColor, RadixThemesComponent
+from ..base import (
+    CommonMarginProps,
+    LiteralAccentColor,
+    LiteralSize,
+    RadixThemesComponent,
+)
+
+LiteralFlexDirection = Literal["row", "column", "row-reverse", "column-reverse"]
 
 class RadioGroupRoot(CommonMarginProps, RadixThemesComponent):
     def get_event_triggers(self) -> Dict[str, Any]: ...
@@ -438,3 +449,10 @@ class RadioGroupItem(CommonMarginProps, RadixThemesComponent):
             A new component instance.
         """
         ...
+
+def radio_group(
+    items: Var[list[str]],
+    direction: Var[LiteralFlexDirection] = "column",
+    gap: Var[LiteralSize] = "2",
+    **props
+) -> Component: ...

--- a/reflex/components/radix/themes/components/radiogroup.pyi
+++ b/reflex/components/radix/themes/components/radiogroup.pyi
@@ -450,10 +450,241 @@ class RadioGroupItem(CommonMarginProps, RadixThemesComponent):
         """
         ...
 
-def radio_group(
-    items: Var[List[str]],
-    direction: Var[LiteralFlexDirection] = Var.create_safe("column"),
-    gap: Var[LiteralSize] = Var.create_safe("2"),
-    size: Var[Literal["1", "2", "3"]] = Var.create_safe("2"),
-    **props
-) -> Component: ...
+class HighLevelRadioGroup(RadioGroupRoot):
+    @overload
+    @classmethod
+    def create(  # type: ignore
+        cls,
+        *children,
+        items: Optional[Union[Var[List[str]], List[str]]] = None,
+        direction: Optional[
+            Union[
+                Var[Literal["row", "column", "row-reverse", "column-reverse"]],
+                Literal["row", "column", "row-reverse", "column-reverse"],
+            ]
+        ] = None,
+        gap: Optional[
+            Union[
+                Var[Literal["1", "2", "3", "4", "5", "6", "7", "8", "9"]],
+                Literal["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+            ]
+        ] = None,
+        size: Optional[
+            Union[Var[Literal["1", "2", "3"]], Literal["1", "2", "3"]]
+        ] = None,
+        variant: Optional[
+            Union[
+                Var[Literal["classic", "surface", "soft"]],
+                Literal["classic", "surface", "soft"],
+            ]
+        ] = None,
+        color: Optional[
+            Union[
+                Var[
+                    Literal[
+                        "tomato",
+                        "red",
+                        "ruby",
+                        "crimson",
+                        "pink",
+                        "plum",
+                        "purple",
+                        "violet",
+                        "iris",
+                        "indigo",
+                        "blue",
+                        "cyan",
+                        "teal",
+                        "jade",
+                        "green",
+                        "grass",
+                        "brown",
+                        "orange",
+                        "sky",
+                        "mint",
+                        "lime",
+                        "yellow",
+                        "amber",
+                        "gold",
+                        "bronze",
+                        "gray",
+                    ]
+                ],
+                Literal[
+                    "tomato",
+                    "red",
+                    "ruby",
+                    "crimson",
+                    "pink",
+                    "plum",
+                    "purple",
+                    "violet",
+                    "iris",
+                    "indigo",
+                    "blue",
+                    "cyan",
+                    "teal",
+                    "jade",
+                    "green",
+                    "grass",
+                    "brown",
+                    "orange",
+                    "sky",
+                    "mint",
+                    "lime",
+                    "yellow",
+                    "amber",
+                    "gold",
+                    "bronze",
+                    "gray",
+                ],
+            ]
+        ] = None,
+        high_contrast: Optional[Union[Var[bool], bool]] = None,
+        value: Optional[Union[Var[str], str]] = None,
+        default_value: Optional[Union[Var[str], str]] = None,
+        disabled: Optional[Union[Var[bool], bool]] = None,
+        name: Optional[Union[Var[str], str]] = None,
+        required: Optional[Union[Var[bool], bool]] = None,
+        orientation: Optional[
+            Union[
+                Var[Literal["horizontal", "vertical"]],
+                Literal["horizontal", "vertical"],
+            ]
+        ] = None,
+        loop: Optional[Union[Var[bool], bool]] = None,
+        m: Optional[
+            Union[
+                Var[Literal["1", "2", "3", "4", "5", "6", "7", "8", "9"]],
+                Literal["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+            ]
+        ] = None,
+        mx: Optional[
+            Union[
+                Var[Literal["1", "2", "3", "4", "5", "6", "7", "8", "9"]],
+                Literal["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+            ]
+        ] = None,
+        my: Optional[
+            Union[
+                Var[Literal["1", "2", "3", "4", "5", "6", "7", "8", "9"]],
+                Literal["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+            ]
+        ] = None,
+        mt: Optional[
+            Union[
+                Var[Literal["1", "2", "3", "4", "5", "6", "7", "8", "9"]],
+                Literal["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+            ]
+        ] = None,
+        mr: Optional[
+            Union[
+                Var[Literal["1", "2", "3", "4", "5", "6", "7", "8", "9"]],
+                Literal["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+            ]
+        ] = None,
+        mb: Optional[
+            Union[
+                Var[Literal["1", "2", "3", "4", "5", "6", "7", "8", "9"]],
+                Literal["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+            ]
+        ] = None,
+        ml: Optional[
+            Union[
+                Var[Literal["1", "2", "3", "4", "5", "6", "7", "8", "9"]],
+                Literal["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+            ]
+        ] = None,
+        style: Optional[Style] = None,
+        key: Optional[Any] = None,
+        id: Optional[Any] = None,
+        class_name: Optional[Any] = None,
+        autofocus: Optional[bool] = None,
+        custom_attrs: Optional[Dict[str, Union[Var, str]]] = None,
+        on_blur: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_click: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_context_menu: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_double_click: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_focus: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_mount: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_mouse_down: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_mouse_enter: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_mouse_leave: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_mouse_move: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_mouse_out: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_mouse_over: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_mouse_up: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_scroll: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_unmount: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_value_change: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        **props
+    ) -> "HighLevelRadioGroup":
+        """Create a radio group component.
+
+        Args:
+            items: The items of the radio group.
+            items: The items of the radio group.
+            direction: The direction of the radio group.
+            gap: The gap between the items of the radio group.
+            size: The size of the radio group: "1" | "2" | "3"
+            variant: The variant of the radio group
+            color: The color of the radio group
+            high_contrast: Whether to render the radio group with higher contrast color against background
+            value: The controlled value of the radio item to check. Should be used in conjunction with onValueChange.
+            default_value: The initial value of checked radio item. Should be used in conjunction with onValueChange.
+            disabled: Whether the radio group is disabled
+            name: The name of the group. Submitted with its owning form as part of a name/value pair.
+            required: Whether the radio group is required
+            orientation: The orientation of the component.
+            loop: When true, keyboard navigation will loop from last item to first, and vice versa.
+            m: Margin: "0" - "9"
+            mx: Margin horizontal: "0" - "9"
+            my: Margin vertical: "0" - "9"
+            mt: Margin top: "0" - "9"
+            mr: Margin right: "0" - "9"
+            mb: Margin bottom: "0" - "9"
+            ml: Margin left: "0" - "9"
+            style: The style of the component.
+            key: A unique key for the component.
+            id: The id for the component.
+            class_name: The class name for the component.
+            autofocus: Whether the component should take the focus once the page is loaded
+            custom_attrs: custom attribute
+            **props: Additional properties to apply to the accordion item.
+
+        Returns:
+            The created radio group component.
+        """
+        ...

--- a/reflex/components/radix/themes/components/radiogroup.pyi
+++ b/reflex/components/radix/themes/components/radiogroup.pyi
@@ -7,7 +7,7 @@ from typing import Any, Dict, Literal, Optional, Union, overload
 from reflex.vars import Var, BaseVar, ComputedVar
 from reflex.event import EventChain, EventHandler, EventSpec
 from reflex.style import Style
-from typing import Any, Dict, Literal, Union
+from typing import Any, Dict, Literal
 import reflex as rx
 from reflex.components.component import Component
 from reflex.components.radix.themes.layout.flex import Flex
@@ -451,8 +451,8 @@ class RadioGroupItem(CommonMarginProps, RadixThemesComponent):
         ...
 
 def radio_group(
-    items: Union[list[str], Var[list[str]]],
-    direction: Union[str, Var[LiteralFlexDirection]] = "column",
-    gap: Union[str, Var[LiteralSize]] = "2",
+    items: Var[list[str]],
+    direction: Var[LiteralFlexDirection] = Var.create_safe("column"),
+    gap: Var[LiteralSize] = Var.create_safe("2"),
     **props
 ) -> Component: ...

--- a/reflex/components/radix/themes/components/radiogroup.pyi
+++ b/reflex/components/radix/themes/components/radiogroup.pyi
@@ -451,8 +451,8 @@ class RadioGroupItem(CommonMarginProps, RadixThemesComponent):
         ...
 
 def radio_group(
-    items: Var[list[str]],
-    direction: Var[LiteralFlexDirection] = "column",
-    gap: Var[LiteralSize] = "2",
+    items: [list[str] | Var[list[str]]],
+    direction: [str | Var[LiteralFlexDirection]] = "column",
+    gap: [str | Var[LiteralSize]] = "2",
     **props
 ) -> Component: ...


### PR DESCRIPTION
Must import as shown" `from reflex.components.radix.themes.components import * `

Most basic usage, pass in a list of strings :

`radio_group(["1", "2", "3", "4", "5"])`

Can set several props such as `direction`, `gap`:

`radio_group(["1", "2", "3", "4", "5"], direction="row", gap="6"))`

and any other prop that the `RadioGroupRoot` component takes:

`radio_group(["1", "2", "3", "4", "5"], direction="row", gap="6", variant="soft", size="3", color_scheme="red", default_value="3")`

The list of strings passed can also be a state var and this will still work




```
from reflex.components.radix.themes.components import *


class State(rx.State):
    """The app state."""

    rad: list[str] = ["Name", "Age", "Location"]


def index():
    """The main view."""
    return rx.center(
        rx.vstack(
            radio_group(["1", "2", "3", "4", "5"]),
            radio_group(State.rad),
            radio_group(["1", "2", "3", "4", "5"], direction="row", gap="6")),
            radio_group(["1", "2", "3", "4", "5"], direction="row", gap="6", variant="soft", size="3", color_scheme="red", default_value="3"),
        ),
    )

app = rx.App()
app.add_page(index)
```