### PR TITLE
[REF-2682] Foreach over dict uses Tuple arg value

### DIFF
--- a/reflex/components/tags/iter_tag.py
+++ b/reflex/components/tags/iter_tag.py
@@ -34,8 +34,10 @@ class IterTag(Tag):
         """
         try:
             if self.iterable._var_type.mro()[0] == dict:
+                # Arg is a tuple of (key, value).
                 return Tuple[get_args(self.iterable._var_type)]  # type: ignore
             elif self.iterable._var_type.mro()[0] == tuple:
+                # Arg is a union of any possible values in the tuple.
                 return Union[get_args(self.iterable._var_type)]  # type: ignore
             else:
                 return get_args(self.iterable._var_type)[0]

--- a/reflex/components/tags/iter_tag.py
+++ b/reflex/components/tags/iter_tag.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import inspect
-from typing import TYPE_CHECKING, Any, Callable, List, Tuple, Type
+from typing import TYPE_CHECKING, Any, Callable, List, Tuple, Type, Union, get_args
 
 from reflex.components.tags.tag import Tag
 from reflex.vars import BaseVar, Var
@@ -33,14 +33,12 @@ class IterTag(Tag):
             The type of the iterable var.
         """
         try:
-            return (
-                Tuple[
-                    self.iterable._var_type.__args__[0],
-                    self.iterable._var_type.__args__[1],
-                ]
-                if self.iterable._var_type.mro()[0] == dict
-                else self.iterable._var_type.__args__[0]
-            )
+            if self.iterable._var_type.mro()[0] == dict:
+                return Tuple[get_args(self.iterable._var_type)]  # type: ignore
+            elif self.iterable._var_type.mro()[0] == tuple:
+                return Union[get_args(self.iterable._var_type)]  # type: ignore
+            else:
+                return get_args(self.iterable._var_type)[0]
         except Exception:
             return Any
 

--- a/reflex/components/tags/iter_tag.py
+++ b/reflex/components/tags/iter_tag.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import inspect
-from typing import TYPE_CHECKING, Any, Callable, List, Type
+from typing import TYPE_CHECKING, Any, Callable, List, Tuple, Type
 
 from reflex.components.tags.tag import Tag
 from reflex.vars import BaseVar, Var
@@ -34,7 +34,10 @@ class IterTag(Tag):
         """
         try:
             return (
-                self.iterable._var_type
+                Tuple[
+                    self.iterable._var_type.__args__[0],
+                    self.iterable._var_type.__args__[1],
+                ]
                 if self.iterable._var_type.mro()[0] == dict
                 else self.iterable._var_type.__args__[0]
             )

--- a/tests/components/core/test_foreach.py
+++ b/tests/components/core/test_foreach.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Set, Tuple
+from typing import Dict, List, Set, Tuple, Union
 
 import pytest
 
@@ -40,6 +40,7 @@ class ForEachState(BaseState):
     )
     colors_set: Set[str] = {"red", "green"}
     bad_annotation_list: list = [["red", "orange"], ["yellow", "blue"]]
+    color_index_tuple: Tuple[int, str] = (0, "red")
 
 
 def display_color(color):
@@ -95,6 +96,11 @@ def display_nested_list_element(element: Var[str], index: Var[int]):
     assert element._var_type == List[str]
     assert index._var_type == int
     return box(text(element[index]))
+
+
+def display_color_index_tuple(color):
+    assert color._var_type == Union[int, str]
+    return box(text(color, "index_tuple"))
 
 
 seen_index_vars = set()
@@ -181,6 +187,14 @@ seen_index_vars = set()
             {
                 "iterable_state": "for_each_state.nested_colors_list",
                 "iterable_type": "list",
+            },
+        ),
+        (
+            ForEachState.color_index_tuple,
+            display_color_index_tuple,
+            {
+                "iterable_state": "for_each_state.color_index_tuple",
+                "iterable_type": "tuple",
             },
         ),
     ],

--- a/tests/components/core/test_foreach.py
+++ b/tests/components/core/test_foreach.py
@@ -5,6 +5,7 @@ import pytest
 from reflex.components import box, foreach, text, theme
 from reflex.components.core import Foreach
 from reflex.state import BaseState
+from reflex.vars import Var
 
 try:
     # When pydantic v2 is installed
@@ -42,26 +43,32 @@ class ForEachState(BaseState):
 
 
 def display_color(color):
+    assert color._var_type == str
     return box(text(color))
 
 
 def display_color_name(color):
+    assert color._var_type == Dict[str, str]
     return box(text(color["name"]))
 
 
 def display_shade(color):
+    assert color._var_type == Dict[str, List[str]]
     return box(text(color["shades"][0]))
 
 
 def display_primary_colors(color):
+    assert color._var_type == Tuple[str, str]
     return box(text(color[0]), text(color[1]))
 
 
 def display_color_with_shades(color):
+    assert color._var_type == Tuple[str, List[str]]
     return box(text(color[0]), text(color[1][0]))
 
 
 def display_nested_color_with_shades(color):
+    assert color._var_type == Tuple[str, Dict[str, List[Dict[str, str]]]]
     return box(text(color[0]), text(color[1]["red"][0]["shade"]))
 
 
@@ -70,18 +77,23 @@ def show_shade(item):
 
 
 def display_nested_color_with_shades_v2(color):
+    assert color._var_type == Tuple[str, Dict[str, List[Dict[str, str]]]]
     return box(text(foreach(color[1], show_shade)))
 
 
 def display_color_tuple(color):
+    assert color._var_type == str
     return box(text(color, "tuple"))
 
 
 def display_colors_set(color):
+    assert color._var_type == str
     return box(text(color, "set"))
 
 
-def display_nested_list_element(element: str, index: int):
+def display_nested_list_element(element: Var[str], index: Var[int]):
+    assert element._var_type == List[str]
+    assert index._var_type == int
     return box(text(element[index]))
 
 


### PR DESCRIPTION
When iterating over a Var with _var_type dict, the resulting arg value _var_type should be Tuple[key, value] so it can be correctly used with other var operations.

Fix https://github.com/reflex-dev/reflex/issues/3157

-----------------

Additionally: Correct _var_type for iteration over Tuple of multiple types

The arg value when iterating over a tuple could be any of the possible values mentioned in the annotation.

When only one type is used, the Union collapses to the base type

------------------

The type ignore comments are there because pyright doesn't like the fact that i'm passing an unknown tuple to `Tuple` and `Union` `__getitem__`, but this is essentially identical to writing a literal tuple inside the square brackets.