### PR TITLE
Updating initialize_gitignore() to avoid modifying the encoding of the .gitignore file

### DIFF
--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -338,7 +338,7 @@ def initialize_gitignore():
             files |= set([line.strip() for line in f.readlines()])
 
     # Write files to the .gitignore file.
-    with open(constants.GitIgnore.FILE, "w") as f:
+    with open(constants.GitIgnore.FILE, "w", newline="\n") as f:
         console.debug(f"Creating {constants.GitIgnore.FILE}")
         f.write(f"{(path_ops.join(sorted(files))).lstrip()}")
 


### PR DESCRIPTION
With the parameter newline=' \n' we avoid that the encoding of the .gitignore file is modified and works correctly in Windows.

Adding to initialize_gitignore() the parameter newline='\n' to avoid modifying the encoding of the .gitignore file and make it work correctly in Windows.

closes[#2788]