### PR TITLE
[REF-2524]Tuple unpacking should apply at component level

### DIFF
--- a/reflex/components/base/body.pyi
+++ b/reflex/components/base/body.pyi
@@ -82,8 +82,5 @@ class Body(Component):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/base/document.pyi
+++ b/reflex/components/base/document.pyi
@@ -83,9 +83,6 @@ class NextDocumentLib(Component):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -163,9 +160,6 @@ class Html(NextDocumentLib):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -242,9 +236,6 @@ class DocumentHead(NextDocumentLib):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -321,9 +312,6 @@ class Main(NextDocumentLib):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -400,8 +388,5 @@ class NextScript(NextDocumentLib):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/base/fragment.pyi
+++ b/reflex/components/base/fragment.pyi
@@ -82,8 +82,5 @@ class Fragment(Component):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/base/head.pyi
+++ b/reflex/components/base/head.pyi
@@ -82,9 +82,6 @@ class NextHeadLib(Component):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 

--- a/reflex/components/base/link.pyi
+++ b/reflex/components/base/link.pyi
@@ -87,9 +87,6 @@ class RawLink(Component):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -180,8 +177,5 @@ class ScriptTag(Component):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/base/meta.pyi
+++ b/reflex/components/base/meta.pyi
@@ -85,9 +85,6 @@ class Title(Component):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -174,9 +171,6 @@ class Meta(Component):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -263,9 +257,6 @@ class Description(Meta):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -352,8 +343,5 @@ class Image(Meta):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/base.pyi
+++ b/reflex/components/chakra/base.pyi
@@ -86,9 +86,6 @@ class ChakraComponent(Component):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -234,9 +231,6 @@ class ChakraColorModeProvider(Component):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 

--- a/reflex/components/chakra/datadisplay/badge.pyi
+++ b/reflex/components/chakra/datadisplay/badge.pyi
@@ -92,8 +92,5 @@ class Badge(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/datadisplay/code.pyi
+++ b/reflex/components/chakra/datadisplay/code.pyi
@@ -82,8 +82,5 @@ class Code(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/datadisplay/divider.pyi
+++ b/reflex/components/chakra/datadisplay/divider.pyi
@@ -97,8 +97,5 @@ class Divider(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/datadisplay/keyboard_key.pyi
+++ b/reflex/components/chakra/datadisplay/keyboard_key.pyi
@@ -82,8 +82,5 @@ class KeyboardKey(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/datadisplay/list.pyi
+++ b/reflex/components/chakra/datadisplay/list.pyi
@@ -169,9 +169,6 @@ class ListItem(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 

--- a/reflex/components/chakra/datadisplay/stat.pyi
+++ b/reflex/components/chakra/datadisplay/stat.pyi
@@ -168,9 +168,6 @@ class StatLabel(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -247,9 +244,6 @@ class StatNumber(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -326,9 +320,6 @@ class StatHelpText(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -407,9 +398,6 @@ class StatArrow(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -486,8 +474,5 @@ class StatGroup(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/datadisplay/table.pyi
+++ b/reflex/components/chakra/datadisplay/table.pyi
@@ -502,9 +502,6 @@ class Th(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -583,9 +580,6 @@ class Td(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -664,9 +658,6 @@ class TableCaption(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -743,8 +734,5 @@ class TableContainer(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/datadisplay/tag.pyi
+++ b/reflex/components/chakra/datadisplay/tag.pyi
@@ -90,9 +90,6 @@ class TagLabel(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -169,9 +166,6 @@ class TagLeftIcon(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -248,9 +242,6 @@ class TagRightIcon(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -327,9 +318,6 @@ class TagCloseButton(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 

--- a/reflex/components/chakra/disclosure/accordion.pyi
+++ b/reflex/components/chakra/disclosure/accordion.pyi
@@ -185,9 +185,6 @@ class AccordionItem(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -264,9 +261,6 @@ class AccordionButton(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -343,9 +337,6 @@ class AccordionPanel(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -422,8 +413,5 @@ class AccordionIcon(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/disclosure/tabs.pyi
+++ b/reflex/components/chakra/disclosure/tabs.pyi
@@ -269,9 +269,6 @@ class Tab(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -348,9 +345,6 @@ class TabList(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -427,9 +421,6 @@ class TabPanels(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -506,8 +497,5 @@ class TabPanel(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/disclosure/transition.pyi
+++ b/reflex/components/chakra/disclosure/transition.pyi
@@ -88,9 +88,6 @@ class Transition(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -171,9 +168,6 @@ class Fade(Transition):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -258,9 +252,6 @@ class ScaleFade(Transition):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -343,9 +334,6 @@ class Slide(Transition):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -432,9 +420,6 @@ class SlideFade(Transition):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -521,8 +506,5 @@ class Collapse(Transition):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/disclosure/visuallyhidden.pyi
+++ b/reflex/components/chakra/disclosure/visuallyhidden.pyi
@@ -82,8 +82,5 @@ class VisuallyHidden(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/feedback/alert.pyi
+++ b/reflex/components/chakra/feedback/alert.pyi
@@ -180,9 +180,6 @@ class AlertIcon(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -259,9 +256,6 @@ class AlertTitle(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -338,8 +332,5 @@ class AlertDescription(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/feedback/circularprogress.pyi
+++ b/reflex/components/chakra/feedback/circularprogress.pyi
@@ -183,8 +183,5 @@ class CircularProgressLabel(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/feedback/progress.pyi
+++ b/reflex/components/chakra/feedback/progress.pyi
@@ -98,8 +98,5 @@ class Progress(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/feedback/skeleton.pyi
+++ b/reflex/components/chakra/feedback/skeleton.pyi
@@ -93,9 +93,6 @@ class Skeleton(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -182,9 +179,6 @@ class SkeletonCircle(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -273,8 +267,5 @@ class SkeletonText(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/feedback/spinner.pyi
+++ b/reflex/components/chakra/feedback/spinner.pyi
@@ -98,8 +98,5 @@ class Spinner(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/forms/button.pyi
+++ b/reflex/components/chakra/forms/button.pyi
@@ -170,9 +170,6 @@ class Button(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -266,8 +263,5 @@ class ButtonGroup(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/forms/checkbox.pyi
+++ b/reflex/components/chakra/forms/checkbox.pyi
@@ -162,9 +162,6 @@ class Checkbox(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -249,8 +246,5 @@ class CheckboxGroup(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/forms/colormodeswitch.pyi
+++ b/reflex/components/chakra/forms/colormodeswitch.pyi
@@ -468,8 +468,5 @@ class ColorModeScript(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/forms/editable.pyi
+++ b/reflex/components/chakra/forms/editable.pyi
@@ -114,9 +114,6 @@ class Editable(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -193,9 +190,6 @@ class EditableInput(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -272,9 +266,6 @@ class EditableTextarea(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -351,8 +342,5 @@ class EditablePreview(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/forms/form.pyi
+++ b/reflex/components/chakra/forms/form.pyi
@@ -355,9 +355,6 @@ class FormHelperText(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -436,9 +433,6 @@ class FormLabel(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -515,8 +509,5 @@ class FormErrorMessage(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/forms/iconbutton.pyi
+++ b/reflex/components/chakra/forms/iconbutton.pyi
@@ -105,8 +105,5 @@ class IconButton(Text):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/forms/input.pyi
+++ b/reflex/components/chakra/forms/input.pyi
@@ -265,9 +265,6 @@ class InputGroup(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -344,9 +341,6 @@ class InputLeftAddon(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -423,9 +417,6 @@ class InputRightAddon(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -502,9 +493,6 @@ class InputLeftElement(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -581,8 +569,5 @@ class InputRightElement(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/forms/numberinput.pyi
+++ b/reflex/components/chakra/forms/numberinput.pyi
@@ -216,9 +216,6 @@ class NumberInputField(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -295,9 +292,6 @@ class NumberInputStepper(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -374,9 +368,6 @@ class NumberIncrementStepper(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -453,8 +444,5 @@ class NumberDecrementStepper(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/forms/pininput.pyi
+++ b/reflex/components/chakra/forms/pininput.pyi
@@ -218,5 +218,8 @@ class PinInputField(ChakraComponent):
 
         Returns:
             The component.
+
+        Raises:
+            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/forms/pininput.pyi
+++ b/reflex/components/chakra/forms/pininput.pyi
@@ -218,8 +218,5 @@ class PinInputField(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/forms/rangeslider.pyi
+++ b/reflex/components/chakra/forms/rangeslider.pyi
@@ -200,9 +200,6 @@ class RangeSliderTrack(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -279,9 +276,6 @@ class RangeSliderFilledTrack(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -361,8 +355,5 @@ class RangeSliderThumb(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/forms/slider.pyi
+++ b/reflex/components/chakra/forms/slider.pyi
@@ -219,9 +219,6 @@ class SliderTrack(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -298,9 +295,6 @@ class SliderFilledTrack(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -379,9 +373,6 @@ class SliderThumb(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -458,8 +449,5 @@ class SliderMark(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/forms/switch.pyi
+++ b/reflex/components/chakra/forms/switch.pyi
@@ -158,8 +158,5 @@ class Switch(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/layout/aspect_ratio.pyi
+++ b/reflex/components/chakra/layout/aspect_ratio.pyi
@@ -85,8 +85,5 @@ class AspectRatio(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/layout/box.pyi
+++ b/reflex/components/chakra/layout/box.pyi
@@ -90,8 +90,5 @@ class Box(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/layout/card.pyi
+++ b/reflex/components/chakra/layout/card.pyi
@@ -90,9 +90,6 @@ class CardHeader(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -169,9 +166,6 @@ class CardBody(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -248,9 +242,6 @@ class CardFooter(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 

--- a/reflex/components/chakra/layout/center.pyi
+++ b/reflex/components/chakra/layout/center.pyi
@@ -82,9 +82,6 @@ class Center(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -161,9 +158,6 @@ class Square(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -240,8 +234,5 @@ class Circle(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/layout/container.pyi
+++ b/reflex/components/chakra/layout/container.pyi
@@ -85,8 +85,5 @@ class Container(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/layout/flex.pyi
+++ b/reflex/components/chakra/layout/flex.pyi
@@ -100,8 +100,5 @@ class Flex(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/layout/grid.pyi
+++ b/reflex/components/chakra/layout/grid.pyi
@@ -98,9 +98,6 @@ class Grid(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -191,9 +188,6 @@ class GridItem(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -296,8 +290,5 @@ class ResponsiveGrid(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/layout/spacer.pyi
+++ b/reflex/components/chakra/layout/spacer.pyi
@@ -82,8 +82,5 @@ class Spacer(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/layout/stack.pyi
+++ b/reflex/components/chakra/layout/stack.pyi
@@ -105,9 +105,6 @@ class Stack(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -205,9 +202,6 @@ class Hstack(Stack):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -305,8 +299,5 @@ class Vstack(Stack):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/layout/wrap.pyi
+++ b/reflex/components/chakra/layout/wrap.pyi
@@ -176,8 +176,5 @@ class WrapItem(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/media/avatar.pyi
+++ b/reflex/components/chakra/media/avatar.pyi
@@ -109,9 +109,6 @@ class Avatar(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -188,9 +185,6 @@ class AvatarBadge(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -271,8 +265,5 @@ class AvatarGroup(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/media/icon.pyi
+++ b/reflex/components/chakra/media/icon.pyi
@@ -84,9 +84,6 @@ class ChakraIconComponent(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 

--- a/reflex/components/chakra/navigation/breadcrumb.pyi
+++ b/reflex/components/chakra/navigation/breadcrumb.pyi
@@ -258,9 +258,6 @@ class BreadcrumbSeparator(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 

--- a/reflex/components/chakra/navigation/linkoverlay.pyi
+++ b/reflex/components/chakra/navigation/linkoverlay.pyi
@@ -87,9 +87,6 @@ class LinkOverlay(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -166,8 +163,5 @@ class LinkBox(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/navigation/stepper.pyi
+++ b/reflex/components/chakra/navigation/stepper.pyi
@@ -224,9 +224,6 @@ class Step(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -303,9 +300,6 @@ class StepDescription(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -382,9 +376,6 @@ class StepIcon(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -461,9 +452,6 @@ class StepIndicator(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -540,9 +528,6 @@ class StepNumber(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -619,9 +604,6 @@ class StepSeparator(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -702,9 +684,6 @@ class StepStatus(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -781,8 +760,5 @@ class StepTitle(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/overlay/alertdialog.pyi
+++ b/reflex/components/chakra/overlay/alertdialog.pyi
@@ -232,9 +232,6 @@ class AlertDialogBody(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -311,9 +308,6 @@ class AlertDialogHeader(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -390,9 +384,6 @@ class AlertDialogFooter(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -469,9 +460,6 @@ class AlertDialogContent(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -548,9 +536,6 @@ class AlertDialogOverlay(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -627,8 +612,5 @@ class AlertDialogCloseButton(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/overlay/drawer.pyi
+++ b/reflex/components/chakra/overlay/drawer.pyi
@@ -274,9 +274,6 @@ class DrawerBody(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -353,9 +350,6 @@ class DrawerHeader(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -432,9 +426,6 @@ class DrawerFooter(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -511,9 +502,6 @@ class DrawerOverlay(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -590,9 +578,6 @@ class DrawerContent(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -669,8 +654,5 @@ class DrawerCloseButton(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/overlay/menu.pyi
+++ b/reflex/components/chakra/overlay/menu.pyi
@@ -218,9 +218,6 @@ class MenuButton(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -385,9 +382,6 @@ class MenuItem(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -482,9 +476,6 @@ class MenuItemOption(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -561,9 +552,6 @@ class MenuGroup(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -646,9 +634,6 @@ class MenuOptionGroup(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -725,8 +710,5 @@ class MenuDivider(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/overlay/modal.pyi
+++ b/reflex/components/chakra/overlay/modal.pyi
@@ -219,9 +219,6 @@ class ModalOverlay(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -298,9 +295,6 @@ class ModalHeader(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -377,9 +371,6 @@ class ModalFooter(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -456,9 +447,6 @@ class ModalContent(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -535,9 +523,6 @@ class ModalBody(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -614,8 +599,5 @@ class ModalCloseButton(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/overlay/popover.pyi
+++ b/reflex/components/chakra/overlay/popover.pyi
@@ -227,9 +227,6 @@ class PopoverContent(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -306,9 +303,6 @@ class PopoverHeader(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -385,9 +379,6 @@ class PopoverFooter(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -464,9 +455,6 @@ class PopoverBody(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -543,9 +531,6 @@ class PopoverArrow(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -622,9 +607,6 @@ class PopoverCloseButton(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -701,9 +683,6 @@ class PopoverAnchor(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -780,8 +759,5 @@ class PopoverTrigger(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/overlay/tooltip.pyi
+++ b/reflex/components/chakra/overlay/tooltip.pyi
@@ -127,8 +127,5 @@ class Tooltip(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/typography/heading.pyi
+++ b/reflex/components/chakra/typography/heading.pyi
@@ -92,8 +92,5 @@ class Heading(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/typography/highlight.pyi
+++ b/reflex/components/chakra/typography/highlight.pyi
@@ -89,8 +89,5 @@ class Highlight(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/typography/span.pyi
+++ b/reflex/components/chakra/typography/span.pyi
@@ -85,8 +85,5 @@ class Span(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/chakra/typography/text.pyi
+++ b/reflex/components/chakra/typography/text.pyi
@@ -87,8 +87,5 @@ class Text(ChakraComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -614,6 +614,9 @@ class Component(BaseComponent, ABC):
 
         Returns:
             The component.
+
+        Raises:
+            TypeError: If an invalid child is passed. # noqa: DAR402
         """
         # Import here to avoid circular imports.
         from reflex.components.base.bare import Bare

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -614,9 +614,6 @@ class Component(BaseComponent, ABC):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed. # noqa: DAR402
         """
         # Import here to avoid circular imports.
         from reflex.components.base.bare import Bare

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -614,9 +614,6 @@ class Component(BaseComponent, ABC):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         # Import here to avoid circular imports.
         from reflex.components.base.bare import Bare

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -622,10 +622,6 @@ class Component(BaseComponent, ABC):
         from reflex.components.base.bare import Bare
         from reflex.components.base.fragment import Fragment
 
-        # if children and isinstance(children, tuple):
-        #     pass
-        # children_ = Fragment.create(*children)
-
         # Translate deprecated props to new names.
         new_prop_names = [
             prop for prop in cls.get_props() if prop in ["type", "min", "max"]

--- a/reflex/components/core/client_side_routing.pyi
+++ b/reflex/components/core/client_side_routing.pyi
@@ -88,9 +88,6 @@ class ClientSideRouting(Component):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -170,8 +167,5 @@ class Default404Page(Component):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/core/upload.pyi
+++ b/reflex/components/core/upload.pyi
@@ -115,9 +115,6 @@ class UploadFilesProvider(Component):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 

--- a/reflex/components/core/upload.pyi
+++ b/reflex/components/core/upload.pyi
@@ -115,6 +115,9 @@ class UploadFilesProvider(Component):
 
         Returns:
             The component.
+
+        Raises:
+            TypeError: If an invalid child is passed.
         """
         ...
 

--- a/reflex/components/el/element.pyi
+++ b/reflex/components/el/element.pyi
@@ -82,8 +82,5 @@ class Element(Component):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/el/elements/base.pyi
+++ b/reflex/components/el/elements/base.pyi
@@ -140,8 +140,5 @@ class BaseHTML(Element):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/el/elements/forms.pyi
+++ b/reflex/components/el/elements/forms.pyi
@@ -189,6 +189,9 @@ class Button(BaseHTML):
 
         Returns:
             The component.
+
+        Raises:
+            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -321,6 +324,9 @@ class Datalist(BaseHTML):
 
         Returns:
             The component.
+
+        Raises:
+            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -405,6 +411,9 @@ class Fieldset(Element):
 
         Returns:
             The component.
+
+        Raises:
+            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -829,6 +838,9 @@ class Input(BaseHTML):
 
         Returns:
             The component.
+
+        Raises:
+            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -967,6 +979,9 @@ class Label(BaseHTML):
 
         Returns:
             The component.
+
+        Raises:
+            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1099,6 +1114,9 @@ class Legend(BaseHTML):
 
         Returns:
             The component.
+
+        Raises:
+            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1249,6 +1267,9 @@ class Meter(BaseHTML):
 
         Returns:
             The component.
+
+        Raises:
+            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1389,6 +1410,9 @@ class Optgroup(BaseHTML):
 
         Returns:
             The component.
+
+        Raises:
+            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1537,6 +1561,9 @@ class Option(BaseHTML):
 
         Returns:
             The component.
+
+        Raises:
+            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1677,6 +1704,9 @@ class Output(BaseHTML):
 
         Returns:
             The component.
+
+        Raises:
+            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1817,6 +1847,9 @@ class Progress(BaseHTML):
 
         Returns:
             The component.
+
+        Raises:
+            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1979,6 +2012,9 @@ class Select(BaseHTML):
 
         Returns:
             The component.
+
+        Raises:
+            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -2178,5 +2214,8 @@ class Textarea(BaseHTML):
 
         Returns:
             The component.
+
+        Raises:
+            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/el/elements/forms.pyi
+++ b/reflex/components/el/elements/forms.pyi
@@ -189,9 +189,6 @@ class Button(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -324,9 +321,6 @@ class Datalist(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -411,9 +405,6 @@ class Fieldset(Element):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -838,9 +829,6 @@ class Input(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -979,9 +967,6 @@ class Label(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1114,9 +1099,6 @@ class Legend(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1267,9 +1249,6 @@ class Meter(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1410,9 +1389,6 @@ class Optgroup(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1561,9 +1537,6 @@ class Option(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1704,9 +1677,6 @@ class Output(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1847,9 +1817,6 @@ class Progress(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -2012,9 +1979,6 @@ class Select(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -2214,8 +2178,5 @@ class Textarea(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/el/elements/inline.pyi
+++ b/reflex/components/el/elements/inline.pyi
@@ -170,9 +170,6 @@ class A(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -305,9 +302,6 @@ class Abbr(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -440,9 +434,6 @@ class B(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -575,9 +566,6 @@ class Bdi(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -710,9 +698,6 @@ class Bdo(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -845,9 +830,6 @@ class Br(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -980,9 +962,6 @@ class Cite(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1115,9 +1094,6 @@ class Code(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1254,9 +1230,6 @@ class Data(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1389,9 +1362,6 @@ class Dfn(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1524,9 +1494,6 @@ class Em(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1659,9 +1626,6 @@ class I(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1794,9 +1758,6 @@ class Kbd(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1929,9 +1890,6 @@ class Mark(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -2066,9 +2024,6 @@ class Q(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -2201,9 +2156,6 @@ class Rp(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -2336,9 +2288,6 @@ class Rt(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -2471,9 +2420,6 @@ class Ruby(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -2606,9 +2552,6 @@ class S(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -2741,9 +2684,6 @@ class Samp(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -2876,9 +2816,6 @@ class Small(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -3011,9 +2948,6 @@ class Span(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -3146,9 +3080,6 @@ class Strong(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -3281,9 +3212,6 @@ class Sub(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -3416,9 +3344,6 @@ class Sup(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -3555,9 +3480,6 @@ class Time(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -3690,9 +3612,6 @@ class U(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -3825,8 +3744,5 @@ class Wbr(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/el/elements/media.pyi
+++ b/reflex/components/el/elements/media.pyi
@@ -176,9 +176,6 @@ class Area(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -339,9 +336,6 @@ class Audio(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -518,9 +512,6 @@ class Img(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -655,9 +646,6 @@ class Map(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -806,9 +794,6 @@ class Track(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -977,9 +962,6 @@ class Video(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1116,9 +1098,6 @@ class Embed(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1281,9 +1260,6 @@ class Iframe(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1428,9 +1404,6 @@ class Object(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1563,9 +1536,6 @@ class Picture(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1698,9 +1668,6 @@ class Portal(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1849,9 +1816,6 @@ class Source(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1984,9 +1948,6 @@ class Svg(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -2121,8 +2082,5 @@ class Path(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/el/elements/metadata.pyi
+++ b/reflex/components/el/elements/metadata.pyi
@@ -145,9 +145,6 @@ class Base(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -280,9 +277,6 @@ class Head(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -436,9 +430,6 @@ class Link(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -581,9 +572,6 @@ class Meta(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -660,8 +648,5 @@ class Title(Element):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/el/elements/other.pyi
+++ b/reflex/components/el/elements/other.pyi
@@ -142,9 +142,6 @@ class Details(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -279,9 +276,6 @@ class Dialog(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -414,9 +408,6 @@ class Summary(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -549,9 +540,6 @@ class Slot(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -684,9 +672,6 @@ class Template(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -819,9 +804,6 @@ class Math(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -958,8 +940,5 @@ class Html(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/el/elements/scripts.pyi
+++ b/reflex/components/el/elements/scripts.pyi
@@ -140,9 +140,6 @@ class Canvas(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -275,9 +272,6 @@ class Noscript(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -442,8 +436,5 @@ class Script(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/el/elements/sectioning.pyi
+++ b/reflex/components/el/elements/sectioning.pyi
@@ -139,9 +139,6 @@ class Body(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -274,9 +271,6 @@ class Address(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -409,9 +403,6 @@ class Article(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -544,9 +535,6 @@ class Aside(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -679,9 +667,6 @@ class Footer(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -814,9 +799,6 @@ class Header(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -949,9 +931,6 @@ class H1(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1084,9 +1063,6 @@ class H2(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1219,9 +1195,6 @@ class H3(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1354,9 +1327,6 @@ class H4(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1489,9 +1459,6 @@ class H5(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1624,9 +1591,6 @@ class H6(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1759,9 +1723,6 @@ class Main(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1894,9 +1855,6 @@ class Nav(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -2029,8 +1987,5 @@ class Section(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/el/elements/tables.pyi
+++ b/reflex/components/el/elements/tables.pyi
@@ -144,9 +144,6 @@ class Caption(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -285,9 +282,6 @@ class Col(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -426,9 +420,6 @@ class Colgroup(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -569,9 +560,6 @@ class Table(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -708,9 +696,6 @@ class Tbody(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -859,9 +844,6 @@ class Td(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -998,9 +980,6 @@ class Tfoot(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1153,9 +1132,6 @@ class Th(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1292,9 +1268,6 @@ class Thead(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1431,8 +1404,5 @@ class Tr(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/el/elements/typography.pyi
+++ b/reflex/components/el/elements/typography.pyi
@@ -142,9 +142,6 @@ class Blockquote(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -277,9 +274,6 @@ class Dd(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -412,9 +406,6 @@ class Div(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -547,9 +538,6 @@ class Dl(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -682,9 +670,6 @@ class Dt(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -817,9 +802,6 @@ class Figcaption(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -956,9 +938,6 @@ class Hr(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1091,9 +1070,6 @@ class Li(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1228,9 +1204,6 @@ class Menu(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1373,9 +1346,6 @@ class Ol(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1508,9 +1478,6 @@ class P(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1643,9 +1610,6 @@ class Pre(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1778,9 +1742,6 @@ class Ul(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1919,9 +1880,6 @@ class Ins(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -2060,8 +2018,5 @@ class Del(BaseHTML):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/gridjs/datatable.pyi
+++ b/reflex/components/gridjs/datatable.pyi
@@ -87,9 +87,6 @@ class Gridjs(Component):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 

--- a/reflex/components/lucide/icon.pyi
+++ b/reflex/components/lucide/icon.pyi
@@ -85,9 +85,6 @@ class LucideIconComponent(Component):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 

--- a/reflex/components/lucide/icon.pyi
+++ b/reflex/components/lucide/icon.pyi
@@ -85,6 +85,9 @@ class LucideIconComponent(Component):
 
         Returns:
             The component.
+
+        Raises:
+            TypeError: If an invalid child is passed.
         """
         ...
 

--- a/reflex/components/next/base.pyi
+++ b/reflex/components/next/base.pyi
@@ -84,8 +84,5 @@ class NextComponent(Component):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/next/link.pyi
+++ b/reflex/components/next/link.pyi
@@ -87,8 +87,5 @@ class NextLink(Component):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/plotly/plotly.pyi
+++ b/reflex/components/plotly/plotly.pyi
@@ -89,9 +89,6 @@ class PlotlyLib(NoSSRComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -180,8 +177,5 @@ class Plotly(PlotlyLib):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/radix/primitives/accordion.pyi
+++ b/reflex/components/radix/primitives/accordion.pyi
@@ -113,9 +113,6 @@ class AccordionComponent(RadixPrimitiveComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 

--- a/reflex/components/radix/primitives/base.pyi
+++ b/reflex/components/radix/primitives/base.pyi
@@ -88,9 +88,6 @@ class RadixPrimitiveComponent(Component):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -169,8 +166,5 @@ class RadixPrimitiveComponentWithClassName(RadixPrimitiveComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/radix/primitives/drawer.pyi
+++ b/reflex/components/radix/primitives/drawer.pyi
@@ -90,9 +90,6 @@ class DrawerComponent(RadixPrimitiveComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -200,9 +197,6 @@ class DrawerRoot(DrawerComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -352,9 +346,6 @@ class DrawerPortal(DrawerComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -531,9 +522,6 @@ class DrawerOverlay(DrawerComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -683,9 +671,6 @@ class DrawerTitle(DrawerComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -764,9 +749,6 @@ class DrawerDescription(DrawerComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -878,9 +860,6 @@ class Drawer(ComponentNamespace):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 

--- a/reflex/components/radix/primitives/form.pyi
+++ b/reflex/components/radix/primitives/form.pyi
@@ -90,9 +90,6 @@ class FormComponent(RadixPrimitiveComponentWithClassName):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -354,9 +351,6 @@ class FormField(FormComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -435,9 +429,6 @@ class FormLabel(FormComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -646,9 +637,6 @@ class FormMessage(FormComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -727,9 +715,6 @@ class FormValidityState(FormComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -808,9 +793,6 @@ class FormSubmit(FormComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 

--- a/reflex/components/radix/primitives/progress.pyi
+++ b/reflex/components/radix/primitives/progress.pyi
@@ -91,9 +91,6 @@ class ProgressComponent(RadixPrimitiveComponentWithClassName):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -179,9 +176,6 @@ class ProgressRoot(ProgressComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -327,9 +321,6 @@ class ProgressIndicator(ProgressComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 

--- a/reflex/components/radix/primitives/slider.pyi
+++ b/reflex/components/radix/primitives/slider.pyi
@@ -91,9 +91,6 @@ class SliderComponent(RadixPrimitiveComponentWithClassName):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -195,9 +192,6 @@ class SliderRoot(SliderComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -276,9 +270,6 @@ class SliderTrack(SliderComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -357,9 +348,6 @@ class SliderRange(SliderComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -438,9 +426,6 @@ class SliderThumb(SliderComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 

--- a/reflex/components/radix/themes/base.pyi
+++ b/reflex/components/radix/themes/base.pyi
@@ -173,9 +173,6 @@ class CommonMarginProps(Component):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -659,9 +656,6 @@ class RadixThemesColorModeProvider(Component):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 

--- a/reflex/components/react_player/audio.pyi
+++ b/reflex/components/react_player/audio.pyi
@@ -102,8 +102,5 @@ class Audio(ReactPlayer):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/react_player/react_player.pyi
+++ b/reflex/components/react_player/react_player.pyi
@@ -101,8 +101,5 @@ class ReactPlayer(NoSSRComponent):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/react_player/video.pyi
+++ b/reflex/components/react_player/video.pyi
@@ -102,8 +102,5 @@ class Video(ReactPlayer):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/recharts/cartesian.pyi
+++ b/reflex/components/recharts/cartesian.pyi
@@ -144,9 +144,6 @@ class Axis(Recharts):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -267,9 +264,6 @@ class XAxis(Axis):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -390,9 +384,6 @@ class YAxis(Axis):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -518,9 +509,6 @@ class ZAxis(Recharts):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -578,9 +566,6 @@ class Brush(Recharts):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -644,9 +629,6 @@ class Cartesian(Recharts):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -764,9 +746,6 @@ class Area(Cartesian):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -845,9 +824,6 @@ class Bar(Cartesian):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -965,9 +941,6 @@ class Line(Cartesian):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1063,9 +1036,6 @@ class Scatter(Cartesian):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1141,9 +1111,6 @@ class Funnel(Cartesian):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1232,9 +1199,6 @@ class ErrorBar(Recharts):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1328,9 +1292,6 @@ class Reference(Recharts):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1426,9 +1387,6 @@ class ReferenceLine(Reference):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1496,9 +1454,6 @@ class ReferenceDot(Reference):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1602,9 +1557,6 @@ class ReferenceArea(Recharts):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1689,9 +1641,6 @@ class Grid(Recharts):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1786,9 +1735,6 @@ class CartesianGrid(Grid):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -1901,8 +1847,5 @@ class CartesianAxis(Grid):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/recharts/general.pyi
+++ b/reflex/components/recharts/general.pyi
@@ -219,9 +219,6 @@ class Legend(Recharts):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -314,9 +311,6 @@ class GraphingTooltip(Recharts):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -446,9 +440,6 @@ class Label(Recharts):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -580,8 +571,5 @@ class LabelList(Recharts):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/recharts/polar.pyi
+++ b/reflex/components/recharts/polar.pyi
@@ -97,9 +97,6 @@ class Pie(Recharts):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -203,9 +200,6 @@ class Radar(Recharts):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -266,9 +260,6 @@ class RadialBar(Recharts):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -345,9 +336,6 @@ class PolarAngleAxis(Recharts):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -440,9 +428,6 @@ class PolarGrid(Recharts):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -558,8 +543,5 @@ class PolarRadiusAxis(Recharts):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...

--- a/reflex/components/recharts/recharts.pyi
+++ b/reflex/components/recharts/recharts.pyi
@@ -83,9 +83,6 @@ class Recharts(Component):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -6,6 +6,7 @@ import reflex as rx
 from reflex.base import Base
 from reflex.compiler.compiler import compile_components
 from reflex.components.base.bare import Bare
+from reflex.components.base.fragment import Fragment
 from reflex.components.chakra.layout.box import Box
 from reflex.components.component import (
     Component,
@@ -13,7 +14,6 @@ from reflex.components.component import (
     StatefulComponent,
     custom_component,
 )
-from reflex.components.base.fragment import Fragment
 from reflex.constants import EventTriggers
 from reflex.event import EventChain, EventHandler
 from reflex.state import BaseState


### PR DESCRIPTION
The code below should work now:

```python

def index() -> rx.Component:
    random_text = rx.text("some text here"),
    return rx.center(
        random_text
    )
    
```

Also the code below will be unwrapped in a fragment: as well
    
```python
def index() -> rx.Component:
    comp = (rx.text("some text here"), rx.text("another text"))
    return rx.center(
        comp
    )
```
Equivalent to below:
    
```python
def index() -> rx.Component:
    return rx.center(
        rx.fragment(
             rx.text("some text here"), 
            rx.text("another text")
       ),
    )
```
    