### PR TITLE
[REF-1827]Meta data for conditional Vars

### DIFF
--- a/reflex/components/core/cond.py
+++ b/reflex/components/core/cond.py
@@ -8,7 +8,7 @@ from reflex.components.component import BaseComponent, Component, MemoizationLea
 from reflex.components.tags import CondTag, Tag
 from reflex.constants import Dirs
 from reflex.utils import format, imports
-from reflex.vars import BaseVar, Var, VarData
+from reflex.vars import BaseVar, Var, VarData, ConditionalVar
 
 _IS_TRUE_IMPORT = {
     f"/{Dirs.STATE_PATH}": {imports.ImportVar(tag="isTrue")},
@@ -168,7 +168,7 @@ def cond(condition: Any, c1: Any, c2: Any = None):
         var_datas.append(c2._var_data)
 
     # Create the conditional var.
-    return cond_var._replace(
+    a=  cond_var._replace(
         _var_name=format.format_cond(
             cond=cond_var._var_full_name,
             true_value=c1,
@@ -179,4 +179,6 @@ def cond(condition: Any, c1: Any, c2: Any = None):
         _var_is_local=False,
         _var_full_name_needs_state_prefix=False,
         merge_var_data=VarData.merge(*var_datas),
+        _var_cond_data = ConditionalVar.create(cond=cond_var, comp1=Var.create(c1), comp2=Var.create(c2))
     )
+    return a

--- a/reflex/components/core/cond.py
+++ b/reflex/components/core/cond.py
@@ -8,7 +8,7 @@ from reflex.components.component import BaseComponent, Component, MemoizationLea
 from reflex.components.tags import CondTag, Tag
 from reflex.constants import Dirs
 from reflex.utils import format, imports
-from reflex.vars import BaseVar, Var, VarData, ConditionalVar
+from reflex.vars import BaseVar, ConditionalVarMetaData, Var, VarData
 
 _IS_TRUE_IMPORT = {
     f"/{Dirs.STATE_PATH}": {imports.ImportVar(tag="isTrue")},
@@ -179,5 +179,7 @@ def cond(condition: Any, c1: Any, c2: Any = None):
         _var_is_local=False,
         _var_full_name_needs_state_prefix=False,
         merge_var_data=VarData.merge(*var_datas),
-        _var_cond_data = ConditionalVar.create(cond=cond_var, comp1=Var.create(c1), comp2=Var.create(c2))
+        _var_cond_data=ConditionalVarMetaData.create(
+            cond=cond_var, comp1=Var.create(c1), comp2=Var.create(c2)
+        ),
     )

--- a/reflex/components/core/cond.py
+++ b/reflex/components/core/cond.py
@@ -168,7 +168,7 @@ def cond(condition: Any, c1: Any, c2: Any = None):
         var_datas.append(c2._var_data)
 
     # Create the conditional var.
-    a=  cond_var._replace(
+    return cond_var._replace(
         _var_name=format.format_cond(
             cond=cond_var._var_full_name,
             true_value=c1,
@@ -181,4 +181,3 @@ def cond(condition: Any, c1: Any, c2: Any = None):
         merge_var_data=VarData.merge(*var_datas),
         _var_cond_data = ConditionalVar.create(cond=cond_var, comp1=Var.create(c1), comp2=Var.create(c2))
     )
-    return a

--- a/reflex/components/core/match.py
+++ b/reflex/components/core/match.py
@@ -237,7 +237,7 @@ class Match(MemoizationLeaf):
             default._var_data,  # type: ignore
         ]
 
-        a =  match_cond_var._replace(
+        return match_cond_var._replace(
             _var_name=format.format_match(
                 cond=match_cond_var._var_name_unwrapped,
                 match_cases=match_cases,  # type: ignore
@@ -250,7 +250,7 @@ class Match(MemoizationLeaf):
             merge_var_data=VarData.merge(*var_data),
             _var_cond_data=ConditionalVar.create(is_match_var=True, cond=match_cond_var, match_cases=match_cases, default=default)
         )
-        return a
+
     def _render(self) -> Tag:
         return MatchTag(
             cond=self.cond, match_cases=self.match_cases, default=self.default

--- a/reflex/components/core/match.py
+++ b/reflex/components/core/match.py
@@ -8,7 +8,7 @@ from reflex.components.tags import MatchTag, Tag
 from reflex.style import Style
 from reflex.utils import format, imports, types
 from reflex.utils.exceptions import MatchTypeError
-from reflex.vars import BaseVar, Var, VarData, ConditionalVar
+from reflex.vars import BaseVar, ConditionalVarMetaData, Var, VarData
 
 
 class Match(MemoizationLeaf):
@@ -248,7 +248,12 @@ class Match(MemoizationLeaf):
             _var_full_name_needs_state_prefix=False,
             _var_is_string=False,
             merge_var_data=VarData.merge(*var_data),
-            _var_cond_data=ConditionalVar.create(is_match_var=True, cond=match_cond_var, match_cases=match_cases, default=default)
+            _var_cond_data=ConditionalVarMetaData.create(
+                is_match_var=True,
+                cond=match_cond_var,
+                match_cases=match_cases,
+                default=default,
+            ),
         )
 
     def _render(self) -> Tag:

--- a/reflex/components/core/match.py
+++ b/reflex/components/core/match.py
@@ -8,7 +8,7 @@ from reflex.components.tags import MatchTag, Tag
 from reflex.style import Style
 from reflex.utils import format, imports, types
 from reflex.utils.exceptions import MatchTypeError
-from reflex.vars import BaseVar, Var, VarData
+from reflex.vars import BaseVar, Var, VarData, ConditionalVar
 
 
 class Match(MemoizationLeaf):
@@ -237,7 +237,7 @@ class Match(MemoizationLeaf):
             default._var_data,  # type: ignore
         ]
 
-        return match_cond_var._replace(
+        a =  match_cond_var._replace(
             _var_name=format.format_match(
                 cond=match_cond_var._var_name_unwrapped,
                 match_cases=match_cases,  # type: ignore
@@ -248,8 +248,9 @@ class Match(MemoizationLeaf):
             _var_full_name_needs_state_prefix=False,
             _var_is_string=False,
             merge_var_data=VarData.merge(*var_data),
+            _var_cond_data=ConditionalVar.create(is_match_var=True, cond=match_cond_var, match_cases=match_cases, default=default)
         )
-
+        return a
     def _render(self) -> Tag:
         return MatchTag(
             cond=self.cond, match_cases=self.match_cases, default=self.default

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -127,12 +127,13 @@ class ConditionalVar(Base, ABC):
 
 
 class CondVar(ConditionalVar):
-    comp1: Var
-    comp2: Optional[Var]
+    comp1: Var[Any]
+    comp2: Optional[Var[Any]]
+
 
 class MatchVar(ConditionalVar):
     match_cases: List[Tuple[Var, ...]]
-    default: BaseVar
+    default: Var[Any]
 
 
 class VarData(Base):
@@ -1992,5 +1993,5 @@ class CallableVar(BaseVar):
 
 
 # resolve type definitions
-MatchVar.update_forward_refs()
 CondVar.update_forward_refs()
+MatchVar.update_forward_refs()

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -1986,6 +1986,9 @@ class ConditionalVarMetaData(Base, ABC):
 
         Returns:
             The Var meta data.
+
+        Raises:
+            ValueError: When insufficient kwargs are passed for creating respective meta data.
         """
         if is_match_var:
             if "match_cases" not in kwargs and "default" in kwargs:

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -439,7 +439,6 @@ class Var:
             and self._var_full_name_needs_state_prefix
             == other._var_full_name_needs_state_prefix
             and self._var_data == other._var_data
-            and self._var_cond_data == other._var_cond_data
         )
 
     def _merge(self, other) -> Var:

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -439,6 +439,7 @@ class Var:
             and self._var_full_name_needs_state_prefix
             == other._var_full_name_needs_state_prefix
             and self._var_data == other._var_data
+            and self._var_cond_data == other._var_cond_data
         )
 
     def _merge(self, other) -> Var:

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -111,30 +111,6 @@ def get_unique_variable_name() -> str:
     return get_unique_variable_name()
 
 
-class ConditionalVar(Base, ABC):
-    cond: Var
-
-    @classmethod
-    def create(cls, cond, is_match_var = False, **kwargs):
-        if is_match_var:
-            if not "match_cases" in kwargs and "default" in kwargs:
-                raise ValueError("match_cases and default args are required for creating match var")
-            return MatchVar(cond=cond, **kwargs)
-        else:
-            if not "comp1" and "comp2" in kwargs:
-                raise ValueError("The True and False arguments are required for creating a cond var")
-            return CondVar(cond=cond, **kwargs)
-
-
-class CondVar(ConditionalVar):
-    comp1: Var[Any]
-    comp2: Optional[Var[Any]]
-
-
-class MatchVar(ConditionalVar):
-    match_cases: List[Tuple[Var, ...]]
-    default: Var[Any]
-
 
 class VarData(Base):
     """Metadata associated with a Var."""
@@ -1992,6 +1968,26 @@ class CallableVar(BaseVar):
         return self.fn(*args, **kwargs)
 
 
-# resolve type definitions
-CondVar.update_forward_refs()
-MatchVar.update_forward_refs()
+class ConditionalVar(Base, ABC):
+    cond: Var
+
+    @classmethod
+    def create(cls, cond, is_match_var = False, **kwargs):
+        if is_match_var:
+            if not "match_cases" in kwargs and "default" in kwargs:
+                raise ValueError("match_cases and default args are required for creating match var")
+            return MatchVar(cond=cond, **kwargs)
+        else:
+            if not "comp1" and "comp2" in kwargs:
+                raise ValueError("The True and False arguments are required for creating a cond var")
+            return CondVar(cond=cond, **kwargs)
+
+
+class CondVar(ConditionalVar):
+    comp1: Var[Any]
+    comp2: Optional[Var[Any]]
+
+
+class MatchVar(ConditionalVar):
+    match_cases: List[Tuple[Var, ...]]
+    default: Var[Any]

--- a/reflex/vars.pyi
+++ b/reflex/vars.pyi
@@ -45,7 +45,7 @@ class Var:
     _var_is_string: bool = False
     _var_full_name_needs_state_prefix: bool = False
     _var_data: VarData | None = None
-    _var_cond_data: ConditionalVar | None = None
+    _var_cond_data: ConditionalVarMetaData | None = None
     @classmethod
     def create(
         cls, value: Any, _var_is_local: bool = False, _var_is_string: bool = False
@@ -124,7 +124,7 @@ class BaseVar(Var):
     _var_is_string: bool = False
     _var_full_name_needs_state_prefix: bool = False
     _var_data: VarData | None = None
-    _var_cond_data: ConditionalVar | None = None
+    _var_cond_data: ConditionalVarMetaData | None = None
     def __hash__(self) -> int: ...
     def get_default_value(self) -> Any: ...
     def get_setter_name(self, include_state: bool = ...) -> str: ...
@@ -151,7 +151,7 @@ class CallableVar(BaseVar):
 class ConditionalVarMetaData(Base, ABC):
     cond: Var
     @classmethod
-    def create(cls, cond, is_match_var=False, **kwargs): ...
+    def create(cls, cond, is_match_var=False, **kwargs) -> CondVarMetaData | MatchVarMetaData: ...
 
 class CondVarMetaData(ConditionalVarMetaData):
     comp1: Var[Any]

--- a/reflex/vars.pyi
+++ b/reflex/vars.pyi
@@ -151,7 +151,9 @@ class CallableVar(BaseVar):
 class ConditionalVarMetaData(Base, ABC):
     cond: Var
     @classmethod
-    def create(cls, cond, is_match_var=False, **kwargs) -> CondVarMetaData | MatchVarMetaData: ...
+    def create(
+        cls, cond, is_match_var=False, **kwargs
+    ) -> CondVarMetaData | MatchVarMetaData: ...
 
 class CondVarMetaData(ConditionalVarMetaData):
     comp1: Var[Any]

--- a/reflex/vars.pyi
+++ b/reflex/vars.pyi
@@ -1,5 +1,6 @@
 """ Generated with stubgen from mypy, then manually edited, do not regen."""
 
+from abc import ABC
 from dataclasses import dataclass
 from _typeshed import Incomplete
 from reflex import constants as constants
@@ -17,6 +18,7 @@ from typing import (
     List,
     Optional,
     Set,
+    Tuple,
     Type,
     Union,
     _GenericAlias,  # type: ignore
@@ -28,6 +30,18 @@ def get_unique_variable_name() -> str: ...
 def _encode_var(value: Var) -> str: ...
 def _decode_var(value: str) -> tuple[VarData, str]: ...
 def _extract_var_data(value: Iterable) -> list[VarData | None]: ...
+
+class ConditionalVar(Base, ABC):
+    cond: Var
+    @classmethod
+    def create(cls, cond, is_match_var=False, **kwargs): ...
+class CondVar(ConditionalVar):
+    comp1: Var[Any]
+    comp2: Optional[Var[Any]]
+
+class MatchVar(ConditionalVar):
+    match_cases: List[Tuple[Var, ...]]
+    default: Var[Any]
 
 class VarData(Base):
     state: str
@@ -43,6 +57,7 @@ class Var:
     _var_is_string: bool = False
     _var_full_name_needs_state_prefix: bool = False
     _var_data: VarData | None = None
+    _var_cond_data: ConditionalVar | None = None
     @classmethod
     def create(
         cls, value: Any, _var_is_local: bool = False, _var_is_string: bool = False

--- a/reflex/vars.pyi
+++ b/reflex/vars.pyi
@@ -148,14 +148,15 @@ class CallableVar(BaseVar):
     def __init__(self, fn: Callable[..., BaseVar]): ...
     def __call__(self, *args, **kwargs) -> BaseVar: ...
 
-class ConditionalVar(Base, ABC):
+class ConditionalVarMetaData(Base, ABC):
     cond: Var
     @classmethod
     def create(cls, cond, is_match_var=False, **kwargs): ...
-class CondVar(ConditionalVar):
+
+class CondVarMetaData(ConditionalVarMetaData):
     comp1: Var[Any]
     comp2: Optional[Var[Any]]
 
-class MatchVar(ConditionalVar):
+class MatchVarMetaData(ConditionalVarMetaData):
     match_cases: List[Tuple[Var, ...]]
     default: Var[Any]

--- a/reflex/vars.pyi
+++ b/reflex/vars.pyi
@@ -31,18 +31,6 @@ def _encode_var(value: Var) -> str: ...
 def _decode_var(value: str) -> tuple[VarData, str]: ...
 def _extract_var_data(value: Iterable) -> list[VarData | None]: ...
 
-class ConditionalVar(Base, ABC):
-    cond: Var
-    @classmethod
-    def create(cls, cond, is_match_var=False, **kwargs): ...
-class CondVar(ConditionalVar):
-    comp1: Var[Any]
-    comp2: Optional[Var[Any]]
-
-class MatchVar(ConditionalVar):
-    match_cases: List[Tuple[Var, ...]]
-    default: Var[Any]
-
 class VarData(Base):
     state: str
     imports: dict[str, set[ImportVar]]
@@ -136,6 +124,7 @@ class BaseVar(Var):
     _var_is_string: bool = False
     _var_full_name_needs_state_prefix: bool = False
     _var_data: VarData | None = None
+    _var_cond_data: ConditionalVar | None = None
     def __hash__(self) -> int: ...
     def get_default_value(self) -> Any: ...
     def get_setter_name(self, include_state: bool = ...) -> str: ...
@@ -158,3 +147,15 @@ def cached_var(fget: Callable[[Any], Any]) -> ComputedVar: ...
 class CallableVar(BaseVar):
     def __init__(self, fn: Callable[..., BaseVar]): ...
     def __call__(self, *args, **kwargs) -> BaseVar: ...
+
+class ConditionalVar(Base, ABC):
+    cond: Var
+    @classmethod
+    def create(cls, cond, is_match_var=False, **kwargs): ...
+class CondVar(ConditionalVar):
+    comp1: Var[Any]
+    comp2: Optional[Var[Any]]
+
+class MatchVar(ConditionalVar):
+    match_cases: List[Tuple[Var, ...]]
+    default: Var[Any]

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -1268,7 +1268,10 @@ def test_var_name_unwrapped(var, expected):
 
 
 def assert_cond_var_cond_data(
-    cond_data: CondVarMetaData, cond: Optional[Var], comp1: Optional[Var], comp2: Optional[Var]
+    cond_data: CondVarMetaData,
+    cond: Optional[Var],
+    comp1: Optional[Var],
+    comp2: Optional[Var],
 ):
     assert cond_data is not None
     assert isinstance(cond_data, CondVarMetaData)

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -1272,8 +1272,16 @@ def assert_cond_var_cond_data(
 ):
     assert cond_data is not None
     assert isinstance(cond_data, CondVarMetaData)
-    assert cond_data.cond._var_full_name == cond._var_full_name if cond is not None else cond  # type: ignore
-    assert cond_data.comp1._var_full_name == comp1._var_full_name if comp1 is not None else comp1  # type: ignore
+    assert (
+        cond_data.cond._var_full_name == cond._var_full_name
+        if cond is not None
+        else cond
+    )
+    assert (
+        cond_data.comp1._var_full_name == comp1._var_full_name
+        if comp1 is not None
+        else comp1
+    )
     assert cond_data.comp2._var_full_name == comp2._var_full_name if comp2 is not None else comp2  # type: ignore
 
 
@@ -1375,7 +1383,7 @@ def test_match_var_cond_data():
         "second": "isTrue(true) ? `second_true` : `second_false`",
     }
     assert_match_var_cond_data(
-        match_cond_var_data,
+        match_cond_var_data,  # type: ignore
         Var.create("condition"),
         [  # type: ignore
             (Var.create(case), Var.create(return_value))
@@ -1385,7 +1393,7 @@ def test_match_var_cond_data():
     )
 
     # Test the first match case ("first": rx.match(...))
-    first_match_case_tuple = match_cond_var_data.match_cases[0]
+    first_match_case_tuple = match_cond_var_data.match_cases[0]  # type: ignore
     match_cond_var_data = first_match_case_tuple[-1]._var_cond_data
     match_case_dict = {
         "nested_first": "isTrue(true) ? `return_nested_first_truth` : `return_nested_first_false`",

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -1,6 +1,6 @@
 import json
 import typing
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 import pytest
 from pandas import DataFrame
@@ -1268,7 +1268,7 @@ def test_var_name_unwrapped(var, expected):
 
 
 def assert_cond_var_cond_data(
-    cond_data: CondVarMetaData, cond: Var | None, comp1: Var | None, comp2: Var | None
+    cond_data: CondVarMetaData, cond: Optional[Var], comp1: Optional[Var], comp2: Optional[Var]
 ):
     assert cond_data is not None
     assert isinstance(cond_data, CondVarMetaData)
@@ -1287,9 +1287,9 @@ def assert_cond_var_cond_data(
 
 def assert_match_var_cond_data(
     cond_data: MatchVarMetaData,
-    cond: Var | None,
+    cond: Optional[Var],
     match_cases: List[Tuple[Var, ...]],
-    default: Var | None,
+    default: Optional[Var],
 ):
     assert cond_data is not None
     assert isinstance(cond_data, MatchVarMetaData)


### PR DESCRIPTION
## PROBLEM STATEMENT

Currently for Vars, once an `rx.cond` is computed, there's no clean way to extract the constituent parts of the `cond` should you need it later as they will be lost. 
Eg.
`cond_var = rx.cond(True, "true-condition", "false-condition")`
becomes
```
cond_var= BaseVar(_var_name='isTrue(true) ? `true-condition` : `false-condition`', _var_type=<class 'str'>, _var_is_local=False, _var_is_string=False, _var_full_name_needs_state_prefix=False, _var_data=VarData(state='', imports={'/utils/state': [ImportVar(tag='isTrue', is_default=False, alias=None, install=True, render=True), ImportVar(tag='isTrue', is_default=False, alias=None, install=True, render=True)]}, hooks=set()))
```

A typical use case on why we need the constituent parts of the cond var after its been converted to a BaseVar is checking the validity of literal prop types when a Var is passed.

Take in the example:

```python
class Heading(RadixThemesComponent):
      size: Literal["1", "2", "3", "4", "5", "6", "7", "8", "9"]
```
```python
...
heading("Header value", size=rx.cond(True, "5", "9"))
```
The true and false values are lost after conversion to a `BaseVar` which makes it harder to validate values against the accepted literal values of the `size` prop.

## SOLUTION

This PR adds an extra `_var_cond_data` to the `Var` data type. Which stores meta data for conditional vars(`rx.match` and `rx.cond`)


