### PR TITLE
[REF-1742] Radio group prop types fix

### DIFF
--- a/reflex/components/radix/themes/components/radiogroup.py
+++ b/reflex/components/radix/themes/components/radiogroup.py
@@ -38,7 +38,7 @@ class RadioGroupRoot(CommonMarginProps, RadixThemesComponent):
     value: Var[str]
 
     # The initial value of checked radio item. Should be used in conjunction with onValueChange.
-    default_value: Var[str]
+    default_value: Var[Any]
 
     # Whether the radio group is disabled
     disabled: Var[bool]
@@ -86,7 +86,7 @@ class HighLevelRadioGroup(RadioGroupRoot):
     """High level wrapper for the RadioGroup component."""
 
     # The items of the radio group.
-    items: Var[List[str]]
+    items: Var[List[Any]]
 
     # The direction of the radio group.
     direction: Var[LiteralFlexDirection] = Var.create_safe("column")

--- a/reflex/components/radix/themes/components/radiogroup.py
+++ b/reflex/components/radix/themes/components/radiogroup.py
@@ -98,7 +98,7 @@ class HighLevelRadioGroup(RadioGroupRoot):
     size: Var[Literal["1", "2", "3"]] = Var.create_safe("2")
 
     @classmethod
-    def create(cls, items: Var[List[str]], **props) -> Component:
+    def create(cls, items: Var[List[Any]], **props) -> Component:
         """Create a radio group component.
 
         Args:
@@ -115,7 +115,7 @@ class HighLevelRadioGroup(RadioGroupRoot):
         def radio_group_item(value: str) -> Component:
             return Text.create(
                 Flex.create(
-                    RadioGroupItem.create(value=value),
+                    RadioGroupItem.create(value=str(value)),
                     value,
                     gap="2",
                 ),

--- a/reflex/components/radix/themes/components/radiogroup.py
+++ b/reflex/components/radix/themes/components/radiogroup.py
@@ -133,7 +133,7 @@ class HighLevelRadioGroup(RadioGroupRoot):
         def radio_group_item(value: str | Var) -> Component:
             item_value = Var.create(value)  # type: ignore
             item_value = rx.cond(
-                item_value.type() == str,  # type: ignore
+                item_value._type() == str,  # type: ignore
                 item_value,
                 item_value.to_string()._replace(_var_is_local=False),  # type: ignore
             )._replace(_var_type=str)

--- a/reflex/components/radix/themes/components/radiogroup.pyi
+++ b/reflex/components/radix/themes/components/radiogroup.pyi
@@ -103,7 +103,7 @@ class RadioGroupRoot(CommonMarginProps, RadixThemesComponent):
         ] = None,
         high_contrast: Optional[Union[Var[bool], bool]] = None,
         value: Optional[Union[Var[str], str]] = None,
-        default_value: Optional[Union[Var[str], str]] = None,
+        default_value: Optional[Union[Var[Any], Any]] = None,
         disabled: Optional[Union[Var[bool], bool]] = None,
         name: Optional[Union[Var[str], str]] = None,
         required: Optional[Union[Var[bool], bool]] = None,
@@ -456,7 +456,7 @@ class HighLevelRadioGroup(RadioGroupRoot):
     def create(  # type: ignore
         cls,
         *children,
-        items: Optional[Union[Var[List[str]], List[str]]] = None,
+        items: Optional[Union[Var[List[Any]], List[Any]]] = None,
         direction: Optional[
             Union[
                 Var[Literal["row", "column", "row-reverse", "column-reverse"]],
@@ -542,7 +542,7 @@ class HighLevelRadioGroup(RadioGroupRoot):
         ] = None,
         high_contrast: Optional[Union[Var[bool], bool]] = None,
         value: Optional[Union[Var[str], str]] = None,
-        default_value: Optional[Union[Var[str], str]] = None,
+        default_value: Optional[Union[Var[Any], Any]] = None,
         disabled: Optional[Union[Var[bool], bool]] = None,
         name: Optional[Union[Var[str], str]] = None,
         required: Optional[Union[Var[bool], bool]] = None,

--- a/reflex/components/radix/themes/components/radiogroup.pyi
+++ b/reflex/components/radix/themes/components/radiogroup.pyi
@@ -7,7 +7,7 @@ from typing import Any, Dict, Literal, Optional, Union, overload
 from reflex.vars import Var, BaseVar, ComputedVar
 from reflex.event import EventChain, EventHandler, EventSpec
 from reflex.style import Style
-from typing import Any, Dict, List, Literal, Union, Optional
+from typing import Any, Dict, List, Literal, Optional, Union
 import reflex as rx
 from reflex.components.component import Component
 from reflex.components.radix.themes.layout.flex import Flex

--- a/reflex/components/radix/themes/components/radiogroup.pyi
+++ b/reflex/components/radix/themes/components/radiogroup.pyi
@@ -7,7 +7,7 @@ from typing import Any, Dict, Literal, Optional, Union, overload
 from reflex.vars import Var, BaseVar, ComputedVar
 from reflex.event import EventChain, EventHandler, EventSpec
 from reflex.style import Style
-from typing import Any, Dict, List, Literal
+from typing import Any, Dict, List, Literal, Union, Optional
 import reflex as rx
 from reflex.components.component import Component
 from reflex.components.radix.themes.layout.flex import Flex
@@ -103,7 +103,7 @@ class RadioGroupRoot(CommonMarginProps, RadixThemesComponent):
         ] = None,
         high_contrast: Optional[Union[Var[bool], bool]] = None,
         value: Optional[Union[Var[str], str]] = None,
-        default_value: Optional[Union[Var[Any], Any]] = None,
+        default_value: Optional[Union[Var[str], str]] = None,
         disabled: Optional[Union[Var[bool], bool]] = None,
         name: Optional[Union[Var[str], str]] = None,
         required: Optional[Union[Var[bool], bool]] = None,
@@ -456,7 +456,7 @@ class HighLevelRadioGroup(RadioGroupRoot):
     def create(  # type: ignore
         cls,
         *children,
-        items: Optional[Union[Var[List[Any]], List[Any]]] = None,
+        items: Optional[Union[Var[List[str]], List[str]]] = None,
         direction: Optional[
             Union[
                 Var[Literal["row", "column", "row-reverse", "column-reverse"]],
@@ -542,7 +542,7 @@ class HighLevelRadioGroup(RadioGroupRoot):
         ] = None,
         high_contrast: Optional[Union[Var[bool], bool]] = None,
         value: Optional[Union[Var[str], str]] = None,
-        default_value: Optional[Union[Var[Any], Any]] = None,
+        default_value: Optional[Union[Var[str], str]] = None,
         disabled: Optional[Union[Var[bool], bool]] = None,
         name: Optional[Union[Var[str], str]] = None,
         required: Optional[Union[Var[bool], bool]] = None,

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -887,7 +887,7 @@ class Var:
         """
         for python_types, js_type in PYTHON_JS_TYPE_MAP.items():
             if not isinstance(other, Var) and other in python_types:
-                return self.compare("===", Var.create(js_type, _var_is_string=True))  # type: ignore
+                return self.compare("!==", Var.create(js_type, _var_is_string=True))  # type: ignore
         return self.compare("!==", other)
 
     def __gt__(self, other: Var) -> Var:

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -87,6 +87,15 @@ REPLACED_NAMES = {
     "deps": "_deps",
 }
 
+PYTHON_JS_TYPE_MAP = {
+    (int, float): "number",
+    (str,): "string",
+    (bool,): "boolean",
+    (list, tuple): "Array",
+    (dict,): "Object",
+    (None,): "undefined",
+}
+
 
 def get_unique_variable_name() -> str:
     """Get a unique variable name.
@@ -843,7 +852,17 @@ class Var:
             _var_is_string=False,
         )
 
-    def __eq__(self, other: Var) -> Var:
+    def type(self) -> Var:
+        """Get the type of the Var in Javascript.
+
+        Returns:
+            A var representing the type check.
+        """
+        return self._replace(
+            _var_name=f"typeof {self._var_name}", _var_type=str, _var_is_string=False
+        )
+
+    def __eq__(self, other: Union[Var, Type]) -> Var:
         """Perform an equality comparison.
 
         Args:
@@ -852,9 +871,12 @@ class Var:
         Returns:
             A var representing the equality comparison.
         """
+        for python_types, js_type in PYTHON_JS_TYPE_MAP.items():
+            if not isinstance(other, Var) and other in python_types:
+                return self.compare("===", Var.create(js_type))  # type: ignore
         return self.compare("===", other)
 
-    def __ne__(self, other: Var) -> Var:
+    def __ne__(self, other: Union[Var, Type]) -> Var:
         """Perform an inequality comparison.
 
         Args:
@@ -863,6 +885,9 @@ class Var:
         Returns:
             A var representing the inequality comparison.
         """
+        for python_types, js_type in PYTHON_JS_TYPE_MAP.items():
+            if not isinstance(other, Var) and other in python_types:
+                return self.compare("===", Var.create(js_type))  # type: ignore
         return self.compare("!==", other)
 
     def __gt__(self, other: Var) -> Var:

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -743,13 +743,13 @@ class Var:
                 operation_name = format.wrap(operation_name, "(")
         else:
             # apply operator to left operand (<operator> left_operand)
-            operation_name = f"{op}{self._var_full_name}"
+            operation_name = f"{op}{get_operand_full_name(self)}"
             # apply function to operands
             if fn is not None:
                 operation_name = (
                     f"{fn}({operation_name})"
                     if not invoke_fn
-                    else f"{self._var_full_name}.{fn}()"
+                    else f"{get_operand_full_name(self)}.{fn}()"
                 )
 
         return self._replace(

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -873,7 +873,7 @@ class Var:
         """
         for python_types, js_type in PYTHON_JS_TYPE_MAP.items():
             if not isinstance(other, Var) and other in python_types:
-                return self.compare("===", Var.create(js_type))  # type: ignore
+                return self.compare("===", Var.create(js_type, _var_is_string=True))  # type: ignore
         return self.compare("===", other)
 
     def __ne__(self, other: Union[Var, Type]) -> Var:
@@ -887,7 +887,7 @@ class Var:
         """
         for python_types, js_type in PYTHON_JS_TYPE_MAP.items():
             if not isinstance(other, Var) and other in python_types:
-                return self.compare("===", Var.create(js_type))  # type: ignore
+                return self.compare("===", Var.create(js_type, _var_is_string=True))  # type: ignore
         return self.compare("!==", other)
 
     def __gt__(self, other: Var) -> Var:

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -852,7 +852,7 @@ class Var:
             _var_is_string=False,
         )
 
-    def type(self) -> Var:
+    def _type(self) -> Var:
         """Get the type of the Var in Javascript.
 
         Returns:

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -93,7 +93,7 @@ PYTHON_JS_TYPE_MAP = {
     (bool,): "boolean",
     (list, tuple): "Array",
     (dict,): "Object",
-    (None,): "undefined",
+    (None,): "null",
 }
 
 
@@ -859,7 +859,10 @@ class Var:
             A var representing the type check.
         """
         return self._replace(
-            _var_name=f"typeof {self._var_name}", _var_type=str, _var_is_string=False
+            _var_name=f"typeof {self._var_full_name}",
+            _var_type=str,
+            _var_is_string=False,
+            _var_full_name_needs_state_prefix=False,
         )
 
     def __eq__(self, other: Union[Var, Type]) -> Var:

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -245,76 +245,110 @@ def test_basic_operations(TestObj):
     Args:
         TestObj: The test object.
     """
-    assert str(v(1) == v(2)) == "{(1 === 2)}"
-    assert str(v(1) != v(2)) == "{(1 !== 2)}"
-    assert str(v(1) < v(2)) == "{(1 < 2)}"
-    assert str(v(1) <= v(2)) == "{(1 <= 2)}"
-    assert str(v(1) > v(2)) == "{(1 > 2)}"
-    assert str(v(1) >= v(2)) == "{(1 >= 2)}"
-    assert str(v(1) + v(2)) == "{(1 + 2)}"
-    assert str(v(1) - v(2)) == "{(1 - 2)}"
-    assert str(v(1) * v(2)) == "{(1 * 2)}"
-    assert str(v(1) / v(2)) == "{(1 / 2)}"
-    assert str(v(1) // v(2)) == "{Math.floor(1 / 2)}"
-    assert str(v(1) % v(2)) == "{(1 % 2)}"
-    assert str(v(1) ** v(2)) == "{Math.pow(1 , 2)}"
-    assert str(v(1) & v(2)) == "{(1 && 2)}"
-    assert str(v(1) | v(2)) == "{(1 || 2)}"
-    assert str(v([1, 2, 3])[v(0)]) == "{[1, 2, 3].at(0)}"
-    assert str(v({"a": 1, "b": 2})["a"]) == '{{"a": 1, "b": 2}["a"]}'
-    assert str(v("foo") == v("bar")) == '{("foo" === "bar")}'
+    # assert str(v(1) == v(2)) == "{(1 === 2)}"
+    # assert str(v(1) != v(2)) == "{(1 !== 2)}"
+    # assert str(v(1) < v(2)) == "{(1 < 2)}"
+    # assert str(v(1) <= v(2)) == "{(1 <= 2)}"
+    # assert str(v(1) > v(2)) == "{(1 > 2)}"
+    # assert str(v(1) >= v(2)) == "{(1 >= 2)}"
+    # assert str(v(1) + v(2)) == "{(1 + 2)}"
+    # assert str(v(1) - v(2)) == "{(1 - 2)}"
+    # assert str(v(1) * v(2)) == "{(1 * 2)}"
+    # assert str(v(1) / v(2)) == "{(1 / 2)}"
+    # assert str(v(1) // v(2)) == "{Math.floor(1 / 2)}"
+    # assert str(v(1) % v(2)) == "{(1 % 2)}"
+    # assert str(v(1) ** v(2)) == "{Math.pow(1 , 2)}"
+    # assert str(v(1) & v(2)) == "{(1 && 2)}"
+    # assert str(v(1) | v(2)) == "{(1 || 2)}"
+    # assert str(v([1, 2, 3])[v(0)]) == "{[1, 2, 3].at(0)}"
+    # assert str(v({"a": 1, "b": 2})["a"]) == '{{"a": 1, "b": 2}["a"]}'
+    # assert str(v("foo") == v("bar")) == '{("foo" === "bar")}'
+    # assert (
+    #     str(
+    #         Var.create("foo", _var_is_local=False)
+    #         == Var.create("bar", _var_is_local=False)
+    #     )
+    #     == "{(foo === bar)}"
+    # )
+    # assert (
+    #     str(
+    #         BaseVar(
+    #             _var_name="foo", _var_type=str, _var_is_string=True, _var_is_local=True
+    #         )
+    #         == BaseVar(
+    #             _var_name="bar", _var_type=str, _var_is_string=True, _var_is_local=True
+    #         )
+    #     )
+    #     == "(`foo` === `bar`)"
+    # )
+    # assert (
+    #     str(
+    #         BaseVar(
+    #             _var_name="foo",
+    #             _var_type=TestObj,
+    #             _var_is_string=True,
+    #             _var_is_local=False,
+    #         )
+    #         ._var_set_state("state")
+    #         .bar
+    #         == BaseVar(
+    #             _var_name="bar", _var_type=str, _var_is_string=True, _var_is_local=True
+    #         )
+    #     )
+    #     == "{(state.foo.bar === `bar`)}"
+    # )
+    # assert (
+    #     str(BaseVar(_var_name="foo", _var_type=TestObj)._var_set_state("state").bar)
+    #     == "{state.foo.bar}"
+    # )
+    # assert str(abs(v(1))) == "{Math.abs(1)}"
+    # assert str(v([1, 2, 3]).length()) == "{[1, 2, 3].length}"
+    # assert str(v([1, 2]) + v([3, 4])) == "{spreadArraysOrObjects([1, 2] , [3, 4])}"
+    #
+    # # Tests for reverse operation
+    # assert str(v([1, 2, 3]).reverse()) == "{[...[1, 2, 3]].reverse()}"
+    # assert str(v(["1", "2", "3"]).reverse()) == '{[...["1", "2", "3"]].reverse()}'
+    # assert (
+    #     str(BaseVar(_var_name="foo", _var_type=list)._var_set_state("state").reverse())
+    #     == "{[...state.foo].reverse()}"
+    # )
+    # assert (
+    #     str(BaseVar(_var_name="foo", _var_type=list).reverse())
+    #     == "{[...foo].reverse()}"
+    # )
+    assert str(BaseVar(_var_name="foo", _var_type=str).type()) == "{typeof foo}"
     assert (
-        str(
-            Var.create("foo", _var_is_local=False)
-            == Var.create("bar", _var_is_local=False)
-        )
-        == "{(foo === bar)}"
+        str(BaseVar(_var_name="foo", _var_type=str).type() == str)
+        == "{(typeof foo === `string`)}"
     )
-    assert (
-        str(
-            BaseVar(
-                _var_name="foo", _var_type=str, _var_is_string=True, _var_is_local=True
-            )
-            == BaseVar(
-                _var_name="bar", _var_type=str, _var_is_string=True, _var_is_local=True
-            )
-        )
-        == "(`foo` === `bar`)"
-    )
-    assert (
-        str(
-            BaseVar(
-                _var_name="foo",
-                _var_type=TestObj,
-                _var_is_string=True,
-                _var_is_local=False,
-            )
-            ._var_set_state("state")
-            .bar
-            == BaseVar(
-                _var_name="bar", _var_type=str, _var_is_string=True, _var_is_local=True
-            )
-        )
-        == "{(state.foo.bar === `bar`)}"
-    )
-    assert (
-        str(BaseVar(_var_name="foo", _var_type=TestObj)._var_set_state("state").bar)
-        == "{state.foo.bar}"
-    )
-    assert str(abs(v(1))) == "{Math.abs(1)}"
-    assert str(v([1, 2, 3]).length()) == "{[1, 2, 3].length}"
-    assert str(v([1, 2]) + v([3, 4])) == "{spreadArraysOrObjects([1, 2] , [3, 4])}"
 
-    # Tests for reverse operation
-    assert str(v([1, 2, 3]).reverse()) == "{[...[1, 2, 3]].reverse()}"
-    assert str(v(["1", "2", "3"]).reverse()) == '{[...["1", "2", "3"]].reverse()}'
     assert (
-        str(BaseVar(_var_name="foo", _var_type=list)._var_set_state("state").reverse())
-        == "{[...state.foo].reverse()}"
+        str(BaseVar(_var_name="foo", _var_type=str).type() == str)
+        == "{(typeof foo === `string`)}"
     )
     assert (
-        str(BaseVar(_var_name="foo", _var_type=list).reverse())
-        == "{[...foo].reverse()}"
+        str(BaseVar(_var_name="foo", _var_type=str).type() == int)
+        == "{(typeof foo === `number`)}"
+    )
+    assert (
+        str(BaseVar(_var_name="foo", _var_type=str).type() == list)
+        == "{(typeof foo === `Array`)}"
+    )
+    assert (
+        str(BaseVar(_var_name="foo", _var_type=str).type() == float)
+        == "{(typeof foo === `number`)}"
+    )
+    assert (
+        str(BaseVar(_var_name="foo", _var_type=str).type() == tuple)
+        == "{(typeof foo === `Array`)}"
+    )
+    assert (
+        str(BaseVar(_var_name="foo", _var_type=str).type() == dict)
+        == "{(typeof foo === `Object`)}"
+    )
+    assert (
+        str(BaseVar(_var_name="foo", _var_type=str).type() is None)
+        == "{(typeof foo === `undefined`)}"
     )
 
 

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -245,77 +245,77 @@ def test_basic_operations(TestObj):
     Args:
         TestObj: The test object.
     """
-    # assert str(v(1) == v(2)) == "{(1 === 2)}"
-    # assert str(v(1) != v(2)) == "{(1 !== 2)}"
-    # assert str(v(1) < v(2)) == "{(1 < 2)}"
-    # assert str(v(1) <= v(2)) == "{(1 <= 2)}"
-    # assert str(v(1) > v(2)) == "{(1 > 2)}"
-    # assert str(v(1) >= v(2)) == "{(1 >= 2)}"
-    # assert str(v(1) + v(2)) == "{(1 + 2)}"
-    # assert str(v(1) - v(2)) == "{(1 - 2)}"
-    # assert str(v(1) * v(2)) == "{(1 * 2)}"
-    # assert str(v(1) / v(2)) == "{(1 / 2)}"
-    # assert str(v(1) // v(2)) == "{Math.floor(1 / 2)}"
-    # assert str(v(1) % v(2)) == "{(1 % 2)}"
-    # assert str(v(1) ** v(2)) == "{Math.pow(1 , 2)}"
-    # assert str(v(1) & v(2)) == "{(1 && 2)}"
-    # assert str(v(1) | v(2)) == "{(1 || 2)}"
-    # assert str(v([1, 2, 3])[v(0)]) == "{[1, 2, 3].at(0)}"
-    # assert str(v({"a": 1, "b": 2})["a"]) == '{{"a": 1, "b": 2}["a"]}'
-    # assert str(v("foo") == v("bar")) == '{("foo" === "bar")}'
-    # assert (
-    #     str(
-    #         Var.create("foo", _var_is_local=False)
-    #         == Var.create("bar", _var_is_local=False)
-    #     )
-    #     == "{(foo === bar)}"
-    # )
-    # assert (
-    #     str(
-    #         BaseVar(
-    #             _var_name="foo", _var_type=str, _var_is_string=True, _var_is_local=True
-    #         )
-    #         == BaseVar(
-    #             _var_name="bar", _var_type=str, _var_is_string=True, _var_is_local=True
-    #         )
-    #     )
-    #     == "(`foo` === `bar`)"
-    # )
-    # assert (
-    #     str(
-    #         BaseVar(
-    #             _var_name="foo",
-    #             _var_type=TestObj,
-    #             _var_is_string=True,
-    #             _var_is_local=False,
-    #         )
-    #         ._var_set_state("state")
-    #         .bar
-    #         == BaseVar(
-    #             _var_name="bar", _var_type=str, _var_is_string=True, _var_is_local=True
-    #         )
-    #     )
-    #     == "{(state.foo.bar === `bar`)}"
-    # )
-    # assert (
-    #     str(BaseVar(_var_name="foo", _var_type=TestObj)._var_set_state("state").bar)
-    #     == "{state.foo.bar}"
-    # )
-    # assert str(abs(v(1))) == "{Math.abs(1)}"
-    # assert str(v([1, 2, 3]).length()) == "{[1, 2, 3].length}"
-    # assert str(v([1, 2]) + v([3, 4])) == "{spreadArraysOrObjects([1, 2] , [3, 4])}"
-    #
-    # # Tests for reverse operation
-    # assert str(v([1, 2, 3]).reverse()) == "{[...[1, 2, 3]].reverse()}"
-    # assert str(v(["1", "2", "3"]).reverse()) == '{[...["1", "2", "3"]].reverse()}'
-    # assert (
-    #     str(BaseVar(_var_name="foo", _var_type=list)._var_set_state("state").reverse())
-    #     == "{[...state.foo].reverse()}"
-    # )
-    # assert (
-    #     str(BaseVar(_var_name="foo", _var_type=list).reverse())
-    #     == "{[...foo].reverse()}"
-    # )
+    assert str(v(1) == v(2)) == "{(1 === 2)}"
+    assert str(v(1) != v(2)) == "{(1 !== 2)}"
+    assert str(v(1) < v(2)) == "{(1 < 2)}"
+    assert str(v(1) <= v(2)) == "{(1 <= 2)}"
+    assert str(v(1) > v(2)) == "{(1 > 2)}"
+    assert str(v(1) >= v(2)) == "{(1 >= 2)}"
+    assert str(v(1) + v(2)) == "{(1 + 2)}"
+    assert str(v(1) - v(2)) == "{(1 - 2)}"
+    assert str(v(1) * v(2)) == "{(1 * 2)}"
+    assert str(v(1) / v(2)) == "{(1 / 2)}"
+    assert str(v(1) // v(2)) == "{Math.floor(1 / 2)}"
+    assert str(v(1) % v(2)) == "{(1 % 2)}"
+    assert str(v(1) ** v(2)) == "{Math.pow(1 , 2)}"
+    assert str(v(1) & v(2)) == "{(1 && 2)}"
+    assert str(v(1) | v(2)) == "{(1 || 2)}"
+    assert str(v([1, 2, 3])[v(0)]) == "{[1, 2, 3].at(0)}"
+    assert str(v({"a": 1, "b": 2})["a"]) == '{{"a": 1, "b": 2}["a"]}'
+    assert str(v("foo") == v("bar")) == '{("foo" === "bar")}'
+    assert (
+        str(
+            Var.create("foo", _var_is_local=False)
+            == Var.create("bar", _var_is_local=False)
+        )
+        == "{(foo === bar)}"
+    )
+    assert (
+        str(
+            BaseVar(
+                _var_name="foo", _var_type=str, _var_is_string=True, _var_is_local=True
+            )
+            == BaseVar(
+                _var_name="bar", _var_type=str, _var_is_string=True, _var_is_local=True
+            )
+        )
+        == "(`foo` === `bar`)"
+    )
+    assert (
+        str(
+            BaseVar(
+                _var_name="foo",
+                _var_type=TestObj,
+                _var_is_string=True,
+                _var_is_local=False,
+            )
+            ._var_set_state("state")
+            .bar
+            == BaseVar(
+                _var_name="bar", _var_type=str, _var_is_string=True, _var_is_local=True
+            )
+        )
+        == "{(state.foo.bar === `bar`)}"
+    )
+    assert (
+        str(BaseVar(_var_name="foo", _var_type=TestObj)._var_set_state("state").bar)
+        == "{state.foo.bar}"
+    )
+    assert str(abs(v(1))) == "{Math.abs(1)}"
+    assert str(v([1, 2, 3]).length()) == "{[1, 2, 3].length}"
+    assert str(v([1, 2]) + v([3, 4])) == "{spreadArraysOrObjects([1, 2] , [3, 4])}"
+
+    # Tests for reverse operation
+    assert str(v([1, 2, 3]).reverse()) == "{[...[1, 2, 3]].reverse()}"
+    assert str(v(["1", "2", "3"]).reverse()) == '{[...["1", "2", "3"]].reverse()}'
+    assert (
+        str(BaseVar(_var_name="foo", _var_type=list)._var_set_state("state").reverse())
+        == "{[...state.foo].reverse()}"
+    )
+    assert (
+        str(BaseVar(_var_name="foo", _var_type=list).reverse())
+        == "{[...foo].reverse()}"
+    )
     assert str(BaseVar(_var_name="foo", _var_type=str).type()) == "{typeof foo}"
     assert (
         str(BaseVar(_var_name="foo", _var_type=str).type() == str)

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -316,57 +316,57 @@ def test_basic_operations(TestObj):
         str(BaseVar(_var_name="foo", _var_type=list).reverse())
         == "{[...foo].reverse()}"
     )
-    assert str(BaseVar(_var_name="foo", _var_type=str).type()) == "{typeof foo}"
+    assert str(BaseVar(_var_name="foo", _var_type=str).type()) == "{typeof foo}"  # type: ignore
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() == str)
+        str(BaseVar(_var_name="foo", _var_type=str).type() == str)  # type: ignore
         == "{(typeof foo === `string`)}"
     )
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() == str)
+        str(BaseVar(_var_name="foo", _var_type=str).type() == str)  # type: ignore
         == "{(typeof foo === `string`)}"
     )
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() == int)
+        str(BaseVar(_var_name="foo", _var_type=str).type() == int)  # type: ignore
         == "{(typeof foo === `number`)}"
     )
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() == list)
+        str(BaseVar(_var_name="foo", _var_type=str).type() == list)  # type: ignore
         == "{(typeof foo === `Array`)}"
     )
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() == float)
+        str(BaseVar(_var_name="foo", _var_type=str).type() == float)  # type: ignore
         == "{(typeof foo === `number`)}"
     )
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() == tuple)
+        str(BaseVar(_var_name="foo", _var_type=str).type() == tuple)  # type: ignore
         == "{(typeof foo === `Array`)}"
     )
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() == dict)
+        str(BaseVar(_var_name="foo", _var_type=str).type() == dict)  # type: ignore
         == "{(typeof foo === `Object`)}"
     )
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() != str)
+        str(BaseVar(_var_name="foo", _var_type=str).type() != str)  # type: ignore
         == "{(typeof foo !== `string`)}"
     )
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() != int)
+        str(BaseVar(_var_name="foo", _var_type=str).type() != int)  # type: ignore
         == "{(typeof foo !== `number`)}"
     )
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() != list)
+        str(BaseVar(_var_name="foo", _var_type=str).type() != list)  # type: ignore
         == "{(typeof foo !== `Array`)}"
     )
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() != float)
+        str(BaseVar(_var_name="foo", _var_type=str).type() != float)  # type: ignore
         == "{(typeof foo !== `number`)}"
     )
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() != tuple)
+        str(BaseVar(_var_name="foo", _var_type=str).type() != tuple)  # type: ignore
         == "{(typeof foo !== `Array`)}"
     )
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() != dict)
+        str(BaseVar(_var_name="foo", _var_type=str).type() != dict)  # type: ignore
         == "{(typeof foo !== `Object`)}"
     )
 

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -346,10 +346,32 @@ def test_basic_operations(TestObj):
         str(BaseVar(_var_name="foo", _var_type=str).type() == dict)
         == "{(typeof foo === `Object`)}"
     )
+
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() is None)
-        == "{(typeof foo === `undefined`)}"
+            str(BaseVar(_var_name="foo", _var_type=str).type() != str)
+            == "{(typeof foo !== `string`)}"
     )
+    assert (
+            str(BaseVar(_var_name="foo", _var_type=str).type() != int)
+            == "{(typeof foo !== `number`)}"
+    )
+    assert (
+            str(BaseVar(_var_name="foo", _var_type=str).type() != list)
+            == "{(typeof foo !== `Array`)}"
+    )
+    assert (
+            str(BaseVar(_var_name="foo", _var_type=str).type() != float)
+            == "{(typeof foo !== `number`)}"
+    )
+    assert (
+            str(BaseVar(_var_name="foo", _var_type=str).type() != tuple)
+            == "{(typeof foo !== `Array`)}"
+    )
+    assert (
+            str(BaseVar(_var_name="foo", _var_type=str).type() != dict)
+            == "{(typeof foo !== `Object`)}"
+    )
+
 
 
 @pytest.mark.parametrize(

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -321,7 +321,6 @@ def test_basic_operations(TestObj):
         str(BaseVar(_var_name="foo", _var_type=str).type() == str)
         == "{(typeof foo === `string`)}"
     )
-
     assert (
         str(BaseVar(_var_name="foo", _var_type=str).type() == str)
         == "{(typeof foo === `string`)}"
@@ -346,7 +345,6 @@ def test_basic_operations(TestObj):
         str(BaseVar(_var_name="foo", _var_type=str).type() == dict)
         == "{(typeof foo === `Object`)}"
     )
-
     assert (
             str(BaseVar(_var_name="foo", _var_type=str).type() != str)
             == "{(typeof foo !== `string`)}"

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -316,57 +316,57 @@ def test_basic_operations(TestObj):
         str(BaseVar(_var_name="foo", _var_type=list).reverse())
         == "{[...foo].reverse()}"
     )
-    assert str(BaseVar(_var_name="foo", _var_type=str).type()) == "{typeof foo}"  # type: ignore
+    assert str(BaseVar(_var_name="foo", _var_type=str)._type()) == "{typeof foo}"  # type: ignore
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() == str)  # type: ignore
+        str(BaseVar(_var_name="foo", _var_type=str)._type() == str)  # type: ignore
         == "{(typeof foo === `string`)}"
     )
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() == str)  # type: ignore
+        str(BaseVar(_var_name="foo", _var_type=str)._type() == str)  # type: ignore
         == "{(typeof foo === `string`)}"
     )
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() == int)  # type: ignore
+        str(BaseVar(_var_name="foo", _var_type=str)._type() == int)  # type: ignore
         == "{(typeof foo === `number`)}"
     )
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() == list)  # type: ignore
+        str(BaseVar(_var_name="foo", _var_type=str)._type() == list)  # type: ignore
         == "{(typeof foo === `Array`)}"
     )
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() == float)  # type: ignore
+        str(BaseVar(_var_name="foo", _var_type=str)._type() == float)  # type: ignore
         == "{(typeof foo === `number`)}"
     )
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() == tuple)  # type: ignore
+        str(BaseVar(_var_name="foo", _var_type=str)._type() == tuple)  # type: ignore
         == "{(typeof foo === `Array`)}"
     )
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() == dict)  # type: ignore
+        str(BaseVar(_var_name="foo", _var_type=str)._type() == dict)  # type: ignore
         == "{(typeof foo === `Object`)}"
     )
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() != str)  # type: ignore
+        str(BaseVar(_var_name="foo", _var_type=str)._type() != str)  # type: ignore
         == "{(typeof foo !== `string`)}"
     )
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() != int)  # type: ignore
+        str(BaseVar(_var_name="foo", _var_type=str)._type() != int)  # type: ignore
         == "{(typeof foo !== `number`)}"
     )
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() != list)  # type: ignore
+        str(BaseVar(_var_name="foo", _var_type=str)._type() != list)  # type: ignore
         == "{(typeof foo !== `Array`)}"
     )
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() != float)  # type: ignore
+        str(BaseVar(_var_name="foo", _var_type=str)._type() != float)  # type: ignore
         == "{(typeof foo !== `number`)}"
     )
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() != tuple)  # type: ignore
+        str(BaseVar(_var_name="foo", _var_type=str)._type() != tuple)  # type: ignore
         == "{(typeof foo !== `Array`)}"
     )
     assert (
-        str(BaseVar(_var_name="foo", _var_type=str).type() != dict)  # type: ignore
+        str(BaseVar(_var_name="foo", _var_type=str)._type() != dict)  # type: ignore
         == "{(typeof foo !== `Object`)}"
     )
 

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -346,30 +346,29 @@ def test_basic_operations(TestObj):
         == "{(typeof foo === `Object`)}"
     )
     assert (
-            str(BaseVar(_var_name="foo", _var_type=str).type() != str)
-            == "{(typeof foo !== `string`)}"
+        str(BaseVar(_var_name="foo", _var_type=str).type() != str)
+        == "{(typeof foo !== `string`)}"
     )
     assert (
-            str(BaseVar(_var_name="foo", _var_type=str).type() != int)
-            == "{(typeof foo !== `number`)}"
+        str(BaseVar(_var_name="foo", _var_type=str).type() != int)
+        == "{(typeof foo !== `number`)}"
     )
     assert (
-            str(BaseVar(_var_name="foo", _var_type=str).type() != list)
-            == "{(typeof foo !== `Array`)}"
+        str(BaseVar(_var_name="foo", _var_type=str).type() != list)
+        == "{(typeof foo !== `Array`)}"
     )
     assert (
-            str(BaseVar(_var_name="foo", _var_type=str).type() != float)
-            == "{(typeof foo !== `number`)}"
+        str(BaseVar(_var_name="foo", _var_type=str).type() != float)
+        == "{(typeof foo !== `number`)}"
     )
     assert (
-            str(BaseVar(_var_name="foo", _var_type=str).type() != tuple)
-            == "{(typeof foo !== `Array`)}"
+        str(BaseVar(_var_name="foo", _var_type=str).type() != tuple)
+        == "{(typeof foo !== `Array`)}"
     )
     assert (
-            str(BaseVar(_var_name="foo", _var_type=str).type() != dict)
-            == "{(typeof foo !== `Object`)}"
+        str(BaseVar(_var_name="foo", _var_type=str).type() != dict)
+        == "{(typeof foo !== `Object`)}"
     )
-
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Radio group component items and default value to support types other than `str`

```python
from typing import List, Tuple, Any, Union
import reflex as rx
import reflex.components.radix.themes as rdxt

class State(rx.State):
    selected: str | int | list | dict = ""
    default: list = [1,2,3]
    items: list = [ 1, 2, 2.578,"hey there", [1,2,3], {1:2, 3: 4}]

def index():
    return rdxt.flex(
            rdxt.flex(rdxt.text(f"selected is {State.selected}"),),
            rdxt.flex(
                rdxt.radio_group(
                items= [ 1, 2, 2.578,"hey there", [1,2,3], {1:2, 3: 4}], #  State.items,
                on_value_change=State.set_selected,
                direction="row",
                default_value=State.default,
                gap="3"
            ),

            ),
        gap="3",
        direction="column",
        align_items="center"
    )

# Add state and page to the app.
app = rx.App(
theme=rdxt.theme(
        has_background=True, radius="none", accent_color="grass", appearance="light",
    ),
)
app.add_page(index)
```