### PR TITLE
Simplify `run_process_with_fallback` logic

### DIFF
--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -568,15 +568,17 @@ def update_next_config(export=False, transpile_packages: Optional[List[str]] = N
         export: if the method run during reflex export.
         transpile_packages: list of packages to transpile via next.config.js.
     """
-    next_config_file = os.path.join(constants.Dirs.WEB, constants.Next.CONFIG_FILE)
+    next_config_file = Path(constants.Dirs.WEB, constants.Next.CONFIG_FILE)
 
     next_config = _update_next_config(
         get_config(), export=export, transpile_packages=transpile_packages
     )
 
-    with open(next_config_file, "w") as file:
-        file.write(next_config)
-        file.write("\n")
+    # Overwriting the next.config.js triggers a full server reload, so make sure
+    # there is actually a diff.
+    orig_next_config = next_config_file.read_text()
+    if orig_next_config != next_config:
+        next_config_file.write_text(next_config)
 
 
 def _update_next_config(

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -576,7 +576,7 @@ def update_next_config(export=False, transpile_packages: Optional[List[str]] = N
 
     # Overwriting the next.config.js triggers a full server reload, so make sure
     # there is actually a diff.
-    orig_next_config = next_config_file.read_text()
+    orig_next_config = next_config_file.read_text() if next_config_file.exists() else ""
     if orig_next_config != next_config:
         next_config_file.write_text(next_config)
 


### PR DESCRIPTION
Include log streaming for initial command and fallback command. This is necessary because if the command produces significant output that is not consumed, it can fill the OS pipe and block the process from running.