### PR TITLE
Add missing header variable in el components in __init__.py file.

### DIFF
--- a/reflex/components/el/elements/__init__.py
+++ b/reflex/components/el/elements/__init__.py
@@ -146,6 +146,7 @@ address = Address.create
 article = Article.create
 aside = Aside.create
 body = Body.create
+header = Header.create
 footer = Footer.create
 
 # Typography


### PR DESCRIPTION
### All Submissions:

- [X] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [X] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

### Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

### Description:

I have added to the   \_\_init__.py file of the html components the header variable, which was not added so that \<header> tags can be created.