### PR TITLE
[REF-2219] vars: set `_was_touched` when updating cached vars

### DIFF
--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -1861,6 +1861,8 @@ class ComputedVar(Var, property):
         # handle caching
         if not hasattr(instance, self._cache_attr):
             setattr(instance, self._cache_attr, super().__get__(instance, owner))
+            # Ensure the computed var gets serialized to redis.
+            instance._was_touched = True
         return getattr(instance, self._cache_attr)
 
     def _deps(


### PR DESCRIPTION
Ensure that updated cached vars are persisted into redis.

Attempt to Fix #2851 