### PR TITLE
rx.color

### DIFF
--- a/reflex/constants/colors.py
+++ b/reflex/constants/colors.py
@@ -55,10 +55,10 @@ class Color:
 
     def __format__(self, format_spec: str) -> str:
         """Format the color as a CSS color string.
-    
+
         Args:
             format_spec (str): The format specification for the color string.
-            
+
         Returns:
             str: The CSS color string
         """
@@ -66,4 +66,3 @@ class Color:
             return f"var(--{self.color}-a{self.shade})"
         else:
             return f"var(--{self.color}-{self.shade})"
-    

--- a/reflex/constants/colors.py
+++ b/reflex/constants/colors.py
@@ -1,6 +1,7 @@
 """The colors used in Reflex are a wrapper around https://www.radix-ui.com/colors."""
 from dataclasses import dataclass
 from typing import Literal
+from reflex import color_mode_cond
 
 ColorType = Literal[
     "gray",
@@ -53,16 +54,28 @@ class Color:
     # Whether to use the alpha variant of the color
     alpha: bool = False
 
+    # The light mode variants of the color
+    light: tuple[ColorType, ShadeType, bool] = None
+
+    # The dark mode variants of the color
+    dark: tuple[ColorType, ShadeType, bool] = None
+
+    def format_color(self, color: ColorType, shade: ShadeType) -> str:
+        """Format a color as a CSS color string."""
+        return f"var(--{color}-{'a' if self.alpha else ''}{shade})"
+
     def __format__(self, format_spec: str) -> str:
-        """Format the color as a CSS color string.
+        """Format the color as a CSS color string."""
 
-        Args:
-            format_spec (str): The format specification for the color string.
+        if self.light and self.dark:
+            return color_mode_cond(
+                self.format_color(*self.light),
+                self.format_color(*self.dark)
+            )
 
-        Returns:
-            str: The CSS color string
-        """
-        if self.alpha:
-            return f"var(--{self.color}-a{self.shade})"
-        else:
-            return f"var(--{self.color}-{self.shade})"
+        if self.light or self.dark:
+            raise ValueError("Both light and dark mode must be specified if you only want to use one shade provide color, shad, and/or alpha directly to rx.color")
+
+        return self.format_color(self.color, self.shade)
+
+

--- a/reflex/constants/colors.py
+++ b/reflex/constants/colors.py
@@ -55,7 +55,10 @@ class Color:
 
     def __format__(self, format_spec: str) -> str:
         """Format the color as a CSS color string.
-        
+    
+        Args:
+            format_spec (str): The format specification for the color string.
+            
         Returns:
             str: The CSS color string
         """

--- a/reflex/constants/colors.py
+++ b/reflex/constants/colors.py
@@ -52,3 +52,15 @@ class Color:
 
     # Whether to use the alpha variant of the color
     alpha: bool = False
+
+    def __format__(self, format_spec: str) -> str:
+        """Format the color as a CSS color string.
+        
+        Returns:
+            str: The CSS color string
+        """
+        if self.alpha:
+            return f"var(--{self.color}-a{self.shade})"
+        else:
+            return f"var(--{self.color}-{self.shade})"
+    


### PR DESCRIPTION
Two ways of referencing color. One by specifying light and dark mode and the other by providing a default shade.

Default:
```python
"""Welcome to Reflex! This file outlines the steps to create a basic app."""
from rxconfig import config

import reflex as rx
import reflex.components.radix.themes as rdxt
import reflex.components.core.colors as colors
import random
docs_url = "https://reflex.dev/docs/getting-started/introduction"
filename = f"{config.app_name}/{config.app_name}.py"


class State(rx.State):
    """The app state."""

    color = colors.color("sky", 9)

    def randomize_color(self) -> None:
        """Randomize the color."""
        self.color = random.choice(["sky", "ruby", "crimson", "violet", "iris", "indigo", "blue", "cyan", "teal", "jade", "green", "grass", "brown", "orange", "sky", "mint", "lime", "yellow", "amber", "gold", "bronze", "gray"])


def index() -> rx.Component:
    return rx.fragment(
        rx.color_mode_button(rx.color_mode_icon(), float="right"),
        rx.vstack(
            rdxt.button(
                "Docs",
                background_color=State.color,
                on_click=State.randomize_color
            ),
            rdxt.button(
                "Docs",
                color_scheme=State.color,
            ),
            rdxt.button(
                "Docs",
                color=colors.color("sky", 9),
                color_scheme="ruby",
            ),
            padding_top="10%",
        ),
    )


# Create app instance and add index page.
app = rx.App()
app.add_page(index)

```
