### PR TITLE
[WIP] Drop cloudpickle v2

### DIFF
--- a/reflex/app.py
+++ b/reflex/app.py
@@ -932,7 +932,7 @@ async def process(
             # assignment will recurse into substates and force recalculation of
             # dependent ComputedVar (dynamic route variables)
             state.router_data = router_data
-            state.router = RouterData(router_data)
+            state.router = RouterData.from_router(router_data)
 
         # Preprocess the event.
         update = await app.preprocess(state, event)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -966,7 +966,7 @@ async def test_dynamic_route_var_route_change_completed_on_load(
             "token": token,
             **on_load_internal.router_data,
         }
-        exp_router = RouterData(exp_router_data)
+        exp_router = RouterData.from_router(exp_router_data)
         process_coro = process(
             app,
             event=on_load_internal,

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -11,7 +11,6 @@ from typing import Any, Dict, Generator, List, Optional, Union
 from unittest.mock import AsyncMock, Mock
 
 import pytest
-from plotly.graph_objects import Figure
 
 import reflex as rx
 from reflex.app import App
@@ -90,7 +89,6 @@ class TestState(BaseState):
     mapping: Dict[str, List[int]] = {"a": [1, 2, 3], "b": [4, 5, 6]}
     obj: Object = Object()
     complex: Dict[int, Object] = {1: Object(), 2: Object()}
-    fig: Figure = Figure()
     dt: datetime.datetime = datetime.datetime.fromisoformat("1989-11-09T18:53:00+01:00")
 
     @ComputedVar
@@ -265,7 +263,6 @@ def test_class_vars(test_state):
         "complex",
         "sum",
         "upper",
-        "fig",
         "dt",
     }
 
@@ -280,7 +277,6 @@ def test_event_handlers(test_state):
         "do_something",
         "set_array",
         "set_complex",
-        "set_fig",
         "set_key",
         "set_mapping",
         "set_num1",
@@ -641,7 +637,6 @@ def test_reset(test_state, child_state):
         "obj",
         "upper",
         "complex",
-        "fig",
         "key",
         "sum",
         "array",
@@ -821,7 +816,7 @@ def test_get_current_page(test_state):
     assert test_state.get_current_page() == ""
 
     route = "mypage/subpage"
-    test_state.router = RouterData({RouteVar.PATH: route})
+    test_state.router = RouterData.from_router({RouteVar.PATH: route})
 
     assert test_state.get_current_page() == route
 

--- a/tests/utils/test_format.py
+++ b/tests/utils/test_format.py
@@ -658,7 +658,6 @@ formatted_router = {
                         2: {"prop1": 42, "prop2": "hello"},
                     },
                     "dt": "1989-11-09 18:53:00+01:00",
-                    "fig": [],
                     "key": "",
                     "map_key": "a",
                     "mapping": {"a": [1, 2, 3], "b": [4, 5, 6]},


### PR DESCRIPTION
In prod mode (`StateManagerRedis`) reflex cloudpickles the whole State which causes problems f.e. with SQLAlchemy, but also with many other libraries. In many cases this also results in unnecessary big redis payloads (all functions, classes, attributes, etc. get pickled for every session).

This PR is still a draft because there are some design decisions to be made.

Essentially, I see 3 options for cloudpickle:
- completely drop cloudpickle
- auto-fallback to cloudpickle (if no serializer could be found)
- explicit cloudpickle only (f.e. with `@rx.var(cloudpickle=True)`)

And the question if we should only rely on pydantics "deserialization" (which the code in this PR currently does) or implement custom "deserialization". Reflex only has an api for custom serializers, but we need both ways to store/restore states from redis.  

We should also think about either disabling pydantic validation for `rx.BaseState` by somehow patching it (pydantic v1 does not allow to disable validation) or using pydantics `construct` instead of `parse_obj` [here](https://github.com/reflex-dev/reflex/pull/2717/files#diff-704efe440192781e072231490ac1d12defd1aba5f6debafbc7907eebcc2abcc7R1948). Using `construct` does require manual construction of sub-models.  

You have to set a `REDIS_URL` env variable to test this PR. Do not forget to clear redis or create a new reflex session, else you will experience problems.  

#2399  
#2189  
#1824  