### PR TITLE
[REF-2676][REF-2751]Windows Skip ARM devices on bun install + Telemetry

### DIFF
--- a/reflex/constants/__init__.py
+++ b/reflex/constants/__init__.py
@@ -4,7 +4,6 @@ from .base import (
     COOKIES,
     ENV_MODE_ENV_VAR,
     IS_WINDOWS,
-    IS_WINDOWS_BUN_SUPPORTED_MACHINE,  # type: ignore
     LOCAL_STORAGE,
     POLLING_MAX_HTTP_BUFFER_SIZE,
     PYTEST_CURRENT_TEST,
@@ -87,7 +86,6 @@ __ALL__ = [
     Hooks,
     Imports,
     IS_WINDOWS,
-    IS_WINDOWS_BUN_SUPPORTED_MACHINE,
     LOCAL_STORAGE,
     LogLevel,
     MemoizationDisposition,

--- a/reflex/constants/base.py
+++ b/reflex/constants/base.py
@@ -11,11 +11,6 @@ from types import SimpleNamespace
 from platformdirs import PlatformDirs
 
 IS_WINDOWS = platform.system() == "Windows"
-# https://github.com/oven-sh/bun/blob/main/src/cli/install.ps1
-IS_WINDOWS_BUN_SUPPORTED_MACHINE = IS_WINDOWS and platform.machine() in [
-    "AMD64",
-    "x86_64",
-]  # filter out 32 bit + ARM
 
 
 class Dirs(SimpleNamespace):

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -271,7 +271,11 @@ def output_system_info():
 
     system = platform.system()
 
-    if system != "Windows":
+    if (
+        system != "Windows"
+        or system == "Windows"
+        and prerequisites.is_windows_bun_supported()
+    ):
         dependencies.extend(
             [
                 f"[FNM {prerequisites.get_fnm_version()} (Expected: {constants.Fnm.VERSION}) (PATH: {constants.Fnm.EXE})]",

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -1431,7 +1431,7 @@ def get_cpu_info() -> CpuInfo | None:
          The CPU info.
     """
     platform_os = platform.system()
-    cpuinfo= {}
+    cpuinfo = {}
     if platform_os == "Windows":
         cmd = "wmic cpu get addresswidth,caption,manufacturer /FORMAT:csv"
         output = processes.execute_command_and_return_output(cmd)

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -1433,11 +1433,11 @@ def get_cpu_info() -> CpuInfo | None:
     platform_os = platform.system()
     cpuinfo= {}
     if platform_os == "Windows":
-        cmd = "wmic cpu get caption,addresswidth, manufacturer"
+        cmd = "wmic cpu get addresswidth,caption,manufacturer /FORMAT:csv"
         output = processes.execute_command_and_return_output(cmd)
-        val = [x for x in [y for y in output.splitlines() if y][1].split("  ") if x]
+        val = output.splitlines()[-1].split(",")[1:]
         cpuinfo["manufacturer_id"] = val[2]
-        cpuinfo["model_name"] = val[1]
+        cpuinfo["model_name"] = val[1].split("Family")[0].strip()
         cpuinfo["address_width"] = int(val[0])
     elif platform_os == "Linux":
         output = processes.execute_command_and_return_output("lscpu")

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -737,7 +737,6 @@ def install_bun():
     Raises:
         FileNotFoundError: If required packages are not found.
     """
-    print(get_cpu_info())
     if constants.IS_WINDOWS and not is_windows_bun_supported():
         console.warn(
             "Bun for Windows is currently only available for x86 64-bit Windows. Installation will fall back on npm."

--- a/reflex/utils/processes.py
+++ b/reflex/utils/processes.py
@@ -349,7 +349,7 @@ def run_process_with_fallback(args, *, show_status_message, fallback=None, **kwa
             )
 
 
-def execute_command_and_return_output(command):
+def execute_command_and_return_output(command) -> str | None:
     """Execute a command and return the output.
 
     Args:
@@ -358,4 +358,10 @@ def execute_command_and_return_output(command):
     Returns:
         The output of the command.
     """
-    return subprocess.check_output(command, shell=True).decode().strip()
+    try:
+        return subprocess.check_output(command, shell=True).decode().strip()
+    except subprocess.SubprocessError as err:
+        console.error(
+            f"The command `{command}` failed with error: {err}. This will return None."
+        )
+        return None

--- a/reflex/utils/processes.py
+++ b/reflex/utils/processes.py
@@ -347,3 +347,15 @@ def run_process_with_fallback(args, *, show_status_message, fallback=None, **kwa
                 fallback=None,
                 **kwargs,
             )
+
+
+def execute_command_and_return_output(command):
+    """Execute a command and return the output.
+
+    Args:
+        command: The command to run.
+
+    Returns:
+        The output of the command.
+    """
+    return subprocess.check_output(command, shell=True).decode().strip()

--- a/reflex/utils/telemetry.py
+++ b/reflex/utils/telemetry.py
@@ -29,6 +29,15 @@ def get_os() -> str:
     Returns:
         The operating system.
     """
+    return platform.system()
+
+
+def get_detailed_platform_str() -> str:
+    """Get the detailed os/platform string.
+
+    Returns:
+        The platform string
+    """
     return platform.platform()
 
 
@@ -121,6 +130,7 @@ def _prepare_event(event: str, **kwargs) -> dict:
             "distinct_id": installation_id,
             "distinct_app_id": project_hash,
             "user_os": get_os(),
+            "user_os_detail": get_detailed_platform_str(),
             "reflex_version": get_reflex_version(),
             "python_version": get_python_version(),
             "cpu_count": get_cpu_count(),
@@ -166,8 +176,6 @@ def send(event: str, telemetry_enabled: bool | None = None, **kwargs) -> bool:
         return False
 
     event_data = _prepare_event(event, **kwargs)
-    print(f"Event data: {event_data}")
     if not event_data:
         return False
-    return True
-    # return _send_event(event_data)
+    return _send_event(event_data)

--- a/reflex/utils/telemetry.py
+++ b/reflex/utils/telemetry.py
@@ -98,6 +98,7 @@ def _prepare_event(event: str, **kwargs) -> dict:
         The event data.
     """
     from reflex.utils.prerequisites import get_cpu_info
+
     installation_id = ensure_reflex_installation_id()
     project_hash = get_project_hash(raise_on_fail=_raise_on_missing_project_hash())
 
@@ -124,7 +125,7 @@ def _prepare_event(event: str, **kwargs) -> dict:
             "python_version": get_python_version(),
             "cpu_count": get_cpu_count(),
             "memory": get_memory(),
-            "cpu_architecture": get_cpu_info(),
+            "cpu_info": dict(get_cpu_info()) if get_cpu_info() else {},
             **(
                 {"template": template}
                 if (template := kwargs.get("template")) is not None
@@ -168,5 +169,5 @@ def send(event: str, telemetry_enabled: bool | None = None, **kwargs) -> bool:
     print(f"Event data: {event_data}")
     if not event_data:
         return False
-
-    return _send_event(event_data)
+    return True
+    # return _send_event(event_data)

--- a/reflex/utils/telemetry.py
+++ b/reflex/utils/telemetry.py
@@ -135,7 +135,7 @@ def _prepare_event(event: str, **kwargs) -> dict:
             "python_version": get_python_version(),
             "cpu_count": get_cpu_count(),
             "memory": get_memory(),
-            "cpu_info": dict(get_cpu_info()) if get_cpu_info() else {},
+            "cpu_info": dict(get_cpu_info()) if get_cpu_info() else {},  # type: ignore
             **(
                 {"template": template}
                 if (template := kwargs.get("template")) is not None

--- a/reflex/utils/telemetry.py
+++ b/reflex/utils/telemetry.py
@@ -123,6 +123,9 @@ def _prepare_event(event: str, **kwargs) -> dict:
     else:
         # for python 3.11 & 3.12
         stamp = datetime.now(UTC).isoformat()
+
+    cpuinfo = get_cpu_info()
+
     return {
         "api_key": "phc_JoMo0fOyi0GQAooY3UyO9k0hebGkMyFJrrCw1Gt5SGb",
         "event": event,
@@ -135,7 +138,7 @@ def _prepare_event(event: str, **kwargs) -> dict:
             "python_version": get_python_version(),
             "cpu_count": get_cpu_count(),
             "memory": get_memory(),
-            "cpu_info": dict(get_cpu_info()) if get_cpu_info() else {},  # type: ignore
+            "cpu_info": dict(cpuinfo) if cpuinfo else {},
             **(
                 {"template": template}
                 if (template := kwargs.get("template")) is not None

--- a/reflex/utils/telemetry.py
+++ b/reflex/utils/telemetry.py
@@ -29,7 +29,7 @@ def get_os() -> str:
     Returns:
         The operating system.
     """
-    return platform.system()
+    return platform.platform()
 
 
 def get_python_version() -> str:
@@ -97,6 +97,7 @@ def _prepare_event(event: str, **kwargs) -> dict:
     Returns:
         The event data.
     """
+    from reflex.utils.prerequisites import get_cpu_info
     installation_id = ensure_reflex_installation_id()
     project_hash = get_project_hash(raise_on_fail=_raise_on_missing_project_hash())
 
@@ -123,6 +124,7 @@ def _prepare_event(event: str, **kwargs) -> dict:
             "python_version": get_python_version(),
             "cpu_count": get_cpu_count(),
             "memory": get_memory(),
+            "cpu_architecture": get_cpu_info(),
             **(
                 {"template": template}
                 if (template := kwargs.get("template")) is not None
@@ -163,6 +165,7 @@ def send(event: str, telemetry_enabled: bool | None = None, **kwargs) -> bool:
         return False
 
     event_data = _prepare_event(event, **kwargs)
+    print(f"Event data: {event_data}")
     if not event_data:
         return False
 

--- a/tests/test_prerequisites.py
+++ b/tests/test_prerequisites.py
@@ -8,8 +8,10 @@ import pytest
 from reflex import constants
 from reflex.config import Config
 from reflex.utils.prerequisites import (
+    CpuInfo,
     _update_next_config,
     cached_procedure,
+    get_cpu_info,
     initialize_requirements_txt,
 )
 
@@ -203,3 +205,14 @@ def test_cached_procedure():
     assert call_count == 2
     _function_with_some_args(100, y=300)
     assert call_count == 2
+
+
+def test_get_cpu_info():
+    cpu_info = get_cpu_info()
+    assert cpu_info is not None
+    assert isinstance(cpu_info, CpuInfo)
+    assert cpu_info.model_name is not None
+
+    for attr in ("manufacturer_id", "model_name", "address_width"):
+        value = getattr(cpu_info, attr)
+        assert value.strip() if attr != "address_width" else value

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -41,6 +41,7 @@ def test_send(mocker, event):
             read_data='{"project_hash": "78285505863498957834586115958872998605"}'
         ),
     )
+    mocker.patch("platform.platform", return_value="Mocked Platform")
 
     telemetry.send(event, telemetry_enabled=True)
     httpx.post.assert_called_once()


### PR DESCRIPTION
Previously, we used `python.machine()` to get the cpu architecture of the underlining host, but since the architecture produced by python is only that of the executable python binary installed on the host, it may not correlate with the actual architecture of the host. A classic eg. Is Installing the `x86_64` version of python on an ARM device. This causes reflex to install bun which later fails when installing frontend packages and then fall back to npm.
In this PR, we use `wmic` on Windows to get accurate info on the host CPU architecture, which should skip bun installation completely on ARM and 32-bit devices.

In addition to this PR, we're collecting more telemetry data on the OS(previously we only collected the OS name without the version and build) and CPU; model, manufacturer or vendor ID and address width (whether the underlining host is `32` or `64 bit`). This should aid us and give us a fair idea in the future where/when necessary during development,  the nature of devices users run.

fixes #3151 