### PR TITLE
[REF-2589] Use errors='replace' with subprocess

### DIFF
--- a/reflex/utils/processes.py
+++ b/reflex/utils/processes.py
@@ -145,6 +145,7 @@ def new_process(args, run: bool = False, show_logs: bool = False, **kwargs):
         "stdout": None if show_logs else subprocess.PIPE,
         "universal_newlines": True,
         "encoding": "UTF-8",
+        "errors": "replace",  # Avoid UnicodeDecodeError in unknown command output
         **kwargs,
     }
     console.debug(f"Running command: {args}")


### PR DESCRIPTION
Running commands on Windows sometimes results in extended characters being written in the byte-encoding of the system locale rather than UTF-8. But since this is primarily for logging and checking for specific ASCII-only strings, we can ignore these bad characters to avoid crashing.

Fix #3094 #1952