### PR TITLE
Perf improvements (part 1)

### DIFF
--- a/reflex/utils/types.py
+++ b/reflex/utils/types.py
@@ -30,6 +30,24 @@ from reflex import constants
 from reflex.base import Base
 from reflex.utils import serializers
 
+# Potential GenericAlias types for isinstance checks.
+GenericAliasTypes = [_GenericAlias]
+
+with contextlib.suppress(ImportError):
+    # For newer versions of Python.
+    from types import GenericAlias  # type: ignore
+
+    GenericAliasTypes.append(GenericAlias)
+
+with contextlib.suppress(ImportError):
+    # For older versions of Python.
+    from typing import _SpecialGenericAlias  # type: ignore
+
+    GenericAliasTypes.append(_SpecialGenericAlias)
+
+GenericAliasTypes = tuple(GenericAliasTypes)
+
+
 # Union of generic types.
 GenericType = Union[Type, _GenericAlias]
 
@@ -75,22 +93,7 @@ def is_generic_alias(cls: GenericType) -> bool:
     Returns:
         Whether the class is a generic alias.
     """
-    # For older versions of Python.
-    if isinstance(cls, _GenericAlias):
-        return True
-
-    with contextlib.suppress(ImportError):
-        from typing import _SpecialGenericAlias  # type: ignore
-
-        if isinstance(cls, _SpecialGenericAlias):
-            return True
-    # For newer versions of Python.
-    try:
-        from types import GenericAlias  # type: ignore
-
-        return isinstance(cls, GenericAlias)
-    except ImportError:
-        return False
+    return isinstance(cls, GenericAliasTypes)
 
 
 def is_union(cls: GenericType) -> bool:

--- a/reflex/utils/types.py
+++ b/reflex/utils/types.py
@@ -47,6 +47,8 @@ with contextlib.suppress(ImportError):
 
 GenericAliasTypes = tuple(GenericAliasTypes)
 
+# Potential Union types for isinstance checks (UnionType added in py3.10).
+UnionTypes = (Union, types.UnionType) if hasattr(types, "UnionType") else (Union,)
 
 # Union of generic types.
 GenericType = Union[Type, _GenericAlias]
@@ -105,11 +107,7 @@ def is_union(cls: GenericType) -> bool:
     Returns:
         Whether the class is a Union.
     """
-    # UnionType added in py3.10
-    if not hasattr(types, "UnionType"):
-        return get_origin(cls) is Union
-
-    return get_origin(cls) in [Union, types.UnionType]
+    return get_origin(cls) in UnionTypes
 
 
 def is_literal(cls: GenericType) -> bool:


### PR DESCRIPTION
Low hanging fruit in reflex itself:

* avoid imports and exception handlers in hot paths inside reflex.utils.types
* avoid recreating regex pattern in _decode_var
* avoid complex logic in _decode_var if the var does not have the special tag