### PR TITLE
Radix Themes + Tailwind Harmony

### DIFF
--- a/reflex/.templates/web/postcss.config.js
+++ b/reflex/.templates/web/postcss.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   plugins: {
+    "postcss-import": {},
     tailwindcss: {},
     autoprefixer: {},
   },

--- a/reflex/.templates/web/styles/tailwind.css
+++ b/reflex/.templates/web/styles/tailwind.css
@@ -1,3 +1,6 @@
-@tailwind base;
+@import "tailwindcss/base";
+
+@import "@radix-ui/themes/styles.css";
+
 @tailwind components;
 @tailwind utilities;

--- a/reflex/components/radix/themes/base.py
+++ b/reflex/components/radix/themes/base.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Literal
 
 from reflex.components import Component
 from reflex.components.tags import Tag
+from reflex.config import get_config
 from reflex.utils import imports
 from reflex.vars import Var
 
@@ -209,12 +210,20 @@ class Theme(RadixThemesComponent):
         return super().create(*children, **props)
 
     def _get_imports(self) -> imports.ImportDict:
-        return imports.merge_imports(
-            super()._get_imports(),
-            {
+        if get_config().tailwind is not None:
+            # If tailwind is used, the radix-ui styles are inlined within tailwind.css for compatibility.
+            style_import = {}
+        else:
+            # When tailwind is disabled, import the radix-ui styles directly.
+            style_import = {
                 "": [
                     imports.ImportVar(tag="@radix-ui/themes/styles.css", install=False)
                 ],
+            }
+        return imports.merge_imports(
+            super()._get_imports(),
+            style_import,
+            {
                 "/utils/theme.js": [
                     imports.ImportVar(tag="theme", is_default=True),
                 ],

--- a/reflex/components/radix/themes/base.py
+++ b/reflex/components/radix/themes/base.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Literal
 from reflex.components import Component
 from reflex.components.tags import Tag
 from reflex.config import get_config
-from reflex.utils import imports
+from reflex.utils.imports import ImportVar
 from reflex.vars import Var
 
 LiteralAlign = Literal["start", "center", "end", "baseline", "stretch"]
@@ -209,26 +209,23 @@ class Theme(RadixThemesComponent):
             children = [ThemePanel.create(), *children]
         return super().create(*children, **props)
 
-    def _get_imports(self) -> imports.ImportDict:
-        if get_config().tailwind is not None:
-            # If tailwind is used, the radix-ui styles are inlined within tailwind.css for compatibility.
-            style_import = {}
-        else:
-            # When tailwind is disabled, import the radix-ui styles directly.
-            style_import = {
-                "": [
-                    imports.ImportVar(tag="@radix-ui/themes/styles.css", install=False)
-                ],
-            }
-        return imports.merge_imports(
-            super()._get_imports(),
-            style_import,
-            {
-                "/utils/theme.js": [
-                    imports.ImportVar(tag="theme", is_default=True),
-                ],
-            },
-        )
+    def add_imports(self) -> dict[str, list[ImportVar] | ImportVar]:
+        """Add imports for the Theme component.
+
+        Returns:
+            The import dict.
+        """
+        _imports: dict[str, list[ImportVar] | ImportVar] = {
+            "/utils/theme.js": [ImportVar(tag="theme", is_default=True)],
+        }
+        if get_config().tailwind is None:
+            # When tailwind is disabled, import the radix-ui styles directly because they will
+            # not be included in the tailwind.css file.
+            _imports[""] = ImportVar(
+                tag="@radix-ui/themes/styles.css",
+                install=False,
+            )
+        return _imports
 
     def _render(self, props: dict[str, Any] | None = None) -> Tag:
         tag = super()._render(props)
@@ -252,13 +249,13 @@ class ThemePanel(RadixThemesComponent):
     # Whether the panel is open. Defaults to False.
     default_open: Var[bool]
 
-    def _get_imports(self) -> dict[str, list[imports.ImportVar]]:
-        return imports.merge_imports(
-            super()._get_imports(),
-            {
-                "react": [imports.ImportVar(tag="useEffect")],
-            },
-        )
+    def add_imports(self) -> dict[str, str]:
+        """Add imports for the ThemePanel component.
+
+        Returns:
+            The import dict.
+        """
+        return {"react": "useEffect"}
 
     def _get_hooks(self) -> str | None:
         # The panel freezes the tab if the user color preference differs from the

--- a/reflex/components/radix/themes/base.pyi
+++ b/reflex/components/radix/themes/base.pyi
@@ -10,6 +10,7 @@ from reflex.style import Style
 from typing import Any, Dict, Literal
 from reflex.components import Component
 from reflex.components.tags import Tag
+from reflex.config import get_config
 from reflex.utils import imports
 from reflex.vars import Var
 

--- a/reflex/components/radix/themes/base.pyi
+++ b/reflex/components/radix/themes/base.pyi
@@ -11,7 +11,7 @@ from typing import Any, Dict, Literal
 from reflex.components import Component
 from reflex.components.tags import Tag
 from reflex.config import get_config
-from reflex.utils import imports
+from reflex.utils.imports import ImportVar
 from reflex.vars import Var
 
 LiteralAlign = Literal["start", "center", "end", "baseline", "stretch"]
@@ -580,8 +580,10 @@ class Theme(RadixThemesComponent):
             A new component instance.
         """
         ...
+    def add_imports(self) -> dict[str, list[ImportVar] | ImportVar]: ...
 
 class ThemePanel(RadixThemesComponent):
+    def add_imports(self) -> dict[str, str]: ...
     @overload
     @classmethod
     def create(  # type: ignore

--- a/reflex/constants/installer.py
+++ b/reflex/constants/installer.py
@@ -123,4 +123,5 @@ class PackageJson(SimpleNamespace):
     DEV_DEPENDENCIES = {
         "autoprefixer": "10.4.14",
         "postcss": "8.4.31",
+        "postcss-import": "16.1.0",
     }


### PR DESCRIPTION
Improve compatibility with tailwind classes used on Radix Themes components. According to the guide
https://www.radix-ui.com/themes/docs/overview/styling#tailwind-base-styles

* Setup postcss-import and manually import Tailwind base styles via @import tailwindcss/base before Radix Themes styles.
* If tailwind is NOT used, then bring in the styles via JS CSS import, like before.