### PR TITLE
Exclude .web dir when running uvicorn

### DIFF
--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -175,6 +175,7 @@ def run_backend(
         log_level=loglevel.value,
         reload=True,
         reload_dirs=[config.app_name],
+        reload_excludes=[constants.Dirs.WEB]
     )
 
 

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -175,7 +175,7 @@ def run_backend(
         log_level=loglevel.value,
         reload=True,
         reload_dirs=[config.app_name],
-        reload_excludes=[constants.Dirs.WEB]
+        reload_excludes=[constants.Dirs.WEB],
     )
 
 


### PR DESCRIPTION
When running uvicorn we should exclude watching the `.web` folder

fixes #2785


