### PR TITLE
Make `rx.Upload` a memoization leaf

### DIFF
--- a/reflex/components/core/upload.py
+++ b/reflex/components/core/upload.py
@@ -8,7 +8,7 @@ from typing import Any, ClassVar, Dict, List, Optional, Union
 from reflex import constants
 from reflex.components.chakra.forms.input import Input
 from reflex.components.chakra.layout.box import Box
-from reflex.components.component import Component
+from reflex.components.component import Component, MemoizationLeaf
 from reflex.constants import Dirs
 from reflex.event import CallableEventSpec, EventChain, EventSpec, call_script
 from reflex.utils import imports
@@ -138,7 +138,7 @@ class UploadFilesProvider(Component):
     tag = "UploadFilesProvider"
 
 
-class Upload(Component):
+class Upload(MemoizationLeaf):
     """A file upload component."""
 
     library = "react-dropzone@14.2.3"

--- a/reflex/components/core/upload.pyi
+++ b/reflex/components/core/upload.pyi
@@ -13,7 +13,7 @@ from typing import Any, ClassVar, Dict, List, Optional, Union
 from reflex import constants
 from reflex.components.chakra.forms.input import Input
 from reflex.components.chakra.layout.box import Box
-from reflex.components.component import Component
+from reflex.components.component import Component, MemoizationLeaf
 from reflex.constants import Dirs
 from reflex.event import CallableEventSpec, EventChain, EventSpec, call_script
 from reflex.utils import imports
@@ -114,7 +114,7 @@ class UploadFilesProvider(Component):
         """
         ...
 
-class Upload(Component):
+class Upload(MemoizationLeaf):
     is_used: ClassVar[bool] = False
 
     @overload


### PR DESCRIPTION
Simple fix to get the code below working:

```python
rx.upload(
            rx.text("Drag and drop files here or click to select files"),
            rx.text("Selected: "),
            rx.foreach(rx.selected_files("upload3"), rx.text),
            id="upload3",
            border="1px dotted rgb(107,99,246)",
            padding="5em",
        ),
```

