### PR TITLE
Allow access to position from HighLevelSelect

### DIFF
--- a/reflex/components/radix/themes/components/select.py
+++ b/reflex/components/radix/themes/components/select.py
@@ -184,7 +184,7 @@ class HighLevelSelect(SelectRoot):
     # The width of the select.
     width: Var[str]
 
-    # The positioning mode to use.
+    # The positioning mode to use. Default is "item-aligned".
     position: Var[Literal["item-aligned", "popper"]]
 
     @classmethod
@@ -199,7 +199,9 @@ class HighLevelSelect(SelectRoot):
             The select component.
         """
         content_props = {
-            prop: props.pop(prop) for prop in ["high_contrast", "position"] if prop in props
+            prop: props.pop(prop)
+            for prop in ["high_contrast", "position"]
+            if prop in props
         }
 
         trigger_props = {

--- a/reflex/components/radix/themes/components/select.py
+++ b/reflex/components/radix/themes/components/select.py
@@ -184,6 +184,9 @@ class HighLevelSelect(SelectRoot):
     # The width of the select.
     width: Var[str]
 
+    # The positioning mode to use.
+    position: Var[Literal["item-aligned", "popper"]]
+
     @classmethod
     def create(cls, items: Union[List[str], Var[List[str]]], **props) -> Component:
         """Create a select component.
@@ -196,7 +199,7 @@ class HighLevelSelect(SelectRoot):
             The select component.
         """
         content_props = {
-            prop: props.pop(prop) for prop in ["high_contrast"] if prop in props
+            prop: props.pop(prop) for prop in ["high_contrast", "position"] if prop in props
         }
 
         trigger_props = {

--- a/reflex/components/radix/themes/components/select.pyi
+++ b/reflex/components/radix/themes/components/select.pyi
@@ -951,7 +951,7 @@ class HighLevelSelect(SelectRoot):
             variant: The variant of the select.
             radius: The radius of the select.
             width: The width of the select.
-            position: The positioning mode to use.
+            position: The positioning mode to use. Default is "item-aligned".
             size: The size of the select: "1" | "2" | "3"
             default_value: The value of the select when initially rendered. Use when you do not need to control the state of the select.
             value: The controlled value of the select. Should be used in conjunction with on_change.
@@ -1151,7 +1151,7 @@ class Select(ComponentNamespace):
             variant: The variant of the select.
             radius: The radius of the select.
             width: The width of the select.
-            position: The positioning mode to use.
+            position: The positioning mode to use. Default is "item-aligned".
             size: The size of the select: "1" | "2" | "3"
             default_value: The value of the select when initially rendered. Use when you do not need to control the state of the select.
             value: The controlled value of the select. Should be used in conjunction with on_change.

--- a/reflex/components/radix/themes/components/select.pyi
+++ b/reflex/components/radix/themes/components/select.pyi
@@ -864,6 +864,12 @@ class HighLevelSelect(SelectRoot):
             ]
         ] = None,
         width: Optional[Union[Var[str], str]] = None,
+        position: Optional[
+            Union[
+                Var[Literal["item-aligned", "popper"]],
+                Literal["item-aligned", "popper"],
+            ]
+        ] = None,
         size: Optional[
             Union[Var[Literal["1", "2", "3"]], Literal["1", "2", "3"]]
         ] = None,
@@ -945,6 +951,7 @@ class HighLevelSelect(SelectRoot):
             variant: The variant of the select.
             radius: The radius of the select.
             width: The width of the select.
+            position: The positioning mode to use.
             size: The size of the select: "1" | "2" | "3"
             default_value: The value of the select when initially rendered. Use when you do not need to control the state of the select.
             value: The controlled value of the select. Should be used in conjunction with on_change.
@@ -1057,6 +1064,12 @@ class Select(ComponentNamespace):
             ]
         ] = None,
         width: Optional[Union[Var[str], str]] = None,
+        position: Optional[
+            Union[
+                Var[Literal["item-aligned", "popper"]],
+                Literal["item-aligned", "popper"],
+            ]
+        ] = None,
         size: Optional[
             Union[Var[Literal["1", "2", "3"]], Literal["1", "2", "3"]]
         ] = None,
@@ -1138,6 +1151,7 @@ class Select(ComponentNamespace):
             variant: The variant of the select.
             radius: The radius of the select.
             width: The width of the select.
+            position: The positioning mode to use.
             size: The size of the select: "1" | "2" | "3"
             default_value: The value of the select when initially rendered. Use when you do not need to control the state of the select.
             value: The controlled value of the select. Should be used in conjunction with on_change.


### PR DESCRIPTION
Access to position prop is buried in Select.content. Should leave finer control such as spacing and offset in content, but have ability to specify behavior of content window at the top-level.

