### PR TITLE
WIP: Minified and explicit state names

### DIFF
--- a/integration/test_client_storage.py
+++ b/integration/test_client_storage.py
@@ -1,4 +1,5 @@
 """Integration tests for client side storage."""
+
 from __future__ import annotations
 
 import time
@@ -199,7 +200,8 @@ async def test_client_side_state(
         driver: WebDriver instance.
         local_storage: Local storage helper.
     """
-    assert client_side.app_instance is not None
+    app = client_side.app_instance
+    assert app is not None
     assert client_side.frontend_url is not None
 
     def poll_for_token():
@@ -291,28 +293,28 @@ async def test_client_side_state(
     set_sub_sub("l1s", "l1s value")
 
     exp_cookies = {
-        "state.client_side_state.client_side_sub_state.c1": {
+        "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c1": {
             "domain": "localhost",
             "httpOnly": False,
-            "name": "state.client_side_state.client_side_sub_state.c1",
+            "name": "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c1",
             "path": "/",
             "sameSite": "Lax",
             "secure": False,
             "value": "c1%20value",
         },
-        "state.client_side_state.client_side_sub_state.c2": {
+        "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c2": {
             "domain": "localhost",
             "httpOnly": False,
-            "name": "state.client_side_state.client_side_sub_state.c2",
+            "name": "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c2",
             "path": "/",
             "sameSite": "Lax",
             "secure": False,
             "value": "c2%20value",
         },
-        "state.client_side_state.client_side_sub_state.c4": {
+        "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c4": {
             "domain": "localhost",
             "httpOnly": False,
-            "name": "state.client_side_state.client_side_sub_state.c4",
+            "name": "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c4",
             "path": "/",
             "sameSite": "Strict",
             "secure": False,
@@ -327,19 +329,19 @@ async def test_client_side_state(
             "secure": False,
             "value": "c6%20value",
         },
-        "state.client_side_state.client_side_sub_state.c7": {
+        "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c7": {
             "domain": "localhost",
             "httpOnly": False,
-            "name": "state.client_side_state.client_side_sub_state.c7",
+            "name": "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c7",
             "path": "/",
             "sameSite": "Lax",
             "secure": False,
             "value": "c7%20value",
         },
-        "state.client_side_state.client_side_sub_state.client_side_sub_sub_state.c1s": {
+        "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.clientside___clientside____client_side_sub_sub_state.c1s": {
             "domain": "localhost",
             "httpOnly": False,
-            "name": "state.client_side_state.client_side_sub_state.client_side_sub_sub_state.c1s",
+            "name": "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.clientside___clientside____client_side_sub_sub_state.c1s",
             "path": "/",
             "sameSite": "Lax",
             "secure": False,
@@ -358,17 +360,17 @@ async def test_client_side_state(
     # Test cookie with expiry by itself to avoid timing flakiness
     set_sub("c3", "c3 value")
     AppHarness._poll_for(
-        lambda: "state.client_side_state.client_side_sub_state.c3"
+        lambda: "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c3"
         in cookie_info_map(driver)
     )
     c3_cookie = cookie_info_map(driver)[
-        "state.client_side_state.client_side_sub_state.c3"
+        "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c3"
     ]
     assert c3_cookie.pop("expiry") is not None
     assert c3_cookie == {
         "domain": "localhost",
         "httpOnly": False,
-        "name": "state.client_side_state.client_side_sub_state.c3",
+        "name": "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c3",
         "path": "/",
         "sameSite": "Lax",
         "secure": False,
@@ -378,28 +380,34 @@ async def test_client_side_state(
     if not isinstance(driver, Firefox):
         # Note: Firefox does not remove expired cookies Bug 576347
         assert (
-            "state.client_side_state.client_side_sub_state.c3"
+            "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c3"
             not in cookie_info_map(driver)
         )
 
     local_storage_items = local_storage.items()
     local_storage_items.pop("chakra-ui-color-mode", None)
     assert (
-        local_storage_items.pop("state.client_side_state.client_side_sub_state.l1")
+        local_storage_items.pop(
+            "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.l1"
+        )
         == "l1 value"
     )
     assert (
-        local_storage_items.pop("state.client_side_state.client_side_sub_state.l2")
+        local_storage_items.pop(
+            "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.l2"
+        )
         == "l2 value"
     )
     assert local_storage_items.pop("l3") == "l3 value"
     assert (
-        local_storage_items.pop("state.client_side_state.client_side_sub_state.l4")
+        local_storage_items.pop(
+            "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.l4"
+        )
         == "l4 value"
     )
     assert (
         local_storage_items.pop(
-            "state.client_side_state.client_side_sub_state.client_side_sub_sub_state.l1s"
+            "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.clientside___clientside____client_side_sub_sub_state.l1s"
         )
         == "l1s value"
     )
@@ -453,7 +461,9 @@ async def test_client_side_state(
     assert l1s.text == "l1s value"
 
     # reset the backend state to force refresh from client storage
-    async with client_side.modify_state(f"{token}_state.client_side_state") as state:
+    async with client_side.modify_state(
+        f"{token}_reflex___state____state.clientside___clientside____client_side_state"
+    ) as state:
         state.reset()
     driver.refresh()
 
@@ -494,15 +504,15 @@ async def test_client_side_state(
 
     # make sure c5 cookie shows up on the `/foo` route
     AppHarness._poll_for(
-        lambda: "state.client_side_state.client_side_sub_state.c5"
+        lambda: "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c5"
         in cookie_info_map(driver)
     )
     assert cookie_info_map(driver)[
-        "state.client_side_state.client_side_sub_state.c5"
+        "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c5"
     ] == {
         "domain": "localhost",
         "httpOnly": False,
-        "name": "state.client_side_state.client_side_sub_state.c5",
+        "name": "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c5",
         "path": "/foo/",
         "sameSite": "Lax",
         "secure": False,

--- a/integration/test_client_storage.py
+++ b/integration/test_client_storage.py
@@ -292,29 +292,37 @@ async def test_client_side_state(
     set_sub_sub("c1s", "c1s value")
     set_sub_sub("l1s", "l1s value")
 
+    state_name = client_side.get_full_state_name(["_client_side_state"])
+    sub_state_name = client_side.get_full_state_name(
+        ["_client_side_state", "_client_side_sub_state"]
+    )
+    sub_sub_state_name = client_side.get_full_state_name(
+        ["_client_side_state", "_client_side_sub_state", "_client_side_sub_sub_state"]
+    )
+
     exp_cookies = {
-        "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c1": {
+        f"{sub_state_name}.c1": {
             "domain": "localhost",
             "httpOnly": False,
-            "name": "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c1",
+            "name": f"{sub_state_name}.c1",
             "path": "/",
             "sameSite": "Lax",
             "secure": False,
             "value": "c1%20value",
         },
-        "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c2": {
+        f"{sub_state_name}.c2": {
             "domain": "localhost",
             "httpOnly": False,
-            "name": "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c2",
+            "name": f"{sub_state_name}.c2",
             "path": "/",
             "sameSite": "Lax",
             "secure": False,
             "value": "c2%20value",
         },
-        "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c4": {
+        f"{sub_state_name}.c4": {
             "domain": "localhost",
             "httpOnly": False,
-            "name": "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c4",
+            "name": f"{sub_state_name}.c4",
             "path": "/",
             "sameSite": "Strict",
             "secure": False,
@@ -329,19 +337,19 @@ async def test_client_side_state(
             "secure": False,
             "value": "c6%20value",
         },
-        "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c7": {
+        f"{sub_state_name}.c7": {
             "domain": "localhost",
             "httpOnly": False,
-            "name": "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c7",
+            "name": f"{sub_state_name}.c7",
             "path": "/",
             "sameSite": "Lax",
             "secure": False,
             "value": "c7%20value",
         },
-        "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.clientside___clientside____client_side_sub_sub_state.c1s": {
+        f"{sub_sub_state_name}.c1s": {
             "domain": "localhost",
             "httpOnly": False,
-            "name": "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.clientside___clientside____client_side_sub_sub_state.c1s",
+            "name": f"{sub_sub_state_name}.c1s",
             "path": "/",
             "sameSite": "Lax",
             "secure": False,
@@ -359,18 +367,13 @@ async def test_client_side_state(
 
     # Test cookie with expiry by itself to avoid timing flakiness
     set_sub("c3", "c3 value")
-    AppHarness._poll_for(
-        lambda: "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c3"
-        in cookie_info_map(driver)
-    )
-    c3_cookie = cookie_info_map(driver)[
-        "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c3"
-    ]
+    AppHarness._poll_for(lambda: f"{sub_state_name}.c3" in cookie_info_map(driver))
+    c3_cookie = cookie_info_map(driver)[f"{sub_state_name}.c3"]
     assert c3_cookie.pop("expiry") is not None
     assert c3_cookie == {
         "domain": "localhost",
         "httpOnly": False,
-        "name": "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c3",
+        "name": f"{sub_state_name}.c3",
         "path": "/",
         "sameSite": "Lax",
         "secure": False,
@@ -379,38 +382,15 @@ async def test_client_side_state(
     time.sleep(2)  # wait for c3 to expire
     if not isinstance(driver, Firefox):
         # Note: Firefox does not remove expired cookies Bug 576347
-        assert (
-            "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c3"
-            not in cookie_info_map(driver)
-        )
+        assert f"{sub_state_name}.c3" not in cookie_info_map(driver)
 
     local_storage_items = local_storage.items()
     local_storage_items.pop("chakra-ui-color-mode", None)
-    assert (
-        local_storage_items.pop(
-            "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.l1"
-        )
-        == "l1 value"
-    )
-    assert (
-        local_storage_items.pop(
-            "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.l2"
-        )
-        == "l2 value"
-    )
+    assert local_storage_items.pop(f"{sub_state_name}.l1") == "l1 value"
+    assert local_storage_items.pop(f"{sub_state_name}.l2") == "l2 value"
     assert local_storage_items.pop("l3") == "l3 value"
-    assert (
-        local_storage_items.pop(
-            "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.l4"
-        )
-        == "l4 value"
-    )
-    assert (
-        local_storage_items.pop(
-            "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.clientside___clientside____client_side_sub_sub_state.l1s"
-        )
-        == "l1s value"
-    )
+    assert local_storage_items.pop(f"{sub_state_name}.l4") == "l4 value"
+    assert local_storage_items.pop(f"{sub_sub_state_name}.l1s") == "l1s value"
     assert not local_storage_items
 
     assert c1.text == "c1 value"
@@ -461,9 +441,7 @@ async def test_client_side_state(
     assert l1s.text == "l1s value"
 
     # reset the backend state to force refresh from client storage
-    async with client_side.modify_state(
-        f"{token}_reflex___state____state.clientside___clientside____client_side_state"
-    ) as state:
+    async with client_side.modify_state(f"{token}_{state_name}") as state:
         state.reset()
     driver.refresh()
 
@@ -503,16 +481,11 @@ async def test_client_side_state(
     assert l1s.text == "l1s value"
 
     # make sure c5 cookie shows up on the `/foo` route
-    AppHarness._poll_for(
-        lambda: "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c5"
-        in cookie_info_map(driver)
-    )
-    assert cookie_info_map(driver)[
-        "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c5"
-    ] == {
+    AppHarness._poll_for(lambda: f"{sub_state_name}.c5" in cookie_info_map(driver))
+    assert cookie_info_map(driver)[f"{sub_state_name}.c5"] == {
         "domain": "localhost",
         "httpOnly": False,
-        "name": "reflex___state____state.clientside___clientside____client_side_state.clientside___clientside____client_side_sub_state.c5",
+        "name": f"{sub_state_name}.c5",
         "path": "/foo/",
         "sameSite": "Lax",
         "secure": False,

--- a/integration/test_dynamic_routes.py
+++ b/integration/test_dynamic_routes.py
@@ -8,7 +8,6 @@ from urllib.parse import urlsplit
 import pytest
 from selenium.webdriver.common.by import By
 
-from reflex.state import State
 from reflex.testing import AppHarness, AppHarnessProd, WebDriver
 
 from .utils import poll_for_navigation
@@ -155,7 +154,6 @@ def poll_for_order(
     Returns:
         An async function that polls for the order list to match the expected order.
     """
-
     dynamic_state_name = dynamic_route.get_state_name("_dynamic_state")
     dynamic_state_full_name = dynamic_route.get_full_state_name(["_dynamic_state"])
 
@@ -189,7 +187,6 @@ async def test_on_load_navigate(
         token: The token visible in the driver browser.
         poll_for_order: function that polls for the order list to match the expected order.
     """
-    dynamic_state_name = dynamic_route.get_state_name("_dynamic_state")
     dynamic_state_full_name = dynamic_route.get_full_state_name(["_dynamic_state"])
     assert dynamic_route.app_instance is not None
     is_prod = isinstance(dynamic_route, AppHarnessProd)

--- a/integration/test_event_actions.py
+++ b/integration/test_event_actions.py
@@ -229,7 +229,6 @@ def poll_for_order(
     Returns:
         An async function that polls for the order list to match the expected order.
     """
-
     state_name = event_action.get_state_name("_event_action_state")
     state_full_name = event_action.get_full_state_name(["_event_action_state"])
 

--- a/integration/test_event_actions.py
+++ b/integration/test_event_actions.py
@@ -1,4 +1,5 @@
 """Ensure stopPropagation and preventDefault work as expected."""
+
 from __future__ import annotations
 
 import asyncio
@@ -229,19 +230,18 @@ def poll_for_order(
         An async function that polls for the order list to match the expected order.
     """
 
+    state_name = event_action.get_state_name("_event_action_state")
+    state_full_name = event_action.get_full_state_name(["_event_action_state"])
+
     async def _poll_for_order(exp_order: list[str]):
         async def _backend_state():
-            return await event_action.get_state(f"{token}_state.event_action_state")
+            return await event_action.get_state(f"{token}_{state_full_name}")
 
         async def _check():
-            return (await _backend_state()).substates[
-                "event_action_state"
-            ].order == exp_order
+            return (await _backend_state()).substates[state_name].order == exp_order
 
         await AppHarness._poll_for_async(_check)
-        assert (await _backend_state()).substates[
-            "event_action_state"
-        ].order == exp_order
+        assert (await _backend_state()).substates[state_name].order == exp_order
 
     return _poll_for_order
 

--- a/integration/test_event_chain.py
+++ b/integration/test_event_chain.py
@@ -1,4 +1,5 @@
 """Ensure that Event Chains are properly queued and handled between frontend and backend."""
+
 from __future__ import annotations
 
 from typing import Generator
@@ -300,7 +301,8 @@ def assert_token(event_chain: AppHarness, driver: WebDriver) -> str:
     token = event_chain.poll_for_value(token_input)
     assert token is not None
 
-    return f"{token}_state.state"
+    state_name = event_chain.get_full_state_name(["_state"])
+    return f"{token}_{state_name}"
 
 
 @pytest.mark.parametrize(
@@ -399,16 +401,17 @@ async def test_event_chain_click(
         exp_event_order: the expected events recorded in the State
     """
     token = assert_token(event_chain, driver)
+    state_name = event_chain.get_state_name("_state")
     btn = driver.find_element(By.ID, button_id)
     btn.click()
 
     async def _has_all_events():
         return len(
-            (await event_chain.get_state(token)).substates["state"].event_order
+            (await event_chain.get_state(token)).substates[state_name].event_order
         ) == len(exp_event_order)
 
     await AppHarness._poll_for_async(_has_all_events)
-    event_order = (await event_chain.get_state(token)).substates["state"].event_order
+    event_order = (await event_chain.get_state(token)).substates[state_name].event_order
     assert event_order == exp_event_order
 
 
@@ -453,14 +456,15 @@ async def test_event_chain_on_load(
     assert event_chain.frontend_url is not None
     driver.get(event_chain.frontend_url + uri)
     token = assert_token(event_chain, driver)
+    state_name = event_chain.get_state_name("_state")
 
     async def _has_all_events():
         return len(
-            (await event_chain.get_state(token)).substates["state"].event_order
+            (await event_chain.get_state(token)).substates[state_name].event_order
         ) == len(exp_event_order)
 
     await AppHarness._poll_for_async(_has_all_events)
-    backend_state = (await event_chain.get_state(token)).substates["state"]
+    backend_state = (await event_chain.get_state(token)).substates[state_name]
     assert backend_state.event_order == exp_event_order
     assert backend_state.is_hydrated is True
 
@@ -525,6 +529,7 @@ async def test_event_chain_on_mount(
     assert event_chain.frontend_url is not None
     driver.get(event_chain.frontend_url + uri)
     token = assert_token(event_chain, driver)
+    state_name = event_chain.get_state_name("_state")
 
     unmount_button = driver.find_element(By.ID, "unmount")
     assert unmount_button
@@ -532,11 +537,11 @@ async def test_event_chain_on_mount(
 
     async def _has_all_events():
         return len(
-            (await event_chain.get_state(token)).substates["state"].event_order
+            (await event_chain.get_state(token)).substates[state_name].event_order
         ) == len(exp_event_order)
 
     await AppHarness._poll_for_async(_has_all_events)
-    event_order = (await event_chain.get_state(token)).substates["state"].event_order
+    event_order = (await event_chain.get_state(token)).substates[state_name].event_order
     assert event_order == exp_event_order
 
 

--- a/integration/test_form_submit.py
+++ b/integration/test_form_submit.py
@@ -1,4 +1,5 @@
 """Integration tests for forms."""
+
 import functools
 import time
 from typing import Generator
@@ -251,10 +252,13 @@ async def test_submit(driver, form_submit: AppHarness):
     submit_input = driver.find_element(By.CLASS_NAME, "rt-Button")
     submit_input.click()
 
+    state_name = form_submit.get_state_name("_form_state")
+    full_state_name = form_submit.get_full_state_name(["_form_state"])
+
     async def get_form_data():
         return (
-            (await form_submit.get_state(f"{token}_state.form_state"))
-            .substates["form_state"]
+            (await form_submit.get_state(f"{token}_{full_state_name}"))
+            .substates[state_name]
             .form_data
         )
 

--- a/integration/test_input.py
+++ b/integration/test_input.py
@@ -1,4 +1,5 @@
 """Integration tests for text input and related components."""
+
 from typing import Generator
 
 import pytest
@@ -85,9 +86,12 @@ async def test_fully_controlled_input(fully_controlled_input: AppHarness):
     token = fully_controlled_input.poll_for_value(token_input)
     assert token
 
+    state_name = fully_controlled_input.get_state_name("_state")
+    full_state_name = fully_controlled_input.get_full_state_name(["_state"])
+
     async def get_state_text():
-        state = await fully_controlled_input.get_state(f"{token}_state.state")
-        return state.substates["state"].text
+        state = await fully_controlled_input.get_state(f"{token}_{full_state_name}")
+        return state.substates[state_name].text
 
     # ensure defaults are set correctly
     assert (
@@ -138,7 +142,7 @@ async def test_fully_controlled_input(fully_controlled_input: AppHarness):
 
     # clear the input on the backend
     async with fully_controlled_input.modify_state(f"{token}_state.state") as state:
-        state.substates["state"].text = ""
+        state.substates[state_name].text = ""
     assert await get_state_text() == ""
     assert (
         fully_controlled_input.poll_for_value(

--- a/integration/test_input.py
+++ b/integration/test_input.py
@@ -141,7 +141,9 @@ async def test_fully_controlled_input(fully_controlled_input: AppHarness):
     assert fully_controlled_input.poll_for_value(plain_value_input) == "ifoonitial"
 
     # clear the input on the backend
-    async with fully_controlled_input.modify_state(f"{token}_state.state") as state:
+    async with fully_controlled_input.modify_state(
+        f"{token}_{full_state_name}"
+    ) as state:
         state.substates[state_name].text = ""
     assert await get_state_text() == ""
     assert (

--- a/integration/test_login_flow.py
+++ b/integration/test_login_flow.py
@@ -1,4 +1,5 @@
 """Integration tests for client side storage."""
+
 from __future__ import annotations
 
 from typing import Generator
@@ -136,6 +137,9 @@ def test_login_flow(
     logout_button = driver.find_element(By.ID, "logout")
     logout_button.click()
 
-    assert login_sample._poll_for(lambda: local_storage["state.state.auth_token"] == "")
+    state_name = login_sample.get_full_state_name(["_state"])
+    assert login_sample._poll_for(
+        lambda: local_storage[f"{state_name}.auth_token"] == ""
+    )
     with pytest.raises(NoSuchElementException):
         driver.find_element(By.ID, "auth-token")

--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -657,7 +657,7 @@ export const useEventLoop = (
         const vars = {};
         vars[storage_to_state_map[e.key]] = e.newValue;
         const event = Event(
-          `${state_name}.update_vars_internal_state.update_vars_internal`,
+          `${state_name}.reflex___state____update_vars_internal_state.update_vars_internal`,
           { vars: vars }
         );
         addEvents([event], e);

--- a/reflex/constants/compiler.py
+++ b/reflex/constants/compiler.py
@@ -62,9 +62,11 @@ class CompileVars(SimpleNamespace):
     # The name of the function for converting a dict to an event.
     TO_EVENT = "Event"
     # The name of the internal on_load event.
-    ON_LOAD_INTERNAL = "on_load_internal_state.on_load_internal"
+    ON_LOAD_INTERNAL = "reflex__state___on_load_internal_state.on_load_internal"
     # The name of the internal event to update generic state vars.
-    UPDATE_VARS_INTERNAL = "update_vars_internal_state.update_vars_internal"
+    UPDATE_VARS_INTERNAL = (
+        "reflex__state___update_vars_internal_state.update_vars_internal"
+    )
 
 
 class PageNames(SimpleNamespace):

--- a/reflex/constants/compiler.py
+++ b/reflex/constants/compiler.py
@@ -62,10 +62,10 @@ class CompileVars(SimpleNamespace):
     # The name of the function for converting a dict to an event.
     TO_EVENT = "Event"
     # The name of the internal on_load event.
-    ON_LOAD_INTERNAL = "reflex__state___on_load_internal_state.on_load_internal"
+    ON_LOAD_INTERNAL = "reflex___state____on_load_internal_state.on_load_internal"
     # The name of the internal event to update generic state vars.
     UPDATE_VARS_INTERNAL = (
-        "reflex__state___update_vars_internal_state.update_vars_internal"
+        "reflex___state____update_vars_internal_state.update_vars_internal"
     )
 
 

--- a/reflex/constants/compiler.py
+++ b/reflex/constants/compiler.py
@@ -1,6 +1,7 @@
 """Compiler variables."""
 
 import enum
+import os
 from enum import Enum
 from types import SimpleNamespace
 
@@ -61,12 +62,23 @@ class CompileVars(SimpleNamespace):
     CONNECT_ERROR = "connectErrors"
     # The name of the function for converting a dict to an event.
     TO_EVENT = "Event"
+    # The env var to toggle minification of states.
+    ENV_MINIFY_STATES = "REFLEX_MINIFY_STATES"
+    # Whether to minify states.
+    MINIFY_STATES = os.environ.get(ENV_MINIFY_STATES, False)
     # The name of the internal on_load event.
-    ON_LOAD_INTERNAL = "reflex___state____on_load_internal_state.on_load_internal"
+    ON_LOAD_INTERNAL = (
+        "l"
+        if MINIFY_STATES
+        else "reflex___state____on_load_internal_state.on_load_internal"
+    )
     # The name of the internal event to update generic state vars.
     UPDATE_VARS_INTERNAL = (
-        "reflex___state____update_vars_internal_state.update_vars_internal"
+        "u"
+        if MINIFY_STATES
+        else ("reflex___state____update_vars_internal_state.update_vars_internal")
     )
+    RESERVED_STATE_NAMES = {ON_LOAD_INTERNAL, UPDATE_VARS_INTERNAL}
 
 
 class PageNames(SimpleNamespace):

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -688,8 +688,8 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
         Returns:
             The name of the state.
         """
-        module = cls.__module__.replace(".", "__")
-        return format.to_snake_case(f"{module}__{cls.__name__}")
+        module = cls.__module__.replace(".", "___")
+        return format.to_snake_case(f"{module}___{cls.__name__}")
 
     @classmethod
     @functools.lru_cache()

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -381,6 +381,21 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
         ]
 
     @classmethod
+    def _validate_module_name(cls) -> None:
+        """Check if the module name is valid.
+
+        Reflex uses ___ as state name module separator.
+
+        Raises:
+            NameError: If the module name is invalid.
+        """
+        if "___" in cls.__module__:
+            raise NameError(
+                "The module name of a State class cannot contain '___'. "
+                "Please rename the module."
+            )
+
+    @classmethod
     def __init_subclass__(cls, **kwargs):
         """Do some magic for the subclass initialization.
 
@@ -391,6 +406,10 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
             ValueError: If a substate class shadows another.
         """
         super().__init_subclass__(**kwargs)
+
+        # Validate the module name.
+        cls._validate_module_name()
+
         # Event handlers should not shadow builtin state methods.
         cls._check_overridden_methods()
 

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1858,6 +1858,7 @@ class OnLoadInternalState(State):
             State.set_is_hydrated(True),  # type: ignore
         ]
 
+
 class ComponentState(Base):
     """The base class for a State that is copied for each Component associated with it."""
 

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -688,7 +688,8 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
         Returns:
             The name of the state.
         """
-        return format.to_snake_case(cls.__name__)
+        module = cls.__module__.replace(".", "__")
+        return format.to_snake_case(f"{module}__{cls.__name__}")
 
     @classmethod
     @functools.lru_cache()
@@ -1856,7 +1857,6 @@ class OnLoadInternalState(State):
             ),
             State.set_is_hydrated(True),  # type: ignore
         ]
-
 
 class ComponentState(Base):
     """The base class for a State that is copied for each Component associated with it."""

--- a/reflex/testing.py
+++ b/reflex/testing.py
@@ -199,7 +199,9 @@ class AppHarness:
         Returns:
             The full state name
         """
-        path = [State.get_name()] + [self.get_state_name(p) for p in path]
+        # NOTE: using State.get_name() somehow causes trouble here
+        # path = [State.get_name()] + [self.get_state_name(p) for p in path]
+        path = ["reflex___state____state"] + [self.get_state_name(p) for p in path]
         return ".".join(path)
 
     def _get_globals_from_signature(self, func: Any) -> dict[str, Any]:

--- a/reflex/testing.py
+++ b/reflex/testing.py
@@ -1,4 +1,5 @@
 """reflex.testing - tools for testing reflex apps."""
+
 from __future__ import annotations
 
 import asyncio
@@ -25,6 +26,7 @@ from typing import (
     AsyncIterator,
     Callable,
     Coroutine,
+    List,
     Optional,
     Type,
     TypeVar,
@@ -38,6 +40,7 @@ import reflex
 import reflex.reflex
 import reflex.utils.build
 import reflex.utils.exec
+import reflex.utils.format
 import reflex.utils.prerequisites
 import reflex.utils.processes
 from reflex.state import (
@@ -173,6 +176,31 @@ class AppHarness:
             app_path=root,
             app_module_path=root / app_name / f"{app_name}.py",
         )
+
+    def get_state_name(self, state_cls_name: str) -> str:
+        """Get the state name for the given state class name.
+
+        Args:
+            state_cls_name: The state class name
+
+        Returns:
+            The state name
+        """
+        return reflex.utils.format.to_snake_case(
+            f"{self.app_name}___{self.app_name}___" + state_cls_name
+        )
+
+    def get_full_state_name(self, path: List[str]) -> str:
+        """Get the full state name for the given state class name.
+
+        Args:
+            path: A list of state class names
+
+        Returns:
+            The full state name
+        """
+        path = [State.get_name()] + [self.get_state_name(p) for p in path]
+        return ".".join(path)
 
     def _get_globals_from_signature(self, func: Any) -> dict[str, Any]:
         """Get the globals from a function or module object.

--- a/tests/components/base/test_script.py
+++ b/tests/components/base/test_script.py
@@ -1,4 +1,5 @@
 """Test that Script from next/script renders correctly."""
+
 import pytest
 
 from reflex.components.base.script import Script
@@ -57,14 +58,14 @@ def test_script_event_handler():
     )
     render_dict = component.render()
     assert (
-        'onReady={(_e) => addEvents([Event("ev_state.on_ready", {})], (_e), {})}'
+        f'onReady={{(_e) => addEvents([Event("{EvState.get_full_name()}.on_ready", {{}})], (_e), {{}})}}'
         in render_dict["props"]
     )
     assert (
-        'onLoad={(_e) => addEvents([Event("ev_state.on_load", {})], (_e), {})}'
+        f'onLoad={{(_e) => addEvents([Event("{EvState.get_full_name()}.on_load", {{}})], (_e), {{}})}}'
         in render_dict["props"]
     )
     assert (
-        'onError={(_e) => addEvents([Event("ev_state.on_error", {})], (_e), {})}'
+        f'onError={{(_e) => addEvents([Event("{EvState.get_full_name()}.on_error", {{}})], (_e), {{}})}}'
         in render_dict["props"]
     )

--- a/tests/components/core/test_colors.py
+++ b/tests/components/core/test_colors.py
@@ -12,6 +12,9 @@ class ColorState(rx.State):
     shade: int = 4
 
 
+color_state_name = ColorState.get_full_name().replace(".", "__")
+
+
 def create_color_var(color):
     return Var.create(color)
 
@@ -24,27 +27,31 @@ def create_color_var(color):
         (create_color_var(rx.color("mint", 3, True)), "var(--mint-a3)"),
         (
             create_color_var(rx.color(ColorState.color, ColorState.shade)),  # type: ignore
-            "var(--${state__color_state.color}-${state__color_state.shade})",
+            f"var(--${{{color_state_name}.color}}-${{{color_state_name}.shade}})",
         ),
         (
             create_color_var(rx.color(f"{ColorState.color}", f"{ColorState.shade}")),  # type: ignore
-            "var(--${state__color_state.color}-${state__color_state.shade})",
+            # "var(--${state__color_state.color}-${state__color_state.shade})",
+            f"var(--${{{color_state_name}.color}}-${{{color_state_name}.shade}})",
         ),
         (
             create_color_var(
                 rx.color(f"{ColorState.color_part}ato", f"{ColorState.shade}")  # type: ignore
             ),
-            "var(--${state__color_state.color_part}ato-${state__color_state.shade})",
+            # "var(--${state__color_state.color_part}ato-${state__color_state.shade})",
+            f"var(--${{{color_state_name}.color_part}}ato-${{{color_state_name}.shade}})",
         ),
         (
             create_color_var(f'{rx.color(ColorState.color, f"{ColorState.shade}")}'),  # type: ignore
-            "var(--${state__color_state.color}-${state__color_state.shade})",
+            # "var(--${state__color_state.color}-${state__color_state.shade})",
+            f"var(--${{{color_state_name}.color}}-${{{color_state_name}.shade}})",
         ),
         (
             create_color_var(
                 f'{rx.color(f"{ColorState.color}", f"{ColorState.shade}")}'  # type: ignore
             ),
-            "var(--${state__color_state.color}-${state__color_state.shade})",
+            # "var(--${state__color_state.color}-${state__color_state.shade})",
+            f"var(--${{{color_state_name}.color}}-${{{color_state_name}.shade}})",
         ),
     ],
 )
@@ -61,7 +68,7 @@ def test_color(color, expected):
         ),
         (
             rx.cond(True, rx.color(ColorState.color), rx.color(ColorState.color, 5)),  # type: ignore
-            "{isTrue(true) ? `var(--${state__color_state.color}-7)` : `var(--${state__color_state.color}-5)`}",
+            f"{{isTrue(true) ? `var(--${{{color_state_name}.color}}-7)` : `var(--${{{color_state_name}.color}}-5)`}}",
         ),
         (
             rx.match(
@@ -72,7 +79,7 @@ def test_color(color, expected):
             ),
             "{(() => { switch (JSON.stringify(`condition`)) {case JSON.stringify(`first`):  return (`var(--mint-7)`);"
             "  break;case JSON.stringify(`second`):  return (`var(--tomato-5)`);  break;default:  "
-            "return (`var(--${state__color_state.color}-2)`);  break;};})()}",
+            f"return (`var(--${{{color_state_name}.color}}-2)`);  break;}};}})()}}",
         ),
         (
             rx.match(
@@ -82,9 +89,9 @@ def test_color(color, expected):
                 rx.color(ColorState.color, 2),  # type: ignore
             ),
             "{(() => { switch (JSON.stringify(`condition`)) {case JSON.stringify(`first`):  "
-            "return (`var(--${state__color_state.color}-7)`);  break;case JSON.stringify(`second`):  "
-            "return (`var(--${state__color_state.color}-5)`);  break;default:  "
-            "return (`var(--${state__color_state.color}-2)`);  break;};})()}",
+            f"return (`var(--${{{color_state_name}.color}}-7)`);  break;case JSON.stringify(`second`):  "
+            f"return (`var(--${{{color_state_name}.color}}-5)`);  break;default:  "
+            f"return (`var(--${{{color_state_name}.color}}-2)`);  break;}};}})()}}",
         ),
     ],
 )

--- a/tests/components/core/test_colors.py
+++ b/tests/components/core/test_colors.py
@@ -31,26 +31,22 @@ def create_color_var(color):
         ),
         (
             create_color_var(rx.color(f"{ColorState.color}", f"{ColorState.shade}")),  # type: ignore
-            # "var(--${state__color_state.color}-${state__color_state.shade})",
             f"var(--${{{color_state_name}.color}}-${{{color_state_name}.shade}})",
         ),
         (
             create_color_var(
                 rx.color(f"{ColorState.color_part}ato", f"{ColorState.shade}")  # type: ignore
             ),
-            # "var(--${state__color_state.color_part}ato-${state__color_state.shade})",
             f"var(--${{{color_state_name}.color_part}}ato-${{{color_state_name}.shade}})",
         ),
         (
             create_color_var(f'{rx.color(ColorState.color, f"{ColorState.shade}")}'),  # type: ignore
-            # "var(--${state__color_state.color}-${state__color_state.shade})",
             f"var(--${{{color_state_name}.color}}-${{{color_state_name}.shade}})",
         ),
         (
             create_color_var(
                 f'{rx.color(f"{ColorState.color}", f"{ColorState.shade}")}'  # type: ignore
             ),
-            # "var(--${state__color_state.color}-${state__color_state.shade})",
             f"var(--${{{color_state_name}.color}}-${{{color_state_name}.shade}})",
         ),
     ],

--- a/tests/components/core/test_cond.py
+++ b/tests/components/core/test_cond.py
@@ -33,7 +33,7 @@ def test_f_string_cond_interpolation():
     ],
     indirect=True,
 )
-def test_validate_cond(cond_state: Var):
+def test_validate_cond(cond_state: BaseState):
     """Test if cond can be a rx.Var with any values.
 
     Args:

--- a/tests/components/core/test_cond.py
+++ b/tests/components/core/test_cond.py
@@ -48,7 +48,7 @@ def test_validate_cond(cond_state: Var):
     assert cond_dict["name"] == "Fragment"
 
     [condition] = cond_dict["children"]
-    assert condition["cond_state"] == "isTrue(cond_state.value)"
+    assert condition["cond_state"] == f"isTrue({cond_state.get_full_name()}.value)"
 
     # true value
     true_value = condition["true_value"]

--- a/tests/components/core/test_foreach.py
+++ b/tests/components/core/test_foreach.py
@@ -113,7 +113,7 @@ seen_index_vars = set()
             ForEachState.colors_list,
             display_color,
             {
-                "iterable_state": "for_each_state.colors_list",
+                "iterable_state": f"{ForEachState.get_full_name()}.colors_list",
                 "iterable_type": "list",
             },
         ),
@@ -121,7 +121,7 @@ seen_index_vars = set()
             ForEachState.colors_dict_list,
             display_color_name,
             {
-                "iterable_state": "for_each_state.colors_dict_list",
+                "iterable_state": f"{ForEachState.get_full_name()}.colors_dict_list",
                 "iterable_type": "list",
             },
         ),
@@ -129,7 +129,7 @@ seen_index_vars = set()
             ForEachState.colors_nested_dict_list,
             display_shade,
             {
-                "iterable_state": "for_each_state.colors_nested_dict_list",
+                "iterable_state": f"{ForEachState.get_full_name()}.colors_nested_dict_list",
                 "iterable_type": "list",
             },
         ),
@@ -137,7 +137,7 @@ seen_index_vars = set()
             ForEachState.primary_color,
             display_primary_colors,
             {
-                "iterable_state": "for_each_state.primary_color",
+                "iterable_state": f"{ForEachState.get_full_name()}.primary_color",
                 "iterable_type": "dict",
             },
         ),
@@ -145,7 +145,7 @@ seen_index_vars = set()
             ForEachState.color_with_shades,
             display_color_with_shades,
             {
-                "iterable_state": "for_each_state.color_with_shades",
+                "iterable_state": f"{ForEachState.get_full_name()}.color_with_shades",
                 "iterable_type": "dict",
             },
         ),
@@ -153,7 +153,7 @@ seen_index_vars = set()
             ForEachState.nested_colors_with_shades,
             display_nested_color_with_shades,
             {
-                "iterable_state": "for_each_state.nested_colors_with_shades",
+                "iterable_state": f"{ForEachState.get_full_name()}.nested_colors_with_shades",
                 "iterable_type": "dict",
             },
         ),
@@ -161,7 +161,7 @@ seen_index_vars = set()
             ForEachState.nested_colors_with_shades,
             display_nested_color_with_shades_v2,
             {
-                "iterable_state": "for_each_state.nested_colors_with_shades",
+                "iterable_state": f"{ForEachState.get_full_name()}.nested_colors_with_shades",
                 "iterable_type": "dict",
             },
         ),
@@ -169,7 +169,7 @@ seen_index_vars = set()
             ForEachState.color_tuple,
             display_color_tuple,
             {
-                "iterable_state": "for_each_state.color_tuple",
+                "iterable_state": f"{ForEachState.get_full_name()}.color_tuple",
                 "iterable_type": "tuple",
             },
         ),
@@ -177,7 +177,7 @@ seen_index_vars = set()
             ForEachState.colors_set,
             display_colors_set,
             {
-                "iterable_state": "for_each_state.colors_set",
+                "iterable_state": f"{ForEachState.get_full_name()}.colors_set",
                 "iterable_type": "set",
             },
         ),
@@ -185,7 +185,7 @@ seen_index_vars = set()
             ForEachState.nested_colors_list,
             lambda el, i: display_nested_list_element(el, i),
             {
-                "iterable_state": "for_each_state.nested_colors_list",
+                "iterable_state": f"{ForEachState.get_full_name()}.nested_colors_list",
                 "iterable_type": "list",
             },
         ),
@@ -193,7 +193,7 @@ seen_index_vars = set()
             ForEachState.color_index_tuple,
             display_color_index_tuple,
             {
-                "iterable_state": "for_each_state.color_index_tuple",
+                "iterable_state": f"{ForEachState.get_full_name()}.color_index_tuple",
                 "iterable_type": "tuple",
             },
         ),

--- a/tests/components/core/test_match.py
+++ b/tests/components/core/test_match.py
@@ -35,7 +35,7 @@ def test_match_components():
     [match_child] = match_dict["children"]
 
     assert match_child["name"] == "match"
-    assert str(match_child["cond"]) == "{match_state.value}"
+    assert str(match_child["cond"]) == f"{{{MatchState.get_name()}.value}}"
 
     match_cases = match_child["match_cases"]
     assert len(match_cases) == 6
@@ -72,7 +72,7 @@ def test_match_components():
     assert fifth_return_value_render["name"] == "RadixThemesText"
     assert fifth_return_value_render["children"][0]["contents"] == "{`fifth value`}"
 
-    assert match_cases[5][0]._var_name == "((match_state.num) + (1))"
+    assert match_cases[5][0]._var_name == f"(({MatchState.get_name()}.num) + (1))"
     assert match_cases[5][0]._var_type == int
     fifth_return_value_render = match_cases[5][1].render()
     assert fifth_return_value_render["name"] == "RadixThemesText"
@@ -99,11 +99,11 @@ def test_match_components():
                 (MatchState.string, f"{MatchState.value} - string"),
                 "default value",
             ),
-            "(() => { switch (JSON.stringify(match_state.value)) {case JSON.stringify(1):  return (`first`);  break;case JSON.stringify(2): case JSON.stringify(3):  return "
+            f"(() => {{ switch (JSON.stringify({MatchState.get_name()}.value)) {{case JSON.stringify(1):  return (`first`);  break;case JSON.stringify(2): case JSON.stringify(3):  return "
             "(`second value`);  break;case JSON.stringify([1, 2]):  return (`third-value`);  break;case JSON.stringify(`random`):  "
             'return (`fourth_value`);  break;case JSON.stringify({"foo": "bar"}):  return (`fifth value`);  '
-            "break;case JSON.stringify(((match_state.num) + (1))):  return (`sixth value`);  break;case JSON.stringify(`${match_state.value} - string`):  "
-            "return (match_state.string);  break;case JSON.stringify(match_state.string):  return (`${match_state.value} - string`);  break;default:  "
+            f"break;case JSON.stringify((({MatchState.get_name()}.num) + (1))):  return (`sixth value`);  break;case JSON.stringify(`${{{MatchState.get_name()}.value}} - string`):  "
+            f"return ({MatchState.get_name()}.string);  break;case JSON.stringify({MatchState.get_name()}.string):  return (`${{{MatchState.get_name()}.value}} - string`);  break;default:  "
             "return (`default value`);  break;};})()",
         ),
         (
@@ -118,12 +118,12 @@ def test_match_components():
                 (MatchState.string, f"{MatchState.value} - string"),
                 MatchState.string,
             ),
-            "(() => { switch (JSON.stringify(match_state.value)) {case JSON.stringify(1):  return (`first`);  break;case JSON.stringify(2): case JSON.stringify(3):  return "
+            f"(() => {{ switch (JSON.stringify({MatchState.get_name()}.value)) {{case JSON.stringify(1):  return (`first`);  break;case JSON.stringify(2): case JSON.stringify(3):  return "
             "(`second value`);  break;case JSON.stringify([1, 2]):  return (`third-value`);  break;case JSON.stringify(`random`):  "
             'return (`fourth_value`);  break;case JSON.stringify({"foo": "bar"}):  return (`fifth value`);  '
-            "break;case JSON.stringify(((match_state.num) + (1))):  return (`sixth value`);  break;case JSON.stringify(`${match_state.value} - string`):  "
-            "return (match_state.string);  break;case JSON.stringify(match_state.string):  return (`${match_state.value} - string`);  break;default:  "
-            "return (match_state.string);  break;};})()",
+            f"break;case JSON.stringify((({MatchState.get_name()}.num) + (1))):  return (`sixth value`);  break;case JSON.stringify(`${{{MatchState.get_name()}.value}} - string`):  "
+            f"return ({MatchState.get_name()}.string);  break;case JSON.stringify({MatchState.get_name()}.string):  return (`${{{MatchState.get_name()}.value}} - string`);  break;default:  "
+            f"return ({MatchState.get_name()}.string);  break;}};}})()",
         ),
     ],
 )

--- a/tests/components/datadisplay/test_datatable.py
+++ b/tests/components/datadisplay/test_datatable.py
@@ -16,14 +16,14 @@ from reflex.utils.serializers import serialize, serialize_dataframe
                     [["foo", "bar"], ["foo1", "bar1"]], columns=["column1", "column2"]
                 )
             },
-            "data_table_state.data",
+            "data",
         ),
-        pytest.param({"data": ["foo", "bar"]}, "data_table_state"),
-        pytest.param({"data": [["foo", "bar"], ["foo1", "bar1"]]}, "data_table_state"),
+        pytest.param({"data": ["foo", "bar"]}, ""),
+        pytest.param({"data": [["foo", "bar"], ["foo1", "bar1"]]}, ""),
     ],
     indirect=["data_table_state"],
 )
-def test_validate_data_table(data_table_state: rx.Var, expected):
+def test_validate_data_table(data_table_state: rx.State, expected):
     """Test the str/render function.
 
     Args:
@@ -39,6 +39,10 @@ def test_validate_data_table(data_table_state: rx.Var, expected):
         data_table_component = DataTable.create(data=data_table_state.data)
 
     data_table_dict = data_table_component.render()
+
+    # prefix expected with state name
+    state_name = data_table_state.get_name()
+    expected = f"{state_name}.{expected}" if expected else state_name
 
     assert data_table_dict["props"] == [
         f"columns={{{expected}.columns}}",

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -673,7 +673,7 @@ def test_component_event_trigger_arbitrary_args():
 
     assert comp.render()["props"][0] == (
         "onFoo={(__e,_alpha,_bravo,_charlie) => addEvents("
-        '[Event("c1_state.mock_handler", {_e:__e.target.value,_bravo:_bravo["nested"],_charlie:((_charlie.custom) + (42))})], '
+        f'[Event("{C1State.get_full_name()}.mock_handler", {{_e:__e.target.value,_bravo:_bravo["nested"],_charlie:((_charlie.custom) + (42))}})], '
         "(__e,_alpha,_bravo,_charlie), {})}"
     )
 

--- a/tests/middleware/conftest.py
+++ b/tests/middleware/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 
 from reflex.event import Event
+from reflex.state import State
 
 
 def create_event(name):
@@ -21,4 +22,4 @@ def create_event(name):
 
 @pytest.fixture
 def event1():
-    return create_event("state.hydrate")
+    return create_event(f"{State.get_name()}.hydrate")

--- a/tests/states/__init__.py
+++ b/tests/states/__init__.py
@@ -1,4 +1,5 @@
 """Common rx.BaseState subclasses for use in tests."""
+
 import reflex as rx
 from reflex.state import BaseState
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -447,20 +447,12 @@ async def test_dynamic_var_event(test_state: Type[ATestState], token: str):
         pytest.param(
             [
                 (
-                    "list_mutation_test_state.make_friend",
-                    {
-                        "list_mutation_test_state": {
-                            "plain_friends": ["Tommy", "another-fd"]
-                        }
-                    },
+                    "make_friend",
+                    {"plain_friends": ["Tommy", "another-fd"]},
                 ),
                 (
-                    "list_mutation_test_state.change_first_friend",
-                    {
-                        "list_mutation_test_state": {
-                            "plain_friends": ["Jenny", "another-fd"]
-                        }
-                    },
+                    "change_first_friend",
+                    {"plain_friends": ["Jenny", "another-fd"]},
                 ),
             ],
             id="append then __setitem__",
@@ -468,12 +460,12 @@ async def test_dynamic_var_event(test_state: Type[ATestState], token: str):
         pytest.param(
             [
                 (
-                    "list_mutation_test_state.unfriend_first_friend",
-                    {"list_mutation_test_state": {"plain_friends": []}},
+                    "unfriend_first_friend",
+                    {"plain_friends": []},
                 ),
                 (
-                    "list_mutation_test_state.make_friend",
-                    {"list_mutation_test_state": {"plain_friends": ["another-fd"]}},
+                    "make_friend",
+                    {"plain_friends": ["another-fd"]},
                 ),
             ],
             id="delitem then append",
@@ -481,24 +473,20 @@ async def test_dynamic_var_event(test_state: Type[ATestState], token: str):
         pytest.param(
             [
                 (
-                    "list_mutation_test_state.make_friends_with_colleagues",
-                    {
-                        "list_mutation_test_state": {
-                            "plain_friends": ["Tommy", "Peter", "Jimmy"]
-                        }
-                    },
+                    "make_friends_with_colleagues",
+                    {"plain_friends": ["Tommy", "Peter", "Jimmy"]},
                 ),
                 (
-                    "list_mutation_test_state.remove_tommy",
-                    {"list_mutation_test_state": {"plain_friends": ["Peter", "Jimmy"]}},
+                    "remove_tommy",
+                    {"plain_friends": ["Peter", "Jimmy"]},
                 ),
                 (
-                    "list_mutation_test_state.remove_last_friend",
-                    {"list_mutation_test_state": {"plain_friends": ["Peter"]}},
+                    "remove_last_friend",
+                    {"plain_friends": ["Peter"]},
                 ),
                 (
-                    "list_mutation_test_state.unfriend_all_friends",
-                    {"list_mutation_test_state": {"plain_friends": []}},
+                    "unfriend_all_friends",
+                    {"plain_friends": []},
                 ),
             ],
             id="extend, remove, pop, clear",
@@ -506,28 +494,16 @@ async def test_dynamic_var_event(test_state: Type[ATestState], token: str):
         pytest.param(
             [
                 (
-                    "list_mutation_test_state.add_jimmy_to_second_group",
-                    {
-                        "list_mutation_test_state": {
-                            "friends_in_nested_list": [["Tommy"], ["Jenny", "Jimmy"]]
-                        }
-                    },
+                    "add_jimmy_to_second_group",
+                    {"friends_in_nested_list": [["Tommy"], ["Jenny", "Jimmy"]]},
                 ),
                 (
-                    "list_mutation_test_state.remove_first_person_from_first_group",
-                    {
-                        "list_mutation_test_state": {
-                            "friends_in_nested_list": [[], ["Jenny", "Jimmy"]]
-                        }
-                    },
+                    "remove_first_person_from_first_group",
+                    {"friends_in_nested_list": [[], ["Jenny", "Jimmy"]]},
                 ),
                 (
-                    "list_mutation_test_state.remove_first_group",
-                    {
-                        "list_mutation_test_state": {
-                            "friends_in_nested_list": [["Jenny", "Jimmy"]]
-                        }
-                    },
+                    "remove_first_group",
+                    {"friends_in_nested_list": [["Jenny", "Jimmy"]]},
                 ),
             ],
             id="nested list",
@@ -535,24 +511,16 @@ async def test_dynamic_var_event(test_state: Type[ATestState], token: str):
         pytest.param(
             [
                 (
-                    "list_mutation_test_state.add_jimmy_to_tommy_friends",
-                    {
-                        "list_mutation_test_state": {
-                            "friends_in_dict": {"Tommy": ["Jenny", "Jimmy"]}
-                        }
-                    },
+                    "add_jimmy_to_tommy_friends",
+                    {"friends_in_dict": {"Tommy": ["Jenny", "Jimmy"]}},
                 ),
                 (
-                    "list_mutation_test_state.remove_jenny_from_tommy",
-                    {
-                        "list_mutation_test_state": {
-                            "friends_in_dict": {"Tommy": ["Jimmy"]}
-                        }
-                    },
+                    "remove_jenny_from_tommy",
+                    {"friends_in_dict": {"Tommy": ["Jimmy"]}},
                 ),
                 (
-                    "list_mutation_test_state.tommy_has_no_fds",
-                    {"list_mutation_test_state": {"friends_in_dict": {"Tommy": []}}},
+                    "tommy_has_no_fds",
+                    {"friends_in_dict": {"Tommy": []}},
                 ),
             ],
             id="list in dict",
@@ -576,12 +544,14 @@ async def test_list_mutation_detection__plain_list(
         result = await list_mutation_state._process(
             Event(
                 token=token,
-                name=event_name,
+                name=f"{list_mutation_state.get_name()}.{event_name}",
                 router_data={"pathname": "/", "query": {}},
                 payload={},
             )
         ).__anext__()
 
+        # prefix keys in expected_delta with the state name
+        expected_delta = {list_mutation_state.get_name(): expected_delta}
         assert result.delta == expected_delta
 
 
@@ -592,24 +562,16 @@ async def test_list_mutation_detection__plain_list(
         pytest.param(
             [
                 (
-                    "dict_mutation_test_state.add_age",
-                    {
-                        "dict_mutation_test_state": {
-                            "details": {"name": "Tommy", "age": 20}
-                        }
-                    },
+                    "add_age",
+                    {"details": {"name": "Tommy", "age": 20}},
                 ),
                 (
-                    "dict_mutation_test_state.change_name",
-                    {
-                        "dict_mutation_test_state": {
-                            "details": {"name": "Jenny", "age": 20}
-                        }
-                    },
+                    "change_name",
+                    {"details": {"name": "Jenny", "age": 20}},
                 ),
                 (
-                    "dict_mutation_test_state.remove_last_detail",
-                    {"dict_mutation_test_state": {"details": {"name": "Jenny"}}},
+                    "remove_last_detail",
+                    {"details": {"name": "Jenny"}},
                 ),
             ],
             id="update then __setitem__",
@@ -617,12 +579,12 @@ async def test_list_mutation_detection__plain_list(
         pytest.param(
             [
                 (
-                    "dict_mutation_test_state.clear_details",
-                    {"dict_mutation_test_state": {"details": {}}},
+                    "clear_details",
+                    {"details": {}},
                 ),
                 (
-                    "dict_mutation_test_state.add_age",
-                    {"dict_mutation_test_state": {"details": {"age": 20}}},
+                    "add_age",
+                    {"details": {"age": 20}},
                 ),
             ],
             id="delitem then update",
@@ -630,20 +592,16 @@ async def test_list_mutation_detection__plain_list(
         pytest.param(
             [
                 (
-                    "dict_mutation_test_state.add_age",
-                    {
-                        "dict_mutation_test_state": {
-                            "details": {"name": "Tommy", "age": 20}
-                        }
-                    },
+                    "add_age",
+                    {"details": {"name": "Tommy", "age": 20}},
                 ),
                 (
-                    "dict_mutation_test_state.remove_name",
-                    {"dict_mutation_test_state": {"details": {"age": 20}}},
+                    "remove_name",
+                    {"details": {"age": 20}},
                 ),
                 (
-                    "dict_mutation_test_state.pop_out_age",
-                    {"dict_mutation_test_state": {"details": {}}},
+                    "pop_out_age",
+                    {"details": {}},
                 ),
             ],
             id="add, remove, pop",
@@ -651,22 +609,16 @@ async def test_list_mutation_detection__plain_list(
         pytest.param(
             [
                 (
-                    "dict_mutation_test_state.remove_home_address",
-                    {
-                        "dict_mutation_test_state": {
-                            "address": [{}, {"work": "work address"}]
-                        }
-                    },
+                    "remove_home_address",
+                    {"address": [{}, {"work": "work address"}]},
                 ),
                 (
-                    "dict_mutation_test_state.add_street_to_home_address",
+                    "add_street_to_home_address",
                     {
-                        "dict_mutation_test_state": {
-                            "address": [
-                                {"street": "street address"},
-                                {"work": "work address"},
-                            ]
-                        }
+                        "address": [
+                            {"street": "street address"},
+                            {"work": "work address"},
+                        ]
                     },
                 ),
             ],
@@ -675,34 +627,26 @@ async def test_list_mutation_detection__plain_list(
         pytest.param(
             [
                 (
-                    "dict_mutation_test_state.change_friend_name",
+                    "change_friend_name",
                     {
-                        "dict_mutation_test_state": {
-                            "friend_in_nested_dict": {
-                                "name": "Nikhil",
-                                "friend": {"name": "Tommy"},
-                            }
+                        "friend_in_nested_dict": {
+                            "name": "Nikhil",
+                            "friend": {"name": "Tommy"},
                         }
                     },
                 ),
                 (
-                    "dict_mutation_test_state.add_friend_age",
+                    "add_friend_age",
                     {
-                        "dict_mutation_test_state": {
-                            "friend_in_nested_dict": {
-                                "name": "Nikhil",
-                                "friend": {"name": "Tommy", "age": 30},
-                            }
+                        "friend_in_nested_dict": {
+                            "name": "Nikhil",
+                            "friend": {"name": "Tommy", "age": 30},
                         }
                     },
                 ),
                 (
-                    "dict_mutation_test_state.remove_friend",
-                    {
-                        "dict_mutation_test_state": {
-                            "friend_in_nested_dict": {"name": "Nikhil"}
-                        }
-                    },
+                    "remove_friend",
+                    {"friend_in_nested_dict": {"name": "Nikhil"}},
                 ),
             ],
             id="nested dict",
@@ -726,11 +670,14 @@ async def test_dict_mutation_detection__plain_list(
         result = await dict_mutation_state._process(
             Event(
                 token=token,
-                name=event_name,
+                name=f"{dict_mutation_state.get_name()}.{event_name}",
                 router_data={"pathname": "/", "query": {}},
                 payload={},
             )
         ).__anext__()
+
+        # prefix keys in expected_delta with the state name
+        expected_delta = {dict_mutation_state.get_name(): expected_delta}
 
         assert result.delta == expected_delta
 
@@ -741,12 +688,16 @@ async def test_dict_mutation_detection__plain_list(
     [
         (
             FileUploadState,
-            {"state.file_upload_state": {"img_list": ["image1.jpg", "image2.jpg"]}},
+            {
+                FileUploadState.get_full_name(): {
+                    "img_list": ["image1.jpg", "image2.jpg"]
+                }
+            },
         ),
         (
             ChildFileUploadState,
             {
-                "state.file_state_base1.child_file_upload_state": {
+                ChildFileUploadState.get_full_name(): {
                     "img_list": ["image1.jpg", "image2.jpg"]
                 }
             },
@@ -754,7 +705,7 @@ async def test_dict_mutation_detection__plain_list(
         (
             GrandChildFileUploadState,
             {
-                "state.file_state_base1.file_state_base2.grand_child_file_upload_state": {
+                GrandChildFileUploadState.get_full_name(): {
                     "img_list": ["image1.jpg", "image2.jpg"]
                 }
             },
@@ -1026,7 +977,7 @@ async def test_dynamic_route_var_route_change_completed_on_load(
                     val=exp_val,
                 ),
                 _event(
-                    name="state.set_is_hydrated",
+                    name=f"{State.get_name()}.set_is_hydrated",
                     payload={"value": True},
                     val=exp_val,
                     router_data={},
@@ -1149,7 +1100,10 @@ async def test_process_events(mocker, token: str):
     app = App(state=GenState)
     mocker.patch.object(app, "postprocess", AsyncMock())
     event = Event(
-        token=token, name="gen_state.go", payload={"c": 5}, router_data=router_data
+        token=token,
+        name=f"{GenState.get_name()}.go",
+        payload={"c": 5},
+        router_data=router_data,
     )
 
     async for _update in process(app, event, "mock_sid", {}, "127.0.0.1"):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -2848,8 +2848,8 @@ async def test_get_state_from_sibling_not_cached(mock_app: rx.App, token: str):
 
     if isinstance(mock_app.state_manager, StateManagerRedis):
         # When redis is used, only states with computed vars are pre-fetched.
-        assert "child2" not in root.substates
-        assert "child3" in root.substates  # (due to @rx.var)
+        assert Child2.get_name() not in root.substates
+        assert Child3.get_name() in root.substates  # (due to @rx.var)
 
     # Get the unconnected sibling state, which will be used to `get_state` other instances.
     child = root.get_substate(Child.get_full_name().split("."))

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -212,7 +212,7 @@ def child_state(test_state) -> ChildState:
     Returns:
         A test child state.
     """
-    child_state = test_state.get_substate(["child_state"])
+    child_state = test_state.get_substate([ChildState.get_name()])
     assert child_state is not None
     return child_state
 
@@ -227,7 +227,7 @@ def child_state2(test_state) -> ChildState2:
     Returns:
         A second test child state.
     """
-    child_state2 = test_state.get_substate(["child_state2"])
+    child_state2 = test_state.get_substate([ChildState2.get_name()])
     assert child_state2 is not None
     return child_state2
 
@@ -242,7 +242,7 @@ def grandchild_state(child_state) -> GrandchildState:
     Returns:
         A test state.
     """
-    grandchild_state = child_state.get_substate(["grandchild_state"])
+    grandchild_state = child_state.get_substate([GrandchildState.get_name()])
     assert grandchild_state is not None
     return grandchild_state
 
@@ -352,20 +352,20 @@ def test_computed_vars(test_state):
     assert test_state.upper == "HELLO WORLD"
 
 
-def test_dict(test_state):
+def test_dict(test_state: TestState):
     """Test that the dict representation of a state is correct.
 
     Args:
         test_state: A state.
     """
     substates = {
-        "test_state",
-        "test_state.child_state",
-        "test_state.child_state.grandchild_state",
-        "test_state.child_state2",
-        "test_state.child_state2.grandchild_state2",
-        "test_state.child_state3",
-        "test_state.child_state3.grandchild_state3",
+        test_state.get_full_name(),
+        ChildState.get_full_name(),
+        GrandchildState.get_full_name(),
+        ChildState2.get_full_name(),
+        GrandchildState2.get_full_name(),
+        ChildState3.get_full_name(),
+        GrandchildState3.get_full_name(),
     }
     test_state_dict = test_state.dict()
     assert set(test_state_dict) == substates
@@ -389,22 +389,30 @@ def test_default_setters(test_state):
 def test_class_indexing_with_vars():
     """Test that we can index into a state var with another var."""
     prop = TestState.array[TestState.num1]
-    assert str(prop) == "{test_state.array.at(test_state.num1)}"
+    assert (
+        str(prop) == f"{{{TestState.get_name()}.array.at({TestState.get_name()}.num1)}}"
+    )
 
     prop = TestState.mapping["a"][TestState.num1]
-    assert str(prop) == '{test_state.mapping["a"].at(test_state.num1)}'
+    assert (
+        str(prop)
+        == f'{{{TestState.get_name()}.mapping["a"].at({TestState.get_name()}.num1)}}'
+    )
 
     prop = TestState.mapping[TestState.map_key]
-    assert str(prop) == "{test_state.mapping[test_state.map_key]}"
+    assert (
+        str(prop)
+        == f"{{{TestState.get_name()}.mapping[{TestState.get_name()}.map_key]}}"
+    )
 
 
 def test_class_attributes():
     """Test that we can get class attributes."""
     prop = TestState.obj.prop1
-    assert str(prop) == "{test_state.obj.prop1}"
+    assert str(prop) == f"{{{TestState.get_name()}.obj.prop1}}"
 
     prop = TestState.complex[1].prop1
-    assert str(prop) == "{test_state.complex[1].prop1}"
+    assert str(prop) == f"{{{TestState.get_name()}.complex[1].prop1}}"
 
 
 def test_get_parent_state():
@@ -426,27 +434,40 @@ def test_get_substates():
 
 def test_get_name():
     """Test getting the name of a state."""
-    assert TestState.get_name() == "test_state"
-    assert ChildState.get_name() == "child_state"
-    assert ChildState2.get_name() == "child_state2"
-    assert GrandchildState.get_name() == "grandchild_state"
+    assert TestState.get_name() == "tests___test_state____test_state"
+    assert ChildState.get_name() == "tests___test_state____child_state"
+    assert ChildState2.get_name() == "tests___test_state____child_state2"
+    assert GrandchildState.get_name() == "tests___test_state____grandchild_state"
 
 
 def test_get_full_name():
     """Test getting the full name."""
-    assert TestState.get_full_name() == "test_state"
-    assert ChildState.get_full_name() == "test_state.child_state"
-    assert ChildState2.get_full_name() == "test_state.child_state2"
-    assert GrandchildState.get_full_name() == "test_state.child_state.grandchild_state"
+    assert TestState.get_full_name() == "tests___test_state____test_state"
+    assert (
+        ChildState.get_full_name()
+        == "tests___test_state____test_state.tests___test_state____child_state"
+    )
+    assert (
+        ChildState2.get_full_name()
+        == "tests___test_state____test_state.tests___test_state____child_state2"
+    )
+    assert (
+        GrandchildState.get_full_name()
+        == "tests___test_state____test_state.tests___test_state____child_state.tests___test_state____grandchild_state"
+    )
 
 
 def test_get_class_substate():
     """Test getting the substate of a class."""
-    assert TestState.get_class_substate(("child_state",)) == ChildState
-    assert TestState.get_class_substate(("child_state2",)) == ChildState2
-    assert ChildState.get_class_substate(("grandchild_state",)) == GrandchildState
+    assert TestState.get_class_substate((ChildState.get_name(),)) == ChildState
+    assert TestState.get_class_substate((ChildState2.get_name(),)) == ChildState2
     assert (
-        TestState.get_class_substate(("child_state", "grandchild_state"))
+        ChildState.get_class_substate((GrandchildState.get_name(),)) == GrandchildState
+    )
+    assert (
+        TestState.get_class_substate(
+            (ChildState.get_name(), GrandchildState.get_name())
+        )
         == GrandchildState
     )
     with pytest.raises(ValueError):
@@ -454,7 +475,7 @@ def test_get_class_substate():
     with pytest.raises(ValueError):
         TestState.get_class_substate(
             (
-                "child_state",
+                ChildState.get_name(),
                 "invalid_child",
             )
         )
@@ -466,13 +487,15 @@ def test_get_class_var():
     assert TestState.get_class_var(("num2",)).equals(TestState.num2)
     assert ChildState.get_class_var(("value",)).equals(ChildState.value)
     assert GrandchildState.get_class_var(("value2",)).equals(GrandchildState.value2)
-    assert TestState.get_class_var(("child_state", "value")).equals(ChildState.value)
+    assert TestState.get_class_var((ChildState.get_name(), "value")).equals(
+        ChildState.value
+    )
     assert TestState.get_class_var(
-        ("child_state", "grandchild_state", "value2")
+        (ChildState.get_name(), GrandchildState.get_name(), "value2")
     ).equals(
         GrandchildState.value2,
     )
-    assert ChildState.get_class_var(("grandchild_state", "value2")).equals(
+    assert ChildState.get_class_var((GrandchildState.get_name(), "value2")).equals(
         GrandchildState.value2,
     )
     with pytest.raises(ValueError):
@@ -480,7 +503,7 @@ def test_get_class_var():
     with pytest.raises(ValueError):
         TestState.get_class_var(
             (
-                "child_state",
+                ChildState.get_name(),
                 "invalid_var",
             )
         )
@@ -508,11 +531,15 @@ def test_set_parent_and_substates(test_state, child_state, grandchild_state):
         grandchild_state: A grandchild state.
     """
     assert len(test_state.substates) == 3
-    assert set(test_state.substates) == {"child_state", "child_state2", "child_state3"}
+    assert set(test_state.substates) == {
+        ChildState.get_name(),
+        ChildState2.get_name(),
+        ChildState3.get_name(),
+    }
 
     assert child_state.parent_state == test_state
     assert len(child_state.substates) == 1
-    assert set(child_state.substates) == {"grandchild_state"}
+    assert set(child_state.substates) == {GrandchildState.get_name()}
 
     assert grandchild_state.parent_state == child_state
     assert len(grandchild_state.substates) == 0
@@ -579,18 +606,21 @@ def test_get_substate(test_state, child_state, child_state2, grandchild_state):
         child_state2: A child state.
         grandchild_state: A grandchild state.
     """
-    assert test_state.get_substate(("child_state",)) == child_state
-    assert test_state.get_substate(("child_state2",)) == child_state2
+    assert test_state.get_substate((ChildState.get_name(),)) == child_state
+    assert test_state.get_substate((ChildState2.get_name(),)) == child_state2
     assert (
-        test_state.get_substate(("child_state", "grandchild_state")) == grandchild_state
+        test_state.get_substate((ChildState.get_name(), GrandchildState.get_name()))
+        == grandchild_state
     )
-    assert child_state.get_substate(("grandchild_state",)) == grandchild_state
+    assert child_state.get_substate((GrandchildState.get_name(),)) == grandchild_state
     with pytest.raises(ValueError):
         test_state.get_substate(("invalid",))
     with pytest.raises(ValueError):
-        test_state.get_substate(("child_state", "invalid"))
+        test_state.get_substate((ChildState.get_name(), "invalid"))
     with pytest.raises(ValueError):
-        test_state.get_substate(("child_state", "grandchild_state", "invalid"))
+        test_state.get_substate(
+            (ChildState.get_name(), GrandchildState.get_name(), "invalid")
+        )
 
 
 def test_set_dirty_var(test_state):
@@ -633,7 +663,7 @@ def test_set_dirty_substate(test_state, child_state, child_state2, grandchild_st
     # Setting a var should mark it as dirty.
     child_state.value = "test"
     assert child_state.dirty_vars == {"value"}
-    assert test_state.dirty_substates == {"child_state"}
+    assert test_state.dirty_substates == {ChildState.get_name()}
     assert child_state.dirty_substates == set()
 
     # Cleaning the parent state should remove the dirty substate.
@@ -643,12 +673,12 @@ def test_set_dirty_substate(test_state, child_state, child_state2, grandchild_st
 
     # Setting a var on the grandchild should bubble up.
     grandchild_state.value2 = "test2"
-    assert child_state.dirty_substates == {"grandchild_state"}
-    assert test_state.dirty_substates == {"child_state"}
+    assert child_state.dirty_substates == {GrandchildState.get_name()}
+    assert test_state.dirty_substates == {ChildState.get_name()}
 
     # Cleaning the middle state should keep the parent state dirty.
     child_state._clean()
-    assert test_state.dirty_substates == {"child_state"}
+    assert test_state.dirty_substates == {ChildState.get_name()}
     assert child_state.dirty_substates == set()
     assert grandchild_state.dirty_vars == set()
 
@@ -693,7 +723,11 @@ def test_reset(test_state, child_state):
     assert child_state.dirty_vars == {"count", "value"}
 
     # The dirty substates should be reset.
-    assert test_state.dirty_substates == {"child_state", "child_state2", "child_state3"}
+    assert test_state.dirty_substates == {
+        ChildState.get_name(),
+        ChildState2.get_name(),
+        ChildState3.get_name(),
+    }
 
 
 @pytest.mark.asyncio
@@ -714,8 +748,8 @@ async def test_process_event_simple(test_state):
     # The delta should contain the changes, including computed vars.
     # assert update.delta == {"test_state": {"num1": 69, "sum": 72.14}}
     assert update.delta == {
-        "test_state": {"num1": 69, "sum": 72.14, "upper": ""},
-        "test_state.child_state3.grandchild_state3": {"computed": ""},
+        TestState.get_full_name(): {"num1": 69, "sum": 72.14, "upper": ""},
+        GrandchildState3.get_full_name(): {"computed": ""},
     }
     assert update.events == []
 
@@ -733,15 +767,17 @@ async def test_process_event_substate(test_state, child_state, grandchild_state)
     assert child_state.value == ""
     assert child_state.count == 23
     event = Event(
-        token="t", name="child_state.change_both", payload={"value": "hi", "count": 12}
+        token="t",
+        name=f"{ChildState.get_name()}.change_both",
+        payload={"value": "hi", "count": 12},
     )
     update = await test_state._process(event).__anext__()
     assert child_state.value == "HI"
     assert child_state.count == 24
     assert update.delta == {
-        "test_state": {"sum": 3.14, "upper": ""},
-        "test_state.child_state": {"value": "HI", "count": 24},
-        "test_state.child_state3.grandchild_state3": {"computed": ""},
+        TestState.get_full_name(): {"sum": 3.14, "upper": ""},
+        ChildState.get_full_name(): {"value": "HI", "count": 24},
+        GrandchildState3.get_full_name(): {"computed": ""},
     }
     test_state._clean()
 
@@ -749,15 +785,15 @@ async def test_process_event_substate(test_state, child_state, grandchild_state)
     assert grandchild_state.value2 == ""
     event = Event(
         token="t",
-        name="child_state.grandchild_state.set_value2",
+        name=f"{GrandchildState.get_full_name()}.set_value2",
         payload={"value": "new"},
     )
     update = await test_state._process(event).__anext__()
     assert grandchild_state.value2 == "new"
     assert update.delta == {
-        "test_state": {"sum": 3.14, "upper": ""},
-        "test_state.child_state.grandchild_state": {"value2": "new"},
-        "test_state.child_state3.grandchild_state3": {"computed": ""},
+        TestState.get_full_name(): {"sum": 3.14, "upper": ""},
+        GrandchildState.get_full_name(): {"value2": "new"},
+        GrandchildState3.get_full_name(): {"computed": ""},
     }
 
 
@@ -781,7 +817,7 @@ async def test_process_event_generator():
         else:
             assert gen_state.value == count
             assert update.delta == {
-                "gen_state": {"value": count},
+                GenState.get_full_name(): {"value": count},
             }
             assert not update.final
 
@@ -1912,7 +1948,7 @@ async def test_background_task_no_block(mock_app: rx.App, token: str):
         mock_app,
         Event(
             token=token,
-            name=f"{BackgroundTaskState.get_name()}.background_task",
+            name=f"{BackgroundTaskState.get_full_name()}.background_task",
             router_data=router_data,
             payload={},
         ),
@@ -1932,7 +1968,7 @@ async def test_background_task_no_block(mock_app: rx.App, token: str):
         mock_app,
         Event(
             token=token,
-            name=f"{BackgroundTaskState.get_name()}.other",
+            name=f"{BackgroundTaskState.get_full_name()}.other",
             router_data=router_data,
             payload={},
         ),
@@ -1943,7 +1979,7 @@ async def test_background_task_no_block(mock_app: rx.App, token: str):
         # other task returns delta
         assert update == StateUpdate(
             delta={
-                BackgroundTaskState.get_name(): {
+                BackgroundTaskState.get_full_name(): {
                     "order": [
                         "background_task:start",
                         "other",
@@ -1979,10 +2015,13 @@ async def test_background_task_no_block(mock_app: rx.App, token: str):
     emit_mock = mock_app.event_namespace.emit
 
     first_ws_message = json.loads(emit_mock.mock_calls[0].args[1])
-    assert first_ws_message["delta"]["background_task_state"].pop("router") is not None
+    assert (
+        first_ws_message["delta"][BackgroundTaskState.get_full_name()].pop("router")
+        is not None
+    )
     assert first_ws_message == {
         "delta": {
-            "background_task_state": {
+            BackgroundTaskState.get_full_name(): {
                 "order": ["background_task:start"],
                 "computed_order": ["background_task:start"],
             }
@@ -1993,14 +2032,16 @@ async def test_background_task_no_block(mock_app: rx.App, token: str):
     for call in emit_mock.mock_calls[1:5]:
         assert json.loads(call.args[1]) == {
             "delta": {
-                "background_task_state": {"computed_order": ["background_task:start"]}
+                BackgroundTaskState.get_full_name(): {
+                    "computed_order": ["background_task:start"],
+                }
             },
             "events": [],
             "final": True,
         }
     assert json.loads(emit_mock.mock_calls[-2].args[1]) == {
         "delta": {
-            "background_task_state": {
+            BackgroundTaskState.get_full_name(): {
                 "order": exp_order,
                 "computed_order": exp_order,
                 "dict_list": {},
@@ -2011,7 +2052,7 @@ async def test_background_task_no_block(mock_app: rx.App, token: str):
     }
     assert json.loads(emit_mock.mock_calls[-1].args[1]) == {
         "delta": {
-            "background_task_state": {
+            BackgroundTaskState.get_full_name(): {
                 "computed_order": exp_order,
             },
         },
@@ -2554,7 +2595,7 @@ async def test_preprocess(app_module_mock, token, test_state, expected, mocker):
         assert isinstance(update, StateUpdate)
         updates.append(update)
     assert len(updates) == 1
-    assert updates[0].delta["state"].pop("router") is not None
+    assert updates[0].delta[State.get_name()].pop("router") is not None
     assert updates[0].delta == exp_is_hydrated(state, False)
 
     events = updates[0].events
@@ -2598,7 +2639,7 @@ async def test_preprocess_multiple_load_events(app_module_mock, token, mocker):
         assert isinstance(update, StateUpdate)
         updates.append(update)
     assert len(updates) == 1
-    assert updates[0].delta["state"].pop("router") is not None
+    assert updates[0].delta[State.get_name()].pop("router") is not None
     assert updates[0].delta == exp_is_hydrated(state, False)
 
     events = updates[0].events
@@ -2630,22 +2671,27 @@ async def test_get_state(mock_app: rx.App, token: str):
     if isinstance(mock_app.state_manager, StateManagerMemory):
         # All substates are available
         assert tuple(sorted(test_state.substates)) == (
-            "child_state",
-            "child_state2",
-            "child_state3",
+            ChildState.get_name(),
+            ChildState2.get_name(),
+            ChildState3.get_name(),
         )
     else:
         # Sibling states are only populated if they have computed vars
-        assert tuple(sorted(test_state.substates)) == ("child_state2", "child_state3")
+        assert tuple(sorted(test_state.substates)) == (
+            ChildState2.get_name(),
+            ChildState3.get_name(),
+        )
 
     # Because ChildState3 has a computed var, it is always dirty, and always populated.
     assert (
-        test_state.substates["child_state3"].substates["grandchild_state3"].computed
+        test_state.substates[ChildState3.get_name()]
+        .substates[GrandchildState3.get_name()]
+        .computed
         == ""
     )
 
     # Get the child_state2 directly.
-    child_state2_direct = test_state.get_substate(["child_state2"])
+    child_state2_direct = test_state.get_substate([ChildState2.get_name()])
     child_state2_get_state = await test_state.get_state(ChildState2)
     # These should be the same object.
     assert child_state2_direct is child_state2_get_state
@@ -2656,19 +2702,21 @@ async def test_get_state(mock_app: rx.App, token: str):
 
     # Now the original root should have all substates populated.
     assert tuple(sorted(test_state.substates)) == (
-        "child_state",
-        "child_state2",
-        "child_state3",
+        ChildState.get_name(),
+        ChildState2.get_name(),
+        ChildState3.get_name(),
     )
 
     # ChildState should be retrievable
-    child_state_direct = test_state.get_substate(["child_state"])
+    child_state_direct = test_state.get_substate([ChildState.get_name()])
     child_state_get_state = await test_state.get_state(ChildState)
     # These should be the same object.
     assert child_state_direct is child_state_get_state
 
     # GrandchildState instance should be the same as the one retrieved from the child_state2.
-    assert grandchild_state is child_state_direct.get_substate(["grandchild_state"])
+    assert grandchild_state is child_state_direct.get_substate(
+        [GrandchildState.get_name()]
+    )
     grandchild_state.value2 = "set_value"
 
     assert test_state.get_delta() == {
@@ -2695,21 +2743,21 @@ async def test_get_state(mock_app: rx.App, token: str):
         test_state._clean()
         # All substates are available
         assert tuple(sorted(new_test_state.substates)) == (
-            "child_state",
-            "child_state2",
-            "child_state3",
+            ChildState.get_name(),
+            ChildState2.get_name(),
+            ChildState3.get_name(),
         )
     else:
         # With redis, we get a whole new instance
         assert new_test_state is not test_state
         # Sibling states are only populated if they have computed vars
         assert tuple(sorted(new_test_state.substates)) == (
-            "child_state2",
-            "child_state3",
+            ChildState2.get_name(),
+            ChildState3.get_name(),
         )
 
     # Set a value on child_state2, should update cached var in grandchild_state2
-    child_state2 = new_test_state.get_substate(("child_state2",))
+    child_state2 = new_test_state.get_substate((ChildState2.get_name(),))
     child_state2.value = "set_c2_value"
 
     assert new_test_state.get_delta() == {

--- a/tests/test_state_tree.py
+++ b/tests/test_state_tree.py
@@ -1,4 +1,5 @@
 """Specialized test for a larger state tree."""
+
 import asyncio
 from typing import Generator
 
@@ -236,7 +237,13 @@ def state_manager_redis(app_module_mock) -> Generator[StateManager, None, None]:
     [
         (
             Root,
-            ["tree_a", "tree_b", "tree_c", "tree_d", "tree_e"],
+            [
+                TreeA.get_name(),
+                TreeB.get_name(),
+                TreeC.get_name(),
+                TreeD.get_name(),
+                TreeE.get_name(),
+            ],
             [
                 TreeA.get_full_name(),
                 SubA_A.get_full_name(),
@@ -260,7 +267,7 @@ def state_manager_redis(app_module_mock) -> Generator[StateManager, None, None]:
         ),
         (
             TreeA,
-            ("tree_a", "tree_d", "tree_e"),
+            (TreeA.get_name(), TreeD.get_name(), TreeE.get_name()),
             [
                 TreeA.get_full_name(),
                 SubA_A.get_full_name(),
@@ -275,7 +282,7 @@ def state_manager_redis(app_module_mock) -> Generator[StateManager, None, None]:
         ),
         (
             SubA_A_A_A,
-            ["tree_a", "tree_d", "tree_e"],
+            [TreeA.get_name(), TreeD.get_name(), TreeE.get_name()],
             [
                 TreeA.get_full_name(),
                 SubA_A.get_full_name(),
@@ -287,7 +294,7 @@ def state_manager_redis(app_module_mock) -> Generator[StateManager, None, None]:
         ),
         (
             TreeB,
-            ["tree_b", "tree_d", "tree_e"],
+            [TreeB.get_name(), TreeD.get_name(), TreeE.get_name()],
             [
                 TreeB.get_full_name(),
                 SubB_A.get_full_name(),
@@ -299,7 +306,7 @@ def state_manager_redis(app_module_mock) -> Generator[StateManager, None, None]:
         ),
         (
             SubB_B,
-            ["tree_b", "tree_d", "tree_e"],
+            [TreeB.get_name(), TreeD.get_name(), TreeE.get_name()],
             [
                 TreeB.get_full_name(),
                 SubB_B.get_full_name(),
@@ -308,7 +315,7 @@ def state_manager_redis(app_module_mock) -> Generator[StateManager, None, None]:
         ),
         (
             SubB_C_A,
-            ["tree_b", "tree_d", "tree_e"],
+            [TreeB.get_name(), TreeD.get_name(), TreeE.get_name()],
             [
                 TreeB.get_full_name(),
                 SubB_C.get_full_name(),
@@ -318,7 +325,7 @@ def state_manager_redis(app_module_mock) -> Generator[StateManager, None, None]:
         ),
         (
             TreeC,
-            ["tree_c", "tree_d", "tree_e"],
+            [TreeC.get_name(), TreeD.get_name(), TreeE.get_name()],
             [
                 TreeC.get_full_name(),
                 SubC_A.get_full_name(),
@@ -327,14 +334,14 @@ def state_manager_redis(app_module_mock) -> Generator[StateManager, None, None]:
         ),
         (
             TreeD,
-            ["tree_d", "tree_e"],
+            [TreeD.get_name(), TreeE.get_name()],
             [
                 *ALWAYS_COMPUTED_DICT_KEYS,
             ],
         ),
         (
             TreeE,
-            ["tree_d", "tree_e"],
+            [TreeE.get_name(), TreeD.get_name()],
             [
                 # Extra siblings of computed var included now.
                 SubE_A_A_A_B.get_full_name(),

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -731,11 +731,11 @@ def test_computed_var_without_annotation_error(request, fixture):
     with pytest.raises(TypeError) as err:
         state = request.getfixturevalue(fixture)
         state.var_without_annotation.foo
-    full_name = state.var_without_annotation._var_full_name
-    assert (
-        err.value.args[0]
-        == f"You must provide an annotation for the state var `{full_name}`. Annotation cannot be `typing.Any`"
-    )
+        full_name = state.var_without_annotation._var_full_name
+        assert (
+            err.value.args[0]
+            == f"You must provide an annotation for the state var `{full_name}`. Annotation cannot be `typing.Any`"
+        )
 
 
 @pytest.mark.parametrize(
@@ -757,11 +757,11 @@ def test_computed_var_with_annotation_error(request, fixture):
     with pytest.raises(AttributeError) as err:
         state = request.getfixturevalue(fixture)
         state.var_with_annotation.foo
-    full_name = state.var_with_annotation._var_full_name
-    assert (
-        err.value.args[0]
-        == f"The State var `{full_name}` has no attribute 'foo' or may have been annotated wrongly."
-    )
+        full_name = state.var_with_annotation._var_full_name
+        assert (
+            err.value.args[0]
+            == f"The State var `{full_name}` has no attribute 'foo' or may have been annotated wrongly."
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -752,7 +752,6 @@ def test_computed_var_with_annotation_error(request, fixture):
     Args:
         request: Fixture Request.
         fixture: The state fixture.
-        full_name: The full name of the state var.
     """
     with pytest.raises(AttributeError) as err:
         state = request.getfixturevalue(fixture)

--- a/tests/utils/test_format.py
+++ b/tests/utils/test_format.py
@@ -400,8 +400,8 @@ def test_format_cond(
             ],
             Var.create("yellow", _var_is_string=True),
             "(() => { switch (JSON.stringify(state__state.value)) {case JSON.stringify(1):  return (`red`);  break;case JSON.stringify(2): case JSON.stringify(3):  "
-            "return (`blue`);  break;case JSON.stringify(test_state.mapping):  return "
-            "(test_state.num1);  break;case JSON.stringify(`${test_state.map_key}-key`):  return (`return-key`);"
+            f"return (`blue`);  break;case JSON.stringify({TestState.get_full_name()}.mapping):  return "
+            f"({TestState.get_full_name()}.num1);  break;case JSON.stringify(`${{{TestState.get_full_name()}.map_key}}-key`):  return (`return-key`);"
             "  break;default:  return (`yellow`);  break;};})()",
         )
     ],
@@ -553,11 +553,14 @@ def test_get_handler_parts(input, output):
 @pytest.mark.parametrize(
     "input,output",
     [
-        (TestState.do_something, "test_state.do_something"),
-        (ChildState.change_both, "test_state.child_state.change_both"),
+        (TestState.do_something, f"{TestState.get_full_name()}.do_something"),
+        (
+            ChildState.change_both,
+            f"{ChildState.get_full_name()}.change_both",
+        ),
         (
             GrandchildState.do_nothing,
-            "test_state.child_state.grandchild_state.do_nothing",
+            f"{GrandchildState.get_full_name()}.do_nothing",
         ),
     ],
 )


### PR DESCRIPTION
Based on #3214  
Allows to set state name explicitly, which allows renaming state classes or move across modules without breaking existing reflex sessions