### PR TITLE
Added Environmental variable REFLEX_DIR

### DIFF
--- a/reflex/constants/base.py
+++ b/reflex/constants/base.py
@@ -63,12 +63,12 @@ class Reflex(SimpleNamespace):
     # The directory to store reflex dependencies.
     # Get directory value from enviroment variables if it exists.
     _dir = os.environ.get("REFLEX_DIR", "")
-    
+
     DIR = _dir or (
         # on windows, we use C:/Users/<username>/AppData/Local/reflex.
         # on macOS, we use ~/Library/Application Support/reflex.
         # on linux, we use ~/.local/share/reflex.
-        # If user sets REFLEX_DIR envroment variable use that instead. 
+        # If user sets REFLEX_DIR envroment variable use that instead.
         PlatformDirs(MODULE_NAME, False).user_data_dir
     )
     # The root directory of the reflex library.

--- a/reflex/constants/base.py
+++ b/reflex/constants/base.py
@@ -61,10 +61,14 @@ class Reflex(SimpleNamespace):
 
     # Files and directories used to init a new project.
     # The directory to store reflex dependencies.
-    DIR = (
+    # Get directory value from enviroment variables if it exists.
+    _dir = os.environ.get("REFLEX_DIR", "")
+    
+    DIR = _dir or (
         # on windows, we use C:/Users/<username>/AppData/Local/reflex.
         # on macOS, we use ~/Library/Application Support/reflex.
         # on linux, we use ~/.local/share/reflex.
+        # If user sets REFLEX_DIR envroment variable use that instead. 
         PlatformDirs(MODULE_NAME, False).user_data_dir
     )
     # The root directory of the reflex library.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import os
 from typing import Any, Dict
 
@@ -200,3 +201,20 @@ def test_replace_defaults(
     c._set_persistent(**set_persistent_vars)
     for key, value in exp_config_values.items():
         assert getattr(c, key) == value
+
+
+def reflex_dir_constant():
+    return rx.constants.Reflex.DIR
+
+
+def test_reflex_dir_env_var(monkeypatch, tmp_path):
+    """Test that the REFLEX_DIR environment variable is used to set the Reflex.DIR constant.
+
+    Args:
+        monkeypatch: The pytest monkeypatch object.
+        tmp_path: The pytest tmp_path object.
+    """
+    monkeypatch.setenv("REFLEX_DIR", str(tmp_path))
+
+    with multiprocessing.Pool(processes=1) as pool:
+        assert pool.apply(reflex_dir_constant) == str(tmp_path)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -216,5 +216,6 @@ def test_reflex_dir_env_var(monkeypatch, tmp_path):
     """
     monkeypatch.setenv("REFLEX_DIR", str(tmp_path))
 
-    with multiprocessing.Pool(processes=1) as pool:
+    mp_ctx = multiprocessing.get_context(method="spawn")
+    with mp_ctx.Pool(processes=1) as pool:
         assert pool.apply(reflex_dir_constant) == str(tmp_path)


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Description
Added environment variable to make constant REFLEX.DIR configurable.  The new environment variable "REFLEX_DIR" can be used to configure the constant DIR.

### Linked Issue
closes #2388  