### PR TITLE
[REF-1978]Fix issue with Accordion header custom code not being imported

### DIFF
--- a/reflex/components/radix/primitives/accordion.py
+++ b/reflex/components/radix/primitives/accordion.py
@@ -471,9 +471,9 @@ class AccordionItem(AccordionComponent):
     @classmethod
     def create(
         cls,
-        *children,
         header: Optional[Component | Var] = None,
         content: Optional[Component | Var] = None,
+        *children,
         **props,
     ) -> Component:
         """Create an accordion item.


### PR DESCRIPTION
Follow up PR to #2600
The `*children`  as the first param in AccordionItem create method means `header` and `content` will always be `None` if there are no positional args. This PR fixes that