### PR TITLE
add initial_value for base vars

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1616,7 +1616,15 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
             self._mark_dirty()
 
         base_vars = {
-            prop_name: self.get_value(getattr(self, prop_name))
+            prop_name: self.__fields__[prop_name].field_info.extra.get("initial_value")
+            if initial
+            and not isinstance(
+                self.__fields__[prop_name].field_info.extra.get(
+                    "initial_value", types.Unset()
+                ),
+                types.Unset,
+            )
+            else self.get_value(getattr(self, prop_name))
             for prop_name in self.base_vars
         }
         if initial:

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Set, Tuple
 
 import pytest
 from pandas import DataFrame
+from pydantic import Field
 
 from reflex.base import Base
 from reflex.state import BaseState
@@ -124,23 +125,43 @@ def ChildWithInitialComputedVar(StateWithInitialComputedVar):
 
 
 @pytest.fixture
-def StateWithRuntimeOnlyVar():
-    class StateWithRuntimeOnlyVar(BaseState):
+def StateWithRuntimeOnlyComputedVar():
+    class StateWithRuntimeOnlyComputedVar(BaseState):
         @computed_var(initial_value=None)
         def var_raises_at_runtime(self) -> str:
             raise ValueError("So nicht, mein Freund")
 
-    return StateWithRuntimeOnlyVar
+    return StateWithRuntimeOnlyComputedVar
 
 
 @pytest.fixture
-def ChildWithRuntimeOnlyVar(StateWithRuntimeOnlyVar):
-    class ChildWithRuntimeOnlyVar(StateWithRuntimeOnlyVar):
+def ChildWithRuntimeOnlyComputedVar(StateWithRuntimeOnlyComputedVar):
+    class ChildWithRuntimeOnlyComputedVar(StateWithRuntimeOnlyComputedVar):
         @computed_var(initial_value="Initial value")
         def var_raises_at_runtime_child(self) -> str:
             raise ValueError("So nicht, mein Freund")
 
-    return ChildWithRuntimeOnlyVar
+    return ChildWithRuntimeOnlyComputedVar
+
+
+@pytest.fixture
+def StateWithInitialBaseVar():
+    class StateWithInitialBaseVar(BaseState):
+        var_with_initial_value: str = Field(
+            "Runtime value", initial_value="Initial value"
+        )
+
+    return StateWithInitialBaseVar
+
+
+@pytest.fixture
+def ChildWithInitialBaseVar(StateWithInitialBaseVar):
+    class ChildWithInitialBaseVar(StateWithInitialBaseVar):
+        var_with_initial_value_child: str = Field(
+            "Runtime value child", initial_value="Initial value child"
+        )
+
+    return ChildWithInitialBaseVar
 
 
 @pytest.mark.parametrize(
@@ -789,18 +810,32 @@ def test_computed_var_with_annotation_error(request, fixture, full_name):
             False,
         ),
         (
-            "StateWithRuntimeOnlyVar",
+            "StateWithRuntimeOnlyComputedVar",
             "var_raises_at_runtime",
             None,
             None,
             True,
         ),
         (
-            "ChildWithRuntimeOnlyVar",
+            "ChildWithRuntimeOnlyComputedVar",
             "var_raises_at_runtime_child",
             "Initial value",
             None,
             True,
+        ),
+        (
+            "StateWithInitialBaseVar",
+            "var_with_initial_value",
+            "Initial value",
+            "Runtime value",
+            False,
+        ),
+        (
+            "ChildWithInitialBaseVar",
+            "var_with_initial_value_child",
+            "Initial value child",
+            "Runtime value child",
+            False,
         ),
     ],
 )


### PR DESCRIPTION
Followup of #2670 which implemented `initial_value` for computed vars.

```python
import reflex as rx

from pydantic import Field


class State(rx.State):
    basevar: str = Field(default="basevar", initial_value="initial")

    @rx.var(initial_value="initial")
    def test(self) -> str:
        return "Hello, world!"


#  cv = State.test
#  cv_initial = cv._initial_value
#  print(f"{cv=}, {cv_initial=}")

#  state = State()
#  state_d = state.dict(initial=True)
#  initial_d_state = state_d["state.state"]
#  initial_test = initial_d_state["test"]
#  print(f"Initial state: {initial_test=}")


def index() -> rx.Component:
    return rx.center(
        rx.vstack(
            rx.heading(State.test),
            rx.heading(State.basevar),
            rx.button(
                "Check out our docs!",
                size="4",
            ),
            align="center",
            spacing="7",
            font_size="2em",
        ),
        height="100vh",
    )


app = rx.App()
app.add_page(index)
```