### PR TITLE
[REF-2045] Implement __reduce_ex__ for MutableProxy 

### DIFF
--- a/reflex/base.py
+++ b/reflex/base.py
@@ -115,6 +115,10 @@ class Base(pydantic.BaseModel):
         Returns:
             The value of the field.
         """
+        if isinstance(key, str) and key in self.__fields__:
+            # Seems like this function signature was wrong all along?
+            # If the user wants a field that we know of, get it and pass it off to _get_value
+            key = getattr(self, key)
         return self._get_value(
             key,
             to_dict=True,

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -2363,6 +2363,21 @@ class MutableProxy(wrapt.ObjectProxy):
         """
         return copy.deepcopy(self.__wrapped__, memo=memo)
 
+    def __reduce_ex__(self, protocol_version):
+        """Get the state for redis serialization.
+
+        This method is called by cloudpickle to serialize the object.
+
+        It explicitly serializes the wrapped object, stripping off the mutable proxy.
+
+        Args:
+            protocol_version: The protocol version.
+
+        Returns:
+            Tuple of (wrapped class, empty args, class __getstate__)
+        """
+        return self.__wrapped__.__reduce_ex__(protocol_version)
+
 
 @serializer
 def serialize_mutable_proxy(mp: MutableProxy) -> SerializedType:


### PR DESCRIPTION
Pass through `__reduce_ex__` onto the wrapped instance to strip it off when cloudpickling to redis.

#### test_state: augment modify_state test for writing MutableProxy

If the object contains a MutableProxy inside of it, then we should not get a pickling error.

Fix #2687 

Also fix `Base.get_value` to actually accept a `str` key like the signature suggests... retain the existing weird behavior of passing `key` as whatever you like for backward compatibility.