### PR TITLE
form: default width="100%"

### DIFF
--- a/reflex/components/radix/primitives/form.py
+++ b/reflex/components/radix/primitives/form.py
@@ -44,7 +44,7 @@ class FormRoot(FormComponent, HTMLForm):
         Returns:
             The style of the component.
         """
-        return Style({"width": "260px"})
+        return Style({"width": "100%"})
 
 
 class FormField(FormComponent):


### PR DESCRIPTION
In 0.4.0 -> 0.4.9 this hardcoded `{"width": "260px"}` was being _returned_ from `_apply_theme`... but `Component` does nothing with the `_apply_theme` return value, so it was essentially ignored.

In 0.5.0, this bit of code was moved to the new `add_style` method which does respect the return value, and thus it was being applied all of a sudden and creating weird visual effects on previously working forms.

# 0.4.0 - 0.4.9 (and also this PR)

<img width="478" alt="image" src="https://github.com/reflex-dev/reflex/assets/1524005/b1edff40-40e9-44e2-a290-e0acf3d79733">

# 0.5.0a1

This is where i noticed the issue

<img width="478" alt="image" src="https://github.com/reflex-dev/reflex/assets/1524005/5ad01980-44d6-4eac-9952-c89ddd00d6f4">
