### PR TITLE
use direction props from radix.Flex

### DIFF
--- a/reflex/components/radix/themes/layout/stack.py
+++ b/reflex/components/radix/themes/layout/stack.py
@@ -42,7 +42,7 @@ class Stack(Flex):
 class VStack(Stack):
     """A vertical stack component."""
 
-    direction: Var[LiteralFlexDirection] = Var.create_safe("column")
+    direction: Var[LiteralFlexDirection] = "column"  # type: ignore
 
 
 class HStack(Stack):

--- a/reflex/components/radix/themes/layout/stack.py
+++ b/reflex/components/radix/themes/layout/stack.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from reflex.components.component import Component
+from reflex.vars import Var
 
 from ..base import LiteralAlign, LiteralSpacing
-from .flex import Flex
+from .flex import Flex, LiteralFlexDirection
 
 
 class Stack(Flex):
@@ -41,32 +42,10 @@ class Stack(Flex):
 class VStack(Stack):
     """A vertical stack component."""
 
-    @classmethod
-    def create(cls, *children, **props) -> Component:
-        """Create a new instance of the component.
-
-        Args:
-            *children: The children of the stack.
-            **props: The properties of the stack.
-
-        Returns:
-            The stack component.
-        """
-        return super().create(*children, direction="column", **props)
+    direction: Var[LiteralFlexDirection] = Var.create_safe("column")
 
 
 class HStack(Stack):
     """A horizontal stack component."""
 
-    @classmethod
-    def create(cls, *children, **props) -> Component:
-        """Create a new instance of the component.
-
-        Args:
-            *children: The children of the stack.
-            **props: The properties of the stack.
-
-        Returns:
-            The stack component.
-        """
-        return super().create(*children, direction="row", **props)
+    direction: Var[LiteralFlexDirection] = Var.create_safe("row")

--- a/reflex/components/radix/themes/layout/stack.py
+++ b/reflex/components/radix/themes/layout/stack.py
@@ -41,12 +41,32 @@ class Stack(Flex):
 class VStack(Stack):
     """A vertical stack component."""
 
-    def _apply_theme(self, theme: Component):
-        self.style.update({"flex_direction": "column"})
+    @classmethod
+    def create(cls, *children, **props) -> Component:
+        """Create a new instance of the component.
+
+        Args:
+            *children: The children of the stack.
+            **props: The properties of the stack.
+
+        Returns:
+            The stack component.
+        """
+        return super().create(*children, direction="column", **props)
 
 
 class HStack(Stack):
     """A horizontal stack component."""
 
-    def _apply_theme(self, theme: Component):
-        self.style.update({"flex_direction": "row"})
+    @classmethod
+    def create(cls, *children, **props) -> Component:
+        """Create a new instance of the component.
+
+        Args:
+            *children: The children of the stack.
+            **props: The properties of the stack.
+
+        Returns:
+            The stack component.
+        """
+        return super().create(*children, direction="row", **props)

--- a/reflex/components/radix/themes/layout/stack.py
+++ b/reflex/components/radix/themes/layout/stack.py
@@ -42,10 +42,12 @@ class Stack(Flex):
 class VStack(Stack):
     """A vertical stack component."""
 
+    # The direction of the stack.
     direction: Var[LiteralFlexDirection] = "column"  # type: ignore
 
 
 class HStack(Stack):
     """A horizontal stack component."""
 
+    # The direction of the stack.
     direction: Var[LiteralFlexDirection] = "row"  # type: ignore

--- a/reflex/components/radix/themes/layout/stack.py
+++ b/reflex/components/radix/themes/layout/stack.py
@@ -48,4 +48,4 @@ class VStack(Stack):
 class HStack(Stack):
     """A horizontal stack component."""
 
-    direction: Var[LiteralFlexDirection] = Var.create_safe("row")
+    direction: Var[LiteralFlexDirection] = "row"  # type: ignore

--- a/reflex/components/radix/themes/layout/stack.pyi
+++ b/reflex/components/radix/themes/layout/stack.pyi
@@ -8,8 +8,9 @@ from reflex.vars import Var, BaseVar, ComputedVar
 from reflex.event import EventChain, EventHandler, EventSpec
 from reflex.style import Style
 from reflex.components.component import Component
+from reflex.vars import Var
 from ..base import LiteralAlign, LiteralSpacing
-from .flex import Flex
+from .flex import Flex, LiteralFlexDirection
 
 class Stack(Flex):
     @overload
@@ -176,19 +177,15 @@ class VStack(Stack):
     def create(  # type: ignore
         cls,
         *children,
-        as_child: Optional[Union[Var[bool], bool]] = None,
+        spacing: Optional[LiteralSpacing] = "2",
+        align: Optional[LiteralAlign] = "start",
         direction: Optional[
             Union[
                 Var[Literal["row", "column", "row-reverse", "column-reverse"]],
                 Literal["row", "column", "row-reverse", "column-reverse"],
             ]
         ] = None,
-        align: Optional[
-            Union[
-                Var[Literal["start", "center", "end", "baseline", "stretch"]],
-                Literal["start", "center", "end", "baseline", "stretch"],
-            ]
-        ] = None,
+        as_child: Optional[Union[Var[bool], bool]] = None,
         justify: Optional[
             Union[
                 Var[Literal["start", "center", "end", "between"]],
@@ -199,12 +196,6 @@ class VStack(Stack):
             Union[
                 Var[Literal["nowrap", "wrap", "wrap-reverse"]],
                 Literal["nowrap", "wrap", "wrap-reverse"],
-            ]
-        ] = None,
-        spacing: Optional[
-            Union[
-                Var[Literal["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]],
-                Literal["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"],
             ]
         ] = None,
         access_key: Optional[
@@ -304,12 +295,12 @@ class VStack(Stack):
 
         Args:
             *children: The children of the stack.
+            spacing: The spacing between each stack item.
+            align: The alignment of the stack items.
             as_child: Change the default rendered element for the one passed as a child, merging their props and behavior.
             direction: How child items are layed out: "row" | "column" | "row-reverse" | "column-reverse"
-            align: Alignment of children along the main axis: "start" | "center" | "end" | "baseline" | "stretch"
             justify: Alignment of children along the cross axis: "start" | "center" | "end" | "between"
             wrap: Whether children should wrap when they reach the end of their container: "nowrap" | "wrap" | "wrap-reverse"
-            spacing: Gap between children: "0" - "9"
             access_key:  Provides a hint for generating a keyboard shortcut for the current element.
             auto_capitalize: Controls whether and how text input is automatically capitalized as it is entered/edited by the user.
             content_editable: Indicates whether the element's content is editable.
@@ -345,19 +336,15 @@ class HStack(Stack):
     def create(  # type: ignore
         cls,
         *children,
-        as_child: Optional[Union[Var[bool], bool]] = None,
+        spacing: Optional[LiteralSpacing] = "2",
+        align: Optional[LiteralAlign] = "start",
         direction: Optional[
             Union[
                 Var[Literal["row", "column", "row-reverse", "column-reverse"]],
                 Literal["row", "column", "row-reverse", "column-reverse"],
             ]
         ] = None,
-        align: Optional[
-            Union[
-                Var[Literal["start", "center", "end", "baseline", "stretch"]],
-                Literal["start", "center", "end", "baseline", "stretch"],
-            ]
-        ] = None,
+        as_child: Optional[Union[Var[bool], bool]] = None,
         justify: Optional[
             Union[
                 Var[Literal["start", "center", "end", "between"]],
@@ -368,12 +355,6 @@ class HStack(Stack):
             Union[
                 Var[Literal["nowrap", "wrap", "wrap-reverse"]],
                 Literal["nowrap", "wrap", "wrap-reverse"],
-            ]
-        ] = None,
-        spacing: Optional[
-            Union[
-                Var[Literal["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]],
-                Literal["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"],
             ]
         ] = None,
         access_key: Optional[
@@ -473,12 +454,12 @@ class HStack(Stack):
 
         Args:
             *children: The children of the stack.
+            spacing: The spacing between each stack item.
+            align: The alignment of the stack items.
             as_child: Change the default rendered element for the one passed as a child, merging their props and behavior.
             direction: How child items are layed out: "row" | "column" | "row-reverse" | "column-reverse"
-            align: Alignment of children along the main axis: "start" | "center" | "end" | "baseline" | "stretch"
             justify: Alignment of children along the cross axis: "start" | "center" | "end" | "between"
             wrap: Whether children should wrap when they reach the end of their container: "nowrap" | "wrap" | "wrap-reverse"
-            spacing: Gap between children: "0" - "9"
             access_key:  Provides a hint for generating a keyboard shortcut for the current element.
             auto_capitalize: Controls whether and how text input is automatically capitalized as it is entered/edited by the user.
             content_editable: Indicates whether the element's content is editable.

--- a/reflex/components/radix/themes/layout/stack.pyi
+++ b/reflex/components/radix/themes/layout/stack.pyi
@@ -176,13 +176,17 @@ class VStack(Stack):
     def create(  # type: ignore
         cls,
         *children,
-        spacing: Optional[LiteralSpacing] = "2",
-        align: Optional[LiteralAlign] = "start",
         as_child: Optional[Union[Var[bool], bool]] = None,
         direction: Optional[
             Union[
                 Var[Literal["row", "column", "row-reverse", "column-reverse"]],
                 Literal["row", "column", "row-reverse", "column-reverse"],
+            ]
+        ] = None,
+        align: Optional[
+            Union[
+                Var[Literal["start", "center", "end", "baseline", "stretch"]],
+                Literal["start", "center", "end", "baseline", "stretch"],
             ]
         ] = None,
         justify: Optional[
@@ -195,6 +199,12 @@ class VStack(Stack):
             Union[
                 Var[Literal["nowrap", "wrap", "wrap-reverse"]],
                 Literal["nowrap", "wrap", "wrap-reverse"],
+            ]
+        ] = None,
+        spacing: Optional[
+            Union[
+                Var[Literal["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]],
+                Literal["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"],
             ]
         ] = None,
         access_key: Optional[
@@ -294,12 +304,12 @@ class VStack(Stack):
 
         Args:
             *children: The children of the stack.
-            spacing: The spacing between each stack item.
-            align: The alignment of the stack items.
             as_child: Change the default rendered element for the one passed as a child, merging their props and behavior.
             direction: How child items are layed out: "row" | "column" | "row-reverse" | "column-reverse"
+            align: Alignment of children along the main axis: "start" | "center" | "end" | "baseline" | "stretch"
             justify: Alignment of children along the cross axis: "start" | "center" | "end" | "between"
             wrap: Whether children should wrap when they reach the end of their container: "nowrap" | "wrap" | "wrap-reverse"
+            spacing: Gap between children: "0" - "9"
             access_key:  Provides a hint for generating a keyboard shortcut for the current element.
             auto_capitalize: Controls whether and how text input is automatically capitalized as it is entered/edited by the user.
             content_editable: Indicates whether the element's content is editable.
@@ -335,13 +345,17 @@ class HStack(Stack):
     def create(  # type: ignore
         cls,
         *children,
-        spacing: Optional[LiteralSpacing] = "2",
-        align: Optional[LiteralAlign] = "start",
         as_child: Optional[Union[Var[bool], bool]] = None,
         direction: Optional[
             Union[
                 Var[Literal["row", "column", "row-reverse", "column-reverse"]],
                 Literal["row", "column", "row-reverse", "column-reverse"],
+            ]
+        ] = None,
+        align: Optional[
+            Union[
+                Var[Literal["start", "center", "end", "baseline", "stretch"]],
+                Literal["start", "center", "end", "baseline", "stretch"],
             ]
         ] = None,
         justify: Optional[
@@ -354,6 +368,12 @@ class HStack(Stack):
             Union[
                 Var[Literal["nowrap", "wrap", "wrap-reverse"]],
                 Literal["nowrap", "wrap", "wrap-reverse"],
+            ]
+        ] = None,
+        spacing: Optional[
+            Union[
+                Var[Literal["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]],
+                Literal["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"],
             ]
         ] = None,
         access_key: Optional[
@@ -453,12 +473,12 @@ class HStack(Stack):
 
         Args:
             *children: The children of the stack.
-            spacing: The spacing between each stack item.
-            align: The alignment of the stack items.
             as_child: Change the default rendered element for the one passed as a child, merging their props and behavior.
             direction: How child items are layed out: "row" | "column" | "row-reverse" | "column-reverse"
+            align: Alignment of children along the main axis: "start" | "center" | "end" | "baseline" | "stretch"
             justify: Alignment of children along the cross axis: "start" | "center" | "end" | "between"
             wrap: Whether children should wrap when they reach the end of their container: "nowrap" | "wrap" | "wrap-reverse"
+            spacing: Gap between children: "0" - "9"
             access_key:  Provides a hint for generating a keyboard shortcut for the current element.
             auto_capitalize: Controls whether and how text input is automatically capitalized as it is entered/edited by the user.
             content_editable: Indicates whether the element's content is editable.

--- a/reflex/components/radix/themes/layout/stack.pyi
+++ b/reflex/components/radix/themes/layout/stack.pyi
@@ -297,8 +297,8 @@ class VStack(Stack):
             *children: The children of the stack.
             spacing: The spacing between each stack item.
             align: The alignment of the stack items.
-            as_child: Change the default rendered element for the one passed as a child, merging their props and behavior.
             direction: How child items are layed out: "row" | "column" | "row-reverse" | "column-reverse"
+            as_child: Change the default rendered element for the one passed as a child, merging their props and behavior.
             justify: Alignment of children along the cross axis: "start" | "center" | "end" | "between"
             wrap: Whether children should wrap when they reach the end of their container: "nowrap" | "wrap" | "wrap-reverse"
             access_key:  Provides a hint for generating a keyboard shortcut for the current element.
@@ -456,8 +456,8 @@ class HStack(Stack):
             *children: The children of the stack.
             spacing: The spacing between each stack item.
             align: The alignment of the stack items.
-            as_child: Change the default rendered element for the one passed as a child, merging their props and behavior.
             direction: How child items are layed out: "row" | "column" | "row-reverse" | "column-reverse"
+            as_child: Change the default rendered element for the one passed as a child, merging their props and behavior.
             justify: Alignment of children along the cross axis: "start" | "center" | "end" | "between"
             wrap: Whether children should wrap when they reach the end of their container: "nowrap" | "wrap" | "wrap-reverse"
             access_key:  Provides a hint for generating a keyboard shortcut for the current element.


### PR DESCRIPTION
new usage for `rx.stack`

```python
rx.stack(..., direction="row")
rx.hstack()

rx.stack(..., direction="column")
rx.vstack()

rx.stack(..., direction="row-reverse")
rx.stack(..., direction="column-reverse")
```