### PR TITLE
Fixed date type var bug

### DIFF
--- a/reflex/utils/types.py
+++ b/reflex/utils/types.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import datetime
 import inspect
 import sys
 import types
@@ -72,6 +73,7 @@ JSONType = {str, int, float, bool}
 PrimitiveType = Union[int, float, bool, str, list, dict, set, tuple]
 StateVar = Union[PrimitiveType, Base, None]
 StateIterVar = Union[list, set, tuple]
+StringVarType = {datetime.date, datetime.datetime}
 
 # ArgsSpec = Callable[[Var], list[Var]]
 ArgsSpec = Callable
@@ -394,6 +396,18 @@ def is_backend_variable(name: str, cls: Type | None = None) -> bool:
     if cls is not None and name.startswith(f"_{cls.__name__}__"):
         return False
     return name.startswith("_") and not name.startswith("__")
+
+
+def check_type_in_var_is_string_type(value_type: Type) -> bool:
+    """Check if this variable type is a string literal.
+
+    Args:
+        value_type: Type of value.
+
+    Returns:
+        bool: The result of the check
+    """
+    return value_type in StringVarType
 
 
 def check_type_in_allowed_types(value_type: Type, allowed_types: Iterable) -> bool:

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -39,6 +39,7 @@ from reflex.utils.exceptions import VarAttributeError, VarTypeError, VarValueErr
 
 # This module used to export ImportVar itself, so we still import it for export here
 from reflex.utils.imports import ImportDict, ImportVar
+from reflex.utils.types import check_type_in_var_is_string_type
 
 if TYPE_CHECKING:
     from reflex.state import BaseState
@@ -363,6 +364,11 @@ class Var:
         # If the value is already a var, do nothing.
         if isinstance(value, Var):
             return value
+
+        # If value type should be used as a string literal, set var is string true, f.e. datetime, date
+        _var_is_string = (
+            True if check_type_in_var_is_string_type(type(value)) else _var_is_string
+        )
 
         # Try to pull the imports and hooks from contained values.
         _var_data = None


### PR DESCRIPTION
### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

Fixed bug with date time and date types of `reflex.Var`. 

Added `check_type_in_var_is_string_type` function that checks if value type in global set `StringVarType` of types that should be used as a string literal and then sets `_var_is_string=true`.

If there will be a need to add more types that should be considered as strings, just add them in set `StringVarType`.

Seems that it solves the problem.

Closes #3235 
