### PR TITLE
Fix annotated EventHandler

### DIFF
--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -474,9 +474,11 @@ class Component(BaseComponent, ABC):
         # e.g. variable declared as EventHandler types.
         for field in self.get_fields().values():
             if types._issubclass(field.type_, EventHandler):
-                default_triggers[field.name] = getattr(
-                    field.type_, "args_spec", lambda: []
-                )
+                args_spec = None
+                annotation = field.annotation
+                if hasattr(annotation, "__metadata__"):
+                    args_spec = annotation.__metadata__[0]
+                default_triggers[field.name] = args_spec or (lambda: [])
         return default_triggers
 
     def __repr__(self) -> str:

--- a/reflex/event.py
+++ b/reflex/event.py
@@ -13,7 +13,6 @@ from typing import (
     Optional,
     Tuple,
     Union,
-    _GenericAlias,  # type: ignore
     get_type_hints,
 )
 
@@ -22,6 +21,11 @@ from reflex.base import Base
 from reflex.utils import console, format
 from reflex.utils.types import ArgsSpec
 from reflex.vars import BaseVar, Var
+
+try:
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
 
 
 class Event(Base):
@@ -118,7 +122,7 @@ class EventHandler(EventActionsMixin):
         frozen = True
 
     @classmethod
-    def __class_getitem__(cls, args_spec: str) -> _GenericAlias:
+    def __class_getitem__(cls, args_spec: str) -> Annotated:
         """Get a typed EventHandler.
 
         Args:
@@ -127,10 +131,7 @@ class EventHandler(EventActionsMixin):
         Returns:
             The EventHandler class item.
         """
-        gen = _GenericAlias(cls, Any)
-        # Cannot subclass special typing classes, so we need to set the args_spec dynamically as an attribute.
-        gen.args_spec = args_spec
-        return gen
+        return Annotated[cls, args_spec]
 
     @property
     def is_background(self) -> bool:


### PR DESCRIPTION
`_GenericAlias` is a private implementation detail, and when we attach the `args_spec` to it as an attribute, it seems to attach it to the class itself, and get overwritten every time the annotation is used.

Instead, reimplement this mechanism using the standard `Annotated` API, which is well supported since 3.9 and is designed for attaching extra information to a type hint.

Update the test cases for this feature to actually ensure the resulting args_spec is identical when defined via `get_event_triggers`.