### PR TITLE
[REF-1815] Radix themes: replace `color_scheme` with `color` in get_fields

### DIFF
--- a/reflex/components/radix/themes/base.py
+++ b/reflex/components/radix/themes/base.py
@@ -114,6 +114,21 @@ class RadixThemesComponent(Component):
         )
         return component
 
+    @classmethod
+    def get_fields(cls) -> dict[str, Any]:
+        """Get the pydantic fields for the component.
+
+        Returns:
+            Mapping of field name to ModelField instance.
+        """
+        fields = super().get_fields()
+        if "color_scheme" in fields:
+            # Treat "color" as a direct prop, so the translation of reflex "color_scheme"
+            # to "color" does not put the "color_scheme" value into the "style" prop.
+            fields["color"] = fields.pop("color_scheme")
+            fields["color"].required = False
+        return fields
+
     @staticmethod
     def _get_app_wrap_components() -> dict[tuple[int, str], Component]:
         return {

--- a/reflex/components/radix/themes/base.pyi
+++ b/reflex/components/radix/themes/base.pyi
@@ -322,6 +322,8 @@ class RadixThemesComponent(Component):
             A new component instance.
         """
         ...
+    @classmethod
+    def get_fields(cls) -> dict[str, Any]: ...
 
 class Theme(RadixThemesComponent):
     @overload


### PR DESCRIPTION
This change ensures that the components never emit an actual `color_scheme` prop to the generated code. Instead of treating the `color` prop swap in `create` as a CSS prop, it will instead will emit `color={...}` as a direct prop. Handling `color` as a style prop already occurs explicitly in `create`.