### PR TITLE
When __REFLEX_SKIP_COMPILE == "yes" allow telemetry to fail

### DIFF
--- a/reflex/app.py
+++ b/reflex/app.py
@@ -77,7 +77,7 @@ from reflex.state import (
     code_uses_state_contexts,
 )
 from reflex.utils import console, exceptions, format, prerequisites, types
-from reflex.utils.exec import is_testing_env
+from reflex.utils.exec import is_testing_env, should_skip_compile
 from reflex.utils.imports import ImportVar
 
 # Define custom types.
@@ -672,7 +672,7 @@ class App(Base):
             Whether the app should be compiled.
         """
         # Check the environment variable.
-        if os.environ.get(constants.SKIP_COMPILE_ENV_VAR) == "yes":
+        if should_skip_compile():
             return False
 
         # Check the nocompile file.

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -307,3 +307,12 @@ def is_prod_mode() -> bool:
         constants.Env.DEV.value,
     )
     return current_mode == constants.Env.PROD.value
+
+
+def should_skip_compile() -> bool:
+    """Whether the app should skip compile.
+
+    Returns:
+        True if the app should skip compile.
+    """
+    return os.environ.get(constants.SKIP_COMPILE_ENV_VAR) == "yes"

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -448,7 +448,7 @@ def get_project_hash(raise_on_fail: bool = False) -> int | None:
     # Open and read the file
     with open(constants.Reflex.JSON, "r") as file:
         data = json.load(file)
-        return data["project_hash"]
+        return data.get("project_hash")
 
 
 def initialize_web_directory():


### PR DESCRIPTION
Allow running `--backend-only` without a .web directory

Creates a new `reflex.utils.exec.should_skip_compile()` check, since this is now checked in multiple places.