### PR TITLE
Use Fallback command on all platforms

### DIFF
--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -821,18 +821,16 @@ def install_frontend_packages(packages: set[str], config: Config):
     Example:
         >>> install_frontend_packages(["react", "react-dom"], get_config())
     """
-    # unsupported archs will use npm anyway. so we dont have to run npm twice
+    # unsupported archs(arm and 32bit machines) will use npm anyway. so we dont have to run npm twice
     fallback_command = (
-        get_package_manager()
+        get_install_package_manager()
         if not constants.IS_WINDOWS
         or constants.IS_WINDOWS
         and constants.IS_WINDOWS_BUN_SUPPORTED_MACHINE
         else None
     )
     processes.run_process_with_fallback(
-        processes.get_command_with_loglevel(
-            [get_install_package_manager(), "install"], config  # type: ignore
-        ),
+        [get_install_package_manager(), "install"],  # type: ignore
         fallback=fallback_command,
         show_status_message="Installing base frontend packages",
         cwd=constants.Dirs.WEB,

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -831,7 +831,7 @@ def install_frontend_packages(packages: set[str], config: Config):
     )
     processes.run_process_with_fallback(
         processes.get_command_with_loglevel(
-            [get_install_package_manager(), "install"], config
+            [get_install_package_manager(), "install"], config  # type: ignore
         ),
         fallback=fallback_command,
         show_status_message="Installing base frontend packages",

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -824,11 +824,15 @@ def install_frontend_packages(packages: set[str], config: Config):
     # unsupported archs will use npm anyway. so we dont have to run npm twice
     fallback_command = (
         get_package_manager()
-        if constants.IS_WINDOWS and constants.IS_WINDOWS_BUN_SUPPORTED_MACHINE
+        if not constants.IS_WINDOWS
+        or constants.IS_WINDOWS
+        and constants.IS_WINDOWS_BUN_SUPPORTED_MACHINE
         else None
     )
     processes.run_process_with_fallback(
-        [get_install_package_manager(), "install", "--loglevel", "silly"],
+        processes.get_command_with_loglevel(
+            [get_install_package_manager(), "install"], config
+        ),
         fallback=fallback_command,
         show_status_message="Installing base frontend packages",
         cwd=constants.Dirs.WEB,

--- a/reflex/utils/processes.py
+++ b/reflex/utils/processes.py
@@ -339,7 +339,7 @@ def run_process_with_fallback(args, *, show_status_message, fallback=None, **kwa
                 f"There was an error running command: {args}. Falling back to: {fallback_args}."
             )
             run_process_with_fallback(
-                get_command_with_loglevel(fallback_args),
+                fallback_args,
                 show_status_message=show_status_message,
                 fallback=None,
                 **kwargs,

--- a/reflex/utils/processes.py
+++ b/reflex/utils/processes.py
@@ -16,6 +16,7 @@ from redis.exceptions import RedisError
 
 from reflex import constants
 from reflex.utils import console, path_ops, prerequisites
+from reflex.config import Config
 
 
 def kill(pid):
@@ -294,6 +295,19 @@ def show_progress(message: str, process: subprocess.Popen, checkpoints: List[str
 def atexit_handler():
     """Display a custom message with the current time when exiting an app."""
     console.log("Reflex app stopped.")
+
+
+def get_command_with_loglevel(command: list[str], config: Config) -> list[str]:
+    """Add the right loglevel flag to the designated command.
+    Bun runs with --verbose while npm uses --loglevel <level>
+
+    command:
+         The command to add loglevel flag.
+         config: The config Object.
+    """
+    if config.bun_path in command:
+        return command + ["--verbose"]
+    return command + ["--loglevel", "silly"]
 
 
 def run_process_with_fallback(args, *, show_status_message, fallback=None, **kwargs):

--- a/reflex/utils/processes.py
+++ b/reflex/utils/processes.py
@@ -15,8 +15,8 @@ import typer
 from redis.exceptions import RedisError
 
 from reflex import constants
-from reflex.utils import console, path_ops, prerequisites
 from reflex.config import Config
+from reflex.utils import console, path_ops, prerequisites
 
 
 def kill(pid):
@@ -299,11 +299,14 @@ def atexit_handler():
 
 def get_command_with_loglevel(command: list[str], config: Config) -> list[str]:
     """Add the right loglevel flag to the designated command.
-    Bun runs with --verbose while npm uses --loglevel <level>
+    Bun runs with --verbose while npm uses --loglevel <level>.
 
-    command:
-         The command to add loglevel flag.
-         config: The config Object.
+    Args:
+        command:The command to add loglevel flag.
+        config: The config Object.
+
+    Returns:
+        The updated command list
     """
     if config.bun_path in command:
         return command + ["--verbose"]


### PR DESCRIPTION
The fallback command(`npm`) when installing packages should be used on all platforms.
Also the `--loglevel` flag is used only for npm when installing packages. Bun already runs in debug mode by default and the `--loglevel` flag has no effect