### PR TITLE
Flaky accordion Attribute Error fix.

### DIFF
--- a/reflex/components/radix/primitives/accordion.py
+++ b/reflex/components/radix/primitives/accordion.py
@@ -339,7 +339,7 @@ class AccordionRoot(AccordionComponent):
     color_scheme: Var[LiteralAccentColor]  # type: ignore
 
     # dynamic themes of the accordion generated at compile time.
-    _dynamic_themes: Var[dict]
+    _dynamic_themes: Var[dict] = Var.create({})
 
     # The var_data associated with the component.
     _var_data: VarData = VarData()  # type: ignore
@@ -375,7 +375,9 @@ class AccordionRoot(AccordionComponent):
         Returns:
             The dictionary of the component style as value and the style notation as key.
         """
-        return {"css": self._dynamic_themes._merge(format_as_emotion(self.style))}  # type: ignore
+        return {"css": self._dynamic_themes._merge(
+            format_as_emotion(self.style)) if self._dynamic_themes is not None else format_as_emotion(
+            self.style)}  # type: ignore
 
     def _apply_theme(self, theme: Component):
         global_color_scheme = getattr(theme, "accent_color", None)


### PR DESCRIPTION
```python
import reflex as rx

class State(rx.State):
    """The app state."""
    items: list[tuple[str, str]] = [
        ("Item 1", "Content 1"),
        ("Item 2", "Content 2"),
        ("Item 3", "Content 3"),
    ]

def index():
    return rx.accordion.root(
        rx.foreach(
            State.items, lambda item: rx.accordion.item(item[0], item[1])
        ),
        collapsible=True,
    )
# Add state and page to the app.
app = rx.App(
theme=rx.theme(
        has_background=True, radius="none", accent_color="grass", appearance="light",
    ),
)
app.add_page(index)

```
Earlier Today running the code above against `reflex-0.4.0` threw an AttributeError for me:

```
  File "/Users/eli/Documents/work/Pynecone-io/pynecone-forks/reflex/reflex/reflex.py", line 257, in run
    _run(env, frontend, backend, frontend_port, backend_port, backend_host, loglevel)
  File "/Users/eli/Documents/work/Pynecone-io/pynecone-forks/reflex/reflex/reflex.py", line 188, in _run
    prerequisites.get_compiled_app()
  File "/Users/eli/Documents/work/Pynecone-io/pynecone-forks/reflex/reflex/utils/prerequisites.py", line 188, in get_compiled_app
    app_module = get_app(reload=reload)
                 ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/eli/Documents/work/Pynecone-io/pynecone-forks/reflex/reflex/utils/prerequisites.py", line 164, in get_app
    app = __import__(module, fromlist=(constants.CompileVars.APP,))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/eli/Documents/work/Pynecone-io/pynecone-forks/reflex/example_prj/exp/exp/exp.py", line 30, in <module>
    app.add_page(index)
  File "/Users/eli/Documents/work/Pynecone-io/pynecone-forks/reflex/reflex/app.py", line 424, in add_page
    component = Fragment.create(
                ^^^^^^^^^^^^^^^^
  File "/Users/eli/Documents/work/Pynecone-io/pynecone-forks/reflex/reflex/components/component.py", line 572, in create
    children = [
               ^
  File "/Users/eli/Documents/work/Pynecone-io/pynecone-forks/reflex/reflex/components/component.py", line 575, in <listcomp>
    else Bare.create(contents=Var.create(child, _var_is_string=True))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/eli/Documents/work/Pynecone-io/pynecone-forks/reflex/reflex/vars.py", line 324, in create
    name = value if type_ in types.JSONType else serializers.serialize(value)
                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/eli/Documents/work/Pynecone-io/pynecone-forks/reflex/reflex/utils/serializers.py", line 78, in serialize
    return serializer(value)
           ^^^^^^^^^^^^^^^^^
  File "/Users/eli/Documents/work/Pynecone-io/pynecone-forks/reflex/reflex/utils/serializers.py", line 181, in serialize_list
    fprop = format.json_dumps(list(value))
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/eli/Documents/work/Pynecone-io/pynecone-forks/reflex/reflex/utils/format.py", line 644, in json_dumps
    return json.dumps(obj, ensure_ascii=False, default=serialize)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
          ^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/json/encoder.py", line 258, in iterencode
    return _iterencode(o, 0)
           ^^^^^^^^^^^^^^^^^
  File "/Users/eli/Documents/work/Pynecone-io/pynecone-forks/reflex/reflex/utils/serializers.py", line 78, in serialize
    return serializer(value)
           ^^^^^^^^^^^^^^^^^
  File "/Users/eli/Documents/work/Pynecone-io/pynecone-forks/reflex/reflex/components/component.py", line 1383, in serialize_component
    return str(comp)
           ^^^^^^^^^
  File "/Users/eli/Documents/work/Pynecone-io/pynecone-forks/reflex/reflex/components/component.py", line 445, in __str__
    return _compile_component(self)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/eli/Documents/work/Pynecone-io/pynecone-forks/reflex/reflex/compiler/compiler.py", line 178, in _compile_component
    return templates.COMPONENT.render(component=component)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/eli/Library/Caches/pypoetry/virtualenvs/reflex-K7o9YeT9-py3.11/lib/python3.11/site-packages/jinja2/environment.py", line 1301, in render
    self.environment.handle_exception()
  File "/Users/eli/Library/Caches/pypoetry/virtualenvs/reflex-K7o9YeT9-py3.11/lib/python3.11/site-packages/jinja2/environment.py", line 936, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/Users/eli/Documents/work/Pynecone-io/pynecone-forks/reflex/reflex/.templates/jinja/web/pages/component.js.jinja2", line 2, in top-level template code
    {{utils.render(component.render())}}
    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/eli/Documents/work/Pynecone-io/pynecone-forks/reflex/reflex/components/component.py", line 637, in render
    tag = self._render()
          ^^^^^^^^^^^^^^
  File "/Users/eli/Documents/work/Pynecone-io/pynecone-forks/reflex/reflex/components/component.py", line 505, in _render
    props.update(self._get_style())
                 ^^^^^^^^^^^^^^^^^
  File "/Users/eli/Documents/work/Pynecone-io/pynecone-forks/reflex/reflex/components/radix/primitives/accordion.py", line 378, in _get_style
    return {"css": self._dynamic_themes._merge(format_as_emotion(self.style))}  # type: ignore
  
AttributeError: 'AccordionRoot' object has no attribute '_dynamic_themes'
```

However, the same code against the same branch seems to work fine without reproducing the error for @Lendemor .
This PR seems to fix the issue, however, the code works now even without this PR changes. Putting this out here as perhaps an investigation may need to be conducted to figure out the flakiness.