### PR TITLE
Remove width prop from rx.select

### DIFF
--- a/reflex/components/radix/themes/components/select.py
+++ b/reflex/components/radix/themes/components/select.py
@@ -181,9 +181,6 @@ class HighLevelSelect(SelectRoot):
     # The radius of the select.
     radius: Var[LiteralRadius]
 
-    # The width of the select.
-    width: Var[str]
-
     # The positioning mode to use. Default is "item-aligned".
     position: Var[Literal["item-aligned", "popper"]]
 
@@ -206,7 +203,7 @@ class HighLevelSelect(SelectRoot):
 
         trigger_props = {
             prop: props.pop(prop)
-            for prop in ["placeholder", "variant", "radius", "width"]
+            for prop in ["placeholder", "variant", "radius"]
             if prop in props
         }
 

--- a/reflex/components/radix/themes/components/select.pyi
+++ b/reflex/components/radix/themes/components/select.pyi
@@ -863,16 +863,12 @@ class HighLevelSelect(SelectRoot):
                 Literal["none", "small", "medium", "large", "full"],
             ]
         ] = None,
-<<<<<<< HEAD
-        width: Optional[Union[Var[str], str]] = None,
         position: Optional[
             Union[
                 Var[Literal["item-aligned", "popper"]],
                 Literal["item-aligned", "popper"],
             ]
         ] = None,
-=======
->>>>>>> 217345f6 (Remove width prop from rx.select)
         size: Optional[
             Union[Var[Literal["1", "2", "3"]], Literal["1", "2", "3"]]
         ] = None,
@@ -953,11 +949,7 @@ class HighLevelSelect(SelectRoot):
             high_contrast: Whether to render the select with higher contrast color against background.
             variant: The variant of the select.
             radius: The radius of the select.
-<<<<<<< HEAD
-            width: The width of the select.
             position: The positioning mode to use. Default is "item-aligned".
-=======
->>>>>>> 217345f6 (Remove width prop from rx.select)
             size: The size of the select: "1" | "2" | "3"
             default_value: The value of the select when initially rendered. Use when you do not need to control the state of the select.
             value: The controlled value of the select. Should be used in conjunction with on_change.
@@ -1069,16 +1061,12 @@ class Select(ComponentNamespace):
                 Literal["none", "small", "medium", "large", "full"],
             ]
         ] = None,
-<<<<<<< HEAD
-        width: Optional[Union[Var[str], str]] = None,
         position: Optional[
             Union[
                 Var[Literal["item-aligned", "popper"]],
                 Literal["item-aligned", "popper"],
             ]
         ] = None,
-=======
->>>>>>> 217345f6 (Remove width prop from rx.select)
         size: Optional[
             Union[Var[Literal["1", "2", "3"]], Literal["1", "2", "3"]]
         ] = None,
@@ -1159,11 +1147,7 @@ class Select(ComponentNamespace):
             high_contrast: Whether to render the select with higher contrast color against background.
             variant: The variant of the select.
             radius: The radius of the select.
-<<<<<<< HEAD
-            width: The width of the select.
             position: The positioning mode to use. Default is "item-aligned".
-=======
->>>>>>> 217345f6 (Remove width prop from rx.select)
             size: The size of the select: "1" | "2" | "3"
             default_value: The value of the select when initially rendered. Use when you do not need to control the state of the select.
             value: The controlled value of the select. Should be used in conjunction with on_change.

--- a/reflex/components/radix/themes/components/select.pyi
+++ b/reflex/components/radix/themes/components/select.pyi
@@ -863,6 +863,7 @@ class HighLevelSelect(SelectRoot):
                 Literal["none", "small", "medium", "large", "full"],
             ]
         ] = None,
+<<<<<<< HEAD
         width: Optional[Union[Var[str], str]] = None,
         position: Optional[
             Union[
@@ -870,6 +871,8 @@ class HighLevelSelect(SelectRoot):
                 Literal["item-aligned", "popper"],
             ]
         ] = None,
+=======
+>>>>>>> 217345f6 (Remove width prop from rx.select)
         size: Optional[
             Union[Var[Literal["1", "2", "3"]], Literal["1", "2", "3"]]
         ] = None,
@@ -950,8 +953,11 @@ class HighLevelSelect(SelectRoot):
             high_contrast: Whether to render the select with higher contrast color against background.
             variant: The variant of the select.
             radius: The radius of the select.
+<<<<<<< HEAD
             width: The width of the select.
             position: The positioning mode to use. Default is "item-aligned".
+=======
+>>>>>>> 217345f6 (Remove width prop from rx.select)
             size: The size of the select: "1" | "2" | "3"
             default_value: The value of the select when initially rendered. Use when you do not need to control the state of the select.
             value: The controlled value of the select. Should be used in conjunction with on_change.
@@ -1063,6 +1069,7 @@ class Select(ComponentNamespace):
                 Literal["none", "small", "medium", "large", "full"],
             ]
         ] = None,
+<<<<<<< HEAD
         width: Optional[Union[Var[str], str]] = None,
         position: Optional[
             Union[
@@ -1070,6 +1077,8 @@ class Select(ComponentNamespace):
                 Literal["item-aligned", "popper"],
             ]
         ] = None,
+=======
+>>>>>>> 217345f6 (Remove width prop from rx.select)
         size: Optional[
             Union[Var[Literal["1", "2", "3"]], Literal["1", "2", "3"]]
         ] = None,
@@ -1150,8 +1159,11 @@ class Select(ComponentNamespace):
             high_contrast: Whether to render the select with higher contrast color against background.
             variant: The variant of the select.
             radius: The radius of the select.
+<<<<<<< HEAD
             width: The width of the select.
             position: The positioning mode to use. Default is "item-aligned".
+=======
+>>>>>>> 217345f6 (Remove width prop from rx.select)
             size: The size of the select: "1" | "2" | "3"
             default_value: The value of the select when initially rendered. Use when you do not need to control the state of the select.
             value: The controlled value of the select. Should be used in conjunction with on_change.


### PR DESCRIPTION
Radix select doesn't have this prop, and it breaks the default styling. Closes #2824 