### PR TITLE
Allow StatefulComponent to also be rendered via __str__

### DIFF
--- a/reflex/compiler/compiler.py
+++ b/reflex/compiler/compiler.py
@@ -174,7 +174,7 @@ def _compile_root_stylesheet(stylesheets: list[str]) -> str:
     return templates.STYLE.render(stylesheets=sheets)
 
 
-def _compile_component(component: Component) -> str:
+def _compile_component(component: Component | StatefulComponent) -> str:
     """Compile a single component.
 
     Args:

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -2103,6 +2103,16 @@ class StatefulComponent(BaseComponent):
         """
         return dict(Tag(name=self.tag))
 
+    def __str__(self) -> str:
+        """Represent the component in React.
+
+        Returns:
+            The code to render the component.
+        """
+        from reflex.compiler.compiler import _compile_component
+
+        return _compile_component(self)
+
     @classmethod
     def compile_from(cls, component: BaseComponent) -> BaseComponent:
         """Walk through the component tree and memoize all stateful components.


### PR DESCRIPTION
This makes it easier to implement React "render functions" when wrapping components that require children to be a callable.