### PR TITLE
When a Var points to a model, prefer access to model fields.

### DIFF
--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -1900,8 +1900,9 @@ class ComputedVar(Var, property):
         """
         d = set()
         if obj is None:
-            if self.fget is not None:
-                obj = cast(FunctionType, self.fget)
+            fget = property.__getattribute__(self, "fget")
+            if fget is not None:
+                obj = cast(FunctionType, fget)
             else:
                 return set()
         with contextlib.suppress(AttributeError):
@@ -1979,7 +1980,7 @@ class ComputedVar(Var, property):
         Returns:
             The type of the var.
         """
-        hints = get_type_hints(self.fget)
+        hints = get_type_hints(property.__getattribute__(self, "fget"))
         if "return" in hints:
             return hints["return"]
         return Any

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -667,6 +667,33 @@ class Var:
             _var_is_string=False,
         )
 
+    def __getattribute__(self, name: str) -> Any:
+        """Get a var attribute.
+
+        Args:
+            name: The name of the attribute.
+
+        Returns:
+            The var attribute.
+
+        Raises:
+            AttributeError: If the attribute cannot be found, or if __getattr__ fallback should be used.
+        """
+        try:
+            var_attribute = super().__getattribute__(name)
+            if not name.startswith("_"):
+                # Check if the attribute should be accessed through the Var instead of
+                # accessing one of the Var operations
+                type_ = types.get_attribute_access_type(
+                    super().__getattribute__("_var_type"), name
+                )
+                if type_ is not None:
+                    raise AttributeError(f"{name} is being accessed through the Var.")
+            # Return the attribute as-is.
+            return var_attribute
+        except AttributeError:
+            raise  # fall back to __getattr__ anyway
+
     def __getattr__(self, name: str) -> Var:
         """Get a var attribute.
 


### PR DESCRIPTION
When a Var points to a model, and fields of the model share the same name as Var operations, access to the model fields is now preferred to avoid having Var operation names shadow model fields. Since most Var operations do not actually work against Models, this does not really block any functionality.

```python
import reflex as rx


class BadModel(rx.Base):
    split: str = "This string just says split"
    reverse: str = "This string just says reverse"
    nice_name: str = "nice.job"


class State(rx.State):
    """The app state."""
    m: BadModel = BadModel()

    @rx.var
    def n(self) -> BadModel:
        return BadModel()


def index() -> rx.Component:
    return rx.fragment(
        rx.color_mode.button(rx.color_mode.icon(), float="right"),
        rx.vstack(
            rx.heading("Welcome to Reflex!", font_size="2em"),
            rx.text(State.m.split),
            rx.text(State.m.reverse),
            rx.text(State.m.nice_name.split(".")[0]),
            rx.text(State.n.split),
            rx.text(State.n.reverse),
            rx.text(State.n.nice_name.split(".")[0]),
            gap="1.5em",
            font_size="2em",
            padding_top="10%",
        ),
    )


# Create app instance and add index page.
app = rx.App()
app.add_page(index)
```