### PR TITLE
Fix rx.progress to support `max` prop

### DIFF
--- a/reflex/components/radix/primitives/progress.py
+++ b/reflex/components/radix/primitives/progress.py
@@ -55,6 +55,9 @@ class ProgressIndicator(ProgressComponent):
     # The current progress value.
     value: Var[Optional[int]]
 
+    # The maximum progress value.
+    max: Var[Optional[int]]
+
     def _apply_theme(self, theme: Component):
         self.style = Style(
             {
@@ -65,7 +68,7 @@ class ProgressIndicator(ProgressComponent):
                 "&[data_state='loading']": {
                     "transition": f"transform {DEFAULT_ANIMATION_DURATION}ms linear",
                 },
-                "transform": f"translateX(calc(-100% + {self.value}%))",  # type: ignore
+                "transform": f"translateX(calc(-100% + ({self.value} / {self.max} * 100%)))",  # type: ignore
                 "boxShadow": "inset 0 0 0 1px var(--gray-a5)",
             }
         )
@@ -91,8 +94,10 @@ class Progress(SimpleNamespace):
         style = props.setdefault("style", {})
         style.update({"width": width})
 
+        max = props.pop("max", 100)
         return ProgressRoot.create(
-            ProgressIndicator.create(value=props.get("value")),
+            ProgressIndicator.create(value=props.get("value"), max=max),
+            max=max,
             **props,
         )
 

--- a/reflex/components/radix/primitives/progress.py
+++ b/reflex/components/radix/primitives/progress.py
@@ -94,10 +94,10 @@ class Progress(SimpleNamespace):
         style = props.setdefault("style", {})
         style.update({"width": width})
 
-        max = props.pop("max", 100)
         return ProgressRoot.create(
-            ProgressIndicator.create(value=props.get("value"), max=max),
-            max=max,
+            ProgressIndicator.create(
+                value=props.get("value"), max=props.get("max", 100)
+            ),
             **props,
         )
 

--- a/reflex/components/radix/primitives/progress.pyi
+++ b/reflex/components/radix/primitives/progress.pyi
@@ -188,6 +188,7 @@ class ProgressIndicator(ProgressComponent):
         cls,
         *children,
         value: Optional[Union[Var[Optional[int]], Optional[int]]] = None,
+        max: Optional[Union[Var[Optional[int]], Optional[int]]] = None,
         as_child: Optional[Union[Var[bool], bool]] = None,
         style: Optional[Style] = None,
         key: Optional[Any] = None,
@@ -247,6 +248,7 @@ class ProgressIndicator(ProgressComponent):
         Args:
             *children: The children of the component.
             value: The current progress value.
+            max: The maximum progress value.
             as_child: Change the default rendered element for the one passed as a child.
             style: The style of the component.
             key: A unique key for the component.


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Description

Support `max` prop in rx.progress

Tested with the following:

```python
import reflex as rx


class State(rx.State):
    val: int = 40
    big: int = 400
    big_max: int = 1000

    def set_end(self, new_val: int):
        self.val = new_val


@rx.page()
def index() -> rx.Component:
    return rx.vstack(
        rx.slider(on_value_commit=State.set_end),
        rx.progress(value=State.val),
        rx.progress(value=State.big, max=State.big_max),
        rx.progress(value=40),
        rx.progress(value=400, max=1000),
        gap="1rem",
        padding="1rem",
    )


app = rx.App()
app.add_page(index)


```