### PR TITLE
adjust share command prompt

### DIFF
--- a/reflex/custom_components/custom_components.py
+++ b/reflex/custom_components/custom_components.py
@@ -910,7 +910,7 @@ def _get_file_from_prompt_in_loop() -> Tuple[bytes, str] | None:
     image_file = file_extension = None
     while image_file is None:
         image_filepath = console.ask(
-            f"Path on your computer from where to upload a preview image of your site (enter to skip)"
+            f"Upload a preview image of your demo app (enter to skip)"
         )
         if not image_filepath:
             break

--- a/reflex/custom_components/custom_components.py
+++ b/reflex/custom_components/custom_components.py
@@ -564,7 +564,7 @@ def _ensure_dist_dir(version_to_publish: str, build: bool):
             needs_rebuild = (
                 console.ask(
                     "Distribution files for the version to be published already exist. Do you want to rebuild?",
-                    choices=["n", "y"],
+                    choices=["y", "n"],
                     default="n",
                 )
                 == "y"
@@ -668,10 +668,10 @@ def publish(
     if validate_project_info and (
         console.ask(
             "Would you like to interactively review the package information?",
-            choices=["Y", "n"],
-            default="Y",
+            choices=["y", "n"],
+            default="y",
         )
-        == "Y"
+        == "y"
     ):
         _validate_project_info()
 
@@ -702,7 +702,7 @@ def publish(
     if (
         console.ask(
             "Would you like to include your published component on our gallery?",
-            choices=["n", "y"],
+            choices=["y", "n"],
             default="y",
         )
         == "n"

--- a/reflex/custom_components/custom_components.py
+++ b/reflex/custom_components/custom_components.py
@@ -919,7 +919,7 @@ def _get_file_from_prompt_in_loop() -> Tuple[bytes, str] | None:
     image_file = file_extension = None
     while image_file is None:
         image_filepath = console.ask(
-            f"Local path to a preview gif or image (enter to skip)"
+            f"Path on your computer from where to upload a preview image of your site (enter to skip)"
         )
         if not image_filepath:
             break

--- a/reflex/custom_components/custom_components.py
+++ b/reflex/custom_components/custom_components.py
@@ -807,11 +807,6 @@ def _collect_details_for_gallery():
     """
     from reflex.reflex import _login
 
-    console.print("We recommend that you deploy a demo app showcasing the component.")
-    console.print("If not already, please deploy it first.")
-    if console.ask("Continue?", choices=["y", "n"], default="y") != "y":
-        return
-
     console.rule("[bold]Authentication with Reflex Services")
     console.print("First let's log in to Reflex backend services.")
     access_token = _login()
@@ -829,47 +824,30 @@ def _collect_details_for_gallery():
         )
         package_name = console.ask("[ Published python package name ]")
     console.print(f"[ Custom component package name ] : {package_name}")
+    params["package_name"] = package_name
 
     # Check the backend services if the user is allowed to update information of this package is already shared.
-    expected_status_code = False
     try:
         console.debug(
-            f"Checking if user has permission to modify information for {package_name} if already exists."
+            f"Checking if user has permission to upsert information for {package_name} by POST."
         )
-        response = httpx.get(
-            f"{GET_CUSTOM_COMPONENTS_GALLERY_BY_NAME_ENDPOINT}/{package_name}",
+        # Send a POST request to achieve two things at once:
+        # 1. Check if the package is already shared by the user. If not, the backend will return 403.
+        # 2. If this package is not shared before, this request records the package name in the backend.
+        response = httpx.post(
+            POST_CUSTOM_COMPONENTS_GALLERY_ENDPOINT,
             headers={"Authorization": f"Bearer {access_token}"},
+            data=params,
         )
         if response.status_code == httpx.codes.FORBIDDEN:
             console.error(
                 f"{package_name} is owned by another user. Unable to update the information for it."
             )
             raise typer.Exit(code=1)
-        elif response.status_code == httpx.codes.NOT_FOUND:
-            console.debug(f"{package_name} is not found. This is a new share.")
-            expected_status_code = True
-
         response.raise_for_status()
-        console.debug(f"{package_name} is found. This is an update.")
     except httpx.HTTPError as he:
-        if not expected_status_code:
-            console.error(f"Unable to complete request due to {he}.")
-            raise typer.Exit(code=1) from he
-
-    params["package_name"] = package_name
-
-    demo_url = None
-    while True:
-        demo_url = (
-            console.ask(
-                "[ Full URL of deployed demo app, e.g. `https://my-app.reflex.run` ] (enter to skip)"
-            )
-            or None
-        )
-        if _validate_url_with_protocol_prefix(demo_url):
-            break
-    if demo_url:
-        params["demo_url"] = demo_url
+        console.error(f"Unable to complete request due to {he}.")
+        raise typer.Exit(code=1) from he
 
     display_name = (
         console.ask("[ Friendly display name for your component ] (enter to skip)")
@@ -883,6 +861,19 @@ def _collect_details_for_gallery():
         files.append(
             ("files", (image_file_and_extension[1], image_file_and_extension[0]))
         )
+
+    demo_url = None
+    while True:
+        demo_url = (
+            console.ask(
+                "[ Full URL of deployed demo app, e.g. `https://my-app.reflex.run` ] (enter to skip)"
+            )
+            or None
+        )
+        if _validate_url_with_protocol_prefix(demo_url):
+            break
+    if demo_url:
+        params["demo_url"] = demo_url
 
     # Now send the post request to Reflex backend services.
     try:


### PR DESCRIPTION
## Summary
- Adjust share command prompt. We won't encourage user to upload gif types. If they deploy apps, their app URL is useful enough.
- Instead of GET, use POST to check if user has permission to update an existing package. This way, we record a package if user has difficulties with any of the remaining steps.
- Move the prompt for demo URL to last: user may not have an app ready, so this step could take long (in a new tab/terminal separately) hence keeping it last.
## Tests
- Use the command against dev CP. Check the DB columns.