### PR TITLE
Account for imports of @rx.memo components for frontend package installation 

### DIFF
--- a/reflex/compiler/compiler.py
+++ b/reflex/compiler/compiler.py
@@ -186,7 +186,9 @@ def _compile_component(component: Component) -> str:
     return templates.COMPONENT.render(component=component)
 
 
-def _compile_components(components: set[CustomComponent]) -> str:
+def _compile_components(
+    components: set[CustomComponent],
+) -> tuple[str, Dict[str, list[ImportVar]]]:
     """Compile the components.
 
     Args:
@@ -208,9 +210,12 @@ def _compile_components(components: set[CustomComponent]) -> str:
         imports = utils.merge_imports(imports, component_imports)
 
     # Compile the components page.
-    return templates.COMPONENTS.render(
-        imports=utils.compile_imports(imports),
-        components=component_renders,
+    return (
+        templates.COMPONENTS.render(
+            imports=utils.compile_imports(imports),
+            components=component_renders,
+        ),
+        imports,
     )
 
 
@@ -401,7 +406,9 @@ def compile_page(
     return output_path, code
 
 
-def compile_components(components: set[CustomComponent]):
+def compile_components(
+    components: set[CustomComponent],
+) -> tuple[str, str, Dict[str, list[ImportVar]]]:
     """Compile the custom components.
 
     Args:
@@ -414,8 +421,8 @@ def compile_components(components: set[CustomComponent]):
     output_path = utils.get_components_path()
 
     # Compile the components.
-    code = _compile_components(components)
-    return output_path, code
+    code, imports = _compile_components(components)
+    return output_path, code, imports
 
 
 def compile_stateful_components(

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -1296,17 +1296,12 @@ class CustomComponent(Component):
                 self.props[format.to_camel_case(key)] = value
                 continue
 
-            # Convert the type to a Var, then get the type of the var.
-            if not types._issubclass(type_, Var):
-                type_ = Var[type_]
-            type_ = types.get_args(type_)[0]
-
             # Handle subclasses of Base.
-            if types._issubclass(type_, Base):
+            if isinstance(value, Base):
                 base_value = Var.create(value)
 
                 # Track hooks and imports associated with Component instances.
-                if base_value is not None and types._issubclass(type_, Component):
+                if base_value is not None and isinstance(value, Component):
                     value = base_value._replace(
                         merge_var_data=VarData(  # type: ignore
                             imports=value.get_imports(),

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -1356,7 +1356,7 @@ class CustomComponent(Component):
                     ImportVar(
                         tag=None,
                         render=False,
-                        install=not any(not imp.install for imp in imps),
+                        install=any(imp.install for imp in imps),
                     ),
                 ]
                 for comp in self.get_custom_components()

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -1352,9 +1352,15 @@ class CustomComponent(Component):
             super()._get_imports(),
             # Sweep up any imports from CustomComponent props for frontend installation.
             {
-                library: [ImportVar(tag=None, render=False, install=True)]
+                library: [
+                    ImportVar(
+                        tag=None,
+                        render=False,
+                        install=not any(not imp.install for imp in imps),
+                    ),
+                ]
                 for comp in self.get_custom_components()
-                for library in comp.get_component(comp).get_imports()
+                for library, imps in comp.get_component(comp).get_imports().items()
             },
         )
 

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -1339,31 +1339,6 @@ class CustomComponent(Component):
         """
         return hash(self.tag)
 
-    def _get_imports(self) -> Dict[str, List[ImportVar]]:
-        """Get the imports for the component.
-
-        This is needed because otherwise the imports for the component are not
-        installed during compile time, but they are rendered into the page.
-
-        Returns:
-            The imports for the component and any custom component props.
-        """
-        return imports.merge_imports(
-            super()._get_imports(),
-            # Sweep up any imports from CustomComponent props for frontend installation.
-            {
-                library: [
-                    ImportVar(
-                        tag=None,
-                        render=False,
-                        install=any(imp.install for imp in imps),
-                    ),
-                ]
-                for comp in self.get_custom_components()
-                for library, imps in comp.get_component(comp).get_imports().items()
-            },
-        )
-
     @classmethod
     def get_props(cls) -> Set[str]:
         """Get the props for the component.

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -4,6 +4,7 @@ import pytest
 
 import reflex as rx
 from reflex.base import Base
+from reflex.compiler.compiler import compile_components
 from reflex.components.base.bare import Bare
 from reflex.components.chakra.layout.box import Box
 from reflex.components.component import (
@@ -1289,8 +1290,21 @@ def test_custom_component_get_imports():
         return Other.create(c)
 
     custom_comp = wrapper()
-    assert "inner" in custom_comp.get_imports()
+
+    # Inner is not imported directly, but it is imported by the custom component.
+    assert "inner" not in custom_comp.get_imports()
+
+    # The imports are only resolved during compilation.
+    _, _, imports_inner = compile_components(custom_comp.get_custom_components())
+    assert "inner" in imports_inner
 
     outer_comp = outer(c=wrapper())
-    assert "inner" in outer_comp.get_imports()
-    assert "other" in outer_comp.get_imports()
+
+    # Libraries are not imported directly, but are imported by the custom component.
+    assert "inner" not in outer_comp.get_imports()
+    assert "other" not in outer_comp.get_imports()
+
+    # The imports are only resolved during compilation.
+    _, _, imports_outer = compile_components(outer_comp.get_custom_components())
+    assert "inner" in imports_outer
+    assert "other" in imports_outer

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -1269,3 +1269,28 @@ def test_deprecated_props(capsys):
     assert "type={`type1`}" in c2_1_render["props"]
     assert "min={`min1`}" in c2_1_render["props"]
     assert "max={`max1`}" in c2_1_render["props"]
+
+
+def test_custom_component_get_imports():
+    class Inner(Component):
+        tag = "Inner"
+        library = "inner"
+
+    class Other(Component):
+        tag = "Other"
+        library = "other"
+
+    @rx.memo
+    def wrapper():
+        return Inner.create()
+
+    @rx.memo
+    def outer(c: Component):
+        return Other.create(c)
+
+    custom_comp = wrapper()
+    assert "inner" in custom_comp.get_imports()
+
+    outer_comp = outer(c=wrapper())
+    assert "inner" in outer_comp.get_imports()
+    assert "other" in outer_comp.get_imports()


### PR DESCRIPTION
More long standing bugs in the CustomComponent (@rx.memo) that were not exposed until other change was made to allow components as props to CustomComponent and we started using that functionality combined with windows only compiling a subset of reflex-web.

See the newly added test case for how simple this is to repro.

This has been an issue for a long time, but I suppose due to various factors around how and where `rx.memo` is used, we just never really noticed that it wasn't installing package deps for components wrapped in `rx.memo` because most likely _somewhere else_ in reflex-web (or large project using `rx.memo`), the package was referenced and installed via another route.

The following app exposes the issue with 0.4.4

```python
import reflex as rx


@rx.memo
def wrapper(child: rx.Component) -> rx.Component:
    return rx.el.div(child, style={"border": "2px solid red"})

@rx.memo
def inner(child: str) -> rx.Component:
    return rx.drawer.root(child)

def index() -> rx.Component:
    return rx.vstack(
        inner(child="foo"),
        wrapper(
            child=inner(child="foo"),
        ),
    )


app = rx.App()
app.add_page(index)
app.add_page(index, route="/index2")
```

This has problems in either dev or prod mode.

```console
./utils/components.js:6:0
Module not found: Can't resolve 'vaul'
  4 | import { memo } from "react"
  5 | import { E, isTrue } from "/utils/state"
> 6 | import { Drawer as VaulDrawer } from "vaul"
  7 |
  8 |
  9 |

https://nextjs.org/docs/messages/module-not-found

Import trace for requested module:
./pages/index.js
```