### PR TITLE
Cache the result of loading pyproject.toml file

### DIFF
--- a/reflex/custom_components/custom_components.py
+++ b/reflex/custom_components/custom_components.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 from collections import namedtuple
 from contextlib import contextmanager
+from functools import lru_cache
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -70,6 +71,7 @@ def _create_package_config(module_name: str, package_name: str):
         )
 
 
+@lru_cache(maxsize=None)
 def _get_package_config(exit_on_fail: bool = True) -> dict:
     """Get the package configuration from the pyproject.toml file.
 


### PR DESCRIPTION
This change adds the functools cache decorator to avoid repeated calls to _get_package_config, which results in IO hits to read a file.

Closes #3341

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
