### PR TITLE
[REF-2425] Reduce unnecessary CI runs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -5,10 +5,6 @@ on:
     branches: [main]
     paths-ignore:
       - '**/*.md'
-  pull_request:
-    branches: [main]
-    paths-ignore:
-      - '**/*.md'
 
 permissions:
   contents: read
@@ -23,7 +19,6 @@ env:
   NODE_OPTIONS: '--max_old_space_size=4096'
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
   PR_TITLE: ${{ github.event.pull_request.title }}
-
 
 jobs:
   reflex-web:
@@ -93,6 +88,15 @@ jobs:
             python-version: '3.9.18'
           - os: windows-latest
             python-version: '3.8.18'
+          # keep only one python version for MacOS
+          - os: macos-latest
+            python-version: '3.8.18'
+          - os: macos-latest
+            python-version: '3.9.18'
+          - os: macos-latest
+            python-version: '3.10.13'
+          - os: macos-latest
+            python-version: '3.12.0'
         include:
           - os: windows-latest
             python-version: '3.10.11'
@@ -143,13 +147,14 @@ jobs:
       - name: Install additional dependencies for DB access
         run: poetry run pip install psycopg2-binary
       - name: Build reflex
-        run: | 
+        run: |
           poetry build
       - name: Upload benchmark results
         # Only run if the database creds are available in this context.
         if: ${{ env.DATABASE_URL }}
-        run: poetry run python scripts/benchmarks/benchmark_reflex_size.py --os ubuntu-latest
-          --python-version 3.11.5 --commit-sha "${{ github.sha }}" --pr-id "${{ github.event.pull_request.id }}" 
+        run:
+          poetry run python scripts/benchmarks/benchmark_reflex_size.py --os ubuntu-latest
+          --python-version 3.11.5 --commit-sha "${{ github.sha }}" --pr-id "${{ github.event.pull_request.id }}"
           --db-url "${{ env.DATABASE_URL }}" --branch-name "${{ github.head_ref || github.ref_name }}"
           --measurement-type "reflex-build" --path ./dist
 
@@ -160,8 +165,8 @@ jobs:
       fail-fast: false
       matrix:
         # Show OS combos first in GUI
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ '3.11.5']
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.11.5']
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -170,7 +175,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
-          version : 1.3.1
+          version: 1.3.1
           virtualenvs-create: true
           virtualenvs-in-project: true
           virtualenvs-path: .venv
@@ -180,14 +185,15 @@ jobs:
         run: |
           python -m venv .venv
           source .venv/*/activate
-          poetry install --without dev --no-interaction --no-root  
+          poetry install --without dev --no-interaction --no-root
 
       - name: Install additional dependencies for DB access
         run: poetry run pip install psycopg2-binary
 
       - if: ${{ env.DATABASE_URL }}
         name: calculate and upload size
-        run: poetry run python scripts/benchmarks/benchmark_reflex_size.py --os "${{ matrix.os }}"
+        run:
+          poetry run python scripts/benchmarks/benchmark_reflex_size.py --os "${{ matrix.os }}"
           --python-version "${{ matrix.python-version }}" --commit-sha "${{ github.sha }}"
           --pr-id "${{ github.event.pull_request.id }}" --db-url "${{ env.DATABASE_URL }}"
           --branch-name "${{ github.head_ref || github.ref_name }}"

--- a/.github/workflows/check_generated_pyi.yml
+++ b/.github/workflows/check_generated_pyi.yml
@@ -1,15 +1,19 @@
 name: check-generated-pyi
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.id }}
+  cancel-in-progress: true
+
 on:
   push:
-    branches: [ "main" ]
+    branches: ['main']
     # We don't just trigger on make_pyi.py and the components dir, because
     # there are other things that can change the generator output
     # e.g. black version, reflex.Component, reflex.Var.
     paths-ignore:
       - '**/*.md'
   pull_request:
-    branches: [ "main" ]
+    branches: ['main']
     paths-ignore:
       - '**/*.md'
 
@@ -21,7 +25,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup_build_env
         with:
-          python-version: "3.11.5"
+          python-version: '3.11.5'
           run-poetry-install: true
           create-venv-at-path: .venv
       - run: |

--- a/.github/workflows/integration_app_harness.yml
+++ b/.github/workflows/integration_app_harness.yml
@@ -1,12 +1,16 @@
 name: integration-app-harness
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.id }}
+  cancel-in-progress: true
+
 on:
   push:
-    branches: [ "main" ]
+    branches: ['main']
     paths-ignore:
       - '**/*.md'
   pull_request:
-    branches: [ "main" ]
+    branches: ['main']
     paths-ignore:
       - '**/*.md'
 
@@ -18,8 +22,8 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        state_manager: [ "redis", "memory" ]
-        python-version: ["3.8.18", "3.11.5", "3.12.0"]
+        state_manager: ['redis', 'memory']
+        python-version: ['3.8.18', '3.11.5', '3.12.0']
     runs-on: ubuntu-latest
     services:
       # Label used to access the service container
@@ -35,22 +39,22 @@ jobs:
           # Maps port 6379 on service container to the host
           - 6379:6379
     steps:
-    - uses: actions/checkout@v4
-    - uses: ./.github/actions/setup_build_env
-      with:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup_build_env
+        with:
           python-version: ${{ matrix.python-version }}
           run-poetry-install: true
           create-venv-at-path: .venv
-    - run: poetry run pip install pyvirtualdisplay pillow
-    - name: Run app harness tests
-      env:
-        SCREENSHOT_DIR: /tmp/screenshots
-        REDIS_URL: ${{ matrix.state_manager == 'redis' && 'redis://localhost:6379' || '' }}
-      run: |
-        poetry run pytest integration
-    - uses: actions/upload-artifact@v4
-      name: Upload failed test screenshots
-      if: always()
-      with:
-        name: failed_test_screenshots
-        path: /tmp/screenshots
+      - run: poetry run pip install pyvirtualdisplay pillow
+      - name: Run app harness tests
+        env:
+          SCREENSHOT_DIR: /tmp/screenshots
+          REDIS_URL: ${{ matrix.state_manager == 'redis' && 'redis://localhost:6379' || '' }}
+        run: |
+          poetry run pytest integration
+      - uses: actions/upload-artifact@v4
+        name: Upload failed test screenshots
+        if: always()
+        with:
+          name: failed_test_screenshots
+          path: /tmp/screenshots

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -10,6 +10,10 @@ on:
     paths-ignore:
       - '**/*.md'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -28,7 +32,6 @@ env:
   NODE_OPTIONS: '--max_old_space_size=4096'
   DATABASE_URL: ${{ secrets.DATABASE_URL }}
   PR_TITLE: ${{ github.event.pull_request.title }}
-
 
 jobs:
   example-counter:
@@ -96,9 +99,10 @@ jobs:
           poetry run bash scripts/integration.sh ./reflex-examples/counter dev
       - name: Measure and upload .web size
         if: ${{ env.DATABASE_URL }}
-        run: poetry run python scripts/benchmarks/benchmark_reflex_size.py --os "${{ matrix.os }}"
+        run:
+          poetry run python scripts/benchmarks/benchmark_reflex_size.py --os "${{ matrix.os }}"
           --python-version "${{ matrix.python-version }}" --commit-sha "${{ github.sha }}"
-          --pr-id "${{ github.event.pull_request.id }}" --db-url "${{ env.DATABASE_URL }}" 
+          --pr-id "${{ github.event.pull_request.id }}" --db-url "${{ env.DATABASE_URL }}"
           --branch-name "${{ github.head_ref || github.ref_name }}"
           --measurement-type "counter-app-dot-web" --path ./reflex-examples/counter/.web
 
@@ -143,8 +147,9 @@ jobs:
           poetry run bash scripts/integration.sh ./reflex-web prod
       - name: Measure and upload .web size
         if: ${{ env.DATABASE_URL }}
-        run: poetry run python scripts/benchmarks/benchmark_reflex_size.py --os "${{ matrix.os }}"
+        run:
+          poetry run python scripts/benchmarks/benchmark_reflex_size.py --os "${{ matrix.os }}"
           --python-version "${{ matrix.python-version }}" --commit-sha "${{ github.sha }}"
-          --pr-id "${{ github.event.pull_request.id }}" 
+          --pr-id "${{ github.event.pull_request.id }}"
           --db-url "${{ env.DATABASE_URL }}" --branch-name "${{ github.head_ref || github.ref_name }}"
           --measurement-type "reflex-web-dot-web" --path ./reflex-web/.web

--- a/.github/workflows/integration_tests_wsl.yml
+++ b/.github/workflows/integration_tests_wsl.yml
@@ -1,5 +1,9 @@
 name: integration-tests-wsl
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.id }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: ['main']

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,5 +1,9 @@
 name: pre-commit
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.id }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     branches: ['main']

--- a/.github/workflows/reflex_init_in_docker_test.yml
+++ b/.github/workflows/reflex_init_in_docker_test.yml
@@ -1,12 +1,16 @@
 name: reflex-init-in-docker-test
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.id }}
+  cancel-in-progress: true
+
 on:
   push:
-    branches: [ "main" ]
+    branches: ['main']
     paths-ignore:
       - '**/*.md'
   pull_request:
-    branches: [ "main" ]
+    branches: ['main']
     paths-ignore:
       - '**/*.md'
 
@@ -17,12 +21,12 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - shell: bash
-      run: |
-        # Run reflex init in a docker container
- 
-        # cwd is repo root
-        docker build -f integration/init-test/Dockerfile -t reflex-init-test integration/init-test
-        docker run --rm -v $(pwd):/reflex-repo/ reflex-init-test /reflex-repo/integration/init-test/in_docker_test_script.sh
+      - shell: bash
+        run: |
+          # Run reflex init in a docker container
+
+          # cwd is repo root
+          docker build -f integration/init-test/Dockerfile -t reflex-init-test integration/init-test
+          docker run --rm -v $(pwd):/reflex-repo/ reflex-init-test /reflex-repo/integration/init-test/in_docker_test_script.sh

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,12 +1,16 @@
 name: unit-tests
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.id }}
+  cancel-in-progress: true
+
 on:
   push:
-    branches: [ "main" ]
+    branches: ['main']
     paths-ignore:
       - '**/*.md'
   pull_request:
-    branches: [ "main" ]
+    branches: ['main']
     paths-ignore:
       - '**/*.md'
 
@@ -14,8 +18,8 @@ permissions:
   contents: read
 
 defaults:
-    run:
-        shell: bash
+  run:
+    shell: bash
 
 jobs:
   unit-tests:
@@ -24,22 +28,22 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8.18", "3.9.18", "3.10.13", "3.11.5", "3.12.0"]
+        python-version: ['3.8.18', '3.9.18', '3.10.13', '3.11.5', '3.12.0']
         # Windows is a bit behind on Python version availability in Github
         exclude:
           - os: windows-latest
-            python-version: "3.10.13"
+            python-version: '3.10.13'
           - os: windows-latest
-            python-version: "3.9.18"
+            python-version: '3.9.18'
           - os: windows-latest
-            python-version: "3.8.18"
+            python-version: '3.8.18'
         include:
           - os: windows-latest
-            python-version: "3.10.11"
+            python-version: '3.10.11'
           - os: windows-latest
-            python-version: "3.9.13"
+            python-version: '3.9.13'
           - os: windows-latest
-            python-version: "3.8.10"
+            python-version: '3.8.10'
     runs-on: ${{ matrix.os }}
     # Service containers to run with `runner-job`
     services:
@@ -56,20 +60,20 @@ jobs:
           # Maps port 6379 on service container to the host
           - 6379:6379
     steps:
-    - uses: actions/checkout@v4
-    - uses: ./.github/actions/setup_build_env
-      with:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup_build_env
+        with:
           python-version: ${{ matrix.python-version }}
           run-poetry-install: true
           create-venv-at-path: .venv
-    - name: Run unit tests
-      run: |
-        export PYTHONUNBUFFERED=1
-        poetry run pytest tests --cov --no-cov-on-fail --cov-report=
-    - name: Run unit tests w/ redis
-      if: ${{ matrix.os == 'ubuntu-latest' }}
-      run: |
-        export PYTHONUNBUFFERED=1
-        export REDIS_URL=redis://localhost:6379
-        poetry run pytest tests --cov --no-cov-on-fail --cov-report=
-    - run: poetry run coverage html
+      - name: Run unit tests
+        run: |
+          export PYTHONUNBUFFERED=1
+          poetry run pytest tests --cov --no-cov-on-fail --cov-report=
+      - name: Run unit tests w/ redis
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          export PYTHONUNBUFFERED=1
+          export REDIS_URL=redis://localhost:6379
+          poetry run pytest tests --cov --no-cov-on-fail --cov-report=
+      - run: poetry run coverage html


### PR DESCRIPTION
## Summary
- Reduce the MacOS jobs to only necessary.
- Only run benchmark jobs on merge.
- Add concurrency groups to cancel in progress.