### PR TITLE
Quick fixes for regressions in 0.4.0

### DIFF
--- a/reflex/__init__.py
+++ b/reflex/__init__.py
@@ -107,6 +107,7 @@ _ALL_COMPONENTS = [
     "list_item",
     "unordered_list",
     "ordered_list",
+    "moment",
 ]
 
 _MAPPING = {

--- a/reflex/__init__.pyi
+++ b/reflex/__init__.pyi
@@ -93,6 +93,7 @@ from reflex.components import markdown as markdown
 from reflex.components import list_item as list_item
 from reflex.components import unordered_list as unordered_list
 from reflex.components import ordered_list as ordered_list
+from reflex.components import moment as moment
 from reflex.components.component import Component as Component
 from reflex.components.component import NoSSRComponent as NoSSRComponent
 from reflex.components.component import memo as memo

--- a/reflex/components/el/elements/media.py
+++ b/reflex/components/el/elements/media.py
@@ -1,5 +1,5 @@
 """Element classes. This is an auto-generated file. Do not edit. See ../generate.py."""
-from typing import Union
+from typing import Any, Union
 
 from reflex.vars import Var as Var
 
@@ -108,7 +108,7 @@ class Img(BaseHTML):
     sizes: Var[Union[str, int, bool]]
 
     # URL of the image to display
-    src: Var[Union[str, int, bool]]
+    src: Var[Any]
 
     # A set of source sizes and URLs for responsive images
     src_set: Var[Union[str, int, bool]]

--- a/reflex/components/el/elements/media.pyi
+++ b/reflex/components/el/elements/media.pyi
@@ -7,7 +7,7 @@ from typing import Any, Dict, Literal, Optional, Union, overload
 from reflex.vars import Var, BaseVar, ComputedVar
 from reflex.event import EventChain, EventHandler, EventSpec
 from reflex.style import Style
-from typing import Union
+from typing import Any, Union
 from reflex.vars import Var as Var
 from .base import BaseHTML
 
@@ -376,7 +376,7 @@ class Img(BaseHTML):
         sizes: Optional[
             Union[Var[Union[str, int, bool]], Union[str, int, bool]]
         ] = None,
-        src: Optional[Union[Var[Union[str, int, bool]], Union[str, int, bool]]] = None,
+        src: Optional[Union[Var[Any], Any]] = None,
         src_set: Optional[
             Union[Var[Union[str, int, bool]], Union[str, int, bool]]
         ] = None,


### PR DESCRIPTION
rx.el.img accepts Any type for src prop: This retains compatibility with the previous chakra image src prop.

Re-add `moment` back to top-level namespace