### PR TITLE
[REF-1763] Rename `color` to `color_scheme` in all radix themes components

### DIFF
--- a/reflex/components/radix/themes/components/avatar.py
+++ b/reflex/components/radix/themes/components/avatar.py
@@ -24,7 +24,7 @@ class Avatar(CommonMarginProps, RadixThemesComponent):
     size: Var[LiteralSize]
 
     # Color theme of the avatar
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # Whether to render the avatar with higher contrast color against background
     high_contrast: Var[bool]

--- a/reflex/components/radix/themes/components/badge.py
+++ b/reflex/components/radix/themes/components/badge.py
@@ -24,7 +24,7 @@ class Badge(el.Span, CommonMarginProps, RadixThemesComponent):
     size: Var[Literal["1", "2"]]
 
     # Color theme of the badge
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # Whether to render the badge with higher contrast color against background
     high_contrast: Var[bool]

--- a/reflex/components/radix/themes/components/callout.py
+++ b/reflex/components/radix/themes/components/callout.py
@@ -31,7 +31,7 @@ class CalloutRoot(el.Div, CommonMarginProps, RadixThemesComponent):
     variant: Var[CalloutVariant]
 
     # Override theme color for button
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # Whether to render the button with higher contrast color against background
     high_contrast: Var[bool]

--- a/reflex/components/radix/themes/components/callout.pyi
+++ b/reflex/components/radix/themes/components/callout.pyi
@@ -809,7 +809,7 @@ class Callout(CalloutRoot):
                 Literal["soft", "surface", "outline"],
             ]
         ] = None,
-        color: Optional[
+        color_scheme: Optional[
             Union[
                 Var[
                     Literal[

--- a/reflex/components/radix/themes/components/callout.pyi
+++ b/reflex/components/radix/themes/components/callout.pyi
@@ -1019,7 +1019,7 @@ class Callout(CalloutRoot):
             as_child: Change the default rendered element for the one passed as a child, merging their props and behavior.
             size: Size "1" - "3"
             variant: Variant of button: "soft" | "surface" | "outline"
-            color: Override theme color for button
+            color_scheme: Override theme color for button
             high_contrast: Whether to render the button with higher contrast color against background
             access_key:  Provides a hint for generating a keyboard shortcut for the current element.
             auto_capitalize: Controls whether and how text input is automatically capitalized as it is entered/edited by the user.

--- a/reflex/components/radix/themes/components/checkbox.py
+++ b/reflex/components/radix/themes/components/checkbox.py
@@ -32,7 +32,7 @@ class Checkbox(CommonMarginProps, RadixThemesComponent):
     variant: Var[LiteralVariant]
 
     # Override theme color for button
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # Whether to render the button with higher contrast color against background
     high_contrast: Var[bool]

--- a/reflex/components/radix/themes/components/checkbox.pyi
+++ b/reflex/components/radix/themes/components/checkbox.pyi
@@ -269,7 +269,7 @@ class HighLevelCheckbox(Checkbox):
                 Literal["classic", "solid", "soft", "surface", "outline", "ghost"],
             ]
         ] = None,
-        color: Optional[
+        color_scheme: Optional[
             Union[
                 Var[
                     Literal[
@@ -445,7 +445,7 @@ class HighLevelCheckbox(Checkbox):
             size: Button size "1" - "3"
             as_child: Change the default rendered element for the one passed as a child, merging their props and behavior.
             variant: Variant of button: "solid" | "soft" | "outline" | "ghost"
-            color: Override theme color for button
+            color_scheme: Override theme color for button
             high_contrast: Whether to render the button with higher contrast color against background
             default_checked: Whether the checkbox is checked by default
             checked: Whether the checkbox is checked

--- a/reflex/components/radix/themes/components/contextmenu.py
+++ b/reflex/components/radix/themes/components/contextmenu.py
@@ -51,7 +51,7 @@ class ContextMenuContent(CommonMarginProps, RadixThemesComponent):
     variant: Var[Literal["solid", "soft"]]
 
     # Override theme color for button
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # Whether to render the button with higher contrast color against background
     high_contrast: Var[bool]
@@ -122,7 +122,7 @@ class ContextMenuItem(CommonMarginProps, RadixThemesComponent):
     tag = "ContextMenu.Item"
 
     # Override theme color for button
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # Shortcut to render a menu item as a link
     shortcut: Var[str]

--- a/reflex/components/radix/themes/components/dialog.py
+++ b/reflex/components/radix/themes/components/dialog.py
@@ -18,9 +18,6 @@ class DialogRoot(CommonMarginProps, RadixThemesComponent):
     # The controlled open state of the dialog.
     open: Var[bool]
 
-    # The modality of the dialog. When set to true, interaction with outside elements will be disabled and only dialog content will be visible to screen readers.
-    modal: Var[bool]
-
     def get_event_triggers(self) -> Dict[str, Any]:
         """Get the events triggers signatures for the component.
 

--- a/reflex/components/radix/themes/components/dialog.pyi
+++ b/reflex/components/radix/themes/components/dialog.pyi
@@ -83,7 +83,6 @@ class DialogRoot(CommonMarginProps, RadixThemesComponent):
             ]
         ] = None,
         open: Optional[Union[Var[bool], bool]] = None,
-        modal: Optional[Union[Var[bool], bool]] = None,
         m: Optional[
             Union[
                 Var[Literal["1", "2", "3", "4", "5", "6", "7", "8", "9"]],
@@ -192,7 +191,6 @@ class DialogRoot(CommonMarginProps, RadixThemesComponent):
             color: map to CSS default color property.
             color_scheme: map to radix color property.
             open: The controlled open state of the dialog.
-            modal: The modality of the dialog. When set to true, interaction with outside elements will be disabled and only dialog content will be visible to screen readers.
             m: Margin: "0" - "9"
             mx: Margin horizontal: "0" - "9"
             my: Margin vertical: "0" - "9"

--- a/reflex/components/radix/themes/components/dropdownmenu.py
+++ b/reflex/components/radix/themes/components/dropdownmenu.py
@@ -83,7 +83,7 @@ class DropdownMenuSubContent(CommonMarginProps, RadixThemesComponent):
     variant: Var[Literal["solid", "soft"]]
 
     # Override theme color for button
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # Whether to render the button with higher contrast color against background
     high_contrast: Var[bool]
@@ -95,7 +95,7 @@ class DropdownMenuItem(CommonMarginProps, RadixThemesComponent):
     tag = "DropdownMenu.Item"
 
     # Override theme color for button
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # Shortcut to render a menu item as a link
     shortcut: Var[str]

--- a/reflex/components/radix/themes/components/iconbutton.py
+++ b/reflex/components/radix/themes/components/iconbutton.py
@@ -30,7 +30,7 @@ class IconButton(el.Button, CommonMarginProps, RadixThemesComponent):
     variant: Var[LiteralVariant]
 
     # Override theme color for button
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # Whether to render the button with higher contrast color against background
     high_contrast: Var[bool]

--- a/reflex/components/radix/themes/components/select.py
+++ b/reflex/components/radix/themes/components/select.py
@@ -66,7 +66,7 @@ class SelectTrigger(CommonMarginProps, RadixThemesComponent):
     variant: Var[Literal["classic", "surface", "soft", "ghost"]]
 
     # The color of the select trigger
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # The radius of the select trigger
     radius: Var[LiteralRadius]
@@ -84,7 +84,7 @@ class SelectContent(CommonMarginProps, RadixThemesComponent):
     variant: Var[Literal["solid", "soft"]]
 
     # The color of the select content
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # Whether to render the select content with higher contrast color against background
     high_contrast: Var[bool]
@@ -161,7 +161,7 @@ class HighLevelSelect(SelectRoot):
     label: Var[str]
 
     # The color of the select.
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # Whether to render the select with higher contrast color against background.
     high_contrast: Var[bool]

--- a/reflex/components/radix/themes/components/select.pyi
+++ b/reflex/components/radix/themes/components/select.pyi
@@ -1466,7 +1466,7 @@ class HighLevelSelect(SelectRoot):
         items: Optional[Union[Var[List[str]], List[str]]] = None,
         placeholder: Optional[Union[Var[str], str]] = None,
         label: Optional[Union[Var[str], str]] = None,
-        color: Optional[
+        color_scheme: Optional[
             Union[
                 Var[
                     Literal[
@@ -1660,7 +1660,7 @@ class HighLevelSelect(SelectRoot):
             items: The items of the select.
             placeholder: The placeholder of the select.
             label: The label of the select.
-            color: The color of the select.
+            color_scheme: The color of the select.
             high_contrast: Whether to render the select with higher contrast color against background.
             variant: The variant of the select.
             radius: The radius of the select.

--- a/reflex/components/radix/themes/components/separator.py
+++ b/reflex/components/radix/themes/components/separator.py
@@ -21,7 +21,7 @@ class Separator(CommonMarginProps, RadixThemesComponent):
     size: Var[LiteralSeperatorSize]
 
     # The color of the select
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # The orientation of the separator.
     orientation: Var[Literal["horizontal", "vertical"]]

--- a/reflex/components/radix/themes/components/separator.py
+++ b/reflex/components/radix/themes/components/separator.py
@@ -18,7 +18,7 @@ class Separator(CommonMarginProps, RadixThemesComponent):
     tag = "Separator"
 
     # The size of the select: "1" | "2" | "3" | "4"
-    size: Var[LiteralSeperatorSize]
+    size: Var[LiteralSeperatorSize] = Var.create_safe("4")
 
     # The color of the select
     color_scheme: Var[LiteralAccentColor]

--- a/reflex/components/radix/themes/components/slider.py
+++ b/reflex/components/radix/themes/components/slider.py
@@ -26,7 +26,7 @@ class Slider(CommonMarginProps, RadixThemesComponent):
     variant: Var[Literal["classic", "surface", "soft"]]
 
     # Override theme color for button
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # Whether to render the button with higher contrast color against background
     high_contrast: Var[bool]

--- a/reflex/components/radix/themes/components/switch.py
+++ b/reflex/components/radix/themes/components/switch.py
@@ -48,7 +48,7 @@ class Switch(CommonMarginProps, RadixThemesComponent):
     variant: Var[LiteralVariant]
 
     # Override theme color for switch
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # Whether to render the switch with higher contrast color against background
     high_contrast: Var[bool]

--- a/reflex/components/radix/themes/components/textarea.py
+++ b/reflex/components/radix/themes/components/textarea.py
@@ -28,7 +28,7 @@ class TextArea(CommonMarginProps, RadixThemesComponent, el.Textarea):
     variant: Var[Literal["classic", "surface", "soft"]]
 
     # The color of the text area
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     @classmethod
     def create(cls, *children, **props) -> Component:

--- a/reflex/components/radix/themes/components/textarea.pyi
+++ b/reflex/components/radix/themes/components/textarea.pyi
@@ -32,7 +32,7 @@ class TextArea(CommonMarginProps, RadixThemesComponent, el.Textarea):
                 Literal["classic", "surface", "soft"],
             ]
         ] = None,
-        color: Optional[
+        color_scheme: Optional[
             Union[
                 Var[
                     Literal[
@@ -282,7 +282,7 @@ class TextArea(CommonMarginProps, RadixThemesComponent, el.Textarea):
             *children: The children of the component.
             size: The size of the text area: "1" | "2" | "3"
             variant: The variant of the text area
-            color: The color of the text area
+            color_scheme: The color of the text area
             m: Margin: "0" - "9"
             mx: Margin horizontal: "0" - "9"
             my: Margin vertical: "0" - "9"

--- a/reflex/components/radix/themes/components/textfield.py
+++ b/reflex/components/radix/themes/components/textfield.py
@@ -33,7 +33,7 @@ class TextFieldRoot(el.Div, CommonMarginProps, RadixThemesComponent):
     variant: Var[LiteralTextFieldVariant]
 
     # Override theme color for text field
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # Override theme radius for text field: "none" | "small" | "medium" | "large" | "full"
     radius: Var[LiteralRadius]
@@ -88,7 +88,7 @@ class TextFieldSlot(RadixThemesComponent):
     tag = "TextField.Slot"
 
     # Override theme color for text field slot
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # Override the gap spacing between slot and input: "1" - "9"
     gap: Var[LiteralSize]
@@ -107,7 +107,7 @@ class Input(RadixThemesComponent):
     variant: Var[LiteralTextFieldVariant]
 
     # Override theme color for text field
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # Override theme radius for text field: "none" | "small" | "medium" | "large" | "full"
     radius: Var[LiteralRadius]

--- a/reflex/components/radix/themes/components/textfield.pyi
+++ b/reflex/components/radix/themes/components/textfield.pyi
@@ -388,7 +388,7 @@ class TextFieldInput(el.Input, TextFieldRoot):
                 Literal["classic", "surface", "soft"],
             ]
         ] = None,
-        color: Optional[
+        color_scheme: Optional[
             Union[
                 Var[
                     Literal[
@@ -641,7 +641,7 @@ class TextFieldInput(el.Input, TextFieldRoot):
             value: Value of the input
             width: The width of the input (only for type="image")
             variant: Variant of text field: "classic" | "surface" | "soft"
-            color: Override theme color for text field
+            color_scheme: Override theme color for text field
             radius: Override theme radius for text field: "none" | "small" | "medium" | "large" | "full"
             access_key:  Provides a hint for generating a keyboard shortcut for the current element.
             auto_capitalize: Controls whether and how text input is automatically capitalized as it is entered/edited by the user.
@@ -848,7 +848,7 @@ class Input(RadixThemesComponent):
                 Literal["classic", "surface", "soft"],
             ]
         ] = None,
-        color: Optional[
+        color_scheme: Optional[
             Union[
                 Var[
                     Literal[
@@ -993,7 +993,7 @@ class Input(RadixThemesComponent):
             icon: The icon to render before the input.
             size: Text field size "1" - "3"
             variant: Variant of text field: "classic" | "surface" | "soft"
-            color: Override theme color for text field
+            color_scheme: Override theme color for text field
             radius: Override theme radius for text field: "none" | "small" | "medium" | "large" | "full"
             auto_complete: Whether the input should have autocomplete enabled
             default_value: The value of the input when initially rendered.

--- a/reflex/components/radix/themes/typography.py
+++ b/reflex/components/radix/themes/typography.py
@@ -45,7 +45,7 @@ class Text(CommonMarginProps, RadixThemesComponent):
     trim: Var[LiteralTextTrim]
 
     # Overrides the accent color inherited from the Theme.
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # Whether to render the text with higher contrast color
     high_contrast: Var[bool]
@@ -69,7 +69,7 @@ class Blockquote(CommonMarginProps, RadixThemesComponent):
     weight: Var[LiteralTextWeight]
 
     # Overrides the accent color inherited from the Theme.
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # Whether to render the text with higher contrast color
     high_contrast: Var[bool]
@@ -123,7 +123,7 @@ class Link(CommonMarginProps, RadixThemesComponent):
     underline: Var[LiteralLinkUnderline]
 
     # Overrides the accent color inherited from the Theme.
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # Whether to render the text with higher contrast color
     high_contrast: Var[bool]

--- a/reflex/components/radix/themes/typography/blockquote.py
+++ b/reflex/components/radix/themes/typography/blockquote.py
@@ -30,7 +30,7 @@ class Blockquote(el.Blockquote, CommonMarginProps, RadixThemesComponent):
     weight: Var[LiteralTextWeight]
 
     # Overrides the accent color inherited from the Theme.
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # Whether to render the text with higher contrast color
     high_contrast: Var[bool]

--- a/reflex/components/radix/themes/typography/code.py
+++ b/reflex/components/radix/themes/typography/code.py
@@ -34,7 +34,7 @@ class Code(el.Code, CommonMarginProps, RadixThemesComponent):
     weight: Var[LiteralTextWeight]
 
     # Overrides the accent color inherited from the Theme.
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # Whether to render the text with higher contrast color
     high_contrast: Var[bool]

--- a/reflex/components/radix/themes/typography/heading.py
+++ b/reflex/components/radix/themes/typography/heading.py
@@ -44,7 +44,7 @@ class Heading(el.H1, CommonMarginProps, RadixThemesComponent):
     trim: Var[LiteralTextTrim]
 
     # Overrides the accent color inherited from the Theme.
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # Whether to render the text with higher contrast color
     high_contrast: Var[bool]

--- a/reflex/components/radix/themes/typography/text.py
+++ b/reflex/components/radix/themes/typography/text.py
@@ -44,7 +44,7 @@ class Text(el.Span, CommonMarginProps, RadixThemesComponent):
     trim: Var[LiteralTextTrim]
 
     # Overrides the accent color inherited from the Theme.
-    color: Var[LiteralAccentColor]
+    color_scheme: Var[LiteralAccentColor]
 
     # Whether to render the text with higher contrast color
     high_contrast: Var[bool]


### PR DESCRIPTION
Avoid shadowing CSS prop "color" which typically controls the text color, not the theme color of the component.
