### PR TITLE
pass lang and custom_attrs from app to html root

### DIFF
--- a/reflex/app.py
+++ b/reflex/app.py
@@ -73,7 +73,6 @@ from reflex.state import (
 )
 from reflex.utils import console, exceptions, format, prerequisites, types
 from reflex.utils.imports import ImportVar
-from reflex.vars import Var
 
 # Define custom types.
 ComponentCallable = Callable[[], Component]
@@ -135,7 +134,7 @@ class App(Base):
     html_lang: Optional[str] = None
 
     # Attributes to add to the html root tag of every page.
-    html_custom_attrs: Optional[Dict[str, Union[Var, str]]] = None
+    html_custom_attrs: Optional[Dict[str, str]] = None
 
     # A component that is present on every page.
     overlay_component: Optional[

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -132,7 +132,7 @@ class App(Base):
     head_components: List[Component] = []
 
     # The language to add to the html root tag of every page.
-    html_lang: Optional[Union[Var[str], str]] = None
+    html_lang: Optional[str] = None
 
     # Attributes to add to the html root tag of every page.
     html_custom_attrs: Optional[Dict[str, Union[Var, str]]] = None

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -132,7 +132,7 @@ class App(Base):
     head_components: List[Component] = []
 
     # The language to add to the html root tag of every page.
-    html_lang: Optional[Union[Var[Union[str, int, bool]], Union[str, int, bool]]] = None
+    html_lang: Optional[Union[Var[str], str]] = None
 
     # Attributes to add to the html root tag of every page.
     html_custom_attrs: Optional[Dict[str, Union[Var, str]]] = None

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -73,6 +73,7 @@ from reflex.state import (
 )
 from reflex.utils import console, exceptions, format, prerequisites, types
 from reflex.utils.imports import ImportVar
+from reflex.vars import Var
 
 # Define custom types.
 ComponentCallable = Callable[[], Component]
@@ -129,6 +130,12 @@ class App(Base):
 
     # Components to add to the head of every page.
     head_components: List[Component] = []
+
+    # The language to add to the html root tag of every page.
+    html_lang: Optional[Union[Var[Union[str, int, bool]], Union[str, int, bool]]] = None
+
+    # Attributes to add to the html root tag of every page.
+    html_custom_attrs: Optional[Dict[str, Union[Var, str]]] = None
 
     # A component that is present on every page.
     overlay_component: Optional[
@@ -779,7 +786,12 @@ class App(Base):
             submit_work(compiler.compile_root_stylesheet, self.stylesheets)
 
             # Compile the root document.
-            submit_work(compiler.compile_document_root, self.head_components)
+            submit_work(
+                compiler.compile_document_root,
+                self.head_components,
+                html_lang=self.html_lang,
+                html_custom_attrs=self.html_custom_attrs,
+            )
 
             # Compile the theme.
             submit_work(compiler.compile_theme, style=self.style)

--- a/reflex/compiler/compiler.py
+++ b/reflex/compiler/compiler.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Iterable, Optional, Type
+from typing import Dict, Iterable, Optional, Type, Union
 
 from reflex import constants
 from reflex.compiler import templates, utils
@@ -17,6 +17,7 @@ from reflex.components.component import (
 from reflex.config import get_config
 from reflex.state import BaseState
 from reflex.utils.imports import ImportVar
+from reflex.vars import Var
 
 
 def _compile_document_root(root: Component) -> str:
@@ -289,7 +290,13 @@ def _compile_tailwind(
     )
 
 
-def compile_document_root(head_components: list[Component]) -> tuple[str, str]:
+def compile_document_root(
+    head_components: list[Component],
+    html_lang: Optional[
+        Union[Var[Union[str, int, bool]], Union[str, int, bool]]
+    ] = None,
+    html_custom_attrs: Optional[Dict[str, Union[Var, str]]] = None,
+) -> tuple[str, str]:
     """Compile the document root.
 
     Args:
@@ -302,7 +309,9 @@ def compile_document_root(head_components: list[Component]) -> tuple[str, str]:
     output_path = utils.get_page_path(constants.PageNames.DOCUMENT_ROOT)
 
     # Create the document root.
-    document_root = utils.create_document_root(head_components)
+    document_root = utils.create_document_root(
+        head_components, html_lang=html_lang, html_custom_attrs=html_custom_attrs
+    )
 
     # Compile the document root.
     code = _compile_document_root(document_root)

--- a/reflex/compiler/compiler.py
+++ b/reflex/compiler/compiler.py
@@ -292,9 +292,7 @@ def _compile_tailwind(
 
 def compile_document_root(
     head_components: list[Component],
-    html_lang: Optional[
-        Union[Var[Union[str, int, bool]], Union[str, int, bool]]
-    ] = None,
+    html_lang: Optional[Union[Var[str], str]] = None,
     html_custom_attrs: Optional[Dict[str, Union[Var, str]]] = None,
 ) -> tuple[str, str]:
     """Compile the document root.

--- a/reflex/compiler/compiler.py
+++ b/reflex/compiler/compiler.py
@@ -301,6 +301,8 @@ def compile_document_root(
 
     Args:
         head_components: The components to include in the head.
+        html_lang: The language of the document, will be added to the html root element.
+        html_custom_attrs: custom attributes added to the html root element.
 
     Returns:
         The path and code of the compiled document root.

--- a/reflex/compiler/compiler.py
+++ b/reflex/compiler/compiler.py
@@ -292,7 +292,7 @@ def _compile_tailwind(
 
 def compile_document_root(
     head_components: list[Component],
-    html_lang: Optional[Union[Var[str], str]] = None,
+    html_lang: Optional[str] = None,
     html_custom_attrs: Optional[Dict[str, Union[Var, str]]] = None,
 ) -> tuple[str, str]:
     """Compile the document root.

--- a/reflex/compiler/utils.py
+++ b/reflex/compiler/utils.py
@@ -264,9 +264,7 @@ def compile_custom_component(
 
 def create_document_root(
     head_components: list[Component] | None = None,
-    html_lang: Optional[
-        Union[Var[Union[str, int, bool]], Union[str, int, bool]]
-    ] = None,
+    html_lang: Optional[Union[Var[str], str]] = None,
     html_custom_attrs: Optional[Dict[str, Union[Var, str]]] = None,
 ) -> Component:
     """Create the document root.

--- a/reflex/compiler/utils.py
+++ b/reflex/compiler/utils.py
@@ -267,14 +267,14 @@ def create_document_root(
     html_lang: Optional[
         Union[Var[Union[str, int, bool]], Union[str, int, bool]]
     ] = None,
-    html_custom_attrs: Union[Dict[str, Union[Var, str]]] = None,
+    html_custom_attrs: Optional[Dict[str, Union[Var, str]]] = None,
 ) -> Component:
     """Create the document root.
 
     Args:
         head_components: The components to add to the head.
-        lang: The language of the document, will be added to the html root element.
-        custom_attrs: custom attributes added to the html root element.
+        html_lang: The language of the document, will be added to the html root element.
+        html_custom_attrs: custom attributes added to the html root element.
 
     Returns:
         The document root.

--- a/reflex/compiler/utils.py
+++ b/reflex/compiler/utils.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Callable, Type
+from typing import Any, Callable, Dict, Optional, Type, Union
 from urllib.parse import urlparse
 
 from pydantic.fields import ModelField
@@ -24,6 +24,7 @@ from reflex.components.component import Component, ComponentStyle, CustomCompone
 from reflex.state import BaseState, Cookie, LocalStorage
 from reflex.style import Style
 from reflex.utils import console, format, imports, path_ops
+from reflex.vars import Var
 
 # To re-export this function.
 merge_imports = imports.merge_imports
@@ -261,11 +262,19 @@ def compile_custom_component(
     )
 
 
-def create_document_root(head_components: list[Component] | None = None) -> Component:
+def create_document_root(
+    head_components: list[Component] | None = None,
+    html_lang: Optional[
+        Union[Var[Union[str, int, bool]], Union[str, int, bool]]
+    ] = None,
+    html_custom_attrs: Union[Dict[str, Union[Var, str]]] = None,
+) -> Component:
     """Create the document root.
 
     Args:
         head_components: The components to add to the head.
+        lang: The language of the document, will be added to the html root element.
+        custom_attrs: custom attributes added to the html root element.
 
     Returns:
         The document root.
@@ -277,6 +286,8 @@ def create_document_root(head_components: list[Component] | None = None) -> Comp
             Main.create(),
             NextScript.create(),
         ),
+        lang=html_lang or "en",
+        custom_attrs=html_custom_attrs or {},
     )
 
 

--- a/reflex/compiler/utils.py
+++ b/reflex/compiler/utils.py
@@ -264,7 +264,7 @@ def compile_custom_component(
 
 def create_document_root(
     head_components: list[Component] | None = None,
-    html_lang: Optional[Union[Var[str], str]] = None,
+    html_lang: Optional[str] = None,
     html_custom_attrs: Optional[Dict[str, Union[Var, str]]] = None,
 ) -> Component:
     """Create the document root.

--- a/reflex/components/base/document.py
+++ b/reflex/components/base/document.py
@@ -34,7 +34,8 @@ class Html(NextDocumentLib):
             Html component.
         """
         if lang is not None and not isinstance(lang, Var):
-            props["lang"] = Var.create(value=lang, _var_is_string=True)
+            lang = Var.create(value=lang, _var_is_string=True)
+        props["lang"] = lang
 
         return super().create(*args, **props)
 

--- a/reflex/components/base/document.py
+++ b/reflex/components/base/document.py
@@ -1,6 +1,9 @@
 """Document components."""
 
+from typing import Optional, Union
+
 from reflex.components.component import Component
+from reflex.vars import Var
 
 
 class NextDocumentLib(Component):
@@ -13,6 +16,8 @@ class Html(NextDocumentLib):
     """The document html."""
 
     tag = "Html"
+
+    lang: Optional[Var[Union[str, int, bool]]] = None
 
 
 class DocumentHead(NextDocumentLib):

--- a/reflex/components/base/document.py
+++ b/reflex/components/base/document.py
@@ -1,6 +1,6 @@
 """Document components."""
 
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from reflex.components.component import Component
 from reflex.vars import Var
@@ -17,7 +17,26 @@ class Html(NextDocumentLib):
 
     tag = "Html"
 
-    lang: Optional[Var[Union[str, int, bool]]] = None
+    lang: Var[str]
+
+    @classmethod
+    def create(
+        cls, *args: Any, lang: Optional[Union[str, Var[str]]] = None, **props: Any
+    ) -> Component:
+        """Create an Html root element.
+
+        Args:
+            *args: The args of the component.
+            lang: The language of the document.
+            **props:The props of the component.
+
+        Returns:
+            Html component.
+        """
+        if lang is not None and not isinstance(lang, Var):
+            props["lang"] = Var.create(value=lang, _var_is_string=True)
+
+        return super().create(*args, **props)
 
 
 class DocumentHead(NextDocumentLib):

--- a/reflex/components/base/document.py
+++ b/reflex/components/base/document.py
@@ -1,9 +1,8 @@
 """Document components."""
 
-from typing import Any, Optional, Union
+from typing import Optional
 
 from reflex.components.component import Component
-from reflex.vars import Var
 
 
 class NextDocumentLib(Component):
@@ -17,27 +16,7 @@ class Html(NextDocumentLib):
 
     tag = "Html"
 
-    lang: Var[str]
-
-    @classmethod
-    def create(
-        cls, *args: Any, lang: Optional[Union[str, Var[str]]] = None, **props: Any
-    ) -> Component:
-        """Create an Html root element.
-
-        Args:
-            *args: The args of the component.
-            lang: The language of the document.
-            **props:The props of the component.
-
-        Returns:
-            Html component.
-        """
-        if lang is not None and not isinstance(lang, Var):
-            lang = Var.create(value=lang, _var_is_string=True)
-        props["lang"] = lang
-
-        return super().create(*args, **props)
+    lang: Optional[str]
 
 
 class DocumentHead(NextDocumentLib):

--- a/reflex/components/base/document.pyi
+++ b/reflex/components/base/document.pyi
@@ -7,7 +7,7 @@ from typing import Any, Dict, Literal, Optional, Union, overload
 from reflex.vars import Var, BaseVar, ComputedVar
 from reflex.event import EventChain, EventHandler, EventSpec
 from reflex.style import Style
-from typing import Optional, Union
+from typing import Any, Optional, Union
 from reflex.components.component import Component
 from reflex.vars import Var
 
@@ -96,7 +96,7 @@ class Html(NextDocumentLib):
     def create(  # type: ignore
         cls,
         *children,
-        lang: Optional[Union[Var[Union[str, int, bool]], Union[str, int, bool]]] = None,
+        lang: Optional[Union[str, Union[Var[str], str]]] = None,
         style: Optional[Style] = None,
         key: Optional[Any] = None,
         id: Optional[Any] = None,
@@ -150,23 +150,21 @@ class Html(NextDocumentLib):
         ] = None,
         **props
     ) -> "Html":
-        """Create the component.
+        """Create an Html root element.
 
         Args:
-            *children: The children of the component.
+            *args: The args of the component.
+            lang: The language of the document.
             style: The style of the component.
             key: A unique key for the component.
             id: The id for the component.
             class_name: The class name for the component.
             autofocus: Whether the component should take the focus once the page is loaded
             custom_attrs: custom attribute
-            **props: The props of the component.
+            **props:The props of the component.
 
         Returns:
-            The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
+            Html component.
         """
         ...
 

--- a/reflex/components/base/document.pyi
+++ b/reflex/components/base/document.pyi
@@ -7,9 +7,8 @@ from typing import Any, Dict, Literal, Optional, Union, overload
 from reflex.vars import Var, BaseVar, ComputedVar
 from reflex.event import EventChain, EventHandler, EventSpec
 from reflex.style import Style
-from typing import Any, Optional, Union
+from typing import Optional
 from reflex.components.component import Component
-from reflex.vars import Var
 
 class NextDocumentLib(Component):
     @overload
@@ -96,7 +95,7 @@ class Html(NextDocumentLib):
     def create(  # type: ignore
         cls,
         *children,
-        lang: Optional[Union[str, Union[Var[str], str]]] = None,
+        lang: Optional[str] = None,
         style: Optional[Style] = None,
         key: Optional[Any] = None,
         id: Optional[Any] = None,
@@ -150,21 +149,23 @@ class Html(NextDocumentLib):
         ] = None,
         **props
     ) -> "Html":
-        """Create an Html root element.
+        """Create the component.
 
         Args:
-            *args: The args of the component.
-            lang: The language of the document.
+            *children: The children of the component.
             style: The style of the component.
             key: A unique key for the component.
             id: The id for the component.
             class_name: The class name for the component.
             autofocus: Whether the component should take the focus once the page is loaded
             custom_attrs: custom attribute
-            **props:The props of the component.
+            **props: The props of the component.
 
         Returns:
-            Html component.
+            The component.
+
+        Raises:
+            TypeError: If an invalid child is passed.
         """
         ...
 

--- a/reflex/components/base/document.pyi
+++ b/reflex/components/base/document.pyi
@@ -7,7 +7,9 @@ from typing import Any, Dict, Literal, Optional, Union, overload
 from reflex.vars import Var, BaseVar, ComputedVar
 from reflex.event import EventChain, EventHandler, EventSpec
 from reflex.style import Style
+from typing import Optional, Union
 from reflex.components.component import Component
+from reflex.vars import Var
 
 class NextDocumentLib(Component):
     @overload
@@ -94,6 +96,7 @@ class Html(NextDocumentLib):
     def create(  # type: ignore
         cls,
         *children,
+        lang: Optional[Union[Var[Union[str, int, bool]], Union[str, int, bool]]] = None,
         style: Optional[Style] = None,
         key: Optional[Any] = None,
         id: Optional[Any] = None,

--- a/tests/compiler/test_compiler.py
+++ b/tests/compiler/test_compiler.py
@@ -199,7 +199,7 @@ def test_create_document_root():
     assert isinstance(root, utils.Html)
     assert isinstance(root.children[0], utils.DocumentHead)
     # Default language.
-    assert str(render_root["lang"]) == "en"
+    assert render_root["lang"] == "en"
     # No children in head.
     assert len(root.children[0].children) == 0
 
@@ -212,6 +212,6 @@ def test_create_document_root():
     # Two children in head.
     assert isinstance(root, utils.Html)
     assert len(root.children[0].children) == 2
-    assert str(render_root["lang"]) == "rx"
+    assert render_root["lang"] == "rx"
     assert isinstance(root.custom_attrs, dict)
     assert root.custom_attrs == {"project": "reflex"}

--- a/tests/compiler/test_compiler.py
+++ b/tests/compiler/test_compiler.py
@@ -195,10 +195,11 @@ def test_create_document_root():
     """Test that the document root is created correctly."""
     # Test with no components.
     root = utils.create_document_root()
+    render_root = root.render()
     assert isinstance(root, utils.Html)
     assert isinstance(root.children[0], utils.DocumentHead)
     # Default language.
-    assert str(root.lang) == "en"
+    assert str(render_root["lang"]) == "en"
     # No children in head.
     assert len(root.children[0].children) == 0
 
@@ -209,7 +210,8 @@ def test_create_document_root():
     ]
     root = utils.create_document_root(head_components=comps, html_lang="rx", html_custom_attrs={"project": "reflex"})  # type: ignore
     # Two children in head.
+    assert isinstance(root, utils.Html)
     assert len(root.children[0].children) == 2
-    assert str(root.lang) == "rx"
+    assert str(render_root["lang"]) == "rx"
     assert isinstance(root.custom_attrs, dict)
     assert root.custom_attrs == {"project": "reflex"}

--- a/tests/compiler/test_compiler.py
+++ b/tests/compiler/test_compiler.py
@@ -195,11 +195,11 @@ def test_create_document_root():
     """Test that the document root is created correctly."""
     # Test with no components.
     root = utils.create_document_root()
-    render_root = root.render()
+    root.render()
     assert isinstance(root, utils.Html)
     assert isinstance(root.children[0], utils.DocumentHead)
     # Default language.
-    assert render_root["lang"] == "en"
+    assert root.lang._var_name == "en"  # type: ignore
     # No children in head.
     assert len(root.children[0].children) == 0
 
@@ -212,6 +212,6 @@ def test_create_document_root():
     # Two children in head.
     assert isinstance(root, utils.Html)
     assert len(root.children[0].children) == 2
-    assert render_root["lang"] == "rx"
+    assert root.lang._var_name == "rx"  # type: ignore
     assert isinstance(root.custom_attrs, dict)
     assert root.custom_attrs == {"project": "reflex"}

--- a/tests/compiler/test_compiler.py
+++ b/tests/compiler/test_compiler.py
@@ -199,7 +199,7 @@ def test_create_document_root():
     assert isinstance(root, utils.Html)
     assert isinstance(root.children[0], utils.DocumentHead)
     # Default language.
-    assert root.lang._var_name == "en"  # type: ignore
+    assert root.lang == "en"  # type: ignore
     # No children in head.
     assert len(root.children[0].children) == 0
 
@@ -212,6 +212,6 @@ def test_create_document_root():
     # Two children in head.
     assert isinstance(root, utils.Html)
     assert len(root.children[0].children) == 2
-    assert root.lang._var_name == "rx"  # type: ignore
+    assert root.lang == "rx"  # type: ignore
     assert isinstance(root.custom_attrs, dict)
     assert root.custom_attrs == {"project": "reflex"}

--- a/tests/compiler/test_compiler.py
+++ b/tests/compiler/test_compiler.py
@@ -198,7 +198,7 @@ def test_create_document_root():
     assert isinstance(root, utils.Html)
     assert isinstance(root.children[0], utils.DocumentHead)
     # Default language.
-    assert root.lang == "en"
+    assert str(root.lang) == "en"
     # No children in head.
     assert len(root.children[0].children) == 0
 
@@ -210,6 +210,6 @@ def test_create_document_root():
     root = utils.create_document_root(head_components=comps, html_lang="rx", html_custom_attrs={"project": "reflex"})  # type: ignore
     # Two children in head.
     assert len(root.children[0].children) == 2
-    assert root.lang == "rx"
+    assert str(root.lang) == "rx"
     assert isinstance(root.custom_attrs, dict)
     assert root.custom_attrs == {"project": "reflex"}

--- a/tests/compiler/test_compiler.py
+++ b/tests/compiler/test_compiler.py
@@ -197,6 +197,8 @@ def test_create_document_root():
     root = utils.create_document_root()
     assert isinstance(root, utils.Html)
     assert isinstance(root.children[0], utils.DocumentHead)
+    # Default language.
+    assert root.lang == "en"
     # No children in head.
     assert len(root.children[0].children) == 0
 
@@ -205,6 +207,9 @@ def test_create_document_root():
         utils.NextScript.create(src="foo.js"),
         utils.NextScript.create(src="bar.js"),
     ]
-    root = utils.create_document_root(head_components=comps)  # type: ignore
+    root = utils.create_document_root(head_components=comps, html_lang="rx", html_custom_attrs={"project": "reflex"})  # type: ignore
     # Two children in head.
     assert len(root.children[0].children) == 2
+    assert root.lang == "rx"
+    assert isinstance(root.custom_attrs, dict)
+    assert root.custom_attrs == {"project": "reflex"}


### PR DESCRIPTION
The HTML root element should have a `lang=en` attribute, mostly for SEO reasons. Also passing custom attributes, can be used for example to add version or xmlns tags.
  
See HTML docs:
- https://www.w3.org/TR/2010/WD-html-markup-20100624/html.html#html.attrs.manifest
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/html?retiredLocale=de 
  
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?
