### PR TITLE
Improved get_attribute_access_type

### DIFF
--- a/reflex/utils/types.py
+++ b/reflex/utils/types.py
@@ -210,14 +210,16 @@ def get_attribute_access_type(cls: GenericType, name: str) -> GenericType | None
             column = insp.columns[name]
             column_type = column.type
             type_ = insp.columns[name].type.python_type
-            if hasattr(column_type, "item_type") and (item_type := column_type.item_type.python_type):  # type: ignore
+            if hasattr(column_type, "item_type") and (
+                item_type := column_type.item_type.python_type
+            ):  # type: ignore
                 if type_ in PrimitiveToAnnotation:
                     type_ = PrimitiveToAnnotation[type_]  # type: ignore
                 type_ = type_[item_type]  # type: ignore
             if column.nullable:
                 type_ = Optional[type_]
             return type_
-        if name not in insp.all_orm_descriptors.keys():
+        if name not in insp.all_orm_descriptors:
             return None
         descriptor = insp.all_orm_descriptors[name]
         if hint := get_property_hint(descriptor):

--- a/reflex/utils/types.py
+++ b/reflex/utils/types.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import inspect
+import sys
 import types
 from functools import wraps
 from typing import (
@@ -259,11 +260,15 @@ def get_attribute_access_type(cls: GenericType, name: str) -> GenericType | None
                 return type_
     elif isinstance(cls, type):
         # Bare class
+        if sys.version_info >= (3, 10):
+            exceptions = NameError
+        else:
+            exceptions = (NameError, TypeError)
         try:
             hints = get_type_hints(cls)
             if name in hints:
                 return hints[name]
-        except NameError as e:
+        except exceptions as e:
             console.warn(f"Failed to resolve ForwardRefs for {cls}.{name} due to {e}")
             pass
     return None  # Attribute is not accessible.

--- a/tests/test_attribute_access_type.py
+++ b/tests/test_attribute_access_type.py
@@ -48,6 +48,19 @@ class SQLAClass(SQLABase):
         return self.name
 
 
+class ModelClass(rx.Model):
+    count: int = 0
+    name: str = "test"
+    int_list: List[int] = []
+    str_list: List[str] = []
+    optional_int: Optional[int] = None
+    sqla_tag: Optional[SQLATag] = None
+    labels: List[SQLALabel] = []
+
+    @property
+    def str_property(self) -> str:
+        return self.name
+
 class BaseClass(rx.Base):
     count: int = 0
     name: str = "test"
@@ -76,7 +89,7 @@ class BareClass:
         return self.name
 
 
-@pytest.fixture(params=[SQLAClass, BaseClass, BareClass])
+@pytest.fixture(params=[SQLAClass, BaseClass, BareClass, ModelClass])
 def cls(request: pytest.FixtureRequest) -> type:
     return request.param
 

--- a/tests/test_attribute_access_type.py
+++ b/tests/test_attribute_access_type.py
@@ -61,6 +61,7 @@ class ModelClass(rx.Model):
     def str_property(self) -> str:
         return self.name
 
+
 class BaseClass(rx.Base):
     count: int = 0
     name: str = "test"

--- a/tests/test_attribute_access_type.py
+++ b/tests/test_attribute_access_type.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import List, Optional
+
+import pytest
+import sqlalchemy
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+import reflex as rx
+from reflex.utils.types import GenericType, get_attribute_access_type
+
+
+class SQLABase(DeclarativeBase):
+    pass
+
+
+class SQLATag(SQLABase):
+    __tablename__: str = "tag"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column()
+
+
+class SQLALabel(SQLABase):
+    __tablename__: str = "label"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    test_id: Mapped[int] = mapped_column(sqlalchemy.ForeignKey("test.id"))
+    test: Mapped[SQLAClass] = relationship(back_populates="labels")
+
+
+class SQLAClass(SQLABase):
+    __tablename__: str = "test"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    count: Mapped[int] = mapped_column()
+    name: Mapped[str] = mapped_column()
+    int_list: Mapped[List[int]] = mapped_column(
+        sqlalchemy.types.ARRAY(item_type=sqlalchemy.INTEGER)
+    )
+    str_list: Mapped[List[str]] = mapped_column(
+        sqlalchemy.types.ARRAY(item_type=sqlalchemy.String)
+    )
+    optional_int: Mapped[Optional[int]] = mapped_column(nullable=True)
+    sqla_tag_id: Mapped[int] = mapped_column(sqlalchemy.ForeignKey(SQLATag.id))
+    sqla_tag: Mapped[Optional[SQLATag]] = relationship()
+    labels: Mapped[List[SQLALabel]] = relationship(back_populates="test")
+
+
+class BaseClass(rx.Base):
+    count: int = 0
+    name: str = "test"
+    int_list: List[int] = []
+    str_list: List[str] = []
+    optional_int: Optional[int] = None
+    sqla_tag: Optional[SQLATag] = None
+    labels: List[SQLALabel] = []
+
+
+class BareClass:
+    count: int = 0
+    name: str = "test"
+    int_list: List[int] = []
+    str_list: List[str] = []
+    optional_int: Optional[int] = None
+    sqla_tag: Optional[SQLATag] = None
+    labels: List[SQLALabel] = []
+
+
+@pytest.fixture(params=[SQLAClass, BaseClass, BareClass])
+def cls(request: pytest.FixtureRequest) -> type:
+    return request.param
+
+
+@pytest.mark.parametrize(
+    "attr, expected",
+    [
+        pytest.param("count", int, id="int"),
+        pytest.param("name", str, id="str"),
+        pytest.param("int_list", List[int], id="List[int]"),
+        pytest.param("str_list", List[str], id="List[str]"),
+        pytest.param("optional_int", Optional[int], id="Optional[int]"),
+        pytest.param("sqla_tag", Optional[SQLATag], id="Optional[SQLATag]"),
+        pytest.param("labels", List[SQLALabel], id="List[SQLALabel]"),
+    ],
+)
+def test_get_attribute_access_type(cls: type, attr: str, expected: GenericType):
+    assert get_attribute_access_type(cls, attr) == expected

--- a/tests/test_attribute_access_type.py
+++ b/tests/test_attribute_access_type.py
@@ -43,6 +43,10 @@ class SQLAClass(SQLABase):
     sqla_tag: Mapped[Optional[SQLATag]] = relationship()
     labels: Mapped[List[SQLALabel]] = relationship(back_populates="test")
 
+    @property
+    def str_property(self) -> str:
+        return self.name
+
 
 class BaseClass(rx.Base):
     count: int = 0
@@ -53,6 +57,10 @@ class BaseClass(rx.Base):
     sqla_tag: Optional[SQLATag] = None
     labels: List[SQLALabel] = []
 
+    @property
+    def str_property(self) -> str:
+        return self.name
+
 
 class BareClass:
     count: int = 0
@@ -62,6 +70,10 @@ class BareClass:
     optional_int: Optional[int] = None
     sqla_tag: Optional[SQLATag] = None
     labels: List[SQLALabel] = []
+
+    @property
+    def str_property(self) -> str:
+        return self.name
 
 
 @pytest.fixture(params=[SQLAClass, BaseClass, BareClass])
@@ -79,6 +91,7 @@ def cls(request: pytest.FixtureRequest) -> type:
         pytest.param("optional_int", Optional[int], id="Optional[int]"),
         pytest.param("sqla_tag", Optional[SQLATag], id="Optional[SQLATag]"),
         pytest.param("labels", List[SQLALabel], id="List[SQLALabel]"),
+        pytest.param("str_property", str, id="str_property"),
     ],
 )
 def test_get_attribute_access_type(cls: type, attr: str, expected: GenericType):

--- a/tests/test_attribute_access_type.py
+++ b/tests/test_attribute_access_type.py
@@ -11,16 +11,22 @@ from reflex.utils.types import GenericType, get_attribute_access_type
 
 
 class SQLABase(DeclarativeBase):
+    """Base class for bare SQLAlchemy models."""
+
     pass
 
 
 class SQLATag(SQLABase):
+    """Tag sqlalchemy model."""
+
     __tablename__: str = "tag"
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column()
 
 
 class SQLALabel(SQLABase):
+    """Label sqlalchemy model."""
+
     __tablename__: str = "label"
     id: Mapped[int] = mapped_column(primary_key=True)
     test_id: Mapped[int] = mapped_column(sqlalchemy.ForeignKey("test.id"))
@@ -28,6 +34,8 @@ class SQLALabel(SQLABase):
 
 
 class SQLAClass(SQLABase):
+    """Test sqlalchemy model."""
+
     __tablename__: str = "test"
     id: Mapped[int] = mapped_column(primary_key=True)
     count: Mapped[int] = mapped_column()
@@ -45,10 +53,17 @@ class SQLAClass(SQLABase):
 
     @property
     def str_property(self) -> str:
+        """String property.
+
+        Returns:
+            Name attribute
+        """
         return self.name
 
 
 class ModelClass(rx.Model):
+    """Test reflex model."""
+
     count: int = 0
     name: str = "test"
     int_list: List[int] = []
@@ -59,10 +74,17 @@ class ModelClass(rx.Model):
 
     @property
     def str_property(self) -> str:
+        """String property.
+
+        Returns:
+            Name attribute
+        """
         return self.name
 
 
 class BaseClass(rx.Base):
+    """Test rx.Base class."""
+
     count: int = 0
     name: str = "test"
     int_list: List[int] = []
@@ -73,10 +95,17 @@ class BaseClass(rx.Base):
 
     @property
     def str_property(self) -> str:
+        """String property.
+
+        Returns:
+            Name attribute
+        """
         return self.name
 
 
 class BareClass:
+    """Bare python class."""
+
     count: int = 0
     name: str = "test"
     int_list: List[int] = []
@@ -87,11 +116,24 @@ class BareClass:
 
     @property
     def str_property(self) -> str:
+        """String property.
+
+        Returns:
+            Name attribute
+        """
         return self.name
 
 
 @pytest.fixture(params=[SQLAClass, BaseClass, BareClass, ModelClass])
 def cls(request: pytest.FixtureRequest) -> type:
+    """Fixture for the class to test.
+
+    Args:
+        request: pytest request object.
+
+    Returns:
+        Class to test.
+    """
     return request.param
 
 
@@ -108,5 +150,12 @@ def cls(request: pytest.FixtureRequest) -> type:
         pytest.param("str_property", str, id="str_property"),
     ],
 )
-def test_get_attribute_access_type(cls: type, attr: str, expected: GenericType):
+def test_get_attribute_access_type(cls: type, attr: str, expected: GenericType) -> None:
+    """Test get_attribute_access_type returns the correct type.
+
+    Args:
+        cls: Class to test.
+        attr: Attribute to test.
+        expected: Expected type.
+    """
     assert get_attribute_access_type(cls, attr) == expected


### PR DESCRIPTION
- Allow parsing of bare python class type annotations
- Add support for sqlalchemy array types
- Improved sqlalchemy type annotation parsing for Optional and Iterable
- Add basic tests for `get_attribute_access_type`