### PR TITLE
Mirgrate from pip to uv

### DIFF
--- a/.github/actions/setup_build_env/action.yml
+++ b/.github/actions/setup_build_env/action.yml
@@ -106,3 +106,8 @@ runs:
       run: |
         source ${{ inputs.create-venv-at-path }}/*/activate
         poetry install --only-root --no-interaction
+
+    - name: Install uv
+      shell: bash
+      run: |
+        poetry run pip install uv

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Install Requirements for reflex-web
         working-directory: ./reflex-web
-        run: poetry run pip install -r requirements.txt
+        run: poetry run uv pip install -r requirements.txt
       - name: Init Website for reflex-web
         working-directory: ./reflex-web
         run: poetry run reflex init
@@ -117,7 +117,7 @@ jobs:
           run-poetry-install: true
           create-venv-at-path: .venv
       - name: Install additional dependencies for DB access
-        run: poetry run pip install psycopg2-binary
+        run: poetry run uv pip install psycopg2-binary
       - name: Run benchmark tests
         env:
           APP_HARNESS_HEADLESS: 1
@@ -149,7 +149,7 @@ jobs:
           run-poetry-install: true
           create-venv-at-path: .venv
       - name: Install additional dependencies for DB access
-        run: poetry run pip install psycopg2-binary
+        run: poetry run uv pip install psycopg2-binary
       - name: Build reflex
         run: |
           poetry build
@@ -192,8 +192,13 @@ jobs:
           source .venv/*/activate
           poetry install --without dev --no-interaction --no-root
 
+      - name: Install uv
+        shell: bash
+        run: |
+          poetry run pip install uv
+
       - name: Install additional dependencies for DB access
-        run: poetry run pip install psycopg2-binary
+        run: poetry run uv pip install psycopg2-binary
 
       - if: ${{ env.DATABASE_URL }}
         name: calculate and upload size

--- a/.github/workflows/integration_app_harness.yml
+++ b/.github/workflows/integration_app_harness.yml
@@ -45,7 +45,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           run-poetry-install: true
           create-venv-at-path: .venv
-      - run: poetry run pip install pyvirtualdisplay pillow
+      - run: poetry run uv pip install pyvirtualdisplay pillow
       - name: Run app harness tests
         env:
           SCREENSHOT_DIR: /tmp/screenshots

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -74,9 +74,9 @@ jobs:
       - name: Install requirements for counter example
         working-directory: ./reflex-examples/counter
         run: |
-          poetry run pip install -r requirements.txt
+          poetry run uv pip install -r requirements.txt
       - name: Install additional dependencies for DB access
-        run: poetry run pip install psycopg2-binary
+        run: poetry run uv pip install psycopg2-binary
       - name: Check export --backend-only before init for counter example
         working-directory: ./reflex-examples/counter
         run: |
@@ -134,9 +134,9 @@ jobs:
 
       - name: Install Requirements for reflex-web
         working-directory: ./reflex-web
-        run: poetry run pip install -r requirements.txt
+        run: poetry run uv pip install -r requirements.txt
       - name: Install additional dependencies for DB access
-        run: poetry run pip install psycopg2-binary
+        run: poetry run uv pip install psycopg2-binary
       - name: Init Website for reflex-web
         working-directory: ./reflex-web
         run: poetry run reflex init

--- a/.github/workflows/integration_tests_wsl.yml
+++ b/.github/workflows/integration_tests_wsl.yml
@@ -56,11 +56,16 @@ jobs:
         run: |
           poetry install
 
+      - name: Install uv
+        shell: wsl-bash {0}
+        run: |
+          poetry run pip install uv
+
       - name: Install requirements for counter example
         working-directory: ./reflex-examples/counter
         shell: wsl-bash {0}
         run: |
-          poetry run pip install -r requirements.txt
+          poetry run uv pip install -r requirements.txt
       - name: Check export --backend-only before init for counter example
         working-directory: ./reflex-examples/counter
         shell: wsl-bash {0}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -28,7 +28,7 @@ jobs:
           create-venv-at-path: .venv
       # TODO pre-commit related stuff can be cached too (not a bottleneck yet)
       - run: |
-          poetry run pip install pre-commit
+          poetry run uv pip install pre-commit
           poetry run pre-commit run --all-files
         env:
           SKIP: update-pyi-files

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -80,6 +80,6 @@ jobs:
       - name: Run unit tests w/ pydantic v1
         run: |
           export PYTHONUNBUFFERED=1
-          poetry run pip install "pydantic~=1.10"
+          poetry run uv pip install "pydantic~=1.10"
           poetry run pytest tests --cov --no-cov-on-fail --cov-report=
       - run: poetry run coverage html


### PR DESCRIPTION
In order to improve build time performance, this change switches usage of pip to uv. The uv command is a pip alternative promising much faster installs of Python packages.

For more information on uv, see:
https://github.com/astral-sh/uv

Closes #2748

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

### **After** these steps, you're ready to open a pull request.

    a. Give a descriptive title to your PR.

    b. Describe your changes.

    c. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

