### PR TITLE
fix telemetry for init event

### DIFF
--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -94,12 +94,15 @@ def _init(
             template = prerequisites.prompt_for_template()
         prerequisites.create_config(app_name)
         prerequisites.initialize_app_directory(app_name, template)
-        telemetry.send("init")
+        telemetry_event = "init"
     else:
-        telemetry.send("reinit")
+        telemetry_event = "reinit"
 
     # Set up the web project.
     prerequisites.initialize_frontend_dependencies()
+
+    # Send the telemetry event after the .web folder is initialized.
+    telemetry.send(telemetry_event)
 
     # Migrate Pynecone projects to Reflex.
     prerequisites.migrate_to_reflex()

--- a/reflex/utils/telemetry.py
+++ b/reflex/utils/telemetry.py
@@ -12,6 +12,8 @@ import psutil
 from reflex import constants
 from reflex.utils.prerequisites import ensure_reflex_installation_id
 
+POSTHOG_API_URL: str = "https://app.posthog.com/capture/"
+
 
 def get_os() -> str:
     """Get the operating system.
@@ -102,7 +104,7 @@ def send(event: str, telemetry_enabled: bool | None = None) -> bool:
             },
             "timestamp": datetime.utcnow().isoformat(),
         }
-        httpx.post("https://app.posthog.com/capture/", json=post_hog)
+        httpx.post(POSTHOG_API_URL, json=post_hog)
         return True
     except Exception:
         return False


### PR DESCRIPTION
since `telemetry.send` rely on `.web/reflex.json` folder existing, send the event after the creation of the folder `.web`.