### PR TITLE
[0.4.0] Namespace the Drawer primitive subcomponents

### DIFF
--- a/reflex/components/radix/primitives/__init__.py
+++ b/reflex/components/radix/primitives/__init__.py
@@ -1,16 +1,7 @@
 """Radix primitive components (https://www.radix-ui.com/primitives)."""
 
 from .accordion import accordion
+from .drawer import drawer
 from .form import form
-from .drawer import (
-    drawer_close,
-    drawer_content,
-    drawer_description,
-    drawer_overlay,
-    drawer_portal,
-    drawer_root,
-    drawer_title,
-    drawer_trigger,
-)
 from .progress import progress
 from .slider import slider

--- a/reflex/components/radix/primitives/drawer.py
+++ b/reflex/components/radix/primitives/drawer.py
@@ -3,6 +3,7 @@
 # Style based on https://ui.shadcn.com/docs/components/drawer
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any, Dict, List, Literal, Optional, Union
 
 from reflex.components.radix.primitives.base import RadixPrimitiveComponentWithClassName
@@ -230,11 +231,17 @@ class DrawerDescription(DrawerComponent):
         return self.style
 
 
-drawer_root = DrawerRoot.create
-drawer_trigger = DrawerTrigger.create
-drawer_portal = DrawerPortal.create
-drawer_content = DrawerContent.create
-drawer_overlay = DrawerOverlay.create
-drawer_close = DrawerClose.create
-drawer_title = DrawerTitle.create
-drawer_description = DrawerDescription.create
+class Drawer(SimpleNamespace):
+    """A namespace for Drawer components."""
+
+    root = __call__ = staticmethod(DrawerRoot.create)
+    trigger = staticmethod(DrawerTrigger.create)
+    portal = staticmethod(DrawerPortal.create)
+    content = staticmethod(DrawerContent.create)
+    overlay = staticmethod(DrawerOverlay.create)
+    close = staticmethod(DrawerClose.create)
+    title = staticmethod(DrawerTitle.create)
+    description = staticmethod(DrawerDescription.create)
+
+
+drawer = Drawer()

--- a/reflex/components/radix/primitives/drawer.pyi
+++ b/reflex/components/radix/primitives/drawer.pyi
@@ -7,6 +7,7 @@ from typing import Any, Dict, Literal, Optional, Union, overload
 from reflex.vars import Var, BaseVar, ComputedVar
 from reflex.event import EventChain, EventHandler, EventSpec
 from reflex.style import Style
+from types import SimpleNamespace
 from typing import Any, Dict, List, Literal, Optional, Union
 from reflex.components.radix.primitives.base import RadixPrimitiveComponentWithClassName
 from reflex.constants import EventTriggers
@@ -786,11 +787,118 @@ class DrawerDescription(DrawerComponent):
         """
         ...
 
-drawer_root = DrawerRoot.create
-drawer_trigger = DrawerTrigger.create
-drawer_portal = DrawerPortal.create
-drawer_content = DrawerContent.create
-drawer_overlay = DrawerOverlay.create
-drawer_close = DrawerClose.create
-drawer_title = DrawerTitle.create
-drawer_description = DrawerDescription.create
+class Drawer(SimpleNamespace):
+    root = staticmethod(DrawerRoot.create)
+    trigger = staticmethod(DrawerTrigger.create)
+    portal = staticmethod(DrawerPortal.create)
+    content = staticmethod(DrawerContent.create)
+    overlay = staticmethod(DrawerOverlay.create)
+    close = staticmethod(DrawerClose.create)
+    title = staticmethod(DrawerTitle.create)
+    description = staticmethod(DrawerDescription.create)
+
+    @staticmethod
+    def __call__(
+        *children,
+        open: Optional[Union[Var[bool], bool]] = None,
+        should_scale_background: Optional[Union[Var[bool], bool]] = None,
+        close_threshold: Optional[Union[Var[float], float]] = None,
+        snap_points: Optional[List[Union[str, float]]] = None,
+        fade_from_index: Optional[Union[Var[int], int]] = None,
+        scroll_lock_timeout: Optional[Union[Var[int], int]] = None,
+        modal: Optional[Union[Var[bool], bool]] = None,
+        direction: Optional[
+            Union[
+                Var[Literal["top", "bottom", "left", "right"]],
+                Literal["top", "bottom", "left", "right"],
+            ]
+        ] = None,
+        preventScrollRestoration: Optional[Union[Var[bool], bool]] = None,
+        as_child: Optional[Union[Var[bool], bool]] = None,
+        style: Optional[Style] = None,
+        key: Optional[Any] = None,
+        id: Optional[Any] = None,
+        class_name: Optional[Any] = None,
+        autofocus: Optional[bool] = None,
+        custom_attrs: Optional[Dict[str, Union[Var, str]]] = None,
+        on_blur: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_click: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_context_menu: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_double_click: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_focus: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_mount: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_mouse_down: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_mouse_enter: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_mouse_leave: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_mouse_move: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_mouse_out: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_mouse_over: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_mouse_up: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_open_change: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_scroll: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_unmount: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        **props
+    ) -> "DrawerRoot":
+        """Create the component.
+
+        Args:
+            *children: The children of the component.
+            open: Whether the drawer is open or not.
+            should_scale_background: Enable background scaling,  it requires an element with [vaul-drawer-wrapper] data attribute to scale its background.
+            close_threshold: Number between 0 and 1 that determines when the drawer should be closed.
+            snap_points: Array of numbers from 0 to 100 that corresponds to % of the screen a given snap point should take up. Should go from least visible.  Also Accept px values, which doesn't take screen height into account.
+            fade_from_index: Index of a snapPoint from which the overlay fade should be applied.  Defaults to the last snap point.  TODO: will it accept -1 then?
+            scroll_lock_timeout: Duration for which the drawer is not draggable after scrolling content inside of the drawer. Defaults to 500ms
+            modal: When `False`, it allows to interact with elements outside of the drawer without closing it.  Defaults to `True`.
+            direction: Direction of the drawer. Defaults to `"bottom"`
+            preventScrollRestoration: When `True`, it prevents scroll restoration  when the drawer is closed after a navigation happens inside of it.  Defaults to `True`.
+            as_child: Change the default rendered element for the one passed as a child.
+            style: The style of the component.
+            key: A unique key for the component.
+            id: The id for the component.
+            class_name: The class name for the component.
+            autofocus: Whether the component should take the focus once the page is loaded
+            custom_attrs: custom attribute
+            **props: The props of the component.
+
+        Returns:
+            The component.
+
+        Raises:
+            TypeError: If an invalid child is passed.
+        """
+        ...
+
+drawer = Drawer()

--- a/scripts/pyi_generator.py
+++ b/scripts/pyi_generator.py
@@ -516,18 +516,15 @@ def _generate_namespace_call_functiondef(
     clz = classes[clz_name]
 
     # Determine which class is wrapped by the namespace __call__ method
-    component_class_name, dot, func_name = clz.__call__.__func__.__qualname__.partition(
-        "."
-    )
-    component_clz = classes[component_class_name]
+    component_clz = clz.__call__.__self__
 
     # Only generate for create functions
-    if func_name != "create":
+    if clz.__call__.__func__.__name__ != "create":
         return None
 
     definition = _generate_component_create_functiondef(
         node=None,
-        clz=component_clz,
+        clz=component_clz,  # type: ignore
         type_hint_globals=type_hint_globals,
     )
     definition.name = "__call__"


### PR DESCRIPTION
Ensure `Drawer` component uses a `SimpleNamespace` like the other primitives.