### PR TITLE
[REF-1705] Do not overwrite Var attributes during format

### DIFF
--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -255,16 +255,20 @@ def format_cond(
 
     # Format prop conds.
     if is_prop:
-        prop1 = Var.create_safe(
-            true_value,
-            _var_is_string=type(true_value) is str,
+        if not isinstance(true_value, Var):
+            true_value = Var.create_safe(
+                true_value,
+                _var_is_string=type(true_value) is str,
+            )
+        prop1 = true_value._replace(
+            _var_is_local=True,
         )
-        prop1._var_is_local = True
-        prop2 = Var.create_safe(
-            false_value,
-            _var_is_string=type(false_value) is str,
-        )
-        prop2._var_is_local = True
+        if not isinstance(false_value, Var):
+            false_value = Var.create_safe(
+                false_value,
+                _var_is_string=type(false_value) is str,
+            )
+        prop2 = false_value._replace(_var_is_local=True)
         prop1, prop2 = str(prop1), str(prop2)  # avoid f-string semantics for Var
         return f"{cond} ? {prop1} : {prop2}".replace("{", "").replace("}", "")
 

--- a/tests/utils/test_format.py
+++ b/tests/utils/test_format.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 from typing import Any, List
 

--- a/tests/utils/test_format.py
+++ b/tests/utils/test_format.py
@@ -276,22 +276,107 @@ def test_format_route(route: str, format_case: bool, expected: bool):
 
 
 @pytest.mark.parametrize(
-    "condition,true_value,false_value,expected",
+    "condition,true_value,false_value,is_prop,expected",
     [
-        ("cond", "<C1>", '""', '{isTrue(cond) ? <C1> : ""}'),
-        ("cond", "<C1>", "<C2>", "{isTrue(cond) ? <C1> : <C2>}"),
+        ("cond", "<C1>", '""', False, '{isTrue(cond) ? <C1> : ""}'),
+        ("cond", "<C1>", "<C2>", False, "{isTrue(cond) ? <C1> : <C2>}"),
+        (
+            "cond",
+            Var.create_safe("<C1>"),
+            "<C2>",
+            False,
+            "{isTrue(cond) ? <C1> : <C2>}",
+        ),
+        (
+            "cond",
+            Var.create_safe("<C1>"),
+            Var.create_safe("<C2>"),
+            False,
+            "{isTrue(cond) ? <C1> : <C2>}",
+        ),
+        (
+            "cond",
+            Var.create_safe("<C1>", _var_is_local=False),
+            Var.create_safe("<C2>"),
+            False,
+            "{isTrue(cond) ? ${<C1>} : <C2>}",
+        ),
+        (
+            "cond",
+            Var.create_safe("<C1>", _var_is_string=True),
+            Var.create_safe("<C2>"),
+            False,
+            "{isTrue(cond) ? {`<C1>`} : <C2>}",
+        ),
+        ("cond", "<C1>", '""', True, 'isTrue(cond) ? `<C1>` : `""`'),
+        ("cond", "<C1>", "<C2>", True, "isTrue(cond) ? `<C1>` : `<C2>`"),
+        (
+            "cond",
+            Var.create_safe("<C1>"),
+            "<C2>",
+            True,
+            "isTrue(cond) ? <C1> : `<C2>`",
+        ),
+        (
+            "cond",
+            Var.create_safe("<C1>"),
+            Var.create_safe("<C2>"),
+            True,
+            "isTrue(cond) ? <C1> : <C2>",
+        ),
+        (
+            "cond",
+            Var.create_safe("<C1>", _var_is_local=False),
+            Var.create_safe("<C2>"),
+            True,
+            "isTrue(cond) ? <C1> : <C2>",
+        ),
+        (
+            "cond",
+            Var.create_safe("<C1>"),
+            Var.create_safe("<C2>", _var_is_local=False),
+            True,
+            "isTrue(cond) ? <C1> : <C2>",
+        ),
+        (
+            "cond",
+            Var.create_safe("<C1>", _var_is_string=True),
+            Var.create_safe("<C2>"),
+            True,
+            "isTrue(cond) ? `<C1>` : <C2>",
+        ),
     ],
 )
-def test_format_cond(condition: str, true_value: str, false_value: str, expected: str):
+def test_format_cond(
+    condition: str,
+    true_value: str | Var,
+    false_value: str | Var,
+    is_prop: bool,
+    expected: str,
+):
     """Test formatting a cond.
 
     Args:
         condition: The condition to check.
         true_value: The value to return if the condition is true.
         false_value: The value to return if the condition is false.
+        is_prop: Whether the values are rendered as props or not.
         expected: The expected output string.
     """
-    assert format.format_cond(condition, true_value, false_value) == expected
+    orig_true_value = (
+        true_value._replace() if isinstance(true_value, Var) else Var.create_safe("")
+    )
+    orig_false_value = (
+        false_value._replace() if isinstance(false_value, Var) else Var.create_safe("")
+    )
+
+    assert format.format_cond(condition, true_value, false_value, is_prop) == expected
+
+    # Ensure the formatting operation didn't change the original Var
+    if isinstance(true_value, Var):
+        assert true_value.equals(orig_true_value)
+    if isinstance(false_value, Var):
+        assert false_value.equals(orig_false_value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
If the values given to `format_cond` are already Var, do NOT mutate the attributes since subsequent usages of the same Var may be adversely affected.

Add test cases for `is_prop=True` path of `format_cond`, where this bug was hiding.

Here is a repro case

```python
import reflex as rx
import reflex.components.radix.themes as rdxt


class State(rx.State):
    val: str = ""


def index() -> rx.Component:
    print(repr(State.val))
    comp = rdxt.flex(
        # The following line exposes the bug: the radio group value gets formatted incorrectly.
        rdxt.text(rx.cond(State.val, State.val, "No Selection")),
        rdxt.text(State.val),
        rdxt.radio_group_root(
            rdxt.radio_group_item(value="1"),
            rdxt.radio_group_item(value="2"),
            rdxt.radio_group_item(value="3"),
            rdxt.radio_group_item(value="4"),
            value=State.val,
            on_value_change=State.set_val,
        ),
        rdxt.button("Clear", on_click=State.set_val("")),
        direction="column",
        justify="center",
        align="center",
        gap="2",
    )
    print(repr(State.val))
    return comp


app = rx.App()
app.add_page(index)
```

Check the output, the `State.val` repr should NOT change just because the value was used in an `rx.cond`.