### PR TITLE
[REF-2878] Map fontFamily to fontFamily and --default-font-family

### DIFF
--- a/reflex/style.py
+++ b/reflex/style.py
@@ -47,6 +47,8 @@ STYLE_PROP_SHORTHAND_MAPPING = {
     "marginY": ("marginTop", "marginBottom"),
     "bg": ("background",),
     "bgColor": ("backgroundColor",),
+    # Radix components derive their font from this CSS var, not inherited from body or class.
+    "fontFamily": ("fontFamily", "--default-font-family"),
 }
 
 


### PR DESCRIPTION
When setting the font_family prop for a component, also set the radix token `--default-font-family` so that child radix components will inherit the font.