### PR TITLE
pin react-focus-lock to 2.11.3

### DIFF
--- a/reflex/constants/installer.py
+++ b/reflex/constants/installer.py
@@ -112,6 +112,7 @@ class PackageJson(SimpleNamespace):
         "next-themes": "0.2.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-focus-lock": "2.11.3",
         "socket.io-client": "4.6.1",
         "universal-cookie": "4.0.4",
     }


### PR DESCRIPTION
Avoid 2.12.0 release, which is broken!