### PR TITLE
Move on_load_internal and update_vars_internal to substates

### DIFF
--- a/reflex/.templates/jinja/web/utils/context.js.jinja2
+++ b/reflex/.templates/jinja/web/utils/context.js.jinja2
@@ -25,10 +25,20 @@ export const clientStorage = {}
 
 {% if state_name %}
 export const state_name = "{{state_name}}"
-export const onLoadInternalEvent = () => [
-    Event('{{state_name}}.{{const.update_vars_internal}}', {vars: hydrateClientStorage(clientStorage)}),
-    Event('{{state_name}}.{{const.on_load_internal}}')
-]
+export const onLoadInternalEvent = () => {
+    const internal_events = [];
+    const client_storage_vars = hydrateClientStorage(clientStorage);
+    if (client_storage_vars) {
+        internal_events.push(
+            Event(
+                '{{state_name}}.{{const.update_vars_internal}}',
+                {vars: client_storage_vars},
+            ),
+        );
+    }
+    internal_events.push(Event('{{state_name}}.{{const.on_load_internal}}'));
+    return internal_events;
+}
 
 export const initialEvents = () => [
     Event('{{state_name}}.{{const.hydrate}}'),

--- a/reflex/.templates/jinja/web/utils/context.js.jinja2
+++ b/reflex/.templates/jinja/web/utils/context.js.jinja2
@@ -28,7 +28,7 @@ export const state_name = "{{state_name}}"
 export const onLoadInternalEvent = () => {
     const internal_events = [];
     const client_storage_vars = hydrateClientStorage(clientStorage);
-    if (client_storage_vars) {
+    if (client_storage_vars && Object.keys(client_storage_vars).length !== 0) {
         internal_events.push(
             Event(
                 '{{state_name}}.{{const.update_vars_internal}}',

--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -585,7 +585,7 @@ export const useEventLoop = (
       if (storage_to_state_map[e.key]) {
         const vars = {}
         vars[storage_to_state_map[e.key]] = e.newValue
-        const event = Event(`${state_name}.update_vars_internal`, {vars: vars})
+        const event = Event(`${state_name}.update_vars_internal_state.update_vars_internal`, {vars: vars})
         addEvents([event], e);
       }
     };

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -177,7 +177,8 @@ class App(Base):
                     deprecation_version="0.3.5",
                     removal_version="0.5.0",
                 )
-            if len(State.class_subclasses) > 0:
+            # 2 substates are built-in and not considered when determining if app is stateless.
+            if len(State.class_subclasses) > 2:
                 self.state = State
         # Get the config
         config = get_config()

--- a/reflex/constants/compiler.py
+++ b/reflex/constants/compiler.py
@@ -59,9 +59,9 @@ class CompileVars(SimpleNamespace):
     # The name of the function for converting a dict to an event.
     TO_EVENT = "Event"
     # The name of the internal on_load event.
-    ON_LOAD_INTERNAL = "on_load_internal"
+    ON_LOAD_INTERNAL = "on_load_internal_state.on_load_internal"
     # The name of the internal event to update generic state vars.
-    UPDATE_VARS_INTERNAL = "update_vars_internal"
+    UPDATE_VARS_INTERNAL = "update_vars_internal_state.update_vars_internal"
 
 
 class PageNames(SimpleNamespace):

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1556,7 +1556,6 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
         if self.dirty_vars and not self._was_touched:
             for var in self.dirty_vars:
                 if var in self.base_vars or var in self._backend_vars:
-                    print(f"Touched: {self.get_full_name()}: {self.dirty_vars}")
                     self._was_touched = True
                     break
         return self._was_touched

--- a/reflex/testing.py
+++ b/reflex/testing.py
@@ -70,6 +70,10 @@ else:
     FRONTEND_POPEN_ARGS["start_new_session"] = True
 
 
+# Save a copy of internal substates to reset after each test.
+INTERNAL_STATES = State.class_subclasses.copy()
+
+
 # borrowed from py3.11
 class chdir(contextlib.AbstractContextManager):
     """Non thread-safe context manager to change the current working directory."""
@@ -220,6 +224,7 @@ class AppHarness:
             reflex.config.get_config(reload=True)
             # reset rx.State subclasses
             State.class_subclasses.clear()
+            State.class_subclasses.update(INTERNAL_STATES)
             State._always_dirty_substates = set()
             State.get_class_substate.cache_clear()
             # Ensure the AppHarness test does not skip State assignment due to running via pytest

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -31,6 +31,7 @@ from reflex.middleware import HydrateMiddleware
 from reflex.model import Model
 from reflex.state import (
     BaseState,
+    OnLoadInternalState,
     RouterData,
     State,
     StateManagerRedis,
@@ -897,7 +898,7 @@ class DynamicState(BaseState):
         # self.side_effect_counter = self.side_effect_counter + 1
         return self.dynamic
 
-    on_load_internal = State.on_load_internal.fn
+    on_load_internal = OnLoadInternalState.on_load_internal.fn
 
 
 @pytest.mark.asyncio
@@ -962,7 +963,7 @@ async def test_dynamic_route_var_route_change_completed_on_load(
     prev_exp_val = ""
     for exp_index, exp_val in enumerate(exp_vals):
         on_load_internal = _event(
-            name=f"{state.get_full_name()}.{constants.CompileVars.ON_LOAD_INTERNAL}",
+            name=f"{state.get_full_name()}.{constants.CompileVars.ON_LOAD_INTERNAL.rpartition('.')[2]}",
             val=exp_val,
         )
         exp_router_data = {
@@ -997,8 +998,8 @@ async def test_dynamic_route_var_route_change_completed_on_load(
                     name="on_load",
                     val=exp_val,
                 ),
-                _dynamic_state_event(
-                    name="set_is_hydrated",
+                _event(
+                    name="state.set_is_hydrated",
                     payload={"value": True},
                     val=exp_val,
                     router_data={},

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -23,6 +23,7 @@ from reflex.state import (
     ImmutableStateError,
     LockExpiredError,
     MutableProxy,
+    OnLoadInternalState,
     RouterData,
     State,
     StateManager,
@@ -2503,7 +2504,9 @@ async def test_preprocess(app_module_mock, token, test_state, expected, mocker):
         expected: Expected delta.
         mocker: pytest mock object.
     """
-    mocker.patch("reflex.state.State.class_subclasses", {test_state})
+    mocker.patch(
+        "reflex.state.State.class_subclasses", {test_state, OnLoadInternalState}
+    )
     app = app_module_mock.app = App(
         state=State, load_events={"index": [test_state.test_handler]}
     )
@@ -2544,7 +2547,9 @@ async def test_preprocess_multiple_load_events(app_module_mock, token, mocker):
         token: A token.
         mocker: pytest mock object.
     """
-    mocker.patch("reflex.state.State.class_subclasses", {OnLoadState})
+    mocker.patch(
+        "reflex.state.State.class_subclasses", {OnLoadState, OnLoadInternalState}
+    )
     app = app_module_mock.app = App(
         state=State,
         load_events={"index": [OnLoadState.test_handler, OnLoadState.test_handler]},

--- a/tests/test_state_tree.py
+++ b/tests/test_state_tree.py
@@ -38,6 +38,25 @@ class SubA_A_A_A(SubA_A_A):
     sub_a_a_a_a: int
 
 
+class SubA_A_A_B(SubA_A_A):
+    """SubA_A_A_B is a child of SubA_A_A."""
+
+    @rx.cached_var
+    def sub_a_a_a_cached(self) -> int:
+        """A cached var.
+
+        Returns:
+            The value of sub_a_a_a + 1
+        """
+        return self.sub_a_a_a + 1
+
+
+class SubA_A_A_C(SubA_A_A):
+    """SubA_A_A_C is a child of SubA_A_A."""
+
+    sub_a_a_a_c: int
+
+
 class SubA_A_B(SubA_A):
     """SubA_A_B is a child of SubA_A."""
 
@@ -158,6 +177,21 @@ class SubE_A_A_A_C(SubE_A_A_A):
     sub_e_a_a_a_c: int
 
 
+class SubE_A_A_A_D(SubE_A_A_A):
+    """SubE_A_A_A_D is a child of SubE_A_A_A."""
+
+    sub_e_a_a_a_d: int
+
+    @rx.cached_var
+    def sub_e_a_a_a_d_var(self) -> int:
+        """A computed var.
+
+        Returns:
+            The value of sub_e_a_a_a_a + 1
+        """
+        return self.sub_e_a_a_a + 1
+
+
 ALWAYS_COMPUTED_VARS = {
     TreeD.get_full_name(): {"d_var": 1},
     SubE_A_A_A_A.get_full_name(): {"sub_e_a_a_a_a_var": 1},
@@ -171,6 +205,7 @@ ALWAYS_COMPUTED_DICT_KEYS = [
     SubE_A_A.get_full_name(),
     SubE_A_A_A.get_full_name(),
     SubE_A_A_A_A.get_full_name(),
+    SubE_A_A_A_D.get_full_name(),
 ]
 
 
@@ -207,6 +242,8 @@ def state_manager_redis(app_module_mock) -> Generator[StateManager, None, None]:
                 SubA_A.get_full_name(),
                 SubA_A_A.get_full_name(),
                 SubA_A_A_A.get_full_name(),
+                SubA_A_A_B.get_full_name(),
+                SubA_A_A_C.get_full_name(),
                 SubA_A_B.get_full_name(),
                 SubA_B.get_full_name(),
                 TreeB.get_full_name(),
@@ -229,6 +266,8 @@ def state_manager_redis(app_module_mock) -> Generator[StateManager, None, None]:
                 SubA_A.get_full_name(),
                 SubA_A_A.get_full_name(),
                 SubA_A_A_A.get_full_name(),
+                SubA_A_A_B.get_full_name(),
+                SubA_A_A_C.get_full_name(),
                 SubA_A_B.get_full_name(),
                 SubA_B.get_full_name(),
                 *ALWAYS_COMPUTED_DICT_KEYS,
@@ -242,6 +281,7 @@ def state_manager_redis(app_module_mock) -> Generator[StateManager, None, None]:
                 SubA_A.get_full_name(),
                 SubA_A_A.get_full_name(),
                 SubA_A_A_A.get_full_name(),
+                SubA_A_A_B.get_full_name(),  # Cached var dep
                 *ALWAYS_COMPUTED_DICT_KEYS,
             ],
         ),


### PR DESCRIPTION
Avoid loading the entire state tree to process these common internal events. If the state tree is very large, this allow page navigation to occur more quickly.

New initial hydrate fast path saves a round trip for pages that do not use any on_load events.

If an app does not set any cookies or local storage, skip `update_vars_internal` syncing of client storage to backend.

Do not persist states that were never modified. Do not persist states during initialization.

Avoid copying router_data into each substate.

Pre-fetch substates that contain cached vars, as they may need to be recomputed if certain vars change.