### PR TITLE
Add domain prop for the PolarRadiusAxis component

### DIFF
--- a/reflex/components/recharts/polar.py
+++ b/reflex/components/recharts/polar.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, List, Union
 
 from reflex.constants import EventTriggers
 from reflex.vars import Var
-import reflex as rx
 
 from .recharts import (
     LiteralAnimationEasing,
@@ -308,10 +307,10 @@ class PolarRadiusAxis(Recharts):
 
     # Valid children components
     _valid_children: List[str] = ["Label"]
-    
+
     # The domain of the polar radius axis, specifying the minimum and maximum values.
     domain: List[int]
-            
+
     def get_event_triggers(self) -> dict[str, Union[Var, Any]]:
         """Get the event triggers that pass the component's value to the handler.
 

--- a/reflex/components/recharts/polar.py
+++ b/reflex/components/recharts/polar.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Union
 
 from reflex.constants import EventTriggers
 from reflex.vars import Var
+import reflex as rx
 
 from .recharts import (
     LiteralAnimationEasing,
@@ -307,7 +308,10 @@ class PolarRadiusAxis(Recharts):
 
     # Valid children components
     _valid_children: List[str] = ["Label"]
-
+    
+    # The domain of the polar radius axis, specifying the minimum and maximum values.
+    domain: List[int]
+            
     def get_event_triggers(self) -> dict[str, Union[Var, Any]]:
         """Get the event triggers that pass the component's value to the handler.
 

--- a/reflex/components/recharts/polar.py
+++ b/reflex/components/recharts/polar.py
@@ -309,7 +309,7 @@ class PolarRadiusAxis(Recharts):
     _valid_children: List[str] = ["Label"]
 
     # The domain of the polar radius axis, specifying the minimum and maximum values.
-    domain: List[int]
+    domain: List[int] = [0, 250]
 
     def get_event_triggers(self) -> dict[str, Union[Var, Any]]:
         """Get the event triggers that pass the component's value to the handler.

--- a/reflex/components/recharts/polar.pyi
+++ b/reflex/components/recharts/polar.pyi
@@ -492,6 +492,7 @@ class PolarRadiusAxis(Recharts):
                 ],
             ]
         ] = None,
+        domain: Optional[List[int]] = None,
         style: Optional[Style] = None,
         key: Optional[Any] = None,
         id: Optional[Any] = None,
@@ -533,6 +534,7 @@ class PolarRadiusAxis(Recharts):
             tick: The width or height of tick.
             tick_count: The count of ticks.
             scale: If 'auto' set, the scale funtion is linear scale. 'auto' | 'linear' | 'pow' | 'sqrt' | 'log' | 'identity' | 'time' | 'band' | 'point' | 'ordinal' | 'quantile' | 'quantize' | 'utc' | 'sequential' | 'threshold'
+            domain: The domain of the polar radius axis, specifying the minimum and maximum values.
             style: The style of the component.
             key: A unique key for the component.
             id: The id for the component.


### PR DESCRIPTION

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue

### Description:
This pull request adds the domain prop to the PolarRadiusAxis component in the Reflex library. The domain prop allows users to specify the minimum and maximum values for the polar radius axis.

### Changes:
- Added the domain prop to the PolarRadiusAxis class definition.
- Specified the type of the domain prop as a list of integers (List[int]).

