### PR TITLE
[REF-2416] Pass shell=True when starting AppHarness on Windows

### DIFF
--- a/reflex/testing.py
+++ b/reflex/testing.py
@@ -73,8 +73,9 @@ FRONTEND_POPEN_ARGS = {}
 T = TypeVar("T")
 TimeoutType = Optional[Union[int, float]]
 
-if platform.system == "Windows":
+if platform.system() == "Windows":
     FRONTEND_POPEN_ARGS["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore
+    FRONTEND_POPEN_ARGS["shell"] = True
 else:
     FRONTEND_POPEN_ARGS["start_new_session"] = True
 


### PR DESCRIPTION
In exec.py, run_process_and_launch_url already passes `shell=True` on windows, but the AppHarness has never really been used on Windows, so we were missing this detail.

Fix #2941 #2943