### PR TITLE
Apply themes to drawer content

### DIFF
--- a/reflex/components/radix/primitives/drawer.py
+++ b/reflex/components/radix/primitives/drawer.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from typing import Any, Dict, List, Literal, Optional, Union
 
 from reflex.components.radix.primitives.base import RadixPrimitiveComponent
+from reflex.components.radix.themes.base import Theme
 from reflex.constants import EventTriggers
 from reflex.vars import Var
 
@@ -141,6 +142,25 @@ class DrawerContent(DrawerComponent):
             EventTriggers.ON_POINTER_DOWN_OUTSIDE: lambda e0: [e0.target.value],
             EventTriggers.ON_INTERACT_OUTSIDE: lambda e0: [e0.target.value],
         }
+
+    @classmethod
+    def create(cls, *children, **props):
+        """Create a Drawer Content.
+         We wrap the Drawer content in an `rx.theme` to make radix themes definitions available to
+         rendered div in the DOM. This is because Vaul Drawer injects the Drawer overlay content in a sibling
+         div to the root div rendered by radix which contains styling definitions. Wrapping in `rx.theme`
+         makes the styling available to the overlay.
+
+        Args:
+            *children: The list of children to use if header and content are not provided.
+            **props: Additional properties to apply to the accordion item.
+
+        Returns:
+                 The drawer content.
+        """
+        comp = super().create(*children, **props)
+
+        return Theme.create(comp)
 
 
 class DrawerOverlay(DrawerComponent):

--- a/reflex/components/radix/primitives/drawer.py
+++ b/reflex/components/radix/primitives/drawer.py
@@ -152,8 +152,8 @@ class DrawerContent(DrawerComponent):
          makes the styling available to the overlay.
 
         Args:
-            *children: The list of children to use if header and content are not provided.
-            **props: Additional properties to apply to the accordion item.
+            *children: The list of children to use.
+            **props: Additional properties to apply to the drawer content.
 
         Returns:
                  The drawer content.

--- a/reflex/components/radix/primitives/drawer.pyi
+++ b/reflex/components/radix/primitives/drawer.pyi
@@ -10,6 +10,7 @@ from reflex.style import Style
 from types import SimpleNamespace
 from typing import Any, Dict, List, Literal, Optional, Union
 from reflex.components.radix.primitives.base import RadixPrimitiveComponent
+from reflex.components.radix.themes.base import Theme
 from reflex.constants import EventTriggers
 from reflex.vars import Var
 
@@ -442,10 +443,14 @@ class DrawerContent(DrawerComponent):
         ] = None,
         **props
     ) -> "DrawerContent":
-        """Create the component.
+        """Create a Drawer Content.
+         We wrap the Drawer content in an `rx.theme` to make radix themes definitions available to
+         rendered div in the DOM. This is because Vaul Drawer injects the Drawer overlay content in a sibling
+         div to the root div rendered by radix which contains styling definitions. Wrapping in `rx.theme`
+         makes the styling available to the overlay.
 
         Args:
-            *children: The children of the component.
+            *children: The list of children to use if header and content are not provided.
             as_child: Change the default rendered element for the one passed as a child.
             style: The style of the component.
             key: A unique key for the component.
@@ -453,13 +458,10 @@ class DrawerContent(DrawerComponent):
             class_name: The class name for the component.
             autofocus: Whether the component should take the focus once the page is loaded
             custom_attrs: custom attribute
-            **props: The props of the component.
+            **props: Additional properties to apply to the accordion item.
 
         Returns:
-            The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
+                 The drawer content.
         """
         ...
 

--- a/reflex/components/radix/primitives/drawer.pyi
+++ b/reflex/components/radix/primitives/drawer.pyi
@@ -450,7 +450,7 @@ class DrawerContent(DrawerComponent):
          makes the styling available to the overlay.
 
         Args:
-            *children: The list of children to use if header and content are not provided.
+            *children: The list of children to use.
             as_child: Change the default rendered element for the one passed as a child.
             style: The style of the component.
             key: A unique key for the component.
@@ -458,7 +458,7 @@ class DrawerContent(DrawerComponent):
             class_name: The class name for the component.
             autofocus: Whether the component should take the focus once the page is loaded
             custom_attrs: custom attribute
-            **props: Additional properties to apply to the accordion item.
+            **props: Additional properties to apply to the drawer content.
 
         Returns:
                  The drawer content.


### PR DESCRIPTION
This PR wraps the Drawer content in an `rx.theme` to make radix themes definitions available to  rendered div in the DOM. This is because Vaul Drawer injects the Drawer overlay content in a sibling div to the root div rendered by radix which contains styling definitions. Wrapping in `rx.theme`  makes the styling available to the overlay

```python
import reflex as rx

def index():
    return rx.fragment(
        rx.drawer.root(
            rx.drawer.trigger(
                rx.button("Open Drawer"),
            ),

            rx.drawer.overlay(),
            rx.drawer.portal(
                    rx.drawer.content(
                        rx.flex(
                            rx.button("another button"),
                            rx.drawer.close("Close"),
                            align_items="start",
                            direction="column",
                        ),
                        top="auto",
                        right="auto",
                        height="100%",
                        width="20em",
                        padding="2em",
                    ),

            ),
            direction="left",
        )
    )

# Add state and page to the app.
app = rx.App(
    theme=rx.theme(
        has_background=True, radius="none", accent_color="orange", appearance="light",
    ),
)
app.add_page(index)
```


![Screenshot 2024-02-14 at 8 59 58 PM](https://github.com/reflex-dev/reflex/assets/19895635/fba3e8ec-04b9-4146-b4df-994a59a7361d)





