### PR TITLE
minimal fix for upload_url in rx.download

### DIFF
--- a/reflex/components/core/upload.py
+++ b/reflex/components/core/upload.py
@@ -140,7 +140,9 @@ def get_upload_url(file_path: str) -> Var[str]:
     """
     Upload.is_used = True
 
-    return Var.create_safe(f"{uploaded_files_url_prefix}/{file_path}")
+    return Var.create_safe(
+        f"{uploaded_files_url_prefix}/{file_path}", _var_is_string=True
+    )
 
 
 def _on_drop_spec(files: Var):


### PR DESCRIPTION
minimal fix on get_upload_url to at least avoid compilation errors.

Disclaimer: this PR ignore the fact that rx.download is not a true download for CORS situation (including the backend), this will be adressed by #3041.