### PR TITLE
add mapping between client_token and socket id

### DIFF
--- a/reflex/app.py
+++ b/reflex/app.py
@@ -1302,6 +1302,12 @@ class EventNamespace(AsyncNamespace):
     # The application object.
     app: App
 
+    # Keep a mapping between socket ID and client token.
+    token_to_sid: dict[str, str] = {}
+
+    # Keep a mapping between client token and socket ID.
+    sid_to_token: dict[str, str] = {}
+
     def __init__(self, namespace: str, app: App):
         """Initialize the event namespace.
 
@@ -1327,7 +1333,9 @@ class EventNamespace(AsyncNamespace):
         Args:
             sid: The Socket.IO session id.
         """
-        pass
+        disconnect_token = self.sid_to_token.pop(sid, None)
+        if disconnect_token:
+            self.token_to_sid.pop(disconnect_token, None)
 
     async def emit_update(self, update: StateUpdate, sid: str) -> None:
         """Emit an update to the client.
@@ -1350,6 +1358,9 @@ class EventNamespace(AsyncNamespace):
         """
         # Get the event.
         event = Event.parse_raw(data)
+
+        self.token_to_sid[event.token] = sid
+        self.sid_to_token[sid] = event.token
 
         # Get the event environment.
         assert self.app.sio is not None


### PR DESCRIPTION
Keep an internal mapping between client token and sid.

Can be used by end user to terminate some logic/tasks if the websocket associated with a given state is disconnected.

Will also be helpful later for some internal use.

Can be used like this to terminate a background task for example : 
```python
class State(rx.State):
    @rx.background
    async def loop_function(self):
        while True:
            if self.router.session.client_token not in app.event_namespace.token_to_sid:
                break
            await asyncio.sleep(2)


@rx.page(on_load=State.loop_function)
def index():
    return rx.text("Hello")
```

Possible improvement : Provide a "cleaner" access to this mapping for end user? 

Close #3387 

