### PR TITLE
textarea: expose auto_height and enter_key_submit props

### DIFF
--- a/reflex/components/el/elements/forms.pyi
+++ b/reflex/components/el/elements/forms.pyi
@@ -8,7 +8,7 @@ from reflex.vars import Var, BaseVar, ComputedVar
 from reflex.event import EventChain, EventHandler, EventSpec
 from reflex.style import Style
 from hashlib import md5
-from typing import Any, Dict, Iterator, Union
+from typing import Any, Dict, Iterator, Set, Union
 from jinja2 import Environment
 from reflex.components.el.element import Element
 from reflex.components.tags.tag import Tag
@@ -2018,7 +2018,11 @@ class Select(BaseHTML):
         """
         ...
 
+AUTO_HEIGHT_JS = '\nconst autoHeightOnInput = (e, is_enabled) => {\n    if (is_enabled) {\n        const el = e.target;\n        el.style.overflowY = "hidden";\n        el.style.height = "auto";\n        el.style.height = (e.target.scrollHeight) + "px";\n        if (el.form && !el.form.data_resize_on_reset) {\n            el.form.addEventListener("reset", () => window.setTimeout(() => autoHeightOnInput(e, is_enabled), 0))\n            el.form.data_resize_on_reset = true;\n        }\n    }\n}\n'
+ENTER_KEY_SUBMIT_JS = "\nconst enterKeySubmitOnKeyDown = (e, is_enabled) => {\n    if (is_enabled && e.which === 13 && !e.shiftKey) {\n        e.preventDefault();\n        if (!e.repeat) {\n            if (e.target.form) {\n                e.target.form.requestSubmit();\n            }\n        }\n    }\n}\n"
+
 class Textarea(BaseHTML):
+    def get_custom_code(self) -> Set[str]: ...
     def get_event_triggers(self) -> Dict[str, Any]: ...
     @overload
     @classmethod
@@ -2031,6 +2035,7 @@ class Textarea(BaseHTML):
         auto_focus: Optional[
             Union[Var[Union[str, int, bool]], Union[str, int, bool]]
         ] = None,
+        auto_height: Optional[Union[Var[bool], bool]] = None,
         cols: Optional[Union[Var[Union[str, int, bool]], Union[str, int, bool]]] = None,
         dirname: Optional[
             Union[Var[Union[str, int, bool]], Union[str, int, bool]]
@@ -2038,6 +2043,7 @@ class Textarea(BaseHTML):
         disabled: Optional[
             Union[Var[Union[str, int, bool]], Union[str, int, bool]]
         ] = None,
+        enter_key_submit: Optional[Union[Var[bool], bool]] = None,
         form: Optional[Union[Var[Union[str, int, bool]], Union[str, int, bool]]] = None,
         max_length: Optional[
             Union[Var[Union[str, int, bool]], Union[str, int, bool]]
@@ -2168,9 +2174,11 @@ class Textarea(BaseHTML):
             *children: The children of the component.
             auto_complete: Whether the form control should have autocomplete enabled
             auto_focus: Automatically focuses the textarea when the page loads
+            auto_height: Automatically fit the content height to the text (use min-height with this prop)
             cols: Visible width of the text control, in average character widths
             dirname: Name part of the textarea to submit in 'dir' and 'name' pair when form is submitted
             disabled: Disables the textarea
+            enter_key_submit: Enter key submits form (shift-enter adds new line)
             form: Associates the textarea with a form (by id)
             max_length: Maximum number of characters allowed in the textarea
             min_length: Minimum number of characters required in the textarea

--- a/reflex/components/radix/themes/components/text_area.pyi
+++ b/reflex/components/radix/themes/components/text_area.pyi
@@ -108,7 +108,9 @@ class TextArea(RadixThemesComponent, el.Textarea):
         rows: Optional[Union[Var[str], str]] = None,
         value: Optional[Union[Var[str], str]] = None,
         wrap: Optional[Union[Var[str], str]] = None,
+        auto_height: Optional[Union[Var[bool], bool]] = None,
         cols: Optional[Union[Var[Union[str, int, bool]], Union[str, int, bool]]] = None,
+        enter_key_submit: Optional[Union[Var[bool], bool]] = None,
         access_key: Optional[
             Union[Var[Union[str, int, bool]], Union[str, int, bool]]
         ] = None,
@@ -232,7 +234,9 @@ class TextArea(RadixThemesComponent, el.Textarea):
             rows: Visible number of lines in the text control
             value: The controlled value of the textarea, read only unless used with on_change
             wrap: How the text in the textarea is to be wrapped when submitting the form
+            auto_height: Automatically fit the content height to the text (use min-height with this prop)
             cols: Visible width of the text control, in average character widths
+            enter_key_submit: Enter key submits form (shift-enter adds new line)
             access_key:  Provides a hint for generating a keyboard shortcut for the current element.
             auto_capitalize: Controls whether and how text input is automatically capitalized as it is entered/edited by the user.
             content_editable: Indicates whether the element's content is editable.


### PR DESCRIPTION
These two props improve the workflow for chat apps and other situations where we want multiline input.

auto_height: resize the textarea based on its contents

enter_key_submit: pressing enter submits the enclosing form (shift+enter inserts new lines)

Fix #1231

### Sample code

```python
import reflex as rx


class State(rx.State):
    last_value: str
    auto_height: bool
    enter_key_submit: bool

    def foo(self, form_data):
        self.last_value = form_data.get("ta")
        print(self.last_value)


def index() -> rx.Component:
    return rx.vstack(
        rx.heading("Expandable Textarea"),
        rx.text("Normal textarea:"),
        rx.text_area(width="80vw"),
        rx.text("Expanding textarea:"),
        rx.text_area(auto_height=True, min_height="0px", rows="1", width="80vw"),
        rx.text("Expanding textarea with submit button with enter_key_submit:"),
        rx.form(
            rx.text_area(
                auto_height=True,
                enter_key_submit=True,
                name="ta",
                min_height="0px",
                rows="1",
                width="80vw",
            ),
            rx.button("Submit"),
            on_submit=State.foo,
            reset_on_submit=True,
        ),
        rx.text("Configurable special props"),
        rx.hstack(
            rx.text("Auto height:"),
            rx.switch(checked=State.auto_height, on_change=State.set_auto_height),
        ),
        rx.hstack(
            rx.text("Enter key submit:"),
            rx.switch(
                checked=State.enter_key_submit, on_change=State.set_enter_key_submit
            ),
        ),
        rx.form(
            rx.text_area(
                auto_height=State.auto_height,
                enter_key_submit=State.enter_key_submit,
                name="ta",
                min_height="0px",
                rows="1",
                width="80vw",
            ),
            rx.button("Submit"),
            on_submit=State.foo,
            reset_on_submit=True,
        ),
        rx.code(State.last_value, white_space="pre"),
        align="center",
        height="100vh",
    )


app = rx.App()
app.add_page(index)
```