### PR TITLE
Revert "Remove width prop from rx.select (#2835)"

### DIFF
--- a/reflex/components/radix/themes/components/select.py
+++ b/reflex/components/radix/themes/components/select.py
@@ -181,6 +181,9 @@ class HighLevelSelect(SelectRoot):
     # The radius of the select.
     radius: Var[LiteralRadius]
 
+    # The width of the select.
+    width: Var[str]
+
     # The positioning mode to use. Default is "item-aligned".
     position: Var[Literal["item-aligned", "popper"]]
 
@@ -203,7 +206,7 @@ class HighLevelSelect(SelectRoot):
 
         trigger_props = {
             prop: props.pop(prop)
-            for prop in ["placeholder", "variant", "radius"]
+            for prop in ["placeholder", "variant", "radius", "width"]
             if prop in props
         }
 

--- a/reflex/components/radix/themes/components/select.pyi
+++ b/reflex/components/radix/themes/components/select.pyi
@@ -863,6 +863,7 @@ class HighLevelSelect(SelectRoot):
                 Literal["none", "small", "medium", "large", "full"],
             ]
         ] = None,
+        width: Optional[Union[Var[str], str]] = None,
         position: Optional[
             Union[
                 Var[Literal["item-aligned", "popper"]],
@@ -949,6 +950,7 @@ class HighLevelSelect(SelectRoot):
             high_contrast: Whether to render the select with higher contrast color against background.
             variant: The variant of the select.
             radius: The radius of the select.
+            width: The width of the select.
             position: The positioning mode to use. Default is "item-aligned".
             size: The size of the select: "1" | "2" | "3"
             default_value: The value of the select when initially rendered. Use when you do not need to control the state of the select.
@@ -1061,6 +1063,7 @@ class Select(ComponentNamespace):
                 Literal["none", "small", "medium", "large", "full"],
             ]
         ] = None,
+        width: Optional[Union[Var[str], str]] = None,
         position: Optional[
             Union[
                 Var[Literal["item-aligned", "popper"]],
@@ -1147,6 +1150,7 @@ class Select(ComponentNamespace):
             high_contrast: Whether to render the select with higher contrast color against background.
             variant: The variant of the select.
             radius: The radius of the select.
+            width: The width of the select.
             position: The positioning mode to use. Default is "item-aligned".
             size: The size of the select: "1" | "2" | "3"
             default_value: The value of the select when initially rendered. Use when you do not need to control the state of the select.


### PR DESCRIPTION
This reverts commit d14292dc9b2c4fe7dfe5e1cebce42cb5a3a317a0.

This change prevented setting the width on high level select at all, we need to find a different approach to solve the overflowing container issue.