### PR TITLE
Inherit _rename_props from parent classes

### DIFF
--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -190,6 +190,14 @@ class Component(BaseComponent, ABC):
                 field.required = False
                 field.default = Var.create(field.default)
 
+        # Ensure renamed props from parent classes are applied to the subclass.
+        if cls._rename_props:
+            inherited_rename_props = {}
+            for parent in reversed(cls.mro()):
+                if issubclass(parent, Component) and parent._rename_props:
+                    inherited_rename_props.update(parent._rename_props)
+            cls._rename_props = inherited_rename_props
+
     def __init__(self, *args, **kwargs):
         """Initialize the component.
 

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -1183,3 +1183,33 @@ def test_validate_invalid_children():
                 ),
             )
         )
+
+
+def test_rename_props():
+    """Test that _rename_props works and is inherited."""
+
+    class C1(Component):
+        tag = "C1"
+
+        prop1: Var[str]
+        prop2: Var[str]
+
+        _rename_props = {"prop1": "renamed_prop1", "prop2": "renamed_prop2"}
+
+    class C2(C1):
+        tag = "C2"
+
+        prop3: Var[str]
+
+        _rename_props = {"prop2": "subclass_prop2", "prop3": "renamed_prop3"}
+
+    c1 = C1.create(prop1="prop1_1", prop2="prop2_1")
+    rendered_c1 = c1.render()
+    assert "renamed_prop1={`prop1_1`}" in rendered_c1["props"]
+    assert "renamed_prop2={`prop2_1`}" in rendered_c1["props"]
+
+    c2 = C2.create(prop1="prop1_2", prop2="prop2_2", prop3="prop3_2")
+    rendered_c2 = c2.render()
+    assert "renamed_prop1={`prop1_2`}" in rendered_c2["props"]
+    assert "subclass_prop2={`prop2_2`}" in rendered_c2["props"]
+    assert "renamed_prop3={`prop3_2`}" in rendered_c2["props"]


### PR DESCRIPTION
Ensure that _rename_props from base classes add to the list of _rename_props in subclasses.

Add a test case to validate this behavior.