### PR TITLE
Clean up Radix Form component

### DIFF
--- a/reflex/components/radix/primitives/form.py
+++ b/reflex/components/radix/primitives/form.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Iterator, Literal
 from jinja2 import Environment
 
 from reflex.components.component import Component
+from reflex.components.radix.themes.components.textfield import TextFieldInput
 from reflex.components.tags.tag import Tag
 from reflex.constants.base import Dirs
 from reflex.constants.event import EventTriggers
@@ -52,7 +53,7 @@ class FormRoot(FormComponent):
     # If true, the form will be cleared after submit.
     reset_on_submit: Var[bool] = False  # type: ignore
 
-    # The name used to make this form's submit handler function unique
+    # The name used to make this form's submit handler function unique.
     handle_submit_unique_name: Var[str]
 
     def get_event_triggers(self) -> Dict[str, Any]:
@@ -64,7 +65,7 @@ class FormRoot(FormComponent):
         return {
             **super().get_event_triggers(),
             EventTriggers.ON_SUBMIT: lambda e0: [FORM_DATA],
-            "on_clear_server_errors": lambda: [],
+            EventTriggers.ON_CLEAR_SERVER_ERRORS: lambda: [],
         }
 
     @classmethod
@@ -171,8 +172,10 @@ class FormField(FormComponent):
 
     alias = "RadixFormField"
 
+    # The name of the form field, that is passed down to the control and used to match with validation messages.
     name: Var[str]
 
+    # Flag to mark the form field as invalid, for server side validation.
     server_invalid: Var[bool]
 
     def _apply_theme(self, theme: Component | None):
@@ -206,6 +209,32 @@ class FormControl(FormComponent):
 
     alias = "RadixFormControl"
 
+    @classmethod
+    def create(cls, *children, **props):
+        """Create a Form Control component.
+
+        Args:
+            *children: The children of the form.
+            **props: The properties of the form.
+
+        Raises:
+            ValueError: If the number of children is greater than 1.
+            TypeError: If the child, if exists, is not a TextFieldInput.
+
+        Returns:
+            The form control component.
+        """
+        if len(children) > 1:
+            raise ValueError(
+                f"FormControl can only have at most one child, got {len(children)} children"
+            )
+        for child in children:
+            if not isinstance(child, TextFieldInput):
+                raise TypeError(
+                    "Only Radix TextFieldInput is allowed as child of FormControl"
+                )
+        return super().create(*children, **props)
+
 
 LiteralMatcher = Literal[
     "badInput",
@@ -235,7 +264,7 @@ class FormMessage(FormComponent):
     match: Var[LiteralMatcher]
 
     # Forces the message to be shown. This is useful when using server-side validation.
-    forceMatch: Var[bool]
+    force_match: Var[bool]
 
     def _apply_theme(self, theme: Component | None):
         return {

--- a/reflex/components/radix/primitives/form.py
+++ b/reflex/components/radix/primitives/form.py
@@ -219,7 +219,7 @@ class FormControl(FormComponent):
 
         Raises:
             ValueError: If the number of children is greater than 1.
-            TypeError: If the child, if exists, is not a TextFieldInput.
+            TypeError: If a child exists but it is not a TextFieldInput.
 
         Returns:
             The form control component.

--- a/reflex/components/radix/primitives/form.pyi
+++ b/reflex/components/radix/primitives/form.pyi
@@ -11,6 +11,7 @@ from hashlib import md5
 from typing import Any, Dict, Iterator, Literal
 from jinja2 import Environment
 from reflex.components.component import Component
+from reflex.components.radix.themes.components.textfield import TextFieldInput
 from reflex.components.tags.tag import Tag
 from reflex.constants.base import Dirs
 from reflex.constants.event import EventTriggers
@@ -180,7 +181,7 @@ class FormRoot(FormComponent):
         Args:
             *children: The children of the form.
             reset_on_submit: If true, the form will be cleared after submit.
-            handle_submit_unique_name: The name used to make this form's submit handler function unique
+            handle_submit_unique_name: The name used to make this form's submit handler function unique.
             as_child: Change the default rendered element for the one passed as a child.
             style: The style of the component.
             key: A unique key for the component.
@@ -261,6 +262,8 @@ class FormField(FormComponent):
 
         Args:
             *children: The children of the component.
+            name: The name of the form field, that is passed down to the control and used to match with validation messages.
+            server_invalid: Flag to mark the form field as invalid, for server side validation.
             as_child: Change the default rendered element for the one passed as a child.
             style: The style of the component.
             key: A unique key for the component.
@@ -419,10 +422,10 @@ class FormControl(FormComponent):
         ] = None,
         **props
     ) -> "FormControl":
-        """Create the component.
+        """Create a Form Control component.
 
         Args:
-            *children: The children of the component.
+            *children: The children of the form.
             as_child: Change the default rendered element for the one passed as a child.
             style: The style of the component.
             key: A unique key for the component.
@@ -430,13 +433,14 @@ class FormControl(FormComponent):
             class_name: The class name for the component.
             autofocus: Whether the component should take the focus once the page is loaded
             custom_attrs: custom attribute
-            **props: The props of the component.
-
-        Returns:
-            The component.
+            **props: The properties of the form.
 
         Raises:
-            TypeError: If an invalid child is passed.
+            ValueError: If the number of children is greater than 1.
+            TypeError: If a child exists but it is not a TextFieldInput.
+
+        Returns:
+            The form control component.
         """
         ...
 
@@ -490,7 +494,7 @@ class FormMessage(FormComponent):
                 ],
             ]
         ] = None,
-        forceMatch: Optional[Union[Var[bool], bool]] = None,
+        force_match: Optional[Union[Var[bool], bool]] = None,
         as_child: Optional[Union[Var[bool], bool]] = None,
         style: Optional[Style] = None,
         key: Optional[Any] = None,
@@ -551,7 +555,7 @@ class FormMessage(FormComponent):
             *children: The children of the component.
             name: Used to target a specific field by name when rendering outside of a Field part.
             match: Used to indicate on which condition the message should be visible.
-            forceMatch: Forces the message to be shown. This is useful when using server-side validation.
+            force_match: Forces the message to be shown. This is useful when using server-side validation.
             as_child: Change the default rendered element for the one passed as a child.
             style: The style of the component.
             key: A unique key for the component.

--- a/reflex/constants/event.py
+++ b/reflex/constants/event.py
@@ -84,3 +84,4 @@ class EventTriggers(SimpleNamespace):
     ON_SUBMIT = "on_submit"
     ON_MOUNT = "on_mount"
     ON_UNMOUNT = "on_unmount"
+    ON_CLEAR_SERVER_ERRORS = "on_clear_server_errors"


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [ ] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### New Feature Submission:

- [ ] Does your submission pass the tests? 
- [ ] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.
- Fix the prop of Form Field `forceMatch -> force_match`.
- Fix comments for prop docs generation.
- Add checks when Form Control create: 
  - cannot have more than 1 child
  - as preview, radix Form Control cannot be constructed by other form components other than TextFieldInput
- Docs at https://github.com/reflex-dev/reflex-web/pull/382
- Example 1
```
import re
import reflex as rx
import reflex.components.radix.themes as rdxt
import reflex.components.radix.primitives as rdxp

class RadixFormState(rx.State):
    # These track the user input real time for validation
    user_entered_username: str
    user_entered_email: str

    # These are the submitted data
    username: str
    email: str

    mock_username_db: list[str] = ["reflex", "admin"]

    @rx.var
    def invalid_email(self) -> bool:
        return not re.match(r"[^@]+@[^@]+\.[^@]+", self.user_entered_email)

    @rx.var
    def username_empty(self) -> bool:
        return not self.user_entered_username.strip()

    @rx.var
    def username_is_taken(self) -> bool:
        return self.user_entered_username in self.mock_username_db

    @rx.var
    def input_invalid(self) -> bool:
        return self.invalid_email or self.username_is_taken or self.username_empty

    def handle_submit(self, form_data: dict):
        """Handle the form submit."""
        self.username = form_data.get("username")
        self.email = form_data.get("email")

def radix_form_example():
    return rdxt.flex(
        rdxp.form_root(
            rdxt.flex(
                rdxp.form_field(
                    rdxt.flex(
                        rdxp.form_label("Username"),
                        rdxp.form_control(
                            rdxt.textfield_input(
                                placeholder="Username",
                                # workaround: `name` seems to be required when on_change is set
                                on_change=RadixFormState.set_user_entered_username,
                                name="username",
                            ),
                            as_child=True,
                        ),
                        # server side validation message can be displayed inside a rx.cond
                        rx.cond(
                            RadixFormState.username_empty,
                            rdxp.form_message(
                                "Username cannot be empty",
                                color="var(--red-11)",
                            ),
                        ),
                        # server side validation message can be displayed by `force_match` prop
                        rdxp.form_message(
                            "Username already taken",
                            # this is a workaround:
                            # `force_match` does not work without `match`
                            # In this case, we do not want client side validation
                            # and intentionally not set `required` on the input
                            # so "valueMissing" is always false
                            match="valueMissing",
                            force_match=RadixFormState.username_is_taken,
                            color="var(--red-11)",
                        ),
                        direction="column",
                        gap="2",
                        align="stretch",
                    ),
                    name="username",
                    server_invalid=RadixFormState.username_is_taken,
                ),
                rdxp.form_field(
                    rdxt.flex(
                        rdxp.form_label("Email"),
                        rdxp.form_control(
                            rdxt.textfield_input(
                                placeholder="Email Address",
                                on_change=RadixFormState.set_user_entered_email,
                                name="email",
                            ),
                            as_child=True,
                        ),
                        rdxp.form_message(
                            "A valid Email is required",
                            match="valueMissing",
                            force_match=RadixFormState.invalid_email,
                            color="var(--red-11)",
                        ),
                        direction="column",
                        gap="2",
                        align="stretch",
                    ),
                    name="email",
                    server_invalid=RadixFormState.invalid_email,
                ),
                rdxp.form_submit(
                    rdxt.button(
                        "Submit",
                        disabled=RadixFormState.input_invalid,
                    ),
                    as_child=True,
                ),
                direction="column",
                gap="4",
                width="25em",
            ),
            on_submit=RadixFormState.handle_submit,
            reset_on_submit=True,
        ),
        rdxt.separator(size="4"),
        rdxt.text(
            "Username submitted: ",
            rdxt.text(
                RadixFormState.username,
                weight="bold",
                color="var(--accent-11)",
            ),
        ),
        rdxt.text(
            "Email submitted: ",
            rdxt.text(
                RadixFormState.email,
                weight="bold",
                color="var(--accent-11)",
            ),
        ),
        direction="column",
        gap="4",
    )
```
- Example 2:
```
import reflex as rx
import reflex.components.radix.themes as rdxt
import reflex.components.radix.primitives as rdxp

class RadixFormSubmissionState(rx.State):
    box1: str
    box2: str
    box3: str
    box4: str
    box5: str
    box6: str
    box7: str

    def handle_submit(self, form_data: dict):
        """Handle the form submit."""
        self.box1 = form_data.get("box1")
        self.box2 = form_data.get("box2")
        self.box3 = form_data.get("box3")
        self.box4 = form_data.get("box4")
        self.box5 = form_data.get("box5")
        self.box6 = form_data.get("box6")
        self.box7 = form_data.get("box7")

def radix_form_submission_example():
    return rdxt.flex(
        rdxp.form_root(
            rdxt.flex(
                rdxt.flex(
                    rdxt.checkbox(
                        default_checked=True,
                        name="box1",
                    ),
                    rdxt.text("box1 checkbox"),
                    direction="row",
                    gap="2",
                    align="center",
                ),
                rdxt.radio_group_root(
                    rdxt.flex(
                        rdxt.radio_group_item(value="1"),
                        "1",
                        direction="row",
                        align="center",
                        gap="2",
                    ),
                    rdxt.flex(
                        rdxt.radio_group_item(value="2"),
                        "2",
                        direction="row",
                        align="center",
                        gap="2",
                    ),
                    rdxt.flex(
                        rdxt.radio_group_item(value="3"),
                        "3",
                        direction="row",
                        align="center",
                        gap="2",
                    ),
                    default_value="1",
                    name="box2",
                ),
                rdxt.textfield_input(
                    placeholder="box3 textfield input",
                    name="box3",
                ),
                rdxt.select_root(
                    rdxt.select_trigger(
                        placeholder="box4 select",
                    ),
                    rdxt.select_content(
                        rdxt.select_group(
                            rdxt.select_item(
                                "Orange",
                                value="orange"
                            ),
                            rdxt.select_item(
                                "Apple",
                                value="apple"
                            ),
                        ),
                    ),
                    name="box4",
                ),
                rdxt.flex(
                    rdxt.switch(
                        default_checked=True,
                        name="box5",
                    ),
                    "box5 switch",
                    gap="2",
                    align="center",
                    direction="row",
                ),
                rdxt.flex(
                    rdxt.slider(
                        default_value=[40],
                        width="100%",
                        name="box6",
                    ),
                    "box6 slider",
                    direction="row",
                    gap="2",
                    align="center",
                ),
                rdxt.textarea(
                    placeholder="Enter for box7 textarea",
                    name="box7",
                ),
                rdxp.form_submit(
                    rdxt.button("Submit"),
                    as_child=True,
                ),
                direction="column",
                gap="4",
            ),
            on_submit=RadixFormSubmissionState.handle_submit,
        ),
        rdxt.separator(size="4"),
        rdxt.text(
            "Results",
            weight="bold",
        ),
        rdxt.text(
            "box1: ",
            RadixFormSubmissionState.box1,
        ),
        rdxt.text(
            "box2: ",
            RadixFormSubmissionState.box2,
        ),
        rdxt.text(
            "box3: ",
            RadixFormSubmissionState.box3,
        ),
        rdxt.text(
            "box4: ",
            RadixFormSubmissionState.box4,
        ),
        rdxt.text(
            "box5: ",
            RadixFormSubmissionState.box5,
        ),
        rdxt.text(
            "box6: ",
            RadixFormSubmissionState.box6,
        ),
        rdxt.text(
            "box7: ",
            RadixFormSubmissionState.box7,
        ),
        direction="column",
        gap="4",
    )
```
