### PR TITLE
Remove modal prop from Dialog

### DIFF
--- a/reflex/components/radix/themes/components/dialog.py
+++ b/reflex/components/radix/themes/components/dialog.py
@@ -18,9 +18,6 @@ class DialogRoot(CommonMarginProps, RadixThemesComponent):
     # The controlled open state of the dialog.
     open: Var[bool]
 
-    # The modality of the dialog. When set to true, interaction with outside elements will be disabled and only dialog content will be visible to screen readers.
-    modal: Var[bool]
-
     def get_event_triggers(self) -> Dict[str, Any]:
         """Get the events triggers signatures for the component.
 

--- a/reflex/components/radix/themes/components/dialog.pyi
+++ b/reflex/components/radix/themes/components/dialog.pyi
@@ -83,7 +83,6 @@ class DialogRoot(CommonMarginProps, RadixThemesComponent):
             ]
         ] = None,
         open: Optional[Union[Var[bool], bool]] = None,
-        modal: Optional[Union[Var[bool], bool]] = None,
         m: Optional[
             Union[
                 Var[Literal["1", "2", "3", "4", "5", "6", "7", "8", "9"]],
@@ -192,7 +191,6 @@ class DialogRoot(CommonMarginProps, RadixThemesComponent):
             color: map to CSS default color property.
             color_scheme: map to radix color property.
             open: The controlled open state of the dialog.
-            modal: The modality of the dialog. When set to true, interaction with outside elements will be disabled and only dialog content will be visible to screen readers.
             m: Margin: "0" - "9"
             mx: Margin horizontal: "0" - "9"
             my: Margin vertical: "0" - "9"


### PR DESCRIPTION
### All Submissions:

- [ ] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [ ] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### New Feature Submission:

- [ ] Does your submission pass the tests? 
- [ ] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.
Per https://www.radix-ui.com/themes/docs/components/dialog#api-reference, this prop is not available in the Dialog in Radix themes components.