### PR TITLE
fix: args issue in __init__ of App class (#3140)

### DIFF
--- a/reflex/app.py
+++ b/reflex/app.py
@@ -160,11 +160,10 @@ class App(Base):
     # The radix theme for the entire app
     theme: Optional[Component] = themes.theme(accent_color="blue")
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, **kwargs):
         """Initialize the app.
 
         Args:
-            *args: Args to initialize the app with.
             **kwargs: Kwargs to initialize the app with.
 
         Raises:
@@ -176,7 +175,7 @@ class App(Base):
             raise ValueError(
                 "`connect_error_component` is deprecated, use `overlay_component` instead"
             )
-        super().__init__(*args, **kwargs)
+        super().__init__(**kwargs)
         base_state_subclasses = BaseState.__subclasses__()
 
         # Special case to allow test cases have multiple subclasses of rx.BaseState.

--- a/reflex/app.pyi
+++ b/reflex/app.pyi
@@ -86,7 +86,6 @@ class App(Base):
     background_tasks: Set[asyncio.Task] = set()
     def __init__(
         self,
-        *args,
         stylesheets: Optional[List[str]] = None,
         style: Optional[ComponentStyle] = None,
         admin_dash: Optional[AdminDash] = None,


### PR DESCRIPTION
Remove passing `*args` to base `__init__()` in `App`.
Remove `*args` from signature.

Details in [related issue](https://github.com/reflex-dev/reflex/issues/3140).

___

* (fix): remove '*args' from '__init__()' method of 'App', update docstrings and .pyi accordingly

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update


### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?


