### PR TITLE
[REF-2086] Avoid "Warning: The path to the Node binary could not be found.

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -36,7 +36,6 @@ jobs:
       matrix:
         # Show OS combos first in GUI
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: ['16.x']
         python-version: ['3.8.18', '3.9.18', '3.10.13', '3.11.5', '3.12.0']
         exclude:
           - os: windows-latest
@@ -56,10 +55,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
       - uses: ./.github/actions/setup_build_env
         with:
           python-version: ${{ matrix.python-version }}
@@ -104,17 +99,12 @@ jobs:
         # Show OS combos first in GUI
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.10.10', '3.11.4']
-        node-version: ['16.x']
 
     env:
       REFLEX_WEB_WINDOWS_OVERRIDE: '1'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
       - uses: ./.github/actions/setup_build_env
         with:
           python-version: ${{ matrix.python-version }}

--- a/reflex/constants/installer.py
+++ b/reflex/constants/installer.py
@@ -71,7 +71,7 @@ class Node(SimpleNamespace):
     # The Node version.
     VERSION = "18.17.0"
     # The minimum required node version.
-    MIN_VERSION = "16.8.0"
+    MIN_VERSION = "18.17.0"
 
     # The node bin path.
     BIN_PATH = os.path.join(

--- a/reflex/utils/processes.py
+++ b/reflex/utils/processes.py
@@ -135,13 +135,20 @@ def new_process(args, run: bool = False, show_logs: bool = False, **kwargs):
 
     Returns:
         Execute a child program in a new process.
+
+    Raises:
+        Exit: When attempting to run a command with a None value.
     """
     node_bin_path = path_ops.get_node_bin_path()
-    if not node_bin_path:
+    if not node_bin_path and not prerequisites.CURRENTLY_INSTALLING_NODE:
         console.warn(
             "The path to the Node binary could not be found. Please ensure that Node is properly "
-            "installed and added to your system's PATH environment variable."
+            "installed and added to your system's PATH environment variable or try running "
+            "`reflex init` again."
         )
+    if None in args:
+        console.error(f"Invalid command: {args}")
+        raise typer.Exit(1)
     # Add the node bin path to the PATH environment variable.
     env = {
         **os.environ,


### PR DESCRIPTION
When bootstrapping node itself, we do not need to warn the user that node cannot be found -- it's obviously not found because we're installing it right now. This warning leads some folks to believe that they need to install node themselves (for example in a docker container), when in reality, reflex will always try to install it's own known-good version of node first.

Also avoid a nasty traceback when Reflex attempts to run node or npm, but it's not actually installed (instead, the warning will be displayed and it will say "Invalid Command").

Move the recently added check (#2767) for node before installing node above the conditional so it can also skip node installation on Windows, which is especially slow.

Yes, I tested this on Windows.