### PR TITLE
Get project name from pyproject

### DIFF
--- a/reflex/custom_components/custom_components.py
+++ b/reflex/custom_components/custom_components.py
@@ -416,7 +416,8 @@ def _run_commands_in_subprocess(cmds: list[str]) -> bool:
 
 def _make_pyi_files():
     """Create pyi files for the custom component."""
-    package_name = tomlkit.load(open(CustomComponents.PYPROJECT_TOML))["project"]["name"]
+    with open(CustomComponents.PYPROJECT_TOML, "rb") as f:
+        package_name = tomlkit.load(f).get("project", {})["name"]
 
     for dir, _, _ in os.walk(f"./{package_name}"):
         if "__pycache__" in dir:

--- a/reflex/custom_components/custom_components.py
+++ b/reflex/custom_components/custom_components.py
@@ -416,9 +416,7 @@ def _run_commands_in_subprocess(cmds: list[str]) -> bool:
 
 def _make_pyi_files():
     """Create pyi files for the custom component."""
-    from glob import glob
-
-    package_name = glob("custom_components/*.egg-info")[0].replace(".egg-info", "")
+    package_name = tomlkit.load(open(CustomComponents.PYPROJECT_TOML))["project"]["name"]
 
     for dir, _, _ in os.walk(f"./{package_name}"):
         if "__pycache__" in dir:


### PR DESCRIPTION
`reflex component build` was throwing an error when the egg folder didn't exist. We can rely on `pyproject.toml` always existing.