### PR TITLE
Add dropdown props inherited from their primitive counterparts

### DIFF
--- a/reflex/components/radix/themes/components/dropdownmenu.py
+++ b/reflex/components/radix/themes/components/dropdownmenu.py
@@ -1,5 +1,5 @@
 """Interactive components provided by @radix-ui/themes."""
-from typing import Any, Dict, Literal
+from typing import Any, Dict, Literal, Union
 
 from reflex.constants import EventTriggers
 from reflex.vars import Var
@@ -9,17 +9,39 @@ from ..base import (
     RadixThemesComponent,
 )
 
+LiteralDirType = Literal["ltr", "rtl"]
+
+LiteralSizeType = Literal["1", "2"]
+
+LiteralVariantType = Literal["solid", "soft"]
+
+LiteralSideType = Literal["top", "right", "bottom", "left"]
+
+LiteralAlignType = Literal["start", "center", "end"]
+
+
+LiteralStickyType = Literal[
+    "partial",
+    "always",
+]
+
 
 class DropdownMenuRoot(RadixThemesComponent):
-    """Trigger an action or event, such as submitting a form or displaying a dialog."""
+    """The Dropdown Menu Root Component."""
 
     tag = "DropdownMenu.Root"
+
+    # The open state of the dropdown menu when it is initially rendered. Use when you do not need to control its open state.
+    default_open: Var[bool]
 
     # The controlled open state of the dropdown menu. Must be used in conjunction with onOpenChange.
     open: Var[bool]
 
-    # The modality of the dropdown menu. When set to true, interaction with outside elements will be disabled and only menu content will be visible to screen readers.
+    # The modality of the dropdown menu. When set to true, interaction with outside elements will be disabled and only menu content will be visible to screen readers. Defaults to True.
     modal: Var[bool]
+
+    # The reading direction of submenus when applicable. If omitted, inherits globally from DirectionProvider or assumes LTR (left-to-right) reading mode.
+    dir: Var[LiteralDirType]
 
     def get_event_triggers(self) -> Dict[str, Any]:
         """Get the events triggers signatures for the component.
@@ -34,15 +56,66 @@ class DropdownMenuRoot(RadixThemesComponent):
 
 
 class DropdownMenuTrigger(RadixThemesComponent):
-    """Trigger an action or event, such as submitting a form or displaying a dialog."""
+    """The button that toggles the dropdown menu."""
 
     tag = "DropdownMenu.Trigger"
 
+    # Change the default rendered element for the one passed as a child, merging their props and behavior. Defaults to False.
+    as_child: Var[bool]
+
 
 class DropdownMenuContent(RadixThemesComponent):
-    """Trigger an action or event, such as submitting a form or displaying a dialog."""
+    """The Dropdown Menu Content component that pops out when the dropdown menu is open."""
 
     tag = "DropdownMenu.Content"
+
+    # Dropdown Menu Content size "1" - "2"
+    size: Var[LiteralSizeType]
+
+    # Variant of Dropdown Menu Content: "solid" | "soft"
+    variant: Var[LiteralVariantType]
+
+    # Override theme color for Dropdown Menu Content
+    color_scheme: Var[LiteralAccentColor]
+
+    # Renders the Dropdown Menu Content in higher contrast
+    high_contrast: Var[bool]
+
+    # Change the default rendered element for the one passed as a child, merging their props and behavior. Defaults to False.
+    as_child: Var[bool]
+
+    # When True, keyboard navigation will loop from last item to first, and vice versa. Defaults to False.
+    loop: Var[bool]
+
+    # Used to force mounting when more control is needed. Useful when controlling animation with React animation libraries.
+    force_mount: Var[bool]
+
+    # The preferred side of the trigger to render against when open. Will be reversed when collisions occur and `avoid_collisions` is enabled.The position of the tooltip. Defaults to "top".
+    side: Var[LiteralSideType]
+
+    # The distance in pixels from the trigger. Defaults to 0.
+    side_offset: Var[Union[float, int]]
+
+    # The preferred alignment against the trigger. May change when collisions occur. Defaults to "center".
+    align: Var[LiteralAlignType]
+
+    # An offset in pixels from the "start" or "end" alignment options.
+    align_offset: Var[Union[float, int]]
+
+    # When true, overrides the side and align preferences to prevent collisions with boundary edges. Defaults to True.
+    avoid_collisions: Var[bool]
+
+    # The distance in pixels from the boundary edges where collision detection should occur. Accepts a number (same for all sides), or a partial padding object, for example: { "top": 20, "left": 20 }. Defaults to 0.
+    collision_padding: Var[Union[float, int, Dict[str, Union[float, int]]]]
+
+    # The padding between the arrow and the edges of the content. If your content has border-radius, this will prevent it from overflowing the corners. Defaults to 0.
+    arrow_padding: Var[Union[float, int]]
+
+    # The sticky behavior on the align axis. "partial" will keep the content in the boundary as long as the trigger is at least partially in the boundary whilst "always" will keep the content in the boundary regardless. Defaults to "partial".
+    sticky: Var[LiteralStickyType]
+
+    # Whether to hide the content when the trigger becomes fully occluded. Defaults to False.
+    hide_when_detached: Var[bool]
 
     def get_event_triggers(self) -> Dict[str, Any]:
         """Get the events triggers signatures for the component.
@@ -55,6 +128,7 @@ class DropdownMenuContent(RadixThemesComponent):
             EventTriggers.ON_CLOSE_AUTO_FOCUS: lambda e0: [e0],
             EventTriggers.ON_ESCAPE_KEY_DOWN: lambda e0: [e0],
             EventTriggers.ON_POINTER_DOWN_OUTSIDE: lambda e0: [e0],
+            EventTriggers.ON_FOCUS_OUTSIDE: lambda e0: [e0],
             EventTriggers.ON_INTERACT_OUTSIDE: lambda e0: [e0],
         }
 
@@ -64,44 +138,134 @@ class DropdownMenuSubTrigger(RadixThemesComponent):
 
     tag = "DropdownMenu.SubTrigger"
 
+    # Change the default rendered element for the one passed as a child, merging their props and behavior. Defaults to False.
+    as_child: Var[bool]
+
+    # When true, prevents the user from interacting with the item.
+    disabled: Var[bool]
+
+    # Optional text used for typeahead purposes. By default the typeahead behavior will use the .textContent of the item. Use this when the content is complex, or you have non-textual content inside.
+    text_value: Var[str]
+
 
 class DropdownMenuSub(RadixThemesComponent):
-    """Trigger an action or event, such as submitting a form or displaying a dialog."""
+    """Contains all the parts of a submenu."""
 
     tag = "DropdownMenu.Sub"
 
+    # The controlled open state of the submenu. Must be used in conjunction with `on_open_change`.
+    open: Var[bool]
+
+    # The open state of the submenu when it is initially rendered. Use when you do not need to control its open state.
+    default_open: Var[bool]
+
+    def get_event_triggers(self) -> Dict[str, Any]:
+        """Get the events triggers signatures for the component.
+
+        Returns:
+            The signatures of the event triggers.
+        """
+        return {
+            **super().get_event_triggers(),
+            EventTriggers.ON_OPEN_CHANGE: lambda e0: [e0.target.value],
+        }
+
 
 class DropdownMenuSubContent(RadixThemesComponent):
-    """Trigger an action or event, such as submitting a form or displaying a dialog."""
+    """The component that pops out when a submenu is open. Must be rendered inside DropdownMenuSub."""
 
     tag = "DropdownMenu.SubContent"
 
-    # Button size "1" - "4"
-    size: Var[Literal["1", "2"]]
+    # Dropdown Menu Sub Content size "1" - "2"
+    size: Var[LiteralSizeType]
 
-    # Variant of button: "solid" | "soft" | "outline" | "ghost"
-    variant: Var[Literal["solid", "soft"]]
+    # Variant of Dropdown Menu Sub Content: "solid" | "soft"
+    variant: Var[LiteralVariantType]
 
-    # Override theme color for button
+    # Override theme color for Dropdown Menu Sub Content
     color_scheme: Var[LiteralAccentColor]
 
-    # Whether to render the button with higher contrast color against background
+    # Whether to render the component with higher contrast color against background
     high_contrast: Var[bool]
+
+    # Change the default rendered element for the one passed as a child, merging their props and behavior. Defaults to False.
+    as_child: Var[bool]
+
+    # When True, keyboard navigation will loop from last item to first, and vice versa. Defaults to False.
+    loop: Var[bool]
+
+    # Used to force mounting when more control is needed. Useful when controlling animation with React animation libraries.
+    force_mount: Var[bool]
+
+    # The distance in pixels from the trigger. Defaults to 0.
+    side_offset: Var[Union[float, int]]
+
+    # An offset in pixels from the "start" or "end" alignment options.
+    align_offset: Var[Union[float, int]]
+
+    # When true, overrides the side and align preferences to prevent collisions with boundary edges. Defaults to True.
+    avoid_collisions: Var[bool]
+
+    # The distance in pixels from the boundary edges where collision detection should occur. Accepts a number (same for all sides), or a partial padding object, for example: { "top": 20, "left": 20 }. Defaults to 0.
+    collision_padding: Var[Union[float, int, Dict[str, Union[float, int]]]]
+
+    # The padding between the arrow and the edges of the content. If your content has border-radius, this will prevent it from overflowing the corners. Defaults to 0.
+    arrow_padding: Var[Union[float, int]]
+
+    # The sticky behavior on the align axis. "partial" will keep the content in the boundary as long as the trigger is at least partially in the boundary whilst "always" will keep the content in the boundary regardless. Defaults to "partial".
+    sticky: Var[LiteralStickyType]
+
+    # Whether to hide the content when the trigger becomes fully occluded. Defaults to False.
+    hide_when_detached: Var[bool]
+
+    def get_event_triggers(self) -> Dict[str, Any]:
+        """Get the events triggers signatures for the component.
+
+        Returns:
+            The signatures of the event triggers.
+        """
+        return {
+            **super().get_event_triggers(),
+            EventTriggers.ON_ESCAPE_KEY_DOWN: lambda e0: [e0],
+            EventTriggers.ON_POINTER_DOWN_OUTSIDE: lambda e0: [e0],
+            EventTriggers.ON_FOCUS_OUTSIDE: lambda e0: [e0],
+            EventTriggers.ON_INTERACT_OUTSIDE: lambda e0: [e0],
+        }
 
 
 class DropdownMenuItem(RadixThemesComponent):
-    """Trigger an action or event, such as submitting a form or displaying a dialog."""
+    """The Dropdown Menu Item Component."""
 
     tag = "DropdownMenu.Item"
 
-    # Override theme color for button
+    # Override theme color for Dropdown Menu Item
     color_scheme: Var[LiteralAccentColor]
 
     # Shortcut to render a menu item as a link
     shortcut: Var[str]
 
+    # Change the default rendered element for the one passed as a child, merging their props and behavior. Defaults to False.
+    as_child: Var[bool]
+
+    # When true, prevents the user from interacting with the item.
+    disabled: Var[bool]
+
+    # Optional text used for typeahead purposes. By default the typeahead behavior will use the .textContent of the item. Use this when the content is complex, or you have non-textual content inside.
+    text_value: Var[str]
+
+    def get_event_triggers(self) -> Dict[str, Any]:
+        """Get the events triggers signatures for the component.
+
+        Returns:
+            The signatures of the event triggers.
+        """
+        return {
+            **super().get_event_triggers(),
+            EventTriggers.ON_SELECT: lambda e0: [e0.target.value],
+        }
+
 
 class DropdownMenuSeparator(RadixThemesComponent):
-    """Trigger an action or event, such as submitting a form or displaying a dialog."""
+    """Dropdown Menu Separator Component. Used to visually separate items in the dropdown menu."""
 
     tag = "DropdownMenu.Separator"

--- a/reflex/components/radix/themes/components/dropdownmenu.pyi
+++ b/reflex/components/radix/themes/components/dropdownmenu.pyi
@@ -7,10 +7,17 @@ from typing import Any, Dict, Literal, Optional, Union, overload
 from reflex.vars import Var, BaseVar, ComputedVar
 from reflex.event import EventChain, EventHandler, EventSpec
 from reflex.style import Style
-from typing import Any, Dict, Literal
+from typing import Any, Dict, Literal, Union
 from reflex.constants import EventTriggers
 from reflex.vars import Var
 from ..base import LiteralAccentColor, RadixThemesComponent
+
+LiteralDirType = Literal["ltr", "rtl"]
+LiteralSizeType = Literal["1", "2"]
+LiteralVariantType = Literal["solid", "soft"]
+LiteralSideType = Literal["top", "right", "bottom", "left"]
+LiteralAlignType = Literal["start", "center", "end"]
+LiteralStickyType = Literal["partial", "always"]
 
 class DropdownMenuRoot(RadixThemesComponent):
     def get_event_triggers(self) -> Dict[str, Any]: ...
@@ -82,8 +89,10 @@ class DropdownMenuRoot(RadixThemesComponent):
                 ],
             ]
         ] = None,
+        default_open: Optional[Union[Var[bool], bool]] = None,
         open: Optional[Union[Var[bool], bool]] = None,
         modal: Optional[Union[Var[bool], bool]] = None,
+        dir: Optional[Union[Var[Literal["ltr", "rtl"]], Literal["ltr", "rtl"]]] = None,
         style: Optional[Style] = None,
         key: Optional[Any] = None,
         id: Optional[Any] = None,
@@ -150,8 +159,10 @@ class DropdownMenuRoot(RadixThemesComponent):
             *children: Child components.
             color: map to CSS default color property.
             color_scheme: map to radix color property.
+            default_open: The open state of the dropdown menu when it is initially rendered. Use when you do not need to control its open state.
             open: The controlled open state of the dropdown menu. Must be used in conjunction with onOpenChange.
-            modal: The modality of the dropdown menu. When set to true, interaction with outside elements will be disabled and only menu content will be visible to screen readers.
+            modal: The modality of the dropdown menu. When set to true, interaction with outside elements will be disabled and only menu content will be visible to screen readers. Defaults to True.
+            dir: The reading direction of submenus when applicable. If omitted, inherits globally from DirectionProvider or assumes LTR (left-to-right) reading mode.
             style: The style of the component.
             key: A unique key for the component.
             id: The id for the component.
@@ -235,6 +246,7 @@ class DropdownMenuTrigger(RadixThemesComponent):
                 ],
             ]
         ] = None,
+        as_child: Optional[Union[Var[bool], bool]] = None,
         style: Optional[Style] = None,
         key: Optional[Any] = None,
         id: Optional[Any] = None,
@@ -298,6 +310,7 @@ class DropdownMenuTrigger(RadixThemesComponent):
             *children: Child components.
             color: map to CSS default color property.
             color_scheme: map to radix color property.
+            as_child: Change the default rendered element for the one passed as a child, merging their props and behavior. Defaults to False.
             style: The style of the component.
             key: A unique key for the component.
             id: The id for the component.
@@ -382,6 +395,42 @@ class DropdownMenuContent(RadixThemesComponent):
                 ],
             ]
         ] = None,
+        size: Optional[Union[Var[Literal["1", "2"]], Literal["1", "2"]]] = None,
+        variant: Optional[
+            Union[Var[Literal["solid", "soft"]], Literal["solid", "soft"]]
+        ] = None,
+        high_contrast: Optional[Union[Var[bool], bool]] = None,
+        as_child: Optional[Union[Var[bool], bool]] = None,
+        loop: Optional[Union[Var[bool], bool]] = None,
+        force_mount: Optional[Union[Var[bool], bool]] = None,
+        side: Optional[
+            Union[
+                Var[Literal["top", "right", "bottom", "left"]],
+                Literal["top", "right", "bottom", "left"],
+            ]
+        ] = None,
+        side_offset: Optional[Union[Var[Union[float, int]], Union[float, int]]] = None,
+        align: Optional[
+            Union[
+                Var[Literal["start", "center", "end"]],
+                Literal["start", "center", "end"],
+            ]
+        ] = None,
+        align_offset: Optional[Union[Var[Union[float, int]], Union[float, int]]] = None,
+        avoid_collisions: Optional[Union[Var[bool], bool]] = None,
+        collision_padding: Optional[
+            Union[
+                Var[Union[float, int, Dict[str, Union[float, int]]]],
+                Union[float, int, Dict[str, Union[float, int]]],
+            ]
+        ] = None,
+        arrow_padding: Optional[
+            Union[Var[Union[float, int]], Union[float, int]]
+        ] = None,
+        sticky: Optional[
+            Union[Var[Literal["partial", "always"]], Literal["partial", "always"]]
+        ] = None,
+        hide_when_detached: Optional[Union[Var[bool], bool]] = None,
         style: Optional[Style] = None,
         key: Optional[Any] = None,
         id: Optional[Any] = None,
@@ -408,6 +457,9 @@ class DropdownMenuContent(RadixThemesComponent):
             Union[EventHandler, EventSpec, list, function, BaseVar]
         ] = None,
         on_focus: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_focus_outside: Optional[
             Union[EventHandler, EventSpec, list, function, BaseVar]
         ] = None,
         on_interact_outside: Optional[
@@ -457,6 +509,21 @@ class DropdownMenuContent(RadixThemesComponent):
             *children: Child components.
             color: map to CSS default color property.
             color_scheme: map to radix color property.
+            size: Dropdown Menu Content size "1" - "2"
+            variant: Variant of Dropdown Menu Content: "solid" | "soft"
+            high_contrast: Renders the Dropdown Menu Content in higher contrast
+            as_child: Change the default rendered element for the one passed as a child, merging their props and behavior. Defaults to False.
+            loop: When True, keyboard navigation will loop from last item to first, and vice versa. Defaults to False.
+            force_mount: Used to force mounting when more control is needed. Useful when controlling animation with React animation libraries.
+            side: The preferred side of the trigger to render against when open. Will be reversed when collisions occur and `avoid_collisions` is enabled.The position of the tooltip. Defaults to "top".
+            side_offset: The distance in pixels from the trigger. Defaults to 0.
+            align: The preferred alignment against the trigger. May change when collisions occur. Defaults to "center".
+            align_offset: An offset in pixels from the "start" or "end" alignment options.
+            avoid_collisions: When true, overrides the side and align preferences to prevent collisions with boundary edges. Defaults to True.
+            collision_padding: The distance in pixels from the boundary edges where collision detection should occur. Accepts a number (same for all sides), or a partial padding object, for example: { "top": 20, "left": 20 }. Defaults to 0.
+            arrow_padding: The padding between the arrow and the edges of the content. If your content has border-radius, this will prevent it from overflowing the corners. Defaults to 0.
+            sticky: The sticky behavior on the align axis. "partial" will keep the content in the boundary as long as the trigger is at least partially in the boundary whilst "always" will keep the content in the boundary regardless. Defaults to "partial".
+            hide_when_detached: Whether to hide the content when the trigger becomes fully occluded. Defaults to False.
             style: The style of the component.
             key: A unique key for the component.
             id: The id for the component.
@@ -540,6 +607,9 @@ class DropdownMenuSubTrigger(RadixThemesComponent):
                 ],
             ]
         ] = None,
+        as_child: Optional[Union[Var[bool], bool]] = None,
+        disabled: Optional[Union[Var[bool], bool]] = None,
+        text_value: Optional[Union[Var[str], str]] = None,
         style: Optional[Style] = None,
         key: Optional[Any] = None,
         id: Optional[Any] = None,
@@ -603,6 +673,9 @@ class DropdownMenuSubTrigger(RadixThemesComponent):
             *children: Child components.
             color: map to CSS default color property.
             color_scheme: map to radix color property.
+            as_child: Change the default rendered element for the one passed as a child, merging their props and behavior. Defaults to False.
+            disabled: When true, prevents the user from interacting with the item.
+            text_value: Optional text used for typeahead purposes. By default the typeahead behavior will use the .textContent of the item. Use this when the content is complex, or you have non-textual content inside.
             style: The style of the component.
             key: A unique key for the component.
             id: The id for the component.
@@ -618,6 +691,7 @@ class DropdownMenuSubTrigger(RadixThemesComponent):
         ...
 
 class DropdownMenuSub(RadixThemesComponent):
+    def get_event_triggers(self) -> Dict[str, Any]: ...
     @overload
     @classmethod
     def create(  # type: ignore
@@ -686,6 +760,8 @@ class DropdownMenuSub(RadixThemesComponent):
                 ],
             ]
         ] = None,
+        open: Optional[Union[Var[bool], bool]] = None,
+        default_open: Optional[Union[Var[bool], bool]] = None,
         style: Optional[Style] = None,
         key: Optional[Any] = None,
         id: Optional[Any] = None,
@@ -732,6 +808,9 @@ class DropdownMenuSub(RadixThemesComponent):
         on_mouse_up: Optional[
             Union[EventHandler, EventSpec, list, function, BaseVar]
         ] = None,
+        on_open_change: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
         on_scroll: Optional[
             Union[EventHandler, EventSpec, list, function, BaseVar]
         ] = None,
@@ -749,6 +828,8 @@ class DropdownMenuSub(RadixThemesComponent):
             *children: Child components.
             color: map to CSS default color property.
             color_scheme: map to radix color property.
+            open: The controlled open state of the submenu. Must be used in conjunction with `on_open_change`.
+            default_open: The open state of the submenu when it is initially rendered. Use when you do not need to control its open state.
             style: The style of the component.
             key: A unique key for the component.
             id: The id for the component.
@@ -764,6 +845,7 @@ class DropdownMenuSub(RadixThemesComponent):
         ...
 
 class DropdownMenuSubContent(RadixThemesComponent):
+    def get_event_triggers(self) -> Dict[str, Any]: ...
     @overload
     @classmethod
     def create(  # type: ignore
@@ -837,6 +919,25 @@ class DropdownMenuSubContent(RadixThemesComponent):
             Union[Var[Literal["solid", "soft"]], Literal["solid", "soft"]]
         ] = None,
         high_contrast: Optional[Union[Var[bool], bool]] = None,
+        as_child: Optional[Union[Var[bool], bool]] = None,
+        loop: Optional[Union[Var[bool], bool]] = None,
+        force_mount: Optional[Union[Var[bool], bool]] = None,
+        side_offset: Optional[Union[Var[Union[float, int]], Union[float, int]]] = None,
+        align_offset: Optional[Union[Var[Union[float, int]], Union[float, int]]] = None,
+        avoid_collisions: Optional[Union[Var[bool], bool]] = None,
+        collision_padding: Optional[
+            Union[
+                Var[Union[float, int, Dict[str, Union[float, int]]]],
+                Union[float, int, Dict[str, Union[float, int]]],
+            ]
+        ] = None,
+        arrow_padding: Optional[
+            Union[Var[Union[float, int]], Union[float, int]]
+        ] = None,
+        sticky: Optional[
+            Union[Var[Literal["partial", "always"]], Literal["partial", "always"]]
+        ] = None,
+        hide_when_detached: Optional[Union[Var[bool], bool]] = None,
         style: Optional[Style] = None,
         key: Optional[Any] = None,
         id: Optional[Any] = None,
@@ -856,7 +957,16 @@ class DropdownMenuSubContent(RadixThemesComponent):
         on_double_click: Optional[
             Union[EventHandler, EventSpec, list, function, BaseVar]
         ] = None,
+        on_escape_key_down: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
         on_focus: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_focus_outside: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_interact_outside: Optional[
             Union[EventHandler, EventSpec, list, function, BaseVar]
         ] = None,
         on_mount: Optional[
@@ -883,6 +993,9 @@ class DropdownMenuSubContent(RadixThemesComponent):
         on_mouse_up: Optional[
             Union[EventHandler, EventSpec, list, function, BaseVar]
         ] = None,
+        on_pointer_down_outside: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
         on_scroll: Optional[
             Union[EventHandler, EventSpec, list, function, BaseVar]
         ] = None,
@@ -900,9 +1013,19 @@ class DropdownMenuSubContent(RadixThemesComponent):
             *children: Child components.
             color: map to CSS default color property.
             color_scheme: map to radix color property.
-            size: Button size "1" - "4"
-            variant: Variant of button: "solid" | "soft" | "outline" | "ghost"
-            high_contrast: Whether to render the button with higher contrast color against background
+            size: Dropdown Menu Sub Content size "1" - "2"
+            variant: Variant of Dropdown Menu Sub Content: "solid" | "soft"
+            high_contrast: Whether to render the component with higher contrast color against background
+            as_child: Change the default rendered element for the one passed as a child, merging their props and behavior. Defaults to False.
+            loop: When True, keyboard navigation will loop from last item to first, and vice versa. Defaults to False.
+            force_mount: Used to force mounting when more control is needed. Useful when controlling animation with React animation libraries.
+            side_offset: The distance in pixels from the trigger. Defaults to 0.
+            align_offset: An offset in pixels from the "start" or "end" alignment options.
+            avoid_collisions: When true, overrides the side and align preferences to prevent collisions with boundary edges. Defaults to True.
+            collision_padding: The distance in pixels from the boundary edges where collision detection should occur. Accepts a number (same for all sides), or a partial padding object, for example: { "top": 20, "left": 20 }. Defaults to 0.
+            arrow_padding: The padding between the arrow and the edges of the content. If your content has border-radius, this will prevent it from overflowing the corners. Defaults to 0.
+            sticky: The sticky behavior on the align axis. "partial" will keep the content in the boundary as long as the trigger is at least partially in the boundary whilst "always" will keep the content in the boundary regardless. Defaults to "partial".
+            hide_when_detached: Whether to hide the content when the trigger becomes fully occluded. Defaults to False.
             style: The style of the component.
             key: A unique key for the component.
             id: The id for the component.
@@ -918,6 +1041,7 @@ class DropdownMenuSubContent(RadixThemesComponent):
         ...
 
 class DropdownMenuItem(RadixThemesComponent):
+    def get_event_triggers(self) -> Dict[str, Any]: ...
     @overload
     @classmethod
     def create(  # type: ignore
@@ -987,6 +1111,9 @@ class DropdownMenuItem(RadixThemesComponent):
             ]
         ] = None,
         shortcut: Optional[Union[Var[str], str]] = None,
+        as_child: Optional[Union[Var[bool], bool]] = None,
+        disabled: Optional[Union[Var[bool], bool]] = None,
+        text_value: Optional[Union[Var[str], str]] = None,
         style: Optional[Style] = None,
         key: Optional[Any] = None,
         id: Optional[Any] = None,
@@ -1036,6 +1163,9 @@ class DropdownMenuItem(RadixThemesComponent):
         on_scroll: Optional[
             Union[EventHandler, EventSpec, list, function, BaseVar]
         ] = None,
+        on_select: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
         on_unmount: Optional[
             Union[EventHandler, EventSpec, list, function, BaseVar]
         ] = None,
@@ -1051,6 +1181,9 @@ class DropdownMenuItem(RadixThemesComponent):
             color: map to CSS default color property.
             color_scheme: map to radix color property.
             shortcut: Shortcut to render a menu item as a link
+            as_child: Change the default rendered element for the one passed as a child, merging their props and behavior. Defaults to False.
+            disabled: When true, prevents the user from interacting with the item.
+            text_value: Optional text used for typeahead purposes. By default the typeahead behavior will use the .textContent of the item. Use this when the content is complex, or you have non-textual content inside.
             style: The style of the component.
             key: A unique key for the component.
             id: The id for the component.

--- a/reflex/constants/event.py
+++ b/reflex/constants/event.py
@@ -92,3 +92,4 @@ class EventTriggers(SimpleNamespace):
     ON_UNMOUNT = "on_unmount"
     ON_CLEAR_SERVER_ERRORS = "on_clear_server_errors"
     ON_VALUE_COMMIT = "on_value_commit"
+    ON_SELECT = "on_select"


### PR DESCRIPTION
## Summary
- Add dropdown props inherited from their primitive counterparts
- Examples:
```
rx.vstack(
    rdxt.dropdownmenu_root(
        rdxt.dropdownmenu_trigger(
            rdxt.button(
                "menu",
                variant="soft",
            ),
        ),
        rdxt.dropdownmenu_content(
            rdxt.dropdownmenu_item("apple"),
            rdxt.dropdownmenu_item("orange"),
            variant="soft",
        ),
    ),
    rdxt.dropdownmenu_root(
        rdxt.dropdownmenu_trigger(
            rdxt.button(
                "menu on left",
                variant="soft",
            ),
        ),
        rdxt.dropdownmenu_content(
            rdxt.dropdownmenu_item("apple"),
            rdxt.dropdownmenu_item("orange"),
            variant="soft",
            side="left",
        ),
    ),
    rdxt.dropdownmenu_root(
        rdxt.dropdownmenu_trigger(
            rdxt.button(
                "menu on left far away",
                variant="soft",
            ),
        ),
        rdxt.dropdownmenu_content(
            rdxt.dropdownmenu_item("apple"),
            rdxt.dropdownmenu_item("orange"),
            variant="soft",
            side="left",
            side_offset=100,
        ),
    ),
    rdxt.dropdownmenu_root(
        rdxt.dropdownmenu_trigger(
            rdxt.button(
                "menu goes up",
                variant="soft",
            ),
        ),
        rdxt.dropdownmenu_content(
            rdxt.dropdownmenu_item("apple"),
            rdxt.dropdownmenu_item("orange"),
            variant="soft",
            side="top",
        ),
    ),
    rdxt.dropdownmenu_root(
        rdxt.dropdownmenu_trigger(
            rdxt.button(
                "sub-menus",
                variant="soft",
            ),
        ),
        rdxt.dropdownmenu_content(
            rdxt.dropdownmenu_item("item"),
            rdxt.dropdownmenu_separator(),
            rdxt.dropdownmenu_sub(
                rdxt.dropdownmenu_sub_trigger(
                    "left more",
                    color_scheme="blue",
                    variant="classic",
                ),
                rdxt.dropdownmenu_sub_content(
                    rdxt.dropdownmenu_item("r1"),
                    rdxt.dropdownmenu_item("r2"),
                ),
            ),
            rdxt.dropdownmenu_separator(),
            rdxt.dropdownmenu_sub(
                rdxt.dropdownmenu_sub_trigger(
                    "more faraway",
                    color_scheme="red",
                    variant="solid",
                ),
                rdxt.dropdownmenu_sub_content(
                    rdxt.dropdownmenu_item("far1"),
                    rdxt.dropdownmenu_item("far2"),
                    side_offset=100,
                ),
            ),
        ),
    ),
)
```