### PR TITLE
improve sqlalchemy type parsing

### DIFF
--- a/reflex/utils/types.py
+++ b/reflex/utils/types.py
@@ -173,10 +173,6 @@ def get_attribute_access_type(cls: GenericType, name: str) -> GenericType | None
             if isinstance(type_, ModelField):
                 return type_.type_  # SQLAlchemy v1.4
             return type_
-        if name in cls.__dict__:
-            value = cls.__dict__[name]
-            if hint := get_property_hint(value):
-                return hint
     elif is_union(cls):
         # Check in each arg of the annotation.
         for arg in get_args(cls):

--- a/reflex/utils/types.py
+++ b/reflex/utils/types.py
@@ -18,8 +18,8 @@ from typing import (
     get_type_hints,
 )
 
+import sqlalchemy
 from pydantic.fields import ModelField
-from sqlalchemy import inspect
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import DeclarativeBase, Mapped, QueryableAttribute, Relationship
 
@@ -149,7 +149,7 @@ def get_attribute_access_type(cls: GenericType, name: str) -> GenericType | None
             type_ = Optional[type_]
         return type_
     elif isinstance(cls, type) and issubclass(cls, DeclarativeBase):
-        insp = inspect(cls)
+        insp = sqlalchemy.inspect(cls)
         if name in insp.columns:
             return insp.columns[name].type.python_type
         if name not in insp.all_orm_descriptors.keys():


### PR DESCRIPTION
Part of #2340  

This PR addresses 3 issues:
- If using sqlalchemy>2.0 one would probably want to benefit from its excellent typing features. However, for many-to-many relations across modules, one would need to use PEP 563 (`from __future__ import annotations`). This breaks reflex's `get_attribute_access_type` because it cannot evaluate those postponed annotations with `get_type_hints`. This PR makes use of sqlalchemys `inspect` which allows us to access the correct python types with ease.  
- support for nested types with sqlalchemy relations
- general support to parse type hints of properties
