### PR TITLE
Fix pyi_generator relative path determination

### DIFF
--- a/scripts/pyi_generator.py
+++ b/scripts/pyi_generator.py
@@ -94,7 +94,9 @@ def _relative_to_pwd(path: Path) -> Path:
     Returns:
         The relative path.
     """
-    return path.relative_to(PWD)
+    if path.is_absolute():
+        return path.relative_to(PWD)
+    return path
 
 
 def _git_diff(args: list[str]) -> str:


### PR DESCRIPTION
Unbreak CI/pre-commit when used with already-relative paths