### PR TITLE
[REF-2229]Dedupe deprecation warnings

### DIFF
--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -621,6 +621,7 @@ class Component(BaseComponent, ABC):
                     reason=f"for consistency. Use `{prop}` instead.",
                     deprecation_version="0.4.0",
                     removal_version="0.5.0",
+                    dedupe=False,
                 )
                 props[prop] = props.pop(under_prop)
 

--- a/reflex/utils/__init__.py
+++ b/reflex/utils/__init__.py
@@ -1,1 +1,2 @@
 """Reflex utilities."""
+DEPRECATED_FEATURES = set()

--- a/reflex/utils/__init__.py
+++ b/reflex/utils/__init__.py
@@ -1,2 +1,1 @@
 """Reflex utilities."""
-DEPRECATED_FEATURES = set()

--- a/reflex/utils/console.py
+++ b/reflex/utils/console.py
@@ -121,7 +121,7 @@ def deprecate(
         reason: The reason for deprecation.
         deprecation_version: The version the feature was deprecated
         removal_version: The version the deprecated feature will be removed
-        dedupe: Whether to allow multiple console logs of deprecation message.
+        dedupe: If True, suppress multiple console logs of deprecation message.
         kwargs: Keyword arguments to pass to the print function.
     """
     from reflex.utils import DEPRECATED_FEATURES

--- a/reflex/utils/console.py
+++ b/reflex/utils/console.py
@@ -16,6 +16,9 @@ _console = Console()
 # The current log level.
 _LOG_LEVEL = LogLevel.INFO
 
+# Deprecated features who's warning has been printed.
+_EMITTED_DEPRECATION_WARNINGS = set()
+
 
 def set_log_level(log_level: LogLevel):
     """Set the log level.
@@ -124,9 +127,7 @@ def deprecate(
         dedupe: If True, suppress multiple console logs of deprecation message.
         kwargs: Keyword arguments to pass to the print function.
     """
-    from reflex.utils import DEPRECATED_FEATURES
-
-    if feature_name not in DEPRECATED_FEATURES:
+    if feature_name not in _EMITTED_DEPRECATION_WARNINGS:
         msg = (
             f"{feature_name} has been deprecated in version {deprecation_version} {reason.rstrip('.')}. It will be completely "
             f"removed in {removal_version}"
@@ -134,7 +135,7 @@ def deprecate(
         if _LOG_LEVEL <= LogLevel.WARNING:
             print(f"[yellow]DeprecationWarning: {msg}[/yellow]", **kwargs)
         if dedupe:
-            DEPRECATED_FEATURES.add(feature_name)
+            _EMITTED_DEPRECATION_WARNINGS.add(feature_name)
 
 
 def error(msg: str, **kwargs):

--- a/reflex/utils/console.py
+++ b/reflex/utils/console.py
@@ -111,6 +111,7 @@ def deprecate(
     reason: str,
     deprecation_version: str,
     removal_version: str,
+    dedupe: bool = True,
     **kwargs,
 ):
     """Print a deprecation warning.
@@ -119,15 +120,21 @@ def deprecate(
         feature_name: The feature to deprecate.
         reason: The reason for deprecation.
         deprecation_version: The version the feature was deprecated
-        removal_version: The version the deprecated feature will be removed.
+        removal_version: The version the deprecated feature will be removed
+        dedupe: Whether to allow multiple console logs of deprecation message.
         kwargs: Keyword arguments to pass to the print function.
     """
-    msg = (
-        f"{feature_name} has been deprecated in version {deprecation_version} {reason.rstrip('.')}. It will be completely "
-        f"removed in {removal_version}"
-    )
-    if _LOG_LEVEL <= LogLevel.WARNING:
-        print(f"[yellow]DeprecationWarning: {msg}[/yellow]", **kwargs)
+    from reflex.utils import DEPRECATED_FEATURES
+
+    if feature_name not in DEPRECATED_FEATURES:
+        msg = (
+            f"{feature_name} has been deprecated in version {deprecation_version} {reason.rstrip('.')}. It will be completely "
+            f"removed in {removal_version}"
+        )
+        if _LOG_LEVEL <= LogLevel.WARNING:
+            print(f"[yellow]DeprecationWarning: {msg}[/yellow]", **kwargs)
+        if dedupe:
+            DEPRECATED_FEATURES.add(feature_name)
 
 
 def error(msg: str, **kwargs):


### PR DESCRIPTION
When you use a deprecated warning n times, we print the warning message `n` times. Ideally we would only want to print the message once. This PR does that.