### PR TITLE
HighLevelSelect: pass flex_shrink prop to SelectTrigger

### DIFF
--- a/reflex/components/radix/themes/components/select.py
+++ b/reflex/components/radix/themes/components/select.py
@@ -206,7 +206,7 @@ class HighLevelSelect(SelectRoot):
 
         trigger_props = {
             prop: props.pop(prop)
-            for prop in ["placeholder", "variant", "radius", "width"]
+            for prop in ["placeholder", "variant", "radius", "width", "flex_shrink"]
             if prop in props
         }
 

--- a/reflex/components/radix/themes/components/select.py
+++ b/reflex/components/radix/themes/components/select.py
@@ -181,6 +181,9 @@ class HighLevelSelect(SelectRoot):
     # The radius of the select.
     radius: Var[LiteralRadius]
 
+    # The width of the select.
+    width: Var[str]
+
     # The positioning mode to use. Default is "item-aligned".
     position: Var[Literal["item-aligned", "popper"]]
 
@@ -203,7 +206,7 @@ class HighLevelSelect(SelectRoot):
 
         trigger_props = {
             prop: props.pop(prop)
-            for prop in ["placeholder", "variant", "radius"]
+            for prop in ["placeholder", "variant", "radius", "width"]
             if prop in props
         }
 

--- a/reflex/components/radix/themes/components/select.pyi
+++ b/reflex/components/radix/themes/components/select.pyi
@@ -863,6 +863,7 @@ class HighLevelSelect(SelectRoot):
                 Literal["none", "small", "medium", "large", "full"],
             ]
         ] = None,
+        width: Optional[Union[Var[str], str]] = None,
         position: Optional[
             Union[
                 Var[Literal["item-aligned", "popper"]],
@@ -949,6 +950,7 @@ class HighLevelSelect(SelectRoot):
             high_contrast: Whether to render the select with higher contrast color against background.
             variant: The variant of the select.
             radius: The radius of the select.
+            width: The width of the select.
             position: The positioning mode to use. Default is "item-aligned".
             size: The size of the select: "1" | "2" | "3"
             default_value: The value of the select when initially rendered. Use when you do not need to control the state of the select.
@@ -1061,6 +1063,7 @@ class Select(ComponentNamespace):
                 Literal["none", "small", "medium", "large", "full"],
             ]
         ] = None,
+        width: Optional[Union[Var[str], str]] = None,
         position: Optional[
             Union[
                 Var[Literal["item-aligned", "popper"]],
@@ -1147,6 +1150,7 @@ class Select(ComponentNamespace):
             high_contrast: Whether to render the select with higher contrast color against background.
             variant: The variant of the select.
             radius: The radius of the select.
+            width: The width of the select.
             position: The positioning mode to use. Default is "item-aligned".
             size: The size of the select: "1" | "2" | "3"
             default_value: The value of the select when initially rendered. Use when you do not need to control the state of the select.


### PR DESCRIPTION
This allows the high level select to have width="100%" and also shrink-to-fit inside a parent container.

Fix https://github.com/reflex-dev/reflex/issues/2824, kind of