### PR TITLE
[REF-1925]Accordion foreach fix

### DIFF
--- a/reflex/components/radix/primitives/accordion.py
+++ b/reflex/components/radix/primitives/accordion.py
@@ -546,10 +546,8 @@ def accordion_item(
     """Create an accordion item.
 
     Args:
-        header: The header of the accordion item. This could be a regular component
-                or a Var when you use a foreach
-        content: The content of the accordion item. This could be a regular component
-                or a Var when you use a foreach.
+        header: The header of the accordion item.
+        content: The content of the accordion item.
         **props: Additional properties to apply to the accordion item.
 
     Returns:

--- a/reflex/components/radix/primitives/accordion.py
+++ b/reflex/components/radix/primitives/accordion.py
@@ -339,7 +339,7 @@ class AccordionRoot(AccordionComponent):
     color_scheme: Var[LiteralAccentColor]  # type: ignore
 
     # dynamic themes of the accordion generated at compile time.
-    _dynamic_themes: Var[dict] = Var.create({})
+    _dynamic_themes: Var[dict] = Var.create({})  # type: ignore
 
     # The var_data associated with the component.
     _var_data: VarData = VarData()  # type: ignore

--- a/reflex/components/radix/primitives/accordion.py
+++ b/reflex/components/radix/primitives/accordion.py
@@ -339,7 +339,7 @@ class AccordionRoot(AccordionComponent):
     color_scheme: Var[LiteralAccentColor]  # type: ignore
 
     # dynamic themes of the accordion generated at compile time.
-    _dynamic_themes: Var[dict]
+    _dynamic_themes: Var[dict] = Var.create({})
 
     # The var_data associated with the component.
     _var_data: VarData = VarData()  # type: ignore
@@ -540,19 +540,23 @@ to {
 """
 
 
-def accordion_item(header: Component, content: Component, **props) -> Component:
+def accordion_item(
+    header: Component | Var, content: Component | Var, **props
+) -> Component:
     """Create an accordion item.
 
     Args:
-        header: The header of the accordion item.
-        content: The content of the accordion item.
+        header: The header of the accordion item. This could be a regular component
+                or a Var when you use a foreach
+        content: The content of the accordion item. This could be a regular component
+                or a Var when you use a foreach.
         **props: Additional properties to apply to the accordion item.
 
     Returns:
         The accordion item.
     """
     # The item requires a value to toggle (use the header as the default value).
-    value = props.pop("value", str(header))
+    value = props.pop("value", header if isinstance(header, Var) else str(header))
 
     return AccordionItem.create(
         AccordionHeader.create(

--- a/reflex/components/radix/primitives/accordion.pyi
+++ b/reflex/components/radix/primitives/accordion.pyi
@@ -625,7 +625,9 @@ class AccordionContent(AccordionComponent):
         """
         ...
 
-def accordion_item(header: Component, content: Component, **props) -> Component: ...
+def accordion_item(
+    header: Component | Var, content: Component | Var, **props
+) -> Component: ...
 
 class Accordion(SimpleNamespace):
     content = staticmethod(AccordionContent.create)


### PR DESCRIPTION
When a foreach is used to create accordion items( like in the example code below) and a value not supplied in the resulting render function, the str of the header value supplied is inferred to be the accordion value (this is what the accordion trigger uses in determining which item to trigger). However, for foreach, the header is passed as a Var. The `str` of the var renders improperly. This PR fixes that.

```python
import reflex as rx


class State(rx.State):
    """The app state."""
    items: list[tuple[str, str]] = [
        ("Item 1", "Content 1"),
        ("Item 2", "Content 2"),
        ("Item 3", "Content 3"),
    ]

def index():
    return rx.accordion.root(
        rx.foreach(
            State.items, lambda item: rx.accordion.item(item[0], item[1])
        ),
        collapsible=True,
    )

# Add state and page to the app.
app = rx.App(
    theme=rx.radix.themes.theme(
        has_background=True, radius="none", accent_color="orange", appearance="light",
    ),
)
app.add_page(index)

```
