### PR TITLE
Reflex run automatically inits when needed

### DIFF
--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -165,7 +165,8 @@ def _run(
         _skip_compile()
 
     # Check that the app is initialized.
-    prerequisites.check_initialized(frontend=frontend)
+    if prerequisites.needs_reinit(frontend=frontend):
+        _init(name=config.app_name, loglevel=loglevel)
 
     # If something is running on the ports, ask the user if they want to kill or change it.
     if frontend and processes.is_process_on_port(frontend_port):
@@ -294,6 +295,10 @@ def export(
 ):
     """Export the app to a zip file."""
     from reflex.utils import export as export_utils
+    from reflex.utils import prerequisites
+
+    if prerequisites.needs_reinit(frontend=True):
+        _init(name=config.app_name, loglevel=loglevel)
 
     export_utils.export(
         zipping=zipping,
@@ -529,7 +534,8 @@ def deploy(
         dependency.check_requirements()
 
     # Check if we are set up.
-    prerequisites.check_initialized(frontend=True)
+    if prerequisites.needs_reinit(frontend=True):
+        _init(name=config.app_name, loglevel=loglevel)
     prerequisites.check_latest_package_version(constants.ReflexHostingCLI.MODULE_NAME)
 
     hosting_cli.deploy(

--- a/reflex/utils/export.py
+++ b/reflex/utils/export.py
@@ -46,9 +46,6 @@ def export(
     # Show system info
     exec.output_system_info()
 
-    # Check that the app is initialized.
-    prerequisites.check_initialized(frontend=frontend)
-
     # Compile the app in production mode and export it.
     console.rule("[bold]Compiling production app and preparing for export.")
 

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -802,38 +802,38 @@ def install_frontend_packages(packages: set[str], config: Config):
         )
 
 
-def check_initialized(frontend: bool = True):
-    """Check that the app is initialized.
+def needs_reinit(frontend: bool = True) -> bool:
+    """Check if an app needs to be reinitialized.
 
     Args:
         frontend: Whether to check if the frontend is initialized.
 
+    Returns:
+        Whether the app needs to be reinitialized.
+
     Raises:
         Exit: If the app is not initialized.
     """
-    has_config = os.path.exists(constants.Config.FILE)
-    has_reflex_dir = not frontend or os.path.exists(constants.Reflex.DIR)
-    has_web_dir = not frontend or os.path.exists(constants.Dirs.WEB)
-
-    # Check if the app is initialized.
-    if not (has_config and has_reflex_dir and has_web_dir):
+    if not os.path.exists(constants.Config.FILE):
         console.error(
-            f"The app is not initialized. Run [bold]{constants.Reflex.MODULE_NAME} init[/bold] first."
+            f"{constants.Config.FILE} not found. Run [bold]{constants.Reflex.MODULE_NAME} init[/bold] first."
         )
         raise typer.Exit(1)
 
-    # Check that the template is up to date.
-    if frontend and not is_latest_template():
-        console.error(
-            "The base app template has updated. Run [bold]reflex init[/bold] again."
-        )
-        raise typer.Exit(1)
+    # Make sure the .reflex directory exists.
+    if not os.path.exists(constants.Reflex.DIR):
+        return True
 
-    # Print a warning for Windows users.
+    # Make sure the .web directory exists in frontend mode.
+    if frontend and not os.path.exists(constants.Dirs.WEB):
+        return True
+
     if constants.IS_WINDOWS:
         console.warn(
             """Windows Subsystem for Linux (WSL) is recommended for improving initial install times."""
         )
+    # No need to reinitialize if the app is already initialized.
+    return False
 
 
 def is_latest_template() -> bool:


### PR DESCRIPTION
Previously if you didn't have a `.web` folder or the app template had updated, `reflex run` would throw a warning saying to run `reflex init` again. This PR just automatically runs init for them, reducing the steps to get the app running.