### PR TITLE
WIP: pickle frontend payloads

### DIFF
--- a/reflex/app.py
+++ b/reflex/app.py
@@ -26,6 +26,7 @@ from typing import (
     get_type_hints,
 )
 
+import dill
 from fastapi import FastAPI, HTTPException, Request, UploadFile
 from fastapi.middleware import cors
 from fastapi.responses import StreamingResponse
@@ -1292,9 +1293,13 @@ class EventNamespace(AsyncNamespace):
             update: The state update to send.
             sid: The Socket.IO session id.
         """
+        payload = dill.dumps(
+            update.dict(),
+            byref=True,
+        )
         # Creating a task prevents the update from being blocked behind other coroutines.
         await asyncio.create_task(
-            self.emit(str(constants.SocketEvent.EVENT), update.json(), to=sid)
+            self.emit(str(constants.SocketEvent.EVENT), payload, to=sid)
         )
 
     async def on_event(self, sid, data):

--- a/reflex/constants/installer.py
+++ b/reflex/constants/installer.py
@@ -1,4 +1,5 @@
 """File for constants related to the installation process. (Bun/FNM/Node)."""
+
 from __future__ import annotations
 
 import os
@@ -119,6 +120,7 @@ class PackageJson(SimpleNamespace):
         "react-focus-lock": "2.11.3",
         "socket.io-client": "4.6.1",
         "universal-cookie": "4.0.4",
+        "pickleparser": "0.2.1",
     }
     DEV_DEPENDENCIES = {
         "autoprefixer": "10.4.14",


### PR DESCRIPTION
Benefit from pickles referential serialization to reduce reflex event payloads this is especially useful when dealing with complex sqlalchemy models which can contain circular and self-referencing relationships