### PR TITLE
[REF-2658] Alembic should use batch mode for autogenerate

### DIFF
--- a/reflex/model.py
+++ b/reflex/model.py
@@ -310,6 +310,7 @@ class Model(Base, sqlmodel.SQLModel):
                 render_item=cls._alembic_render_item,
                 process_revision_directives=writer,  # type: ignore
                 compare_type=False,
+                render_as_batch=True,  # for sqlite compatibility
             )
             env.run_migrations()
         changes_detected = False


### PR DESCRIPTION
Better support for column changes when using the default sqlite database.

Only sqlite is affected by batch operations, other databases still use the same mechanisms they used before this change.

See: https://alembic.sqlalchemy.org/en/latest/batch.html