### PR TITLE
[REF-2586] Pass child event_trigger through DebounceInput

### DIFF
--- a/reflex/components/core/debounce.py
+++ b/reflex/components/core/debounce.py
@@ -79,7 +79,9 @@ class DebounceInput(Component):
             for p in cls.get_props()
             if getattr(child, p, None) is not None
         }
-        props_from_child.update(child.event_triggers)
+        props[EventTriggers.ON_CHANGE] = child.event_triggers.pop(
+            EventTriggers.ON_CHANGE
+        )
         props = {**props_from_child, **props}
 
         # Carry all other child props directly via custom_attrs
@@ -117,6 +119,7 @@ class DebounceInput(Component):
 
         component = super().create(**props)
         component._get_style = child._get_style
+        component.event_triggers.update(child.event_triggers)
         return component
 
     def get_event_triggers(self) -> dict[str, Any]:


### PR DESCRIPTION
Fix #3060

## Sample Code

```python
import reflex as rx


class State(rx.State):
    v: str = ""

    def handle_on_key_down(self, key):
        print(key)

    def set_v(self, value):
        self.v = value
        print(self.v)


def index() -> rx.Component:
    return rx.center(
        rx.input(
            value=State.v,
            on_change=State.set_v,
            on_key_down=State.handle_on_key_down,
        ),
    )


app = rx.App()
app.add_page(index)
```