### PR TITLE
[REF-1902] [REF-1987] Chakra upgrade message

### DIFF
--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -84,6 +84,10 @@ def _init(
 
     prerequisites.ensure_reflex_installation_id()
 
+    # When upgrading to 0.4, show migration instructions.
+    if prerequisites.should_show_rx_chakra_migration_instructions():
+        prerequisites.show_rx_chakra_migration_instructions()
+
     # Set up the app directory, only if the config doesn't exist.
     if not os.path.exists(constants.Config.FILE):
         if template is None:
@@ -99,9 +103,6 @@ def _init(
 
     # Migrate Pynecone projects to Reflex.
     prerequisites.migrate_to_reflex()
-
-    if prerequisites.should_show_rx_chakra_migration_instructions():
-        prerequisites.show_rx_chakra_migration_instructions()
 
     # Initialize the .gitignore.
     prerequisites.initialize_gitignore()

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -982,7 +982,7 @@ def show_rx_chakra_migration_instructions():
         "[bold]Run `reflex script keep-chakra` to automatically update your app."
     )
     console.log("")
-    console.log("For more details, please see https://TODO")  # TODO add link to docs
+    console.log("For more details, please see https://reflex.dev/blog/2024-02-15-reflex-v0.4.0")
 
 
 def migrate_to_rx_chakra():

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -949,8 +949,15 @@ def should_show_rx_chakra_migration_instructions() -> bool:
     if os.getenv("REFLEX_PROMPT_MIGRATE_TO_RX_CHAKRA") == "yes":
         return True
 
-    with open(constants.Dirs.REFLEX_JSON, "r") as f:
-        data = json.load(f)
+    if not Path(constants.Config.FILE).exists():
+        # They are running reflex init for the first time.
+        return False
+
+    existing_init_reflex_version = None
+    reflex_json = Path(constants.Dirs.REFLEX_JSON)
+    if reflex_json.exists():
+        with reflex_json.open("r") as f:
+            data = json.load(f)
         existing_init_reflex_version = data.get("version", None)
 
     if existing_init_reflex_version is None:


### PR DESCRIPTION
Show rx.chakra upgrade message _before_ overwriting the version

Ensure that the conditions for showing the rx.chakra upgrade message are checked before overwriting the version saved in .web/reflex.json.

Check for the absense of a config file to suppress the upgrade message when init'ing a brand new project.

Check for the existance of `reflex.json` before opening it, since it might not exist at the point it's checked.

Update more information link to point to the soon-to-be-published blog post.