### PR TITLE
[REF-1746] Define `value` prop on base rx.el.textarea

### DIFF
--- a/reflex/components/el/elements/forms.py
+++ b/reflex/components/el/elements/forms.py
@@ -413,6 +413,9 @@ class Textarea(BaseHTML):
     # Visible number of lines in the text control
     rows: Var[Union[str, int, bool]]
 
+    # The controlled value of the textarea, read only unless used with on_change
+    value: Var[Union[str, int, bool]]
+
     # How the text in the textarea is to be wrapped when submitting the form
     wrap: Var[Union[str, int, bool]]
 

--- a/reflex/components/el/elements/forms.pyi
+++ b/reflex/components/el/elements/forms.pyi
@@ -2094,6 +2094,9 @@ class Textarea(BaseHTML):
             Union[Var[Union[str, int, bool]], Union[str, int, bool]]
         ] = None,
         rows: Optional[Union[Var[Union[str, int, bool]], Union[str, int, bool]]] = None,
+        value: Optional[
+            Union[Var[Union[str, int, bool]], Union[str, int, bool]]
+        ] = None,
         wrap: Optional[Union[Var[Union[str, int, bool]], Union[str, int, bool]]] = None,
         access_key: Optional[
             Union[Var[Union[str, int, bool]], Union[str, int, bool]]
@@ -2217,6 +2220,7 @@ class Textarea(BaseHTML):
             read_only: Indicates whether the textarea is read-only
             required: Indicates that the textarea is required
             rows: Visible number of lines in the text control
+            value: The controlled value of the textarea, read only unless used with on_change
             wrap: How the text in the textarea is to be wrapped when submitting the form
             access_key:  Provides a hint for generating a keyboard shortcut for the current element.
             auto_capitalize: Controls whether and how text input is automatically capitalized as it is entered/edited by the user.

--- a/reflex/components/radix/themes/components/textarea.pyi
+++ b/reflex/components/radix/themes/components/textarea.pyi
@@ -167,6 +167,9 @@ class TextArea(CommonMarginProps, RadixThemesComponent, el.Textarea):
             Union[Var[Union[str, int, bool]], Union[str, int, bool]]
         ] = None,
         rows: Optional[Union[Var[Union[str, int, bool]], Union[str, int, bool]]] = None,
+        value: Optional[
+            Union[Var[Union[str, int, bool]], Union[str, int, bool]]
+        ] = None,
         wrap: Optional[Union[Var[Union[str, int, bool]], Union[str, int, bool]]] = None,
         access_key: Optional[
             Union[Var[Union[str, int, bool]], Union[str, int, bool]]
@@ -300,6 +303,7 @@ class TextArea(CommonMarginProps, RadixThemesComponent, el.Textarea):
             read_only: Indicates whether the textarea is read-only
             required: Indicates that the textarea is required
             rows: Visible number of lines in the text control
+            value: The controlled value of the textarea, read only unless used with on_change
             wrap: How the text in the textarea is to be wrapped when submitting the form
             access_key:  Provides a hint for generating a keyboard shortcut for the current element.
             auto_capitalize: Controls whether and how text input is automatically capitalized as it is entered/edited by the user.


### PR DESCRIPTION
The value prop on textarea allows binding a state var to the contents of the textarea control.

Since the prop wasn't defined before, attempting to set it would cause reflex to treat `value` as a CSS/style prop.

### Sample App

```python
import reflex as rx
import reflex.components.radix.themes as rdxt


class State(rx.State):
    val: str = "default value"


def index() -> rx.Component:
    return rdxt.flex(
        rdxt.heading(f"Textarea value: {State.val}"),
        rdxt.separator(size="4"),
        rdxt.code("rx.el.textarea"),
        rx.el.textarea(
            value=State.val,
            on_change=State.set_val,
            border="1px dashed var(--accent-11)",
            padding="var(--space-2)",
        ),
        rdxt.text("Note: the plain textarea above has no debounce and eats fast input!", size="1"),
        rdxt.separator(size="4"),
        rdxt.code("rdxt.textarea"),
        rdxt.textarea(
            value=State.val,
            on_change=State.set_val,
        ),
        rdxt.button("Reset", on_click=State.set_val("")),
        direction="column",
        gap="3",
        padding="var(--space-4)",
        width="50%",
    )


# Create app instance and add index page.
app = rx.App(theme=rdxt.theme())
app.add_page(index)
```


https://github.com/reflex-dev/reflex/assets/1524005/c6112a4b-c49d-458c-924a-74729590f02f

