### PR TITLE
radix link renders as next link by default use

### DIFF
--- a/reflex/components/radix/themes/typography/link.py
+++ b/reflex/components/radix/themes/typography/link.py
@@ -10,7 +10,7 @@ from reflex.components.component import Component
 from reflex.components.el.elements.inline import A
 from reflex.components.next.link import NextLink
 from reflex.utils import imports
-from reflex.vars import BaseVar, Var
+from reflex.vars import Var
 
 from ..base import (
     CommonMarginProps,
@@ -32,9 +32,6 @@ class Link(CommonMarginProps, RadixThemesComponent, A):
     """A semantic element for navigation between pages."""
 
     tag = "Link"
-
-    # What the link renders to.
-    as_: Var[str] = BaseVar.create(value="{NextLink}", _var_is_local=False)  # type: ignore
 
     # Change the default rendered element for the one passed as a child, merging their props and behavior.
     as_child: Var[bool]
@@ -77,7 +74,9 @@ class Link(CommonMarginProps, RadixThemesComponent, A):
         if props.get("href") is not None:
             if not len(children):
                 raise ValueError("Link without a child will not display")
-        else:
-            # Don't use a NextLink if there is no href.
-            props["as_"] = ""
+            if "as_child" not in props:
+                # If user does not use `as_child`, by default we render using next_link to avoid page refresh during internal navigation
+                return super().create(
+                    NextLink.create(*children, **props), as_child=True
+                )
         return super().create(*children, **props)

--- a/reflex/components/radix/themes/typography/link.py
+++ b/reflex/components/radix/themes/typography/link.py
@@ -49,7 +49,7 @@ class Link(CommonMarginProps, RadixThemesComponent, A):
     underline: Var[LiteralLinkUnderline]
 
     # Overrides the accent color inherited from the Theme.
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # Whether to render the text with higher contrast color
     high_contrast: Var[bool]

--- a/reflex/components/radix/themes/typography/link.py
+++ b/reflex/components/radix/themes/typography/link.py
@@ -6,8 +6,11 @@ from __future__ import annotations
 
 from typing import Literal
 
+from reflex.components.component import Component
 from reflex.components.el.elements.inline import A
-from reflex.vars import Var
+from reflex.components.next.link import NextLink
+from reflex.utils import imports
+from reflex.vars import BaseVar, Var
 
 from ..base import (
     CommonMarginProps,
@@ -22,11 +25,16 @@ from .base import (
 
 LiteralLinkUnderline = Literal["auto", "hover", "always"]
 
+next_link = NextLink.create()
+
 
 class Link(CommonMarginProps, RadixThemesComponent, A):
     """A semantic element for navigation between pages."""
 
     tag = "Link"
+
+    # What the link renders to.
+    as_: Var[str] = BaseVar.create(value="{NextLink}", _var_is_local=False)  # type: ignore
 
     # Change the default rendered element for the one passed as a child, merging their props and behavior.
     as_child: Var[bool]
@@ -48,3 +56,28 @@ class Link(CommonMarginProps, RadixThemesComponent, A):
 
     # Whether to render the text with higher contrast color
     high_contrast: Var[bool]
+
+    def _get_imports(self) -> imports.ImportDict:
+        return {**super()._get_imports(), **next_link._get_imports()}
+
+    @classmethod
+    def create(cls, *children, **props) -> Component:
+        """Create a Link component.
+
+        Args:
+            *children: The children of the component.
+            **props: The props of the component.
+
+        Raises:
+            ValueError: in case of missing children
+
+        Returns:
+            Component: The link component
+        """
+        if props.get("href") is not None:
+            if not len(children):
+                raise ValueError("Link without a child will not display")
+        else:
+            # Don't use a NextLink if there is no href.
+            props["as_"] = ""
+        return super().create(*children, **props)

--- a/reflex/components/radix/themes/typography/link.pyi
+++ b/reflex/components/radix/themes/typography/link.pyi
@@ -50,7 +50,7 @@ class Link(CommonMarginProps, RadixThemesComponent, A):
                 Literal["auto", "hover", "always"],
             ]
         ] = None,
-        color: Optional[
+        color_scheme: Optional[
             Union[
                 Var[
                     Literal[
@@ -281,7 +281,7 @@ class Link(CommonMarginProps, RadixThemesComponent, A):
             weight: Thickness of text: "light" | "regular" | "medium" | "bold"
             trim: Removes the leading trim space: "normal" | "start" | "end" | "both"
             underline: Sets the visibility of the underline affordance: "auto" | "hover" | "always"
-            color: Overrides the accent color inherited from the Theme.
+            color_scheme: Overrides the accent color inherited from the Theme.
             high_contrast: Whether to render the text with higher contrast color
             m: Margin: "0" - "9"
             mx: Margin horizontal: "0" - "9"

--- a/reflex/components/radix/themes/typography/link.pyi
+++ b/reflex/components/radix/themes/typography/link.pyi
@@ -25,7 +25,6 @@ class Link(CommonMarginProps, RadixThemesComponent, A):
     def create(  # type: ignore
         cls,
         *children,
-        as_: Optional[Union[Var[str], str]] = None,
         as_child: Optional[Union[Var[bool], bool]] = None,
         size: Optional[
             Union[
@@ -277,7 +276,6 @@ class Link(CommonMarginProps, RadixThemesComponent, A):
 
         Args:
             *children: The children of the component.
-            as_: What the link renders to.
             as_child: Change the default rendered element for the one passed as a child, merging their props and behavior.
             size: Text size: "1" - "9"
             weight: Thickness of text: "light" | "regular" | "medium" | "bold"

--- a/reflex/components/radix/themes/typography/link.pyi
+++ b/reflex/components/radix/themes/typography/link.pyi
@@ -8,12 +8,16 @@ from reflex.vars import Var, BaseVar, ComputedVar
 from reflex.event import EventChain, EventHandler, EventSpec
 from reflex.style import Style
 from typing import Literal
+from reflex.components.component import Component
 from reflex.components.el.elements.inline import A
-from reflex.vars import Var
+from reflex.components.next.link import NextLink
+from reflex.utils import imports
+from reflex.vars import BaseVar, Var
 from ..base import CommonMarginProps, LiteralAccentColor, RadixThemesComponent
 from .base import LiteralTextSize, LiteralTextTrim, LiteralTextWeight
 
 LiteralLinkUnderline = Literal["auto", "hover", "always"]
+next_link = NextLink.create()
 
 class Link(CommonMarginProps, RadixThemesComponent, A):
     @overload
@@ -21,8 +25,33 @@ class Link(CommonMarginProps, RadixThemesComponent, A):
     def create(  # type: ignore
         cls,
         *children,
-        color: Optional[Union[Var[str], str]] = None,
-        color_scheme: Optional[
+        as_: Optional[Union[Var[str], str]] = None,
+        as_child: Optional[Union[Var[bool], bool]] = None,
+        size: Optional[
+            Union[
+                Var[Literal["1", "2", "3", "4", "5", "6", "7", "8", "9"]],
+                Literal["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+            ]
+        ] = None,
+        weight: Optional[
+            Union[
+                Var[Literal["light", "regular", "medium", "bold"]],
+                Literal["light", "regular", "medium", "bold"],
+            ]
+        ] = None,
+        trim: Optional[
+            Union[
+                Var[Literal["normal", "start", "end", "both"]],
+                Literal["normal", "start", "end", "both"],
+            ]
+        ] = None,
+        underline: Optional[
+            Union[
+                Var[Literal["auto", "hover", "always"]],
+                Literal["auto", "hover", "always"],
+            ]
+        ] = None,
+        color: Optional[
             Union[
                 Var[
                     Literal[
@@ -82,31 +111,6 @@ class Link(CommonMarginProps, RadixThemesComponent, A):
                     "bronze",
                     "gray",
                 ],
-            ]
-        ] = None,
-        as_child: Optional[Union[Var[bool], bool]] = None,
-        size: Optional[
-            Union[
-                Var[Literal["1", "2", "3", "4", "5", "6", "7", "8", "9"]],
-                Literal["1", "2", "3", "4", "5", "6", "7", "8", "9"],
-            ]
-        ] = None,
-        weight: Optional[
-            Union[
-                Var[Literal["light", "regular", "medium", "bold"]],
-                Literal["light", "regular", "medium", "bold"],
-            ]
-        ] = None,
-        trim: Optional[
-            Union[
-                Var[Literal["normal", "start", "end", "both"]],
-                Literal["normal", "start", "end", "both"],
-            ]
-        ] = None,
-        underline: Optional[
-            Union[
-                Var[Literal["auto", "hover", "always"]],
-                Literal["auto", "hover", "always"],
             ]
         ] = None,
         high_contrast: Optional[Union[Var[bool], bool]] = None,
@@ -269,20 +273,17 @@ class Link(CommonMarginProps, RadixThemesComponent, A):
         ] = None,
         **props
     ) -> "Link":
-        """Create a new component instance.
-
-        Will prepend "RadixThemes" to the component tag to avoid conflicts with
-        other UI libraries for common names, like Text and Button.
+        """Create a Link component.
 
         Args:
-            *children: Child components.
-            color: map to CSS default color property.
-            color_scheme: map to radix color property.
+            *children: The children of the component.
+            as_: What the link renders to.
             as_child: Change the default rendered element for the one passed as a child, merging their props and behavior.
             size: Text size: "1" - "9"
             weight: Thickness of text: "light" | "regular" | "medium" | "bold"
             trim: Removes the leading trim space: "normal" | "start" | "end" | "both"
             underline: Sets the visibility of the underline affordance: "auto" | "hover" | "always"
+            color: Overrides the accent color inherited from the Theme.
             high_contrast: Whether to render the text with higher contrast color
             m: Margin: "0" - "9"
             mx: Margin horizontal: "0" - "9"
@@ -323,9 +324,12 @@ class Link(CommonMarginProps, RadixThemesComponent, A):
             class_name: The class name for the component.
             autofocus: Whether the component should take the focus once the page is loaded
             custom_attrs: custom attribute
-            **props: Component properties.
+            **props: The props of the component.
+
+        Raises:
+            ValueError: in case of missing children
 
         Returns:
-            A new component instance.
+            Component: The link component
         """
         ...

--- a/reflex/components/radix/themes/typography/link.pyi
+++ b/reflex/components/radix/themes/typography/link.pyi
@@ -12,7 +12,7 @@ from reflex.components.component import Component
 from reflex.components.el.elements.inline import A
 from reflex.components.next.link import NextLink
 from reflex.utils import imports
-from reflex.vars import BaseVar, Var
+from reflex.vars import Var
 from ..base import CommonMarginProps, LiteralAccentColor, RadixThemesComponent
 from .base import LiteralTextSize, LiteralTextTrim, LiteralTextWeight
 


### PR DESCRIPTION
### All Submissions:

- [ ] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [ ] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### New Feature Submission:

- [ ] Does your submission pass the tests? 
- [ ] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.
- Update Radix link creation
  - Raise ValueError if link has `href` but no children: it does not display. Chakra link does this check.  
  - Radix link has `href` and does not set `as_child` explicitly: we default to pass all children and props to next_link creation and pass this next_link as children and `as_child=True` props in the Radix Link component creation.
  - With `href` and `as_child` both set, assume the user knows how it works, use default creation.
  - Otherwise, use `super().create` for default creation.
- Tested:
```
import reflex as rx
import reflex.components.radix.themes as rdxt

...
rdxt.link(rx.next_link("Link I know what to do in low level", href="/another"), as_child=True),
rdxt.link("Link by Default", href="/another"),
rdxt.link(rx.button("Link is a button"), href="/another"),
rdxt.link("Link I just want the refresh", href="/another", as_child=False),
rdxt.link("Link does not work", href="/another", as_child=True),
# rdxt.link(href="/another"), # link does not compile
```
