### PR TITLE
[REF-1984]Drawer component styles should only be in css dict

### DIFF
--- a/reflex/components/radix/primitives/drawer.py
+++ b/reflex/components/radix/primitives/drawer.py
@@ -119,12 +119,7 @@ class DrawerContent(DrawerComponent):
         }
         style = self.style or {}
         base_style.update(style)
-        self.style.update(
-            {
-                "css": base_style,
-            }
-        )
-        return self.style
+        return {"css": base_style}
 
     def get_event_triggers(self) -> Dict[str, Any]:
         """Get the events triggers signatures for the component.
@@ -188,12 +183,7 @@ class DrawerOverlay(DrawerComponent):
         }
         style = self.style or {}
         base_style.update(style)
-        self.style.update(
-            {
-                "css": base_style,
-            }
-        )
-        return self.style
+        return {"css": base_style}
 
 
 class DrawerClose(DrawerComponent):
@@ -226,12 +216,7 @@ class DrawerTitle(DrawerComponent):
         }
         style = self.style or {}
         base_style.update(style)
-        self.style.update(
-            {
-                "css": base_style,
-            }
-        )
-        return self.style
+        return {"css": base_style}
 
 
 class DrawerDescription(DrawerComponent):
@@ -253,12 +238,7 @@ class DrawerDescription(DrawerComponent):
         }
         style = self.style or {}
         base_style.update(style)
-        self.style.update(
-            {
-                "css": base_style,
-            }
-        )
-        return self.style
+        return {"css": base_style}
 
 
 class Drawer(ComponentNamespace):

--- a/reflex/components/tags/tag.py
+++ b/reflex/components/tags/tag.py
@@ -62,11 +62,15 @@ class Tag(Base):
         Returns:
             The tag with the props added.
         """
+        from reflex.components.core.colors import Color
+
         self.props.update(
             {
                 format.to_camel_case(name, allow_hyphens=True): prop
                 if types._isinstance(prop, Union[EventChain, dict])
-                else Var.create(prop)
+                else Var.create(
+                    prop, _var_is_string=isinstance(prop, Color)
+                )  # rx.color is always a string
                 for name, prop in kwargs.items()
                 if self.is_valid_prop(prop)
             }


### PR DESCRIPTION
Currently, the drawer component adds style props into the `css` dict as well as props on the tag. It also adds a nested `css` dict of the same style key-value pairs.

```python
def index():
    return rx.vstack(
        rx.drawer.root(
            rx.drawer.trigger(
                rx.button("Open Drawer"),
                background_color=rx.color("green", 3)
            ),
            rx.drawer.overlay(),
            rx.drawer.portal(

                rx.drawer.content(
                    rx.flex(
                        rx.drawer.close(rx.box(rx.button("Close"))),
                        align_items="start",
                        direction="column",
                    ),
                    top="auto",
                    right="auto",
                    height="100%",
                    width="20em",
                    padding="2em",
                    background_color=rx.color("green", 3),

                ),
            ),
            direction="left",
        ),
    )
```
For instance the drawer content renders in the js like below
```javascript
...
<VaulDrawer.Content backgroundColor={`var(--green-3)`} css={{"left": "0", "right": "auto", "bottom": "0", "top": "auto", "position": "fixed", "zIndex": 50, "display": "flex", "height": "100%", "width": "20em", "padding": "2em", "backgroundColor": "var(--green-3)", "css": {"left": "0", "right": "auto", "bottom": "0", "top": "auto", "position": "fixed", "zIndex": 50, "display": "flex", "height": "100%", "width": "20em", "padding": "2em", "backgroundColor": "var(--green-3)"}}} height={`100%`} padding={`2em`} right={`auto`} top={`auto`} width={`20em`}>
     <RadixThemesFlex css={{ "alignItems": "start" }} direction={`column`}>
           <VaulDrawer.Close>
                 <RadixThemesBox>
                      <RadixThemesButton>
                        {`Close`}
                      </RadixThemesButton>
                 </RadixThemesBox>
            </VaulDrawer.Close>
       </RadixThemesFlex>
</VaulDrawer.Content>

```

This PR ensures that style props end up only in the `css` dict.

Also fixes the error below reported in this PR #465 
<img width="1401" alt="Screenshot 2024-02-14 at 4 52 12 PM (2)" src="https://github.com/reflex-dev/reflex/assets/19895635/31ecabe4-ec84-47e6-8d01-59d947c7e311">

