### PR TITLE
Use sync redis client to determine prod mode worker number and add sanity check

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1,4 +1,5 @@
 """Define the reflex state specification."""
+
 from __future__ import annotations
 
 import asyncio


### PR DESCRIPTION
## Summary
- Use sync redis client to determine prod mode worker number and add sanity check.
- Redis async connection tries to acquire the lock when initializing. In python 3.8 and 3.9, a loop argument was not passed when acquiring lock and fails to find the event loop. From python 3.10, loop was removed and the asyncio APIs are simplified.
## Tests
- Using python 3.8 or 3.9 and run simple apps such as counter: `REDIS_URL='redis://localhost:6379' reflex run --env prod`, the app crashes. With this fix, the app no longer crashes.

