### PR TITLE
Text default as p

### DIFF
--- a/reflex/components/radix/themes/typography/text.py
+++ b/reflex/components/radix/themes/typography/text.py
@@ -28,7 +28,7 @@ class Text(el.Span, RadixThemesComponent):
     as_child: Var[bool]
 
     # Change the default rendered element into a semantically appropriate alternative (cannot be used with asChild)
-    as_: Var[str]
+    as_: Var[str] = "p"
 
     # Text size: "1" - "9"
     size: Var[LiteralTextSize]

--- a/reflex/components/radix/themes/typography/text.py
+++ b/reflex/components/radix/themes/typography/text.py
@@ -4,6 +4,8 @@ https://www.radix-ui.com/themes/docs/theme/typography
 """
 from __future__ import annotations
 
+from typing import Literal
+
 from reflex import el
 from reflex.vars import Var
 
@@ -18,6 +20,8 @@ from .base import (
     LiteralTextWeight,
 )
 
+LiteralType = Literal["p", "label", "div", "span"]
+
 
 class Text(el.Span, RadixThemesComponent):
     """A foundational text primitive based on the <span> element."""
@@ -28,7 +32,7 @@ class Text(el.Span, RadixThemesComponent):
     as_child: Var[bool]
 
     # Change the default rendered element into a semantically appropriate alternative (cannot be used with asChild)
-    as_: Var[str] = "p" # type: ignore
+    as_: Var[LiteralType] = "p"  # type: ignore
 
     # Text size: "1" - "9"
     size: Var[LiteralTextSize]

--- a/reflex/components/radix/themes/typography/text.py
+++ b/reflex/components/radix/themes/typography/text.py
@@ -28,7 +28,7 @@ class Text(el.Span, RadixThemesComponent):
     as_child: Var[bool]
 
     # Change the default rendered element into a semantically appropriate alternative (cannot be used with asChild)
-    as_: Var[str] = "p"
+    as_: Var[str] = "p" # type: ignore
 
     # Text size: "1" - "9"
     size: Var[LiteralTextSize]

--- a/reflex/components/radix/themes/typography/text.pyi
+++ b/reflex/components/radix/themes/typography/text.pyi
@@ -7,10 +7,13 @@ from typing import Any, Dict, Literal, Optional, Union, overload
 from reflex.vars import Var, BaseVar, ComputedVar
 from reflex.event import EventChain, EventHandler, EventSpec
 from reflex.style import Style
+from typing import Literal
 from reflex import el
 from reflex.vars import Var
 from ..base import LiteralAccentColor, RadixThemesComponent
 from .base import LiteralTextAlign, LiteralTextSize, LiteralTextTrim, LiteralTextWeight
+
+LiteralType = Literal["p", "label", "div", "span"]
 
 class Text(el.Span, RadixThemesComponent):
     @overload
@@ -82,7 +85,12 @@ class Text(el.Span, RadixThemesComponent):
             ]
         ] = None,
         as_child: Optional[Union[Var[bool], bool]] = None,
-        as_: Optional[Union[Var[str], str]] = None,
+        as_: Optional[
+            Union[
+                Var[Literal["p", "label", "div", "span"]],
+                Literal["p", "label", "div", "span"],
+            ]
+        ] = None,
         size: Optional[
             Union[
                 Var[Literal["1", "2", "3", "4", "5", "6", "7", "8", "9"]],


### PR DESCRIPTION
Unlike chakra where text defaults to p radix defaults to span change the default behavior 

https://www.radix-ui.com/themes/docs/components/text
