### PR TITLE
Fix infinite recursion when a substate named "state" has a computed var

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1505,14 +1505,13 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
         """
         # _always_dirty_substates need to be fetched to recalc computed vars.
         fetch_substates = set(
-            cls.get_class_substate(tuple(substate_name.split(".")))
+            cls.get_class_substate((cls.get_name(), *substate_name.split(".")))
             for substate_name in cls._always_dirty_substates
         )
-        # Substates with cached vars also need to be fetched.
         for dependent_substates in cls._substate_var_dependencies.values():
             fetch_substates.update(
                 set(
-                    cls.get_class_substate(tuple(substate_name.split(".")))
+                    cls.get_class_substate((cls.get_name(), *substate_name.split(".")))
                     for substate_name in dependent_substates
                 )
             )

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -2719,3 +2719,28 @@ async def test_get_state(mock_app: rx.App, token: str):
             "computed": "",
         },
     }
+
+
+# Save a reference to the rx.State to shadow the name State for testing.
+RxState = State
+
+
+def test_potentially_dirty_substates():
+    """Test that potentially_dirty_substates returns the correct substates.
+
+    Even if the name "State" is shadowed, it should still work correctly.
+    """
+
+    class State(RxState):
+        @ComputedVar
+        def foo(self) -> str:
+            return ""
+
+    class C1(State):
+        @ComputedVar
+        def bar(self) -> str:
+            return ""
+
+    assert RxState._potentially_dirty_substates() == {State}
+    assert State._potentially_dirty_substates() == {C1}
+    assert C1._potentially_dirty_substates() == set()


### PR DESCRIPTION
The new `_potentially_dirty_substates` function tries to enumerate all substates that have computed or cached vars, however it was passing just the substate name to `get_class_substate`, which works most of the time, except when the current state class and the substate class have the same name.

To avoid this issue, always look up the "qualified substate name" by prefixing the current state's name before the substate name.