### PR TITLE
Bump axios version to 1.6.0

### DIFF
--- a/reflex/constants/installer.py
+++ b/reflex/constants/installer.py
@@ -103,7 +103,7 @@ class PackageJson(SimpleNamespace):
 
     DEPENDENCIES = {
         "@emotion/react": "11.11.1",
-        "axios": "1.4.0",
+        "axios": "1.6.0",
         "json5": "2.2.3",
         "next": "14.0.1",
         "next-sitemap": "4.1.8",


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

An issue discovered in Axios 0.8.1 through 1.5.1 inadvertently reveals the confidential XSRF-TOKEN stored in cookies by including it in the HTTP header X-XSRF-TOKEN for every request made to any host allowing attackers to view sensitive information.

This bugfix bumps axios to a secure version

