### PR TITLE
Fix es6 escaping

### DIFF
--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -216,6 +216,26 @@ def _escape_js_string(string: str) -> str:
     string = string.replace("`", r"\`")
     return string
 
+def _escape_js_string_prop(string: str) -> str:
+    """Escape the string for use as a JS string literal.
+
+    Args:
+        string: The string to escape.
+
+    Returns:
+        The escaped string.
+    """
+
+    str_ = str(string)
+
+    # Escape backticks.
+    string = string.replace(r"\`", "`")
+    string = string.replace("\\", "\\\\")
+    string = string.replace('{', '\\{')
+    string = string.replace('}', '\\}')    
+    string = string.replace("`", r"\`")
+
+    return string
 
 def _wrap_js_string(string: str) -> str:
     """Wrap string so it looks like {`string`}.
@@ -242,6 +262,16 @@ def format_string(string: str) -> str:
     """
     return _wrap_js_string(_escape_js_string(string))
 
+def format_string_prop(string: str) -> str:
+    """Format the given string as a JS string literal..
+
+    Args:
+        string: The string to format.
+
+    Returns:
+        The formatted string.
+    """
+    return _wrap_js_string(_escape_js_string_prop(string))
 
 def format_f_string_prop(prop: BaseVar) -> str:
     """Format the string in a given prop as an f-string.

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -535,7 +535,7 @@ class Var:
             else format.wrap(self._var_full_name, "{")
         )
         if self._var_is_string:
-            out = format.format_string(out)
+            out = format.format_string_prop(out)
         return out
 
     def __bool__(self) -> bool:

--- a/tests/components/base/test_script.py
+++ b/tests/components/base/test_script.py
@@ -4,7 +4,6 @@ import pytest
 from reflex.components.base.script import Script
 from reflex.state import BaseState
 
-
 def test_script_inline():
     """Test inline scripts are rendered as children."""
     component = Script.create("let x = 42")
@@ -13,6 +12,15 @@ def test_script_inline():
     assert not render_dict["contents"]
     assert len(render_dict["children"]) == 1
     assert render_dict["children"][0]["contents"] == "{`let x = 42`}"
+
+def test_script_inline_escaping_string_interpolation():
+    """Test inline scripts are rendered as children."""
+    component = Script.create("let world = 'reflex'; console.log(`hello ${world}`);")
+    render_dict = component.render()
+    assert render_dict["name"] == "Script"
+    assert not render_dict["contents"]
+    assert len(render_dict["children"]) == 1
+    assert render_dict["children"][0]["contents"] == "{`let world = 'reflex'; console.log(\`hello $\{world\}\`);`}"
 
 
 def test_script_src():

--- a/tests/components/base/test_script.py
+++ b/tests/components/base/test_script.py
@@ -20,7 +20,7 @@ def test_script_inline_escaping_string_interpolation():
     assert render_dict["name"] == "Script"
     assert not render_dict["contents"]
     assert len(render_dict["children"]) == 1
-    assert render_dict["children"][0]["contents"] == "{`let world = 'reflex'; console.log(\`hello $\{world\}\`);`}"
+    assert render_dict["children"][0]["contents"] == "{`let world = 'reflex'; console.log(\\`hello $\\{world\\}\\`);`}"
 
 
 def test_script_src():


### PR DESCRIPTION
I had some problems when using ES6 Code in the script tag. 
So I wrote a test that shows the problem. My futile approach to fix it duplicates some code and breaks many other tests.
Without the test passing using the script tag from the script within an example app results in the following error:
![image](https://github.com/reflex-dev/reflex/assets/14158137/c12de3b0-ebd7-4e64-9953-586cfade964d)
