### PR TITLE
Windows `--frontend-only`  fix ctrl + c

### DIFF
--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -212,7 +212,7 @@ def _run(
     # Run the frontend on a separate thread.
     if frontend:
         setup_frontend(Path.cwd())
-        commands.append((frontend_cmd, Path.cwd(), frontend_port))
+        commands.append((frontend_cmd, Path.cwd(), frontend_port, backend))
 
     # In prod mode, run the backend on a separate thread.
     if backend and env == constants.Env.PROD:

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -142,8 +142,8 @@ def run_frontend(root: Path, port: str, backend_present=True):
     console.rule("[bold green]App Running")
     os.environ["PORT"] = str(get_config().frontend_port if port is None else port)
     run_process_and_launch_url(
-        [prerequisites.get_package_manager(), "run", "dev"],
-        backend_present,  # type: ignore
+        [prerequisites.get_package_manager(), "run", "dev"],  # type: ignore
+        backend_present,
     )
 
 
@@ -164,8 +164,8 @@ def run_frontend_prod(root: Path, port: str, backend_present=True):
     # Run the frontend in production mode.
     console.rule("[bold green]App Running")
     run_process_and_launch_url(
-        [prerequisites.get_package_manager(), "run", "prod"],
-        backend_present,  # type: ignore
+        [prerequisites.get_package_manager(), "run", "prod"],  # type: ignore
+        backend_present,
     )
 
 

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -73,7 +73,7 @@ def kill(proc_pid: int):
 # run_process_and_launch_url is assumed to be used
 # only to launch the frontend
 # If this is not the case, might have to change the logic
-def run_process_and_launch_url(run_command: list[str]):
+def run_process_and_launch_url(run_command: list[str], backend_present = True):
     """Run the process and launch the URL.
 
     Args:
@@ -89,7 +89,7 @@ def run_process_and_launch_url(run_command: list[str]):
     while True:
         if process is None:
             kwargs = {}
-            if constants.IS_WINDOWS:
+            if constants.IS_WINDOWS and backend_present:
                 kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore
             process = processes.new_process(
                 run_command,
@@ -122,7 +122,7 @@ def run_process_and_launch_url(run_command: list[str]):
             break  # while True
 
 
-def run_frontend(root: Path, port: str):
+def run_frontend(root: Path, port: str, backend_present=True):
     """Run the frontend.
 
     Args:
@@ -139,10 +139,10 @@ def run_frontend(root: Path, port: str):
     # Run the frontend in development mode.
     console.rule("[bold green]App Running")
     os.environ["PORT"] = str(get_config().frontend_port if port is None else port)
-    run_process_and_launch_url([prerequisites.get_package_manager(), "run", "dev"])  # type: ignore
+    run_process_and_launch_url([prerequisites.get_package_manager(), "run", "dev"], backend_present)  # type: ignore
 
 
-def run_frontend_prod(root: Path, port: str):
+def run_frontend_prod(root: Path, port: str, backend_present=True):
     """Run the frontend.
 
     Args:
@@ -157,7 +157,7 @@ def run_frontend_prod(root: Path, port: str):
     prerequisites.validate_frontend_dependencies(init=False)
     # Run the frontend in production mode.
     console.rule("[bold green]App Running")
-    run_process_and_launch_url([prerequisites.get_package_manager(), "run", "prod"])  # type: ignore
+    run_process_and_launch_url([prerequisites.get_package_manager(), "run", "prod"], backend_present)  # type: ignore
 
 
 def run_backend(

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -73,11 +73,12 @@ def kill(proc_pid: int):
 # run_process_and_launch_url is assumed to be used
 # only to launch the frontend
 # If this is not the case, might have to change the logic
-def run_process_and_launch_url(run_command: list[str], backend_present = True):
+def run_process_and_launch_url(run_command: list[str], backend_present=True):
     """Run the process and launch the URL.
 
     Args:
         run_command: The command to run.
+        backend_present: Whether the backend is present.
     """
     from reflex.utils import processes
 
@@ -128,6 +129,7 @@ def run_frontend(root: Path, port: str, backend_present=True):
     Args:
         root: The root path of the project.
         port: The port to run the frontend on.
+        backend_present: Whether the backend is present.
     """
     from reflex.utils import prerequisites
 
@@ -139,7 +141,9 @@ def run_frontend(root: Path, port: str, backend_present=True):
     # Run the frontend in development mode.
     console.rule("[bold green]App Running")
     os.environ["PORT"] = str(get_config().frontend_port if port is None else port)
-    run_process_and_launch_url([prerequisites.get_package_manager(), "run", "dev"], backend_present)  # type: ignore
+    run_process_and_launch_url(
+        [prerequisites.get_package_manager(), "run", "dev"], backend_present
+    )  # type: ignore
 
 
 def run_frontend_prod(root: Path, port: str, backend_present=True):
@@ -148,6 +152,7 @@ def run_frontend_prod(root: Path, port: str, backend_present=True):
     Args:
         root: The root path of the project (to keep same API as run_frontend).
         port: The port to run the frontend on.
+        backend_present: Whether the backend is present.
     """
     from reflex.utils import prerequisites
 
@@ -157,7 +162,9 @@ def run_frontend_prod(root: Path, port: str, backend_present=True):
     prerequisites.validate_frontend_dependencies(init=False)
     # Run the frontend in production mode.
     console.rule("[bold green]App Running")
-    run_process_and_launch_url([prerequisites.get_package_manager(), "run", "prod"], backend_present)  # type: ignore
+    run_process_and_launch_url(
+        [prerequisites.get_package_manager(), "run", "prod"], backend_present
+    )  # type: ignore
 
 
 def run_backend(

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -142,8 +142,9 @@ def run_frontend(root: Path, port: str, backend_present=True):
     console.rule("[bold green]App Running")
     os.environ["PORT"] = str(get_config().frontend_port if port is None else port)
     run_process_and_launch_url(
-        [prerequisites.get_package_manager(), "run", "dev"], backend_present
-    )  # type: ignore
+        [prerequisites.get_package_manager(), "run", "dev"],
+        backend_present,  # type: ignore
+    )
 
 
 def run_frontend_prod(root: Path, port: str, backend_present=True):
@@ -163,8 +164,9 @@ def run_frontend_prod(root: Path, port: str, backend_present=True):
     # Run the frontend in production mode.
     console.rule("[bold green]App Running")
     run_process_and_launch_url(
-        [prerequisites.get_package_manager(), "run", "prod"], backend_present
-    )  # type: ignore
+        [prerequisites.get_package_manager(), "run", "prod"],
+        backend_present,  # type: ignore
+    )
 
 
 def run_backend(


### PR DESCRIPTION
We introduced a workaround(#2954) to fix the `ctrl + c` bug  in windows affecting uvicorn which causes the frontend to exit on hot reload. This fix applied to the case of running the frontend and backend concurrently, however another issue was introduced where `ctrl + c`  does not work at all when running the frontend only. This PR makes sure the frontend is created as a subprocess group independent of its parent ONLY when the backend exists.  This should keep the frontend process in the same group as the parent process and allow SIGINT reach.

