### PR TITLE
[REF-2370] Combine library/version into ImportVar and replace _get_imports with _get_imports_list

### DIFF
--- a/reflex/app.py
+++ b/reflex/app.py
@@ -627,7 +627,7 @@ class App(Base):
         Example:
             >>> get_frontend_packages({"react": "16.14.0", "react-dom": "16.14.0"})
         """
-        page_imports = [i.package for i in imports.collapse().values() if i.install]
+        page_imports = [i.package for i in imports if i.install and i.package]
         frontend_packages = get_config().frontend_packages
         _frontend_packages = []
         for package in frontend_packages:
@@ -643,7 +643,7 @@ class App(Base):
                 continue
             _frontend_packages.append(package)
         page_imports.extend(_frontend_packages)
-        prerequisites.install_frontend_packages(page_imports, get_config())
+        prerequisites.install_frontend_packages(set(page_imports), get_config())
 
     def _app_root(self, app_wrappers: dict[tuple[int, str], Component]) -> Component:
         for component in tuple(app_wrappers.values()):

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -79,7 +79,7 @@ from reflex.state import (
 )
 from reflex.utils import console, exceptions, format, prerequisites, types
 from reflex.utils.exec import is_testing_env, should_skip_compile
-from reflex.utils.imports import ImportVar
+from reflex.utils.imports import ImportList
 
 # Define custom types.
 ComponentCallable = Callable[[], Component]
@@ -618,27 +618,16 @@ class App(Base):
 
             admin.mount_to(self.api)
 
-    def get_frontend_packages(self, imports: Dict[str, set[ImportVar]]):
+    def get_frontend_packages(self, imports: ImportList):
         """Gets the frontend packages to be installed and filters out the unnecessary ones.
 
         Args:
-            imports: A dictionary containing the imports used in the current page.
+            imports: A list containing the imports used in the current page.
 
         Example:
             >>> get_frontend_packages({"react": "16.14.0", "react-dom": "16.14.0"})
         """
-        page_imports = {
-            i
-            for i, tags in imports.items()
-            if i
-            not in [
-                *constants.PackageJson.DEPENDENCIES.keys(),
-                *constants.PackageJson.DEV_DEPENDENCIES.keys(),
-            ]
-            and not any(i.startswith(prefix) for prefix in ["/", ".", "next/"])
-            and i != ""
-            and any(tag.install for tag in tags)
-        }
+        page_imports = [i.package for i in imports.collapse().values() if i.install]
         frontend_packages = get_config().frontend_packages
         _frontend_packages = []
         for package in frontend_packages:
@@ -653,7 +642,7 @@ class App(Base):
                 )
                 continue
             _frontend_packages.append(package)
-        page_imports.update(_frontend_packages)
+        page_imports.extend(_frontend_packages)
         prerequisites.install_frontend_packages(page_imports, get_config())
 
     def _app_root(self, app_wrappers: dict[tuple[int, str], Component]) -> Component:
@@ -794,7 +783,7 @@ class App(Base):
         self.style = evaluate_style_namespaces(self.style)
 
         # Track imports and custom components found.
-        all_imports = {}
+        all_imports = ImportList()
         custom_components = set()
 
         for _route, component in self.pages.items():
@@ -804,7 +793,7 @@ class App(Base):
             component.apply_theme(self.theme)
 
             # Add component._get_all_imports() to all_imports.
-            all_imports.update(component._get_all_imports())
+            all_imports.extend(component._get_all_imports())
 
             # Add the app wrappers from this component.
             app_wrappers.update(component._get_all_app_wrap_components())
@@ -932,10 +921,10 @@ class App(Base):
                 custom_components_imports,
             ) = custom_components_future.result()
             compile_results.append(custom_components_result)
-            all_imports.update(custom_components_imports)
+            all_imports.extend(custom_components_imports)
 
         # Get imports from AppWrap components.
-        all_imports.update(app_root._get_all_imports())
+        all_imports.extend(app_root._get_all_imports())
 
         progress.advance(task)
 
@@ -951,7 +940,7 @@ class App(Base):
         # Setup the next.config.js
         transpile_packages = [
             package
-            for package, import_vars in all_imports.items()
+            for package, import_vars in all_imports.collapse().items()
             if any(import_var.transpile for import_var in import_vars)
         ]
         prerequisites.update_next_config(

--- a/reflex/compiler/compiler.py
+++ b/reflex/compiler/compiler.py
@@ -188,7 +188,7 @@ def _compile_component(component: Component) -> str:
 
 def _compile_components(
     components: set[CustomComponent],
-) -> tuple[str, Dict[str, list[ImportVar]]]:
+) -> tuple[str, ImportList]:
     """Compile the components.
 
     Args:

--- a/reflex/compiler/utils.py
+++ b/reflex/compiler/utils.py
@@ -247,7 +247,7 @@ def compile_custom_component(
     render = component.get_component(component)
 
     # Get the imports.
-    component_library_name = format.format_library_name(component.library)
+    component_library_name = format.format_library_name(component.library or "")
     _imports = imports.ImportList(
         imp
         for imp in render._get_all_imports()

--- a/reflex/components/chakra/base.py
+++ b/reflex/components/chakra/base.py
@@ -35,19 +35,18 @@ class ChakraComponent(Component):
 
     @classmethod
     @lru_cache(maxsize=None)
-    def _get_dependencies_imports(cls) -> imports.ImportDict:
+    def _get_dependencies_imports(cls) -> imports.ImportList:
         """Get the imports from lib_dependencies for installing.
 
         Returns:
             The dependencies imports of the component.
         """
-        return {
-            dep: [imports.ImportVar(tag=None, render=False)]
-            for dep in [
-                "@chakra-ui/system@2.5.7",
-                "framer-motion@10.16.4",
-            ]
-        }
+        return [
+            imports.ImportVar(
+                package="@chakra-ui/system@2.5.7", tag=None, render=False
+            ),
+            imports.ImportVar(package="framer-motion@10.16.4", tag=None, render=False),
+        ]
 
 
 class ChakraProvider(ChakraComponent):

--- a/reflex/components/chakra/base.py
+++ b/reflex/components/chakra/base.py
@@ -35,7 +35,7 @@ class ChakraComponent(Component):
 
     @classmethod
     @lru_cache(maxsize=None)
-    def _get_dependencies_imports(cls) -> imports.ImportList:
+    def _get_dependencies_imports(cls) -> List[imports.ImportVar]:
         """Get the imports from lib_dependencies for installing.
 
         Returns:
@@ -67,13 +67,21 @@ class ChakraProvider(ChakraComponent):
             theme=Var.create("extendTheme(theme)", _var_is_local=False),
         )
 
-    def _get_imports(self) -> imports.ImportDict:
-        _imports = super()._get_imports()
-        _imports.setdefault(self.__fields__["library"].default, []).append(
-            imports.ImportVar(tag="extendTheme", is_default=False),
-        )
-        _imports.setdefault("/utils/theme.js", []).append(
-            imports.ImportVar(tag="theme", is_default=True),
+    def _get_imports_list(self) -> List[imports.ImportVar]:
+        _imports = super()._get_imports_list()
+        _imports.extend(
+            [
+                imports.ImportVar(
+                    package=self.__fields__["library"].default,
+                    tag="extendTheme",
+                    is_default=False,
+                ),
+                imports.ImportVar(
+                    package="/utils/theme.js",
+                    tag="theme",
+                    is_default=True,
+                ),
+            ],
         )
         return _imports
 

--- a/reflex/components/chakra/forms/pininput.py
+++ b/reflex/components/chakra/forms/pininput.py
@@ -9,7 +9,7 @@ from reflex.components.component import Component
 from reflex.components.tags.tag import Tag
 from reflex.constants import EventTriggers
 from reflex.utils import format
-from reflex.utils.imports import ImportDict, merge_imports
+from reflex.utils.imports import ImportVar
 from reflex.vars import Var
 
 
@@ -63,18 +63,18 @@ class PinInput(ChakraComponent):
     # The name of the form field
     name: Var[str]
 
-    def _get_imports(self) -> ImportDict:
+    def _get_imports_list(self) -> list[ImportVar]:
         """Include PinInputField explicitly because it may not be a child component at compile time.
 
         Returns:
             The merged import dict.
         """
         range_var = Var.range(0)
-        return merge_imports(
-            super()._get_imports(),
-            PinInputField()._get_all_imports(),  # type: ignore
-            range_var._var_data.imports if range_var._var_data is not None else {},
-        )
+        return [
+            *super()._get_imports_list(),
+            *PinInputField()._get_all_imports(),  # type: ignore
+            *(range_var._var_data.imports if range_var._var_data is not None else []),
+        ]
 
     def get_event_triggers(self) -> dict[str, Union[Var, Any]]:
         """Get the event triggers that pass the component's value to the handler.

--- a/reflex/components/chakra/forms/pininput.pyi
+++ b/reflex/components/chakra/forms/pininput.pyi
@@ -13,7 +13,7 @@ from reflex.components.component import Component
 from reflex.components.tags.tag import Tag
 from reflex.constants import EventTriggers
 from reflex.utils import format
-from reflex.utils.imports import ImportDict, merge_imports
+from reflex.utils.imports import ImportVar
 from reflex.vars import Var
 
 class PinInput(ChakraComponent):

--- a/reflex/components/chakra/navigation/link.py
+++ b/reflex/components/chakra/navigation/link.py
@@ -1,5 +1,6 @@
 """A link component."""
 
+from __future__ import annotations
 
 from reflex.components.chakra import ChakraComponent
 from reflex.components.component import Component

--- a/reflex/components/chakra/navigation/link.py
+++ b/reflex/components/chakra/navigation/link.py
@@ -30,8 +30,8 @@ class Link(ChakraComponent):
     # If true, the link will open in new tab.
     is_external: Var[bool]
 
-    def _get_imports(self) -> imports.ImportDict:
-        return {**super()._get_imports(), **next_link._get_imports()}
+    def _get_imports_list(self) -> list[imports.ImportVar]:
+        return [*super()._get_imports_list(), *next_link._get_imports_list()]
 
     @classmethod
     def create(cls, *children, **props) -> Component:

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import itertools
 import typing
 from abc import ABC, abstractmethod
 from functools import lru_cache, wraps
@@ -95,11 +96,11 @@ class BaseComponent(Base, ABC):
         """
 
     @abstractmethod
-    def _get_all_imports(self) -> imports.ImportDict:
+    def _get_all_imports(self) -> imports.ImportList:
         """Get all the libraries and fields that are used by the component.
 
         Returns:
-            The import dict with the required imports.
+            The list of all required ImportVar.
         """
 
     @abstractmethod
@@ -994,17 +995,22 @@ class Component(BaseComponent, ABC):
         # Return the dynamic imports
         return dynamic_imports
 
-    def _get_props_imports(self) -> List[str]:
+    def _get_props_imports(self) -> imports.ImportList:
         """Get the imports needed for components props.
 
         Returns:
-            The  imports for the components props of the component.
+            The imports for the components props of the component.
         """
-        return [
-            getattr(self, prop)._get_all_imports()
-            for prop in self.get_component_props()
-            if getattr(self, prop) is not None
-        ]
+        return imports.ImportList(
+            sum(
+                (
+                    getattr(self, prop)._get_all_imports()
+                    for prop in self.get_component_props()
+                    if getattr(self, prop) is not None
+                ),
+                [],
+            )
+        )
 
     def _should_transpile(self, dep: str | None) -> bool:
         """Check if a dependency should be transpiled.
@@ -1020,97 +1026,129 @@ class Component(BaseComponent, ABC):
             or format.format_library_name(dep or "") in self.transpile_packages
         )
 
-    def _get_dependencies_imports(self) -> imports.ImportDict:
+    def _get_dependencies_imports(self) -> imports.ImportList:
         """Get the imports from lib_dependencies for installing.
 
         Returns:
             The dependencies imports of the component.
         """
-        return {
-            dep: [
-                ImportVar(
-                    tag=None,
-                    render=False,
-                    transpile=self._should_transpile(dep),
-                )
-            ]
+        return imports.ImportList(
+            ImportVar(
+                package=dep,
+                tag=None,
+                render=False,
+                transpile=self._should_transpile(dep),
+            )
             for dep in self.lib_dependencies
-        }
+        )
 
-    def _get_hooks_imports(self) -> imports.ImportDict:
+    def _get_hooks_imports(self) -> imports.ImportList:
         """Get the imports required by certain hooks.
 
         Returns:
             The imports required for all selected hooks.
         """
-        _imports = {}
+        _imports = imports.ImportList()
 
         if self._get_ref_hook():
             # Handle hooks needed for attaching react refs to DOM nodes.
-            _imports.setdefault("react", set()).add(ImportVar(tag="useRef"))
-            _imports.setdefault(f"/{Dirs.STATE_PATH}", set()).add(ImportVar(tag="refs"))
+            _imports.extend(
+                [
+                    ImportVar(package="react", tag="useRef"),
+                    ImportVar(package=f"/{Dirs.STATE_PATH}", tag="refs"),
+                ]
+            )
 
         if self._get_mount_lifecycle_hook():
             # Handle hooks for `on_mount` / `on_unmount`.
-            _imports.setdefault("react", set()).add(ImportVar(tag="useEffect"))
+            _imports.append(ImportVar(package="react", tag="useEffect"))
 
         if self._get_special_hooks():
             # Handle additional internal hooks (autofocus, etc).
-            _imports.setdefault("react", set()).update(
-                {
-                    ImportVar(tag="useRef"),
-                    ImportVar(tag="useEffect"),
-                },
+            _imports.extend(
+                [
+                    ImportVar(package="react", tag="useEffect"),
+                    ImportVar(package="react", tag="useRef"),
+                ]
             )
 
         user_hooks = self._get_hooks()
         if user_hooks is not None and isinstance(user_hooks, Var):
-            _imports = imports.merge_imports(_imports, user_hooks._var_data.imports)  # type: ignore
+            _imports.extend(user_hooks._var_data.imports)
 
         return _imports
 
     def _get_imports(self) -> imports.ImportDict:
-        """Get all the libraries and fields that are used by the component.
+        """Deprecated method to get all the libraries and fields used by the component.
 
         Returns:
             The imports needed by the component.
         """
-        _imports = {}
+        return {}
+
+    def _get_imports_list(self) -> imports.ImportList:
+        """Internal method to get the imports as a list.
+
+        Returns:
+            The imports as a list.
+        """
+        _imports = imports.ImportList(
+            itertools.chain(
+                self._get_props_imports(),
+                self._get_dependencies_imports(),
+                self._get_hooks_imports(),
+            )
+        )
+
+        # Handle deprecated _get_imports
+        import_dict = self._get_imports()
+        if import_dict:
+            console.deprecate(
+                feature_name="_get_imports",
+                reason="use add_imports instead",
+                deprecation_version="0.5.0",
+                removal_version="0.6.0",
+            )
+            _imports.extend(imports.ImportList.from_import_dict(import_dict))
 
         # Import this component's tag from the main library.
         if self.library is not None and self.tag is not None:
-            _imports[self.library] = {self.import_var}
+            _imports.append(self.import_var)
 
         # Get static imports required for event processing.
-        event_imports = Imports.EVENTS if self.event_triggers else {}
+        if self.event_triggers:
+            _imports.append(Imports.EVENTS)
 
         # Collect imports from Vars used directly by this component.
-        var_imports = [
-            var._var_data.imports for var in self._get_vars() if var._var_data
-        ]
+        for var in self._get_vars():
+            if var._var_data:
+                _imports.extend(var._var_data.imports)
+        return _imports
 
-        return imports.merge_imports(
-            *self._get_props_imports(),
-            self._get_dependencies_imports(),
-            self._get_hooks_imports(),
-            _imports,
-            event_imports,
-            *var_imports,
-        )
-
-    def _get_all_imports(self, collapse: bool = False) -> imports.ImportDict:
+    def _get_all_imports(self, collapse: bool = False) -> imports.ImportList:
         """Get all the libraries and fields that are used by the component and its children.
 
         Args:
-            collapse: Whether to collapse the imports by removing duplicates.
+            collapse: Whether to collapse the imports into a dict (deprecated).
 
         Returns:
-            The import dict with the required imports.
+            The list of all required imports.
         """
-        _imports = imports.merge_imports(
-            self._get_imports(), *[child._get_all_imports() for child in self.children]
+        _imports = imports.ImportList(
+            self._get_imports_list()
+            + sum((child._get_all_imports() for child in self.children), [])
         )
-        return imports.collapse_imports(_imports) if collapse else _imports
+
+        if collapse:
+            console.deprecate(
+                feature_name="collapse kwarg to _get_all_imports",
+                reason="use ImportList.collapse instead",
+                deprecation_version="0.5.0",
+                removal_version="0.6.0",
+            )
+            return _imports.collapse()  # type: ignore
+
+        return _imports
 
     def _get_mount_lifecycle_hook(self) -> str | None:
         """Generate the component lifecycle hook.
@@ -1296,6 +1334,7 @@ class Component(BaseComponent, ABC):
         tag = self.tag.partition(".")[0] if self.tag else None
         alias = self.alias.partition(".")[0] if self.alias else None
         return ImportVar(
+            package=self.library,
             tag=tag,
             is_default=self.is_default,
             alias=alias,
@@ -1575,7 +1614,6 @@ class NoSSRComponent(Component):
         return imports.merge_imports(
             dynamic_import,
             _imports,
-            self._get_dependencies_imports(),
         )
 
     def _get_dynamic_imports(self) -> str:
@@ -1893,18 +1931,21 @@ class StatefulComponent(BaseComponent):
         """
         return {}
 
-    def _get_all_imports(self) -> imports.ImportDict:
+    def _get_all_imports(self) -> imports.ImportList:
         """Get all the libraries and fields that are used by the component.
 
         Returns:
-            The import dict with the required imports.
+            The list of all required imports.
         """
         if self.rendered_as_shared:
-            return {
-                f"/{Dirs.UTILS}/{PageNames.STATEFUL_COMPONENTS}": [
-                    ImportVar(tag=self.tag)
+            return imports.ImportList(
+                [
+                    imports.ImportVar(
+                        package=f"/{Dirs.UTILS}/{PageNames.STATEFUL_COMPONENTS}",
+                        tag=self.tag,
+                    )
                 ]
-            }
+            )
         return self.component._get_all_imports()
 
     def _get_all_dynamic_imports(self) -> set[str]:

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -1593,32 +1593,29 @@ memo = custom_component
 class NoSSRComponent(Component):
     """A dynamic component that is not rendered on the server."""
 
-    def _get_imports(self) -> imports.ImportDict:
+    def _get_imports_list(self) -> list[ImportVar]:
         """Get the imports for the component.
 
         Returns:
             The imports for dynamically importing the component at module load time.
         """
-        # Next.js dynamic import mechanism.
-        dynamic_import = {"next/dynamic": [ImportVar(tag="dynamic", is_default=True)]}
+        return [
+            *super()._get_imports_list(),
+            # Next.js dynamic import mechanism.
+            ImportVar(package="next/dynamic", tag="dynamic", is_default=True),
+        ]
 
-        # The normal imports for this component.
-        _imports = super()._get_imports()
+    @property
+    def import_var(self) -> ImportVar:
+        """Will not actually render the tag to import, get it dynamically instead.
 
-        # Do NOT import the main library/tag statically.
-        if self.library is not None:
-            _imports[self.library] = [
-                imports.ImportVar(
-                    tag=None,
-                    render=False,
-                    transpile=self._should_transpile(self.library),
-                ),
-            ]
-
-        return imports.merge_imports(
-            dynamic_import,
-            _imports,
-        )
+        Returns:
+            An import var.
+        """
+        imp = super().import_var
+        imp.tag = None
+        imp.render = False
+        return imp
 
     def _get_dynamic_imports(self) -> str:
         opts_fragment = ", { ssr: false });"

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -1026,7 +1026,7 @@ class Component(BaseComponent, ABC):
             or format.format_library_name(dep or "") in self.transpile_packages
         )
 
-    def _get_dependencies_imports(self) -> imports.ImportList:
+    def _get_dependencies_imports(self) -> List[ImportVar]:
         """Get the imports from lib_dependencies for installing.
 
         Returns:
@@ -1073,7 +1073,11 @@ class Component(BaseComponent, ABC):
             )
 
         user_hooks = self._get_hooks()
-        if user_hooks is not None and isinstance(user_hooks, Var):
+        if (
+            user_hooks is not None
+            and isinstance(user_hooks, Var)
+            and user_hooks._var_data is not None
+        ):
             _imports.extend(user_hooks._var_data.imports)
 
         return _imports
@@ -1086,7 +1090,7 @@ class Component(BaseComponent, ABC):
         """
         return {}
 
-    def _get_imports_list(self) -> imports.ImportList:
+    def _get_imports_list(self) -> List[ImportVar]:
         """Internal method to get the imports as a list.
 
         Returns:
@@ -1117,7 +1121,7 @@ class Component(BaseComponent, ABC):
 
         # Get static imports required for event processing.
         if self.event_triggers:
-            _imports.append(Imports.EVENTS)
+            _imports.extend(Imports.EVENTS)
 
         # Collect imports from Vars used directly by this component.
         for var in self._get_vars():

--- a/reflex/components/core/banner.py
+++ b/reflex/components/core/banner.py
@@ -51,11 +51,14 @@ has_too_many_connection_errors: Var = Var.create_safe(
 class WebsocketTargetURL(Bare):
     """A component that renders the websocket target URL."""
 
-    def _get_imports(self) -> imports.ImportDict:
-        return {
-            f"/{Dirs.STATE_PATH}": [imports.ImportVar(tag="getBackendURL")],
-            "/env.json": [imports.ImportVar(tag="env", is_default=True)],
-        }
+    def _get_imports_list(self) -> list[imports.ImportVar]:
+        return [
+            imports.ImportVar(
+                library=f"/{Dirs.STATE_PATH}",
+                tag="getBackendURL",
+            ),
+            imports.ImportVar(library="/env.json", tag="env", is_default=True),
+        ]
 
     @classmethod
     def create(cls) -> Component:

--- a/reflex/components/core/cond.py
+++ b/reflex/components/core/cond.py
@@ -12,9 +12,9 @@ from reflex.style import LIGHT_COLOR_MODE, color_mode
 from reflex.utils import format, imports
 from reflex.vars import BaseVar, Var, VarData
 
-_IS_TRUE_IMPORT = {
-    f"/{Dirs.STATE_PATH}": {imports.ImportVar(tag="isTrue")},
-}
+_IS_TRUE_IMPORT = imports.ImportList(
+    [imports.ImportVar(library=f"/{Dirs.STATE_PATH}", tag="isTrue")]
+)
 
 
 class Cond(MemoizationLeaf):
@@ -95,11 +95,13 @@ class Cond(MemoizationLeaf):
             cond_state=f"isTrue({self.cond._var_full_name})",
         )
 
-    def _get_imports(self) -> imports.ImportDict:
-        return imports.merge_imports(
-            super()._get_imports(),
-            getattr(self.cond._var_data, "imports", {}),
-            _IS_TRUE_IMPORT,
+    def _get_imports_list(self) -> imports.ImportList:
+        return imports.ImportList(
+            [
+                *super()._get_imports_list(),
+                *getattr(self.cond._var_data, "imports", []),
+                *_IS_TRUE_IMPORT,
+            ]
         )
 
     def _apply_theme(self, theme: Component):

--- a/reflex/components/core/debounce.py
+++ b/reflex/components/core/debounce.py
@@ -112,7 +112,7 @@ class DebounceInput(Component):
             )._replace(
                 _var_type=Type[Component],
                 merge_var_data=VarData(  # type: ignore
-                    imports=child._get_imports(),
+                    imports=child._get_imports_list(),
                     hooks=child._get_hooks_internal(),
                 ),
             ),

--- a/reflex/components/core/match.py
+++ b/reflex/components/core/match.py
@@ -1,5 +1,7 @@
 """rx.match."""
 
+from __future__ import annotations
+
 import textwrap
 from typing import Any, Dict, List, Optional, Tuple, Union
 

--- a/reflex/components/core/match.py
+++ b/reflex/components/core/match.py
@@ -268,11 +268,11 @@ class Match(MemoizationLeaf):
         tag.name = "match"
         return dict(tag)
 
-    def _get_imports(self) -> imports.ImportDict:
-        return imports.merge_imports(
-            super()._get_imports(),
-            getattr(self.cond._var_data, "imports", {}),
-        )
+    def _get_imports_list(self) -> list[imports.ImportVar]:
+        return [
+            *super()._get_imports_list(),
+            *getattr(self.cond._var_data, "imports", []),
+        ]
 
     def _apply_theme(self, theme: Component):
         """Apply the theme to this component.

--- a/reflex/components/markdown/markdown.py
+++ b/reflex/components/markdown/markdown.py
@@ -180,7 +180,7 @@ class Markdown(Component):
                     is_default=True,
                 ),
                 ImportVar(
-                    package="remark-katex@6.0.3",
+                    package="rehype-katex@6.0.3",
                     tag=_REHYPE_KATEX._var_name,
                     is_default=True,
                 ),

--- a/reflex/components/markdown/markdown.pyi
+++ b/reflex/components/markdown/markdown.pyi
@@ -11,7 +11,6 @@ import textwrap
 from functools import lru_cache
 from hashlib import md5
 from typing import Any, Callable, Dict, Union
-from reflex.compiler import utils
 from reflex.components.component import Component, CustomComponent
 from reflex.components.radix.themes.layout.list import (
     ListItem,

--- a/reflex/components/radix/primitives/accordion.py
+++ b/reflex/components/radix/primitives/accordion.py
@@ -425,12 +425,12 @@ class AccordionRoot(AccordionComponent):
             accordion_theme_root
         )
 
-    def _get_imports(self):
-        return imports.merge_imports(
-            super()._get_imports(),
-            self._var_data.imports if self._var_data else {},
-            {"@emotion/react": [imports.ImportVar(tag="keyframes")]},
-        )
+    def _get_imports_list(self) -> list[imports.ImportVar]:
+        return [
+            *super()._get_imports_list(),
+            *(self._var_data.imports if self._var_data else {}),
+            imports.ImportVar(package="@emotion/react", tag="keyframes"),
+        ]
 
     def get_event_triggers(self) -> Dict[str, Any]:
         """Get the events triggers signatures for the component.
@@ -643,12 +643,6 @@ class AccordionContent(AccordionComponent):
 
     def _apply_theme(self, theme: Component):
         self.style = Style({**self.style})
-
-    # def _get_imports(self):
-    #     return {
-    #         **super()._get_imports(),
-    #         "@emotion/react": [imports.ImportVar(tag="keyframes")],
-    #     }
 
 
 class Accordion(ComponentNamespace):

--- a/reflex/components/radix/themes/base.py
+++ b/reflex/components/radix/themes/base.py
@@ -243,13 +243,11 @@ class ThemePanel(RadixThemesComponent):
     # Whether the panel is open. Defaults to False.
     default_open: Var[bool]
 
-    def _get_imports(self) -> dict[str, list[imports.ImportVar]]:
-        return imports.merge_imports(
-            super()._get_imports(),
-            {
-                "react": [imports.ImportVar(tag="useEffect")],
-            },
-        )
+    def _get_imports_list(self) -> list[imports.ImportVar]:
+        return [
+            *super()._get_imports_list(),
+            imports.ImportVar(package="react", tag="useEffect"),
+        ]
 
     def _get_hooks(self) -> str | None:
         # The panel freezes the tab if the user color preference differs from the

--- a/reflex/components/radix/themes/typography/link.py
+++ b/reflex/components/radix/themes/typography/link.py
@@ -59,8 +59,8 @@ class Link(RadixThemesComponent, A, MemoizationLeaf):
     # If True, the link will open in a new tab
     is_external: Var[bool]
 
-    def _get_imports(self) -> imports.ImportDict:
-        return {**super()._get_imports(), **next_link._get_imports()}
+    def _get_imports_list(self) -> list[imports.ImportVar]:
+        return [*super()._get_imports_list(), *next_link._get_imports_list()]
 
     @classmethod
     def create(cls, *children, **props) -> Component:

--- a/reflex/constants/compiler.py
+++ b/reflex/constants/compiler.py
@@ -102,11 +102,13 @@ class ComponentName(Enum):
 class Imports(SimpleNamespace):
     """Common sets of import vars."""
 
-    EVENTS: ImportList = [
-        ImportVar(package="react", tag="useContext"),
-        ImportVar(package=f"/{Dirs.CONTEXTS_PATH}", tag="EventLoopContext"),
-        ImportVar(package=f"/{Dirs.STATE_PATH}", tag=CompileVars.TO_EVENT),
-    ]
+    EVENTS: ImportList = ImportList(
+        [
+            ImportVar(package="react", tag="useContext"),
+            ImportVar(package=f"/{Dirs.CONTEXTS_PATH}", tag="EventLoopContext"),
+            ImportVar(package=f"/{Dirs.STATE_PATH}", tag=CompileVars.TO_EVENT),
+        ]
+    )
 
 
 class Hooks(SimpleNamespace):

--- a/reflex/constants/compiler.py
+++ b/reflex/constants/compiler.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 
 from reflex.base import Base
 from reflex.constants import Dirs
-from reflex.utils.imports import ImportVar
+from reflex.utils.imports import ImportList, ImportVar
 
 # The prefix used to create setters for state vars.
 SETTER_PREFIX = "set_"
@@ -102,11 +102,11 @@ class ComponentName(Enum):
 class Imports(SimpleNamespace):
     """Common sets of import vars."""
 
-    EVENTS = {
-        "react": {ImportVar(tag="useContext")},
-        f"/{Dirs.CONTEXTS_PATH}": {ImportVar(tag="EventLoopContext")},
-        f"/{Dirs.STATE_PATH}": {ImportVar(tag=CompileVars.TO_EVENT)},
-    }
+    EVENTS: ImportList = [
+        ImportVar(package="react", tag="useContext"),
+        ImportVar(package=f"/{Dirs.CONTEXTS_PATH}", tag="EventLoopContext"),
+        ImportVar(package=f"/{Dirs.STATE_PATH}", tag=CompileVars.TO_EVENT),
+    ]
 
 
 class Hooks(SimpleNamespace):

--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 from reflex import constants
 from reflex.utils import exceptions, serializers, types
+from reflex.utils.imports import split_library_name_version
 from reflex.utils.serializers import serialize
 from reflex.vars import BaseVar, Var
 
@@ -716,11 +717,7 @@ def format_library_name(library_fullname: str):
     Returns:
         The name without the @version if it was part of the name
     """
-    lib, at, version = library_fullname.rpartition("@")
-    if not lib:
-        lib = at + version
-
-    return lib
+    return split_library_name_version(library_fullname)[0]
 
 
 def json_dumps(obj: Any) -> str:

--- a/reflex/utils/imports.py
+++ b/reflex/utils/imports.py
@@ -284,7 +284,10 @@ class ImportList(List[ImportVar]):
                     f"Imports from {lib} have conflicting version specifiers: "
                     f"{packages} {imps}"
                 )
-            deduped[list(packages)[0] or ""] = list(imps.values())
+            package = lib
+            if packages:
+                package = packages.pop() or ""
+            deduped[package] = list(imps.values())
         return deduped
 
 

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -22,6 +22,7 @@ from typing import (
     List,
     Literal,
     Optional,
+    Sequence,
     Tuple,
     Type,
     Union,
@@ -129,7 +130,7 @@ class VarData(Base):
     def __init__(
         self,
         imports: ImportList
-        | List[ImportVar | Dict[str, Optional[Union[str, bool]]]]
+        | Sequence[ImportVar | Dict[str, Optional[Union[str, bool]]]]
         | ImportDict
         | Dict[str, set[ImportVar]]
         | None = None,

--- a/reflex/vars.pyi
+++ b/reflex/vars.pyi
@@ -9,7 +9,7 @@ from reflex.base import Base as Base
 from reflex.state import State as State
 from reflex.state import BaseState as BaseState
 from reflex.utils import console as console, format as format, types as types
-from reflex.utils.imports import ImportVar
+from reflex.utils.imports import ImportDict, ImportList, ImportVar
 from types import FunctionType
 from typing import (
     Any,
@@ -35,9 +35,18 @@ def _extract_var_data(value: Iterable) -> list[VarData | None]: ...
 
 class VarData(Base):
     state: str
-    imports: dict[str, set[ImportVar]]
+    imports: ImportList
     hooks: Dict[str, None]
     interpolations: List[Tuple[int, int]]
+    def __init__(
+        self,
+        imports: ImportList
+        | List[ImportVar | Dict[str, Optional[Union[str, bool]]]]
+        | ImportDict
+        | Dict[str, set[ImportVar]]
+        | None = None,
+        **kwargs,
+    ): ...
     @classmethod
     def merge(cls, *others: VarData | None) -> VarData | None: ...
 

--- a/reflex/vars.pyi
+++ b/reflex/vars.pyi
@@ -18,6 +18,7 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Type,
@@ -41,7 +42,7 @@ class VarData(Base):
     def __init__(
         self,
         imports: ImportList
-        | List[ImportVar | Dict[str, Optional[Union[str, bool]]]]
+        | Sequence[ImportVar | Dict[str, Optional[Union[str, bool]]]]
         | ImportDict
         | Dict[str, set[ImportVar]]
         | None = None,

--- a/tests/compiler/test_compiler.py
+++ b/tests/compiler/test_compiler.py
@@ -4,8 +4,7 @@ from typing import List
 import pytest
 
 from reflex.compiler import compiler, utils
-from reflex.utils import imports
-from reflex.utils.imports import ImportVar
+from reflex.utils.imports import ImportList, ImportVar
 
 
 @pytest.mark.parametrize(
@@ -48,43 +47,56 @@ def test_compile_import_statement(
 
 
 @pytest.mark.parametrize(
-    "import_dict,test_dicts",
+    "import_list,test_dicts",
     [
-        ({}, []),
+        (ImportList(), []),
         (
-            {"axios": [ImportVar(tag="axios", is_default=True)]},
+            ImportList([ImportVar(library="axios", tag="axios", is_default=True)]),
             [{"lib": "axios", "default": "axios", "rest": []}],
         ),
         (
-            {"axios": [ImportVar(tag="foo"), ImportVar(tag="bar")]},
+            ImportList(
+                [
+                    ImportVar(library="axios", tag="foo"),
+                    ImportVar(library="axios", tag="bar"),
+                ]
+            ),
             [{"lib": "axios", "default": "", "rest": ["bar", "foo"]}],
         ),
         (
-            {
-                "axios": [
-                    ImportVar(tag="axios", is_default=True),
-                    ImportVar(tag="foo"),
-                    ImportVar(tag="bar"),
-                ],
-                "react": [ImportVar(tag="react", is_default=True)],
-            },
+            ImportList(
+                [
+                    ImportVar(library="axios", tag="axios", is_default=True),
+                    ImportVar(library="axios", tag="foo"),
+                    ImportVar(library="axios", tag="bar"),
+                    ImportVar(library="react", tag="react", is_default=True),
+                ]
+            ),
             [
                 {"lib": "axios", "default": "axios", "rest": ["bar", "foo"]},
                 {"lib": "react", "default": "react", "rest": []},
             ],
         ),
         (
-            {"": [ImportVar(tag="lib1.js"), ImportVar(tag="lib2.js")]},
+            ImportList(
+                [
+                    ImportVar(library="", tag="lib1.js"),
+                    ImportVar(library="", tag="lib2.js"),
+                ]
+            ),
             [
                 {"lib": "lib1.js", "default": "", "rest": []},
                 {"lib": "lib2.js", "default": "", "rest": []},
             ],
         ),
         (
-            {
-                "": [ImportVar(tag="lib1.js"), ImportVar(tag="lib2.js")],
-                "axios": [ImportVar(tag="axios", is_default=True)],
-            },
+            ImportList(
+                [
+                    ImportVar(library="", tag="lib1.js"),
+                    ImportVar(library="", tag="lib2.js"),
+                    ImportVar(library="axios", tag="axios", is_default=True),
+                ]
+            ),
             [
                 {"lib": "lib1.js", "default": "", "rest": []},
                 {"lib": "lib2.js", "default": "", "rest": []},
@@ -93,14 +105,14 @@ def test_compile_import_statement(
         ),
     ],
 )
-def test_compile_imports(import_dict: imports.ImportDict, test_dicts: List[dict]):
+def test_compile_imports(import_list: ImportList, test_dicts: List[dict]):
     """Test the compile_imports function.
 
     Args:
-        import_dict: The import dictionary.
+        import_list: The list of ImportVar.
         test_dicts: The expected output.
     """
-    imports = utils.compile_imports(import_dict)
+    imports = utils.compile_imports(import_list)
     for import_dict, test_dict in zip(imports, test_dicts):
         assert import_dict["lib"] == test_dict["lib"]
         assert import_dict["default"] == test_dict["default"]

--- a/tests/components/core/test_banner.py
+++ b/tests/components/core/test_banner.py
@@ -9,14 +9,14 @@ from reflex.components.radix.themes.typography.text import Text
 
 def test_websocket_target_url():
     url = WebsocketTargetURL.create()
-    _imports = url._get_all_imports(collapse=True)
-    assert list(_imports.keys()) == ["/utils/state", "/env.json"]
+    _imports = url._get_all_imports()
+    assert [i.library for i in _imports] == ["/utils/state", "/env.json"]
 
 
 def test_connection_banner():
     banner = ConnectionBanner.create()
-    _imports = banner._get_all_imports(collapse=True)
-    assert list(_imports.keys()) == [
+    _imports = banner._get_all_imports()
+    assert [i.library for i in _imports] == [
         "react",
         "/utils/context",
         "/utils/state",
@@ -31,8 +31,8 @@ def test_connection_banner():
 
 def test_connection_modal():
     modal = ConnectionModal.create()
-    _imports = modal._get_all_imports(collapse=True)
-    assert list(_imports.keys()) == [
+    _imports = modal._get_all_imports()
+    assert [i.library for i in _imports] == [
         "react",
         "/utils/context",
         "/utils/state",
@@ -48,4 +48,4 @@ def test_connection_modal():
 def test_connection_pulser():
     pulser = ConnectionPulser.create()
     _custom_code = pulser._get_all_custom_code()
-    _imports = pulser._get_all_imports(collapse=True)
+    _imports = pulser._get_all_imports()

--- a/tests/components/core/test_banner.py
+++ b/tests/components/core/test_banner.py
@@ -20,7 +20,7 @@ def test_connection_banner():
         "react",
         "/utils/context",
         "/utils/state",
-        "@radix-ui/themes@^3.0.0",
+        "@radix-ui/themes",
         "/env.json",
     ]
 
@@ -36,7 +36,7 @@ def test_connection_modal():
         "react",
         "/utils/context",
         "/utils/state",
-        "@radix-ui/themes@^3.0.0",
+        "@radix-ui/themes",
         "/env.json",
     ]
 

--- a/tests/components/core/test_banner.py
+++ b/tests/components/core/test_banner.py
@@ -15,12 +15,12 @@ def test_websocket_target_url():
 
 def test_connection_banner():
     banner = ConnectionBanner.create()
-    _imports = banner._get_all_imports()
-    assert [i.library for i in _imports] == [
+    _imports = banner._get_all_imports().collapse()
+    assert list(_imports) == [
         "react",
         "/utils/context",
         "/utils/state",
-        "@radix-ui/themes",
+        "@radix-ui/themes@^3.0.0",
         "/env.json",
     ]
 
@@ -31,12 +31,12 @@ def test_connection_banner():
 
 def test_connection_modal():
     modal = ConnectionModal.create()
-    _imports = modal._get_all_imports()
-    assert [i.library for i in _imports] == [
+    _imports = modal._get_all_imports().collapse()
+    assert list(_imports) == [
         "react",
         "/utils/context",
         "/utils/state",
-        "@radix-ui/themes",
+        "@radix-ui/themes@^3.0.0",
         "/env.json",
     ]
 

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -296,11 +296,11 @@ def test_get_imports(component1, component2):
     """
     c1 = component1.create()
     c2 = component2.create(c1)
-    assert c1._get_all_imports() == {"react": [ImportVar(tag="Component")]}
-    assert c2._get_all_imports() == {
-        "react-redux": [ImportVar(tag="connect")],
-        "react": [ImportVar(tag="Component")],
-    }
+    assert c1._get_all_imports() == [ImportVar(library="react", tag="Component")]
+    assert c2._get_all_imports() == [
+        ImportVar(library="react-redux", tag="connect"),
+        ImportVar(library="react", tag="Component"),
+    ]
 
 
 def test_get_custom_code(component1, component2):
@@ -1514,22 +1514,24 @@ def test_custom_component_get_imports():
     custom_comp = wrapper()
 
     # Inner is not imported directly, but it is imported by the custom component.
-    assert "inner" not in custom_comp._get_all_imports()
+    inner_import = ImportVar(library="inner", tag="Inner")
+    assert inner_import not in custom_comp._get_all_imports()
 
     # The imports are only resolved during compilation.
     _, _, imports_inner = compile_components(custom_comp._get_all_custom_components())
-    assert "inner" in imports_inner
+    assert inner_import in imports_inner
 
     outer_comp = outer(c=wrapper())
 
     # Libraries are not imported directly, but are imported by the custom component.
-    assert "inner" not in outer_comp._get_all_imports()
-    assert "other" not in outer_comp._get_all_imports()
+    other_import = ImportVar(library="other", tag="Other")
+    assert inner_import not in outer_comp._get_all_imports()
+    assert other_import not in outer_comp._get_all_imports()
 
     # The imports are only resolved during compilation.
     _, _, imports_outer = compile_components(outer_comp._get_all_custom_components())
-    assert "inner" in imports_outer
-    assert "other" in imports_outer
+    assert inner_import in imports_outer
+    assert other_import in imports_outer
 
 
 def test_custom_component_declare_event_handlers_in_fields():

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -837,7 +837,7 @@ def test_state_with_initial_computed_var(
         (f"{BaseVar(_var_name='var', _var_type=str)}", "${var}"),
         (
             f"testing f-string with {BaseVar(_var_name='myvar', _var_type=int)._var_set_state('state')}",
-            'testing f-string with $<reflex.Var>{"state": "state", "interpolations": [], "imports": {"/utils/context": [{"tag": "StateContexts", "is_default": false, "alias": null, "install": true, "render": true, "transpile": false}], "react": [{"tag": "useContext", "is_default": false, "alias": null, "install": true, "render": true, "transpile": false}]}, "hooks": {"const state = useContext(StateContexts.state)": null}, "string_length": 13}</reflex.Var>{state.myvar}',
+            'testing f-string with $<reflex.Var>{"state": "state", "interpolations": [], "imports": [{"library": "/utils/context", "tag": "StateContexts", "is_default": false, "alias": null, "version": null, "install": false, "render": true, "transpile": false}, {"library": "react", "tag": "useContext", "is_default": false, "alias": null, "version": null, "install": false, "render": true, "transpile": false}], "hooks": {"const state = useContext(StateContexts.state)": null}, "string_length": 13}</reflex.Var>{state.myvar}',
         ),
         (
             f"testing local f-string {BaseVar(_var_name='x', _var_is_local=True, _var_type=str)}",


### PR DESCRIPTION
Refactor the method for specifying ImportVar to a more flat format which is easier to combine and work with the intermediate format. No need to `merge_imports`, just append the new `ImportVar` to the list.

Combination occurs in the new `ImportList.collapse` function which handles version conflict detection and combination of other metadata that doesn't influence the identity of the ImportVar, like `install`, `render`, and `transpile`

--------------

2024-04-30: converted to draft to focus on component public API first.