### PR TITLE
Allow app harness tests to import State subclasses

### DIFF
--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -163,7 +163,9 @@ def get_app(reload: bool = False) -> ModuleType:
         from reflex.state import State
 
         # Reset rx.State subclasses to avoid conflict when reloading.
-        State.class_subclasses.clear()
+        for subclass in tuple(State.class_subclasses):
+            if subclass.__module__ == module:
+                State.class_subclasses.remove(subclass)
         # Reload the app module.
         importlib.reload(app)
 


### PR DESCRIPTION
Otherwise importing with `reload=True` would remove all known state subclasses, even those defined in modules that would NOT be reloaded, which resulted in test failures for AppHarness tests that relied on state defined in another module.

https://discord.com/channels/1029853095527727165/1061874061250150441/1197312746224615514