### PR TITLE
keep-chakra: whitelist is always whitelist

### DIFF
--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -1003,18 +1003,17 @@ def _get_rx_chakra_component_to_migrate() -> set[str]:
     rx_chakra_names = set(dir(reflex.chakra))
 
     names_to_migrate = set()
+
+    # whitelist names will always be rewritten as rx.chakra.<x>
     whitelist = {
-        "CodeBlock",
         "ColorModeIcon",
         "MultiSelect",
         "MultiSelectOption",
-        "base",
-        "code_block",
-        "color_mode_cond",
         "color_mode_icon",
         "multi_select",
         "multi_select_option",
     }
+
     for rx_chakra_name in sorted(rx_chakra_names):
         if rx_chakra_name.startswith("_"):
             continue
@@ -1032,12 +1031,8 @@ def _get_rx_chakra_component_to_migrate() -> set[str]:
                 rx_chakra_object, ChakraComponent
             ):
                 names_to_migrate.add(rx_chakra_name)
-                pass
-            else:
-                # For the given rx.chakra.<x>, does rx.<x> exist?
-                # And of these, should we include in migration?
-                if hasattr(reflex, rx_chakra_name) and rx_chakra_name in whitelist:
-                    names_to_migrate.add(rx_chakra_name)
+            elif rx_chakra_name in whitelist:
+                names_to_migrate.add(rx_chakra_name)
 
         except Exception:
             raise


### PR DESCRIPTION
Regardless of whether the same name exists in the top level rx.<x> namespace, always convert whitelisted names to rx.chakra.<x>

Prior to this change, `rx.color_mode_icon()` was not getting converted to `rx.chakra.color_mode_icon()` because `rx.color_mode_icon` no longer exists (in radix, it has become `rx.color_mode.icon()`).

Remove the `code_block` and `color_mode_cond` from the whitelist, since those were moved out of the chakra namespace.

Remove `base` from the whitelist, because `rx.base` still exists and never pointed into the chakra namespace.