### PR TITLE
[REF-2284]Benchmark add extra info on publishing data

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -123,4 +123,4 @@ jobs:
           --python-version "${{ matrix.python-version }}" --commit-sha "${{ github.sha }}" 
           --benchmark-json "${{ env.OUTPUT_FILE }}" --pr-title "${{ github.event.pull_request.title }}"
           --db-url "${{ env.DATABASE_URL }}" --branch-name "${{ github.head_ref || github.ref_name }}"
-          --event-type "${{ github.event_name }}" --actor "${{ github.actor }}"
+          --event-type "${{ github.event_name }}" --actor "${{ github.actor }}" --pr-id "${{ github.event.pull_request.id }}"

--- a/scripts/simple_app_benchmark_upload.py
+++ b/scripts/simple_app_benchmark_upload.py
@@ -29,20 +29,17 @@ def extract_stats_from_json(json_file: str) -> list[dict]:
 
     # Iterate over each test in the 'benchmarks' list
     for test in data.get("benchmarks", []):
+        group = test.get("group", None)
         stats = test.get("stats", {})
+        full_name = test.get("full_name")
         test_name = test.get("name", "Unknown Test")
-        min_value = stats.get("min", None)
-        max_value = stats.get("max", None)
-        mean_value = stats.get("mean", None)
-        stdev_value = stats.get("stddev", None)
 
         test_stats.append(
             {
                 "test_name": test_name,
-                "min": min_value,
-                "max": max_value,
-                "mean": mean_value,
-                "stdev": stdev_value,
+                "group": group,
+                "stats": stats,
+                "full_name": full_name,
             }
         )
     return test_stats

--- a/scripts/simple_app_benchmark_upload.py
+++ b/scripts/simple_app_benchmark_upload.py
@@ -31,7 +31,7 @@ def extract_stats_from_json(json_file: str) -> list[dict]:
     for test in data.get("benchmarks", []):
         group = test.get("group", None)
         stats = test.get("stats", {})
-        full_name = test.get("full_name")
+        full_name = test.get("fullname")
         test_name = test.get("name", "Unknown Test")
 
         test_stats.append(

--- a/scripts/simple_app_benchmark_upload.py
+++ b/scripts/simple_app_benchmark_upload.py
@@ -99,7 +99,7 @@ def insert_benchmarking_data(
                 event_type,
                 actor,
                 simple_app_performance_json,
-                pr_id
+                pr_id,
             ),
         )
         # Commit the transaction
@@ -168,7 +168,7 @@ def main():
         branch_name=args.branch_name,
         event_type=args.event_type,
         actor=args.actor,
-        pr_id=args.pr_id
+        pr_id=args.pr_id,
     )
 
 

--- a/scripts/simple_app_benchmark_upload.py
+++ b/scripts/simple_app_benchmark_upload.py
@@ -32,7 +32,11 @@ def extract_stats_from_json(json_file: str) -> list[dict]:
         group = test.get("group", None)
         stats = test.get("stats", {})
         full_name = test.get("fullname")
-        file_name = full_name.split("/")[-1].split("::")[0].removesuffix(".py") if full_name else None
+        file_name = (
+            full_name.split("/")[-1].split("::")[0].removesuffix(".py")
+            if full_name
+            else None
+        )
         test_name = test.get("name", "Unknown Test")
 
         test_stats.append(
@@ -41,7 +45,7 @@ def extract_stats_from_json(json_file: str) -> list[dict]:
                 "group": group,
                 "stats": stats,
                 "full_name": full_name,
-                "file_name": file_name
+                "file_name": file_name,
             }
         )
     return test_stats

--- a/scripts/simple_app_benchmark_upload.py
+++ b/scripts/simple_app_benchmark_upload.py
@@ -32,6 +32,7 @@ def extract_stats_from_json(json_file: str) -> list[dict]:
         group = test.get("group", None)
         stats = test.get("stats", {})
         full_name = test.get("fullname")
+        file_name = full_name.split("/")[-1].split("::")[0].removesuffix(".py") if full_name else None
         test_name = test.get("name", "Unknown Test")
 
         test_stats.append(
@@ -40,6 +41,7 @@ def extract_stats_from_json(json_file: str) -> list[dict]:
                 "group": group,
                 "stats": stats,
                 "full_name": full_name,
+                "file_name": file_name
             }
         )
     return test_stats

--- a/scripts/simple_app_benchmark_upload.py
+++ b/scripts/simple_app_benchmark_upload.py
@@ -33,9 +33,7 @@ def extract_stats_from_json(json_file: str) -> list[dict]:
         stats = test.get("stats", {})
         full_name = test.get("fullname")
         file_name = (
-            full_name.split("/")[-1].split("::")[0].removesuffix(".py")
-            if full_name
-            else None
+            full_name.split("/")[-1].split("::")[0].strip(".py") if full_name else None
         )
         test_name = test.get("name", "Unknown Test")
 

--- a/scripts/simple_app_benchmark_upload.py
+++ b/scripts/simple_app_benchmark_upload.py
@@ -59,6 +59,7 @@ def insert_benchmarking_data(
     branch_name: str,
     event_type: str,
     actor: str,
+    pr_id: str,
 ):
     """Insert the benchmarking data into the database.
 
@@ -72,6 +73,7 @@ def insert_benchmarking_data(
         branch_name: The name of the branch.
         event_type: Type of github event(push, pull request, etc)
         actor: Username of the user that triggered the run.
+        pr_id: Id of the PR.
     """
     # Serialize the JSON data
     simple_app_performance_json = json.dumps(performance_data)
@@ -82,8 +84,8 @@ def insert_benchmarking_data(
     # Connect to the database and insert the data
     with psycopg2.connect(db_connection_url) as conn, conn.cursor() as cursor:
         insert_query = """
-            INSERT INTO simple_app_benchmarks (os, python_version, commit_sha, time, pr_title, branch_name, event_type, actor, performance)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s);
+            INSERT INTO simple_app_benchmarks (os, python_version, commit_sha, time, pr_title, branch_name, event_type, actor, performance, pr_id)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
             """
         cursor.execute(
             insert_query,
@@ -97,6 +99,7 @@ def insert_benchmarking_data(
                 event_type,
                 actor,
                 simple_app_performance_json,
+                pr_id
             ),
         )
         # Commit the transaction
@@ -145,6 +148,11 @@ def main():
         help="Username of the user that triggered the run.",
         required=True,
     )
+    parser.add_argument(
+        "--pr-id",
+        help="ID of the PR.",
+        required=True,
+    )
     args = parser.parse_args()
 
     # Get the results of pytest benchmarks
@@ -160,6 +168,7 @@ def main():
         branch_name=args.branch_name,
         event_type=args.event_type,
         actor=args.actor,
+        pr_id=args.pr_id
     )
 
 


### PR DESCRIPTION
Add more data to benchmark values, like full name and group to help differentiate tests for display. We should also not be picky on what stats(mean, min, etc) to save.