### PR TITLE
[REF-1692] re-enable partial reflex web windows

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -102,12 +102,12 @@ jobs:
       fail-fast: false
       matrix:
         # Show OS combos first in GUI
-        # os: [ ubuntu-latest, windows-latest, macos-latest ]
-        # XXX: windows builds are disabled for now due to "EMFILE: too many open files"
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
         python-version: [ "3.10.10", "3.11.4" ]
         node-version: [ "16.x" ]
 
+    env:
+      REFLEX_WEB_WINDOWS_OVERRIDE: "1"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Re-enable reflex-web on windows integration test, with a limited number of routes.