### PR TITLE
[REF-2774] Add ReflexError and subclasses, send in telemetry

### DIFF
--- a/reflex/base.py
+++ b/reflex/base.py
@@ -1,4 +1,5 @@
 """Define the base Reflex class."""
+
 from __future__ import annotations
 
 import os
@@ -26,15 +27,17 @@ def validate_field_name(bases: List[Type["BaseModel"]], field_name: str) -> None
         field_name: name of attribute
 
     Raises:
-        NameError: If state var field shadows another in its parent state
+        VarNameError: If state var field shadows another in its parent state
     """
+    from reflex.utils.exceptions import VarNameError
+
     reload = os.getenv(constants.RELOAD_CONFIG) == "True"
     for base in bases:
         try:
             if not reload and getattr(base, field_name, None):
                 pass
         except TypeError as te:
-            raise NameError(
+            raise VarNameError(
                 f'State var "{field_name}" in {base} has been shadowed by a substate var; '
                 f'use a different field name instead".'
             ) from te

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -731,6 +731,7 @@ class Component(BaseComponent, ABC):
         # Import here to avoid circular imports.
         from reflex.components.base.bare import Bare
         from reflex.components.base.fragment import Fragment
+        from reflex.utils.exceptions import ComponentTypeError
 
         # Translate deprecated props to new names.
         new_prop_names = [
@@ -757,7 +758,7 @@ class Component(BaseComponent, ABC):
                     validate_children(child)
                 # Make sure the child is a valid type.
                 if not types._isinstance(child, ComponentChild):
-                    raise TypeError(
+                    raise ComponentTypeError(
                         "Children of Reflex components must be other components, "
                         "state vars, or primitive Python types. "
                         f"Got child {child} of type {type(child)}.",

--- a/reflex/config.py
+++ b/reflex/config.py
@@ -251,8 +251,10 @@ class Config(Base):
             The updated config values.
 
         Raises:
-            ValueError: If an environment variable is set to an invalid type.
+            EnvVarValueError: If an environment variable is set to an invalid type.
         """
+        from reflex.utils.exceptions import EnvVarValueError
+
         updated_values = {}
         # Iterate over the fields.
         for key, field in self.__fields__.items():
@@ -273,11 +275,11 @@ class Config(Base):
                         env_var = env_var.lower() in ["true", "1", "yes"]
                     else:
                         env_var = field.type_(env_var)
-                except ValueError:
+                except ValueError as ve:
                     console.error(
                         f"Could not convert {key.upper()}={env_var} to type {field.type_}"
                     )
-                    raise
+                    raise EnvVarValueError from ve
 
                 # Set the value.
                 updated_values[key] = env_var

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1688,10 +1688,12 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
         if initial:
             computed_vars = {
                 # Include initial computed vars.
-                prop_name: cv._initial_value
-                if isinstance(cv, ComputedVar)
-                and not isinstance(cv._initial_value, types.Unset)
-                else self.get_value(getattr(self, prop_name))
+                prop_name: (
+                    cv._initial_value
+                    if isinstance(cv, ComputedVar)
+                    and not isinstance(cv._initial_value, types.Unset)
+                    else self.get_value(getattr(self, prop_name))
+                )
                 for prop_name, cv in self.computed_vars.items()
             }
         elif include_computed:
@@ -2006,7 +2008,8 @@ class StateProxy(wrapt.ObjectProxy):
         if name in ["substates", "parent_state"] and not self._self_mutable:
             raise ImmutableStateError(
                 "Background task StateProxy is immutable outside of a context "
-                "manager. Use `async with self` to modify state."
+                "manager. Use `async with self` to modify state.",
+                analytics_enabled=True,
             )
         value = super().__getattr__(name)
         if not name.startswith("_self_") and isinstance(value, MutableProxy):
@@ -2052,7 +2055,8 @@ class StateProxy(wrapt.ObjectProxy):
 
         raise ImmutableStateError(
             "Background task StateProxy is immutable outside of a context "
-            "manager. Use `async with self` to modify state."
+            "manager. Use `async with self` to modify state.",
+            analytics_enabled=True,
         )
 
     def get_substate(self, path: Sequence[str]) -> BaseState:
@@ -2070,7 +2074,8 @@ class StateProxy(wrapt.ObjectProxy):
         if not self._self_mutable:
             raise ImmutableStateError(
                 "Background task StateProxy is immutable outside of a context "
-                "manager. Use `async with self` to modify state."
+                "manager. Use `async with self` to modify state.",
+                analytics_enabled=True,
             )
         return self.__wrapped__.get_substate(path)
 
@@ -2089,7 +2094,8 @@ class StateProxy(wrapt.ObjectProxy):
         if not self._self_mutable:
             raise ImmutableStateError(
                 "Background task StateProxy is immutable outside of a context "
-                "manager. Use `async with self` to modify state."
+                "manager. Use `async with self` to modify state.",
+                analytics_enabled=True,
             )
         return await self.__wrapped__.get_state(state_cls)
 
@@ -2495,7 +2501,8 @@ class StateManagerRedis(StateManager):
             raise LockExpiredError(
                 f"Lock expired for token {token} while processing. Consider increasing "
                 f"`app.state_manager.lock_expiration` (currently {self.lock_expiration}) "
-                "or use `@rx.background` decorator for long-running tasks."
+                "or use `@rx.background` decorator for long-running tasks.",
+                analytics_enabled=True,
             )
         client_token, substate_name = _split_substate_key(token)
         # If the substate name on the token doesn't match the instance name, it cannot have a parent.
@@ -3054,7 +3061,8 @@ class ImmutableMutableProxy(MutableProxy):
         if not self._self_state._self_mutable:
             raise ImmutableStateError(
                 "Background task StateProxy is immutable outside of a context "
-                "manager. Use `async with self` to modify state."
+                "manager. Use `async with self` to modify state.",
+                analytics_enabled=True,
             )
         return super()._mark_dirty(
             wrapped=wrapped, instance=instance, args=args, kwargs=kwargs

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1688,12 +1688,10 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
         if initial:
             computed_vars = {
                 # Include initial computed vars.
-                prop_name: (
-                    cv._initial_value
-                    if isinstance(cv, ComputedVar)
-                    and not isinstance(cv._initial_value, types.Unset)
-                    else self.get_value(getattr(self, prop_name))
-                )
+                prop_name: cv._initial_value
+                if isinstance(cv, ComputedVar)
+                and not isinstance(cv._initial_value, types.Unset)
+                else self.get_value(getattr(self, prop_name))
                 for prop_name, cv in self.computed_vars.items()
             }
         elif include_computed:
@@ -2008,8 +2006,7 @@ class StateProxy(wrapt.ObjectProxy):
         if name in ["substates", "parent_state"] and not self._self_mutable:
             raise ImmutableStateError(
                 "Background task StateProxy is immutable outside of a context "
-                "manager. Use `async with self` to modify state.",
-                analytics_enabled=True,
+                "manager. Use `async with self` to modify state."
             )
         value = super().__getattr__(name)
         if not name.startswith("_self_") and isinstance(value, MutableProxy):
@@ -2055,8 +2052,7 @@ class StateProxy(wrapt.ObjectProxy):
 
         raise ImmutableStateError(
             "Background task StateProxy is immutable outside of a context "
-            "manager. Use `async with self` to modify state.",
-            analytics_enabled=True,
+            "manager. Use `async with self` to modify state."
         )
 
     def get_substate(self, path: Sequence[str]) -> BaseState:
@@ -2074,8 +2070,7 @@ class StateProxy(wrapt.ObjectProxy):
         if not self._self_mutable:
             raise ImmutableStateError(
                 "Background task StateProxy is immutable outside of a context "
-                "manager. Use `async with self` to modify state.",
-                analytics_enabled=True,
+                "manager. Use `async with self` to modify state."
             )
         return self.__wrapped__.get_substate(path)
 
@@ -2094,8 +2089,7 @@ class StateProxy(wrapt.ObjectProxy):
         if not self._self_mutable:
             raise ImmutableStateError(
                 "Background task StateProxy is immutable outside of a context "
-                "manager. Use `async with self` to modify state.",
-                analytics_enabled=True,
+                "manager. Use `async with self` to modify state."
             )
         return await self.__wrapped__.get_state(state_cls)
 
@@ -2501,8 +2495,7 @@ class StateManagerRedis(StateManager):
             raise LockExpiredError(
                 f"Lock expired for token {token} while processing. Consider increasing "
                 f"`app.state_manager.lock_expiration` (currently {self.lock_expiration}) "
-                "or use `@rx.background` decorator for long-running tasks.",
-                analytics_enabled=True,
+                "or use `@rx.background` decorator for long-running tasks."
             )
         client_token, substate_name = _split_substate_key(token)
         # If the substate name on the token doesn't match the instance name, it cannot have a parent.
@@ -3061,8 +3054,7 @@ class ImmutableMutableProxy(MutableProxy):
         if not self._self_state._self_mutable:
             raise ImmutableStateError(
                 "Background task StateProxy is immutable outside of a context "
-                "manager. Use `async with self` to modify state.",
-                analytics_enabled=True,
+                "manager. Use `async with self` to modify state."
             )
         return super()._mark_dirty(
             wrapped=wrapped, instance=instance, args=args, kwargs=kwargs

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -279,11 +279,13 @@ class EventHandlerSetVar(EventHandler):
 
         Raises:
             AttributeError: If the given Var name does not exist on the state.
-            ValueError: If the given Var name is not a str
+            EventHandlerValueError: If the given Var name is not a str
         """
+        from reflex.utils.exceptions import EventHandlerValueError
+
         if args:
             if not isinstance(args[0], str):
-                raise ValueError(
+                raise EventHandlerValueError(
                     f"Var name must be passed as a string, got {args[0]!r}"
                 )
             # Check that the requested Var setter exists on the State at compile time.
@@ -380,10 +382,12 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
             **kwargs: The kwargs to pass to the Pydantic init method.
 
         Raises:
-            RuntimeError: If the state is instantiated directly by end user.
+            ReflexRuntimeError: If the state is instantiated directly by end user.
         """
+        from reflex.utils.exceptions import ReflexRuntimeError
+
         if not _reflex_internal_init and not is_testing_env():
-            raise RuntimeError(
+            raise ReflexRuntimeError(
                 "State classes should not be instantiated directly in a Reflex app. "
                 "See https://reflex.dev/docs/state/ for further information."
             )
@@ -438,8 +442,10 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
             **kwargs: The kwargs to pass to the pydantic init_subclass method.
 
         Raises:
-            ValueError: If a substate class shadows another.
+            StateValueError: If a substate class shadows another.
         """
+        from reflex.utils.exceptions import StateValueError
+
         super().__init_subclass__(**kwargs)
         # Event handlers should not shadow builtin state methods.
         cls._check_overridden_methods()
@@ -471,7 +477,7 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
                 else:
                     # During normal operation, subclasses cannot have the same name, even if they are
                     # defined in different modules.
-                    raise ValueError(
+                    raise StateValueError(
                         f"The substate class '{cls.__name__}' has been defined multiple times. "
                         "Shadowing substate classes is not allowed."
                     )
@@ -829,10 +835,12 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
             prop: The variable to initialize
 
         Raises:
-            TypeError: if the variable has an incorrect type
+            VarTypeError: if the variable has an incorrect type
         """
+        from reflex.utils.exceptions import VarTypeError
+
         if not types.is_valid_var_type(prop._var_type):
-            raise TypeError(
+            raise VarTypeError(
                 "State vars must be primitive Python types, "
                 "Plotly figures, Pandas dataframes, "
                 "or subclasses of rx.Base. "
@@ -1688,10 +1696,12 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
         if initial:
             computed_vars = {
                 # Include initial computed vars.
-                prop_name: cv._initial_value
-                if isinstance(cv, ComputedVar)
-                and not isinstance(cv._initial_value, types.Unset)
-                else self.get_value(getattr(self, prop_name))
+                prop_name: (
+                    cv._initial_value
+                    if isinstance(cv, ComputedVar)
+                    and not isinstance(cv._initial_value, types.Unset)
+                    else self.get_value(getattr(self, prop_name))
+                )
                 for prop_name, cv in self.computed_vars.items()
             }
         elif include_computed:

--- a/reflex/utils/exceptions.py
+++ b/reflex/utils/exceptions.py
@@ -4,7 +4,18 @@
 class ReflexError(Exception):
     """Base exception for all Reflex exceptions."""
 
-    pass
+    def __init__(self, message: str, analytics_enabled: bool = False) -> None:
+        """Custom constructor. If analytics enabled, send telemetry.
+
+        Args:
+            message: the exception message
+            analytics_enabled: whether to include this exception when telemetry is enabled.
+        """
+        from reflex.utils import telemetry
+
+        if analytics_enabled:
+            telemetry.send("error", context="backend", message=message)
+        super().__init__(message)
 
 
 class InvalidStylePropError(ReflexError, TypeError):

--- a/reflex/utils/exceptions.py
+++ b/reflex/utils/exceptions.py
@@ -4,19 +4,6 @@
 class ReflexError(Exception):
     """Base exception for all Reflex exceptions."""
 
-    def __init__(self, message: str, analytics_enabled: bool = False) -> None:
-        """Custom constructor. If analytics enabled, send telemetry.
-
-        Args:
-            message: the exception message
-            analytics_enabled: whether to include this exception when telemetry is enabled.
-        """
-        from reflex.utils import telemetry
-
-        if analytics_enabled:
-            telemetry.send("error", context="backend", message=message)
-        super().__init__(message)
-
 
 class InvalidStylePropError(ReflexError, TypeError):
     """Custom Type Error when style props have invalid values."""

--- a/reflex/utils/exceptions.py
+++ b/reflex/utils/exceptions.py
@@ -5,10 +5,64 @@ class ReflexError(Exception):
     """Base exception for all Reflex exceptions."""
 
 
+class ReflexRuntimeError(ReflexError, RuntimeError):
+    """Custom RuntimeError for Reflex."""
+
+
+class UploadTypeError(ReflexError, TypeError):
+    """Custom TypeError for upload related errors."""
+
+
+class EnvVarValueError(ReflexError, ValueError):
+    """Custom ValueError raised when unable to convert env var to expected type."""
+
+
+class ComponentTypeError(ReflexError, TypeError):
+    """Custom TypeError for component related errors."""
+
+
+class EventHandlerTypeError(ReflexError, TypeError):
+    """Custom TypeError for event handler related errors."""
+
+
+class EventHandlerValueError(ReflexError, ValueError):
+    """Custom ValueError for event handler related errors."""
+
+
+class StateValueError(ReflexError, ValueError):
+    """Custom ValueError for state related errors."""
+
+
+class VarNameError(ReflexError, NameError):
+    """Custom NameError for when a state var has been shadowed by a substate var."""
+
+
+class VarTypeError(ReflexError, TypeError):
+    """Custom TypeError for var related errors."""
+
+
+class VarValueError(ReflexError, ValueError):
+    """Custom ValueError for var related errors."""
+
+
+class VarAttributeError(ReflexError, AttributeError):
+    """Custom AttributeError for var related errors."""
+
+
+class UploadValueError(ReflexError, ValueError):
+    """Custom ValueError for upload related errors."""
+
+
+class RouteValueError(ReflexError, ValueError):
+    """Custom ValueError for route related errors."""
+
+
+class VarOperationTypeError(ReflexError, TypeError):
+    """Custom TypeError for when unsupported operations are performed on vars."""
+
+
 class InvalidStylePropError(ReflexError, TypeError):
     """Custom Type Error when style props have invalid values."""
-
-    pass
 
 
 class ImmutableStateError(ReflexError):
@@ -21,5 +75,3 @@ class LockExpiredError(ReflexError):
 
 class MatchTypeError(ReflexError, TypeError):
     """Raised when the return types of match cases are different."""
-
-    pass

--- a/reflex/utils/exceptions.py
+++ b/reflex/utils/exceptions.py
@@ -1,21 +1,27 @@
 """Custom Exceptions."""
 
 
-class InvalidStylePropError(TypeError):
+class ReflexError(Exception):
+    """Base exception for all Reflex exceptions."""
+
+    pass
+
+
+class InvalidStylePropError(ReflexError, TypeError):
     """Custom Type Error when style props have invalid values."""
 
     pass
 
 
-class ImmutableStateError(AttributeError):
+class ImmutableStateError(ReflexError):
     """Raised when a background task attempts to modify state outside of context."""
 
 
-class LockExpiredError(Exception):
+class LockExpiredError(ReflexError):
     """Raised when the state lock expires while an event is being processed."""
 
 
-class MatchTypeError(TypeError):
+class MatchTypeError(ReflexError, TypeError):
     """Raised when the return types of match cases are different."""
 
     pass

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -210,28 +210,35 @@ def get_app(reload: bool = False) -> ModuleType:
 
     Raises:
         RuntimeError: If the app name is not set in the config.
+        exceptions.ReflexError: Reflex specific errors.
     """
-    os.environ[constants.RELOAD_CONFIG] = str(reload)
-    config = get_config()
-    if not config.app_name:
-        raise RuntimeError(
-            "Cannot get the app module because `app_name` is not set in rxconfig! "
-            "If this error occurs in a reflex test case, ensure that `get_app` is mocked."
-        )
-    module = config.module
-    sys.path.insert(0, os.getcwd())
-    app = __import__(module, fromlist=(constants.CompileVars.APP,))
+    from reflex.utils import exceptions, telemetry
 
-    if reload:
-        from reflex.state import reload_state_module
+    try:
+        os.environ[constants.RELOAD_CONFIG] = str(reload)
+        config = get_config()
+        if not config.app_name:
+            raise RuntimeError(
+                "Cannot get the app module because `app_name` is not set in rxconfig! "
+                "If this error occurs in a reflex test case, ensure that `get_app` is mocked."
+            )
+        module = config.module
+        sys.path.insert(0, os.getcwd())
+        app = __import__(module, fromlist=(constants.CompileVars.APP,))
 
-        # Reset rx.State subclasses to avoid conflict when reloading.
-        reload_state_module(module=module)
+        if reload:
+            from reflex.state import reload_state_module
 
-        # Reload the app module.
-        importlib.reload(app)
+            # Reset rx.State subclasses to avoid conflict when reloading.
+            reload_state_module(module=module)
 
-    return app
+            # Reload the app module.
+            importlib.reload(app)
+
+        return app
+    except exceptions.ReflexError as ex:
+        telemetry.send("error", context="backend", detail=str(ex))
+        raise
 
 
 def get_compiled_app(reload: bool = False, export: bool = False) -> ModuleType:

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -237,7 +237,7 @@ def get_app(reload: bool = False) -> ModuleType:
 
         return app
     except exceptions.ReflexError as ex:
-        telemetry.send("error", context="backend", detail=str(ex))
+        telemetry.send("error", context="frontend", detail=str(ex))
         raise
 
 

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -466,7 +466,7 @@ class Var:
             return self._var_name
         try:
             return json.loads(self._var_name)
-        except VarValueError:
+        except ValueError:
             return self._var_name
 
     def equals(self, other: Var) -> bool:
@@ -1829,7 +1829,7 @@ class BaseVar(Var):
                 try:
                     value = self._var_type(value)
                     setattr(state, self._var_name, value)
-                except VarValueError:
+                except ValueError:
                     console.debug(
                         f"{type(state).__name__}.{self._var_name}: Failed conversion of {value} to '{self._var_type.__name__}'. Value not set.",
                     )


### PR DESCRIPTION
## Summary
- Add ReflexError as base type exception for all reflex specific errors.
- Add more fine grained exception subclasses for state, var, etc.
- Catch and send in telemetry certain reflex errors.
- Need the change in telemetry from #3270, merge after #3270.