### PR TITLE
prevent shadowing

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -450,6 +450,8 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
         super().__init_subclass__(**kwargs)
         # Event handlers should not shadow builtin state methods.
         cls._check_overridden_methods()
+        # Computed vars should not shadow builtin state props.
+        cls._check_overriden_basevars()
 
         # Reset subclass tracking for this class.
         cls.class_subclasses = set()
@@ -695,6 +697,19 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
             raise NameError(
                 f"The event handler name `{method_name}` shadows a builtin State method; use a different name instead"
             )
+
+    @classmethod
+    def _check_overriden_basevars(cls):
+        """Check for shadow base vars and raise error if any.
+
+        Raises:
+            NameError: When a computed var shadows a base var.
+        """
+        for name, value in cls.__dict__.items():
+            if isinstance(value, ComputedVar) and name in cls.__annotations__:
+                raise NameError(
+                    f"The computed var name `{name}` shadows a base var; use a different name instead"
+                )
 
     @classmethod
     def get_skip_vars(cls) -> set[str]:

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -705,10 +705,10 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
         Raises:
             NameError: When a computed var shadows a base var.
         """
-        for name, value in cls.__dict__.items():
-            if isinstance(value, ComputedVar) and name in cls.__annotations__:
+        for computed_var_ in cls._get_computed_vars():
+            if computed_var_._var_name in cls.__annotations__:
                 raise NameError(
-                    f"The computed var name `{name}` shadows a base var; use a different name instead"
+                    f"The computed var name `{computed_var_._var_name}` shadows a base var in {cls.__name__}; use a different name instead"
                 )
 
     @classmethod

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -708,7 +708,7 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
         for computed_var_ in cls._get_computed_vars():
             if computed_var_._var_name in cls.__annotations__:
                 raise NameError(
-                    f"The computed var name `{computed_var_._var_name}` shadows a base var in {cls.__name__}; use a different name instead"
+                    f"The computed var name `{computed_var_._var_name}` shadows a base var in {cls.__module__}.{cls.__name__}; use a different name instead"
                 )
 
     @classmethod


### PR DESCRIPTION
```python

class TestState(rx.State):
    val: bool = True

    @rx.var
    def val(self) -> bool:
        return True


@rx.page(route="/", image="settings.ico")
def index():
    return rx.container(
        rx.text(TestState.val),
    )
```

The above code will now raise an error
![image](https://github.com/reflex-dev/reflex/assets/4015177/c13dc1b6-b9a9-4f9c-968b-21a03c5c90ae)
