### PR TITLE
Remove extra spaces in the keywords in pyproject.toml template

### DIFF
--- a/reflex/.templates/jinja/custom_components/pyproject.toml.jinja2
+++ b/reflex/.templates/jinja/custom_components/pyproject.toml.jinja2
@@ -10,7 +10,7 @@ readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.8"
 authors = [{ name = "", email = "YOUREMAIL@domain.com" }]
-keywords = ["reflex", "reflex-custom-components"]
+keywords = ["reflex","reflex-custom-components"]
 
 dependencies = ["reflex>=0.4.2"]
 


### PR DESCRIPTION
## Summary
- PyPI doesn't seem to remove spaces around the commas when processing the list of keywords. Remove that space from template.