### PR TITLE
fixed bug in var type for iterable types

### DIFF
--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -585,9 +585,9 @@ class Var:
 
             # Get the type of the indexed var.
             if types.is_generic_alias(self._var_type):
-                index  = i if not isinstance(i, Var) else 0
+                index = i if not isinstance(i, Var) else 0
                 type_ = types.get_args(self._var_type)
-                type_ = type_[index%len(type_)]
+                type_ = type_[index % len(type_)]
             elif types._issubclass(self._var_type, str):
                 type_ = str
 

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -585,7 +585,9 @@ class Var:
 
             # Get the type of the indexed var.
             if types.is_generic_alias(self._var_type):
-                type_ = types.get_args(self._var_type)[0]
+                index  = i if not isinstance(i, Var) else 0
+                type_ = types.get_args(self._var_type)
+                type_ = type_[index%len(type_)]
             elif types._issubclass(self._var_type, str):
                 type_ = str
 

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -458,6 +458,7 @@ def test_var_indexing_lists(var):
     # Test negative indexing.
     assert str(var[-1]) == f"{{{var._var_name}.at(-1)}}"
 
+
 @pytest.mark.parametrize(
     "var, type_",
     [
@@ -470,12 +471,11 @@ def test_var_indexing_types(var, type_):
 
     Args:
         var   : The list, typle base var.
-        type_ : The type on indexed object. 
+        type_ : The type on indexed object.
 
     """
     assert var[2]._var_type == type_[0]
     assert var[3]._var_type == type_[1]
-
 
 
 def test_var_indexing_str():

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -469,8 +469,8 @@ def test_var_indexing_types(var, type_):
     """Test that indexing returns valid types.
 
     Args:
-    var   : The list, typle base var.
-    type_ : The type on indexed object. 
+        var   : The list, typle base var.
+        type_ : The type on indexed object. 
 
     """
     assert var[2]._var_type == type_[0]

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -458,6 +458,25 @@ def test_var_indexing_lists(var):
     # Test negative indexing.
     assert str(var[-1]) == f"{{{var._var_name}.at(-1)}}"
 
+@pytest.mark.parametrize(
+    "var, type_",
+    [
+        (BaseVar(_var_name="list", _var_type=List[int]), [int, int]),
+        (BaseVar(_var_name="tuple", _var_type=Tuple[int, str]), [int, str]),
+    ],
+)
+def test_var_indexing_types(var, type_):
+    """Test that indexing returns valid types.
+
+    Args:
+    var   : The list, typle base var.
+    type_ : The type on indexed object. 
+
+    """
+    assert var[2]._var_type == type_[0]
+    assert var[3]._var_type == type_[1]
+
+
 
 def test_var_indexing_str():
     """Test that we can index into str vars."""


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

## Description
Fixed bug with assigning var type incase of Iterable types

## Linked Issue
closes #2543   