### PR TITLE
fix: File upload error after using rx.clear_selected_files

### DIFF
--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -341,7 +341,7 @@ export const connect = async (
  */
 export const uploadFiles = async (handler, files, upload_id, on_upload_progress, socket) => {
   // return if there's no file to upload
-  if (files.length == 0) {
+  if (files === undefined || files.length === 0) {
     return false;
   }
 


### PR DESCRIPTION
After rx.clear_selected_files events, uploading the empty list fails with an error. I have tested it manually in reflex.examples, where the clear_selected_files has been removed when moving to 0.4.0.
