### PR TITLE
include resize and radius props to the text area component

### DIFF
--- a/reflex/components/radix/themes/components/text_area.py
+++ b/reflex/components/radix/themes/components/text_area.py
@@ -17,7 +17,6 @@ LiteralTextAreaSize = Literal["1", "2", "3"]
 
 LiteralTextAreaResize = Literal["none", "vertical", "horizontal", "both"]
 
-
 class TextArea(RadixThemesComponent, el.Textarea):
     """The input part of a TextArea, may be used by itself."""
 

--- a/reflex/components/radix/themes/components/text_area.py
+++ b/reflex/components/radix/themes/components/text_area.py
@@ -9,10 +9,13 @@ from reflex.vars import Var
 
 from ..base import (
     LiteralAccentColor,
+    LiteralRadius,
     RadixThemesComponent,
 )
 
 LiteralTextAreaSize = Literal["1", "2", "3"]
+
+LiteralTextAreaResize = Literal["none", "vertical", "horizontal", "both"]
 
 
 class TextArea(RadixThemesComponent, el.Textarea):
@@ -26,8 +29,14 @@ class TextArea(RadixThemesComponent, el.Textarea):
     # The variant of the text area
     variant: Var[Literal["classic", "surface", "soft"]]
 
+    # The resize behavior of the text area: "none" | "vertical" | "horizontal" | "both"
+    resize: Var[LiteralTextAreaResize]
+
     # The color of the text area
     color_scheme: Var[LiteralAccentColor]
+
+    # The radius of the text area: "none" | "small" | "medium" | "large" | "full"
+    radius: Var[LiteralRadius]
 
     # Whether the form control should have autocomplete enabled
     auto_complete: Var[bool]

--- a/reflex/components/radix/themes/components/text_area.py
+++ b/reflex/components/radix/themes/components/text_area.py
@@ -17,6 +17,7 @@ LiteralTextAreaSize = Literal["1", "2", "3"]
 
 LiteralTextAreaResize = Literal["none", "vertical", "horizontal", "both"]
 
+
 class TextArea(RadixThemesComponent, el.Textarea):
     """The input part of a TextArea, may be used by itself."""
 

--- a/reflex/components/radix/themes/components/text_area.pyi
+++ b/reflex/components/radix/themes/components/text_area.pyi
@@ -13,9 +13,10 @@ from reflex.components.component import Component
 from reflex.components.core.debounce import DebounceInput
 from reflex.constants import EventTriggers
 from reflex.vars import Var
-from ..base import LiteralAccentColor, RadixThemesComponent
+from ..base import LiteralAccentColor, LiteralRadius, RadixThemesComponent
 
 LiteralTextAreaSize = Literal["1", "2", "3"]
+LiteralTextAreaResize = Literal["none", "vertical", "horizontal", "both"]
 
 class TextArea(RadixThemesComponent, el.Textarea):
     @overload
@@ -231,7 +232,9 @@ class TextArea(RadixThemesComponent, el.Textarea):
             *children: The children of the component.
             size: The size of the text area: "1" | "2" | "3"
             variant: The variant of the text area
+            resize: The resize behavior of the text area: "none" | "vertical" | "horizontal" | "both"
             color_scheme: The color of the text area
+            radius: The radius of the text area: "none" | "small" | "medium" | "large" | "full"
             auto_complete: Whether the form control should have autocomplete enabled
             auto_focus: Automatically focuses the textarea when the page loads
             dirname: Name part of the textarea to submit in 'dir' and 'name' pair when form is submitted

--- a/reflex/components/radix/themes/components/text_area.pyi
+++ b/reflex/components/radix/themes/components/text_area.pyi
@@ -32,6 +32,12 @@ class TextArea(RadixThemesComponent, el.Textarea):
                 Literal["classic", "surface", "soft"],
             ]
         ] = None,
+        resize: Optional[
+            Union[
+                Var[Literal["none", "vertical", "horizontal", "both"]],
+                Literal["none", "vertical", "horizontal", "both"],
+            ]
+        ] = None,
         color_scheme: Optional[
             Union[
                 Var[
@@ -92,6 +98,12 @@ class TextArea(RadixThemesComponent, el.Textarea):
                     "bronze",
                     "gray",
                 ],
+            ]
+        ] = None,
+        radius: Optional[
+            Union[
+                Var[Literal["none", "small", "medium", "large", "full"]],
+                Literal["none", "small", "medium", "large", "full"],
             ]
         ] = None,
         auto_complete: Optional[Union[Var[bool], bool]] = None,


### PR DESCRIPTION
Included the following props for the [text area component](https://reflex.dev/docs/library/forms/textarea/#textarea) from the [radix component](https://www.radix-ui.com/themes/docs/components/text-area)

- resize
- radius