### PR TITLE
[REF-2587] Ignore top-level theme appearance

### DIFF
--- a/reflex/app.py
+++ b/reflex/app.py
@@ -839,6 +839,9 @@ class App(Base):
         compile_results.append(
             compiler.compile_contexts(self.state, self.theme),
         )
+        # Fix #2992 by removing the top-level appearance prop
+        if self.theme is not None:
+            self.theme.appearance = None
 
         app_root = self._app_root(app_wrappers=app_wrappers)
 

--- a/reflex/utils/pyi_generator.py
+++ b/reflex/utils/pyi_generator.py
@@ -34,6 +34,7 @@ PWD = Path(".").resolve()
 
 EXCLUDED_FILES = [
     "__init__.py",
+    "app.py",
     "component.py",
     "bare.py",
     "foreach.py",
@@ -795,7 +796,11 @@ class PyiGenerator:
         file_targets = []
         for target in targets:
             target_path = Path(target)
-            if target_path.is_file() and target_path.suffix == ".py":
+            if (
+                target_path.is_file()
+                and target_path.suffix == ".py"
+                and target_path.name not in EXCLUDED_FILES
+            ):
                 file_targets.append(target_path)
                 continue
             if not target_path.is_dir():


### PR DESCRIPTION
From the Radix docs, it is not recommended to actually set `appearance`, but instead use next-themes to set and switch the appearance dynamically.
    
Because Reflex already compiles the top-level theme into the next-themes ThemeProvider, we can blank out the appearance prop after compiling contexts.js to avoid a mismatch between the selected app appearance and the appearance in the rx.theme when displaying overlay components.

Fix #2992

-----

Bonus: fix the pyi_generator with pre-commit to stop creating .pyi files for those in the EXCLUDED_FILES list

-----

## Sample code

```python
import reflex as rx


def dialogme():
    return rx.dialog.root(
        rx.dialog.trigger(rx.button("Dialog")),
        rx.dialog.content(
            rx.dialog.title("Foo"),
            rx.dialog.description("This is a dialog"),
            rx.dialog.close(
                rx.button("Close"),
            ),
        ),
    )


def index() -> rx.Component:
    return rx.vstack(
        rx.color_mode.button(rx.color_mode.icon()),
        dialogme(),
        rx.theme(
            dialogme(),
            appearance="dark",
        ),
        rx.theme(
            dialogme(),
            appearance="light",
        ),
    )


app = rx.App(theme=rx.theme(appearance="dark"))
app.add_page(index)
```