### PR TITLE
bump github action versions

### DIFF
--- a/.github/actions/setup_build_env/action.yml
+++ b/.github/actions/setup_build_env/action.yml
@@ -29,10 +29,10 @@ inputs:
     default: '.venv'
 
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Set up Python ${{ inputs.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ inputs.python-version }}
 
@@ -51,7 +51,7 @@ runs:
 
     - name: Restore cached poetry install
       id: restore-poetry-cache
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: ~/.local
         key: ${{ runner.os }}-python-${{ inputs.python-version }}-poetry-${{ inputs.poetry-version }}
@@ -67,14 +67,14 @@ runs:
 
     - if: steps.restore-poetry-cache.outputs.cache-hit != 'true'
       name: Save poetry install to cache
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       with:
         path: ~/.local
         key: ${{ steps.restore-poetry-cache.outputs.cache-primary-key }}
 
     - name: Restore cached project python deps
       id: restore-pydeps-cache
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       with:
         path: ${{ inputs.create-venv-at-path }}
         key: ${{ runner.os }}-python-${{ inputs.python-version }}-pydeps-${{ hashFiles('**/poetry.lock') }}
@@ -93,7 +93,7 @@ runs:
 
     - if: steps.restore-pydeps-cache.outputs.cache-hit != 'true'
       name: Save Python deps to cache
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       with:
         path: ${{ inputs.create-venv-at-path }}
         key: ${{ steps.restore-pydeps-cache.outputs.cache-primary-key }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,11 +2,11 @@ name: benchmarking
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths-ignore:
       - '**/*.md'
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths-ignore:
       - '**/*.md'
 
@@ -18,9 +18,9 @@ defaults:
     shell: bash
 
 env:
-  PYTHONIOENCODING: "utf8"
+  PYTHONIOENCODING: 'utf8'
   TELEMETRY_ENABLED: false
-  NODE_OPTIONS: "--max_old_space_size=4096"
+  NODE_OPTIONS: '--max_old_space_size=4096'
 
 jobs:
   reflex-web:
@@ -28,15 +28,15 @@ jobs:
       fail-fast: false
       matrix:
         # Show OS combos first in GUI
-        os: [ ubuntu-latest]
-        python-version: [ "3.11.4" ]
-        node-version: [ "16.x" ]
+        os: [ubuntu-latest]
+        python-version: ['3.11.4']
+        node-version: ['16.x']
 
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - uses: ./.github/actions/setup_build_env
@@ -64,12 +64,11 @@ jobs:
           npm -v
           poetry run bash scripts/benchmarks.sh ./reflex-web prod
         env:
-            LHCI_GITHUB_APP_TOKEN: $
+          LHCI_GITHUB_APP_TOKEN: $
       - name: Run Benchmarks
         working-directory: ./integration/benchmarks
-        run: 
-          poetry run python benchmarks.py "$GITHUB_SHA" .lighthouseci
+        run: poetry run python benchmarks.py "$GITHUB_SHA" .lighthouseci
         env:
-            GITHUB_SHA: ${{ github.sha }}
-            DATABASE_URL: ${{ secrets.DATABASE_URL }}
-            PR_TITLE: ${{ github.event.pull_request.title }}
+          GITHUB_SHA: ${{ github.sha }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/integration_app_harness.yml
+++ b/.github/workflows/integration_app_harness.yml
@@ -48,7 +48,7 @@ jobs:
         REDIS_URL: ${{ matrix.state_manager == 'redis' && 'redis://localhost:6379' || '' }}
       run: |
         poetry run pytest integration
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       name: Upload failed test screenshots
       if: always()
       with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -2,11 +2,11 @@ name: integration-tests
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ['main']
     paths-ignore:
       - '**/*.md'
   pull_request:
-    branches: [ "main" ]
+    branches: ['main']
     paths-ignore:
       - '**/*.md'
 
@@ -23,9 +23,9 @@ env:
   # TODO: can we fix windows encoding natively within reflex? Bug above can hit real users too (less common, but possible)
   # - Catch encoding errors when printing logs
   # - Best effort print lines that contain illegal chars (map to some default char, etc.)
-  PYTHONIOENCODING: "utf8"
+  PYTHONIOENCODING: 'utf8'
   TELEMETRY_ENABLED: false
-  NODE_OPTIONS: "--max_old_space_size=4096"
+  NODE_OPTIONS: '--max_old_space_size=4096'
 
 jobs:
   example-counter:
@@ -35,29 +35,29 @@ jobs:
       fail-fast: false
       matrix:
         # Show OS combos first in GUI
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
-        node-version: [ "16.x" ]
-        python-version: ["3.8.18", "3.9.18", "3.10.13", "3.11.5", "3.12.0"]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        node-version: ['16.x']
+        python-version: ['3.8.18', '3.9.18', '3.10.13', '3.11.5', '3.12.0']
         exclude:
           - os: windows-latest
-            python-version: "3.10.13"
+            python-version: '3.10.13'
           - os: windows-latest
-            python-version: "3.9.18"
+            python-version: '3.9.18'
           - os: windows-latest
-            python-version: "3.8.18"
+            python-version: '3.8.18'
         include:
           - os: windows-latest
-            python-version: "3.10.11"
+            python-version: '3.10.11'
           - os: windows-latest
-            python-version: "3.9.13"
+            python-version: '3.9.13'
           - os: windows-latest
-            python-version: "3.8.10"
+            python-version: '3.8.10'
 
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - uses: ./.github/actions/setup_build_env
@@ -102,17 +102,17 @@ jobs:
       fail-fast: false
       matrix:
         # Show OS combos first in GUI
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ "3.10.10", "3.11.4" ]
-        node-version: [ "16.x" ]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.10.10', '3.11.4']
+        node-version: ['16.x']
 
     env:
-      REFLEX_WEB_WINDOWS_OVERRIDE: "1"
+      REFLEX_WEB_WINDOWS_OVERRIDE: '1'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - uses: ./.github/actions/setup_build_env

--- a/.github/workflows/integration_tests_wsl.yml
+++ b/.github/workflows/integration_tests_wsl.yml
@@ -2,11 +2,11 @@ name: integration-tests-wsl
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ['main']
     paths-ignore:
       - '**/*.md'
   pull_request:
-    branches: [ "main" ]
+    branches: ['main']
     paths-ignore:
       - '**/*.md'
 
@@ -15,7 +15,7 @@ permissions:
 
 env:
   TELEMETRY_ENABLED: false
-  NODE_OPTIONS: "--max_old_space_size=4096"
+  NODE_OPTIONS: '--max_old_space_size=4096'
 
 jobs:
   example-counter-wsl:
@@ -32,7 +32,7 @@ jobs:
           repository: reflex-dev/reflex-examples
           path: reflex-examples
 
-      - uses: Vampire/setup-wsl@v2
+      - uses: Vampire/setup-wsl@v3
 
       - name: Install Python
         shell: wsl-bash {0}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,12 +2,12 @@ name: pre-commit
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: ['main']
   push:
     # Note even though this job is called "pre-commit" and runs "pre-commit", this job will run
     # also POST-commit on main also!  In case there are mishandled merge conflicts / bad auto-resolves
     # when merging into main branch.
-    branches: [ "main" ]
+    branches: ['main']
 
 jobs:
   pre-commit:
@@ -21,7 +21,6 @@ jobs:
           # i.e. ruff, black, etc.
           python-version: 3.11.5
           run-poetry-install: true
-          shell: bash
           create-venv-at-path: .venv
       # TODO pre-commit related stuff can be cached too (not a bottleneck yet)
       - run: |


### PR DESCRIPTION
## Summary
- Bump up github actions versions for deprecation warning: 
`Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: Vampire/setup-wsl@v2.` `Please update the following actions to use Node.js 20: actions/setup-python@v4, actions/cache/restore@v3. ` etc
