### PR TITLE
[REF-2776] enable telemetry for frontend package download subprocess

### DIFF
--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -848,6 +848,8 @@ def install_frontend_packages(packages: set[str], config: Config):
     processes.run_process_with_fallback(
         [get_install_package_manager(), "install"],  # type: ignore
         fallback=fallback_command,
+        analytics_enabled=True,
+        error_filter_fn=lambda output: "404" in output,
         show_status_message="Installing base frontend packages",
         cwd=constants.Dirs.WEB,
         shell=constants.IS_WINDOWS,
@@ -863,6 +865,8 @@ def install_frontend_packages(packages: set[str], config: Config):
                 *((config.tailwind or {}).get("plugins", [])),
             ],
             fallback=fallback_command,
+            analytics_enabled=True,
+            error_filter_fn=lambda output: "404" in output,
             show_status_message="Installing tailwind",
             cwd=constants.Dirs.WEB,
             shell=constants.IS_WINDOWS,
@@ -873,6 +877,8 @@ def install_frontend_packages(packages: set[str], config: Config):
         processes.run_process_with_fallback(
             [get_install_package_manager(), "add", *packages],
             fallback=fallback_command,
+            analytics_enabled=True,
+            error_filter_fn=lambda output: "404" in output,
             show_status_message="Installing frontend packages from config and components",
             cwd=constants.Dirs.WEB,
             shell=constants.IS_WINDOWS,

--- a/reflex/utils/telemetry.py
+++ b/reflex/utils/telemetry.py
@@ -126,6 +126,10 @@ def _prepare_event(event: str, **kwargs) -> dict:
 
     cpuinfo = get_cpu_info()
 
+    additional_keys = ["template", "context", "detail"]
+    additional_fields = {
+        key: value for key in additional_keys if (value := kwargs.get(key)) is not None
+    }
     return {
         "api_key": "phc_JoMo0fOyi0GQAooY3UyO9k0hebGkMyFJrrCw1Gt5SGb",
         "event": event,
@@ -139,11 +143,7 @@ def _prepare_event(event: str, **kwargs) -> dict:
             "cpu_count": get_cpu_count(),
             "memory": get_memory(),
             "cpu_info": dict(cpuinfo) if cpuinfo else {},
-            **(
-                {"template": template}
-                if (template := kwargs.get("template")) is not None
-                else {}
-            ),
+            **additional_fields,
         },
         "timestamp": stamp,
     }


### PR DESCRIPTION
## Summary
- enable telemetry for frontend package download subprocess
- send the package not found error as detail
## Tests
<img width="943" alt="image" src="https://github.com/reflex-dev/reflex/assets/15661672/4ce66975-cf27-4304-8522-f9b747382daa">
