### PR TITLE
Windows Pin Version followup (Use Windows Install Link)

### DIFF
--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -746,7 +746,7 @@ def install_bun():
             [
                 "powershell",
                 "-c",
-                f"irm {constants.Bun.WINDOWS_INSTALL_URL}.ps1|iex",
+                f"irm {constants.Bun.WINDOWS_INSTALL_URL}|iex",
             ],
             env={
                 "BUN_INSTALL": constants.Bun.ROOT_PATH,

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -746,8 +746,8 @@ def install_bun():
             [
                 "powershell",
                 "-c",
-                f"irm {constants.Bun.INSTALL_URL}.ps1|iex",
-            ],  # TODO: change install url to constants.BUN.WINDOWS_INSTALL_URL
+                f"irm {constants.Bun.WINDOWS_INSTALL_URL}.ps1|iex",
+            ],
             env={
                 "BUN_INSTALL": constants.Bun.ROOT_PATH,
                 "BUN_VERSION": constants.Bun.VERSION,


### PR DESCRIPTION
A follow to #3192, to change the install link for windows from that of bun to the modified install script that now lives in `/scripts/install.ps1`