### PR TITLE
Layout property not pushed through on rx.plotly

### DIFF
--- a/reflex/components/plotly/plotly.py
+++ b/reflex/components/plotly/plotly.py
@@ -46,9 +46,12 @@ class Plotly(PlotlyLib):
 
     def _render(self):
         tag = super()._render()
+        figure = self.data.to(dict)
         if self.layout is None:
             tag.remove_props("data", "layout")
-            tag.special_props.add(Var.create_safe(f"{{...{self.data._var_name_unwrapped}}}"))
+            tag.special_props.add(
+                Var.create_safe(f"{{...{figure._var_name_unwrapped}}}")
+            )
         else:
-            tag.add_props(data=self.data.to(dict)["data"])
+            tag.add_props(data=figure["data"])
         return tag

--- a/reflex/components/plotly/plotly.py
+++ b/reflex/components/plotly/plotly.py
@@ -35,12 +35,6 @@ class Plotly(PlotlyLib):
     # The config of the graph.
     config: Var[Dict]
 
-    # The width of the graph.
-    width: Var[str]
-
-    # The height of the graph.
-    height: Var[str]
-
     # If true, the graph will resize when the window is resized.
     use_resize_handler: Var[bool]
 

--- a/reflex/components/plotly/plotly.py
+++ b/reflex/components/plotly/plotly.py
@@ -33,10 +33,10 @@ class Plotly(PlotlyLib):
     layout: Var[Dict]
 
     # The config of the graph.
-    config: Var[Dict]
+    # config: Var[Dict]
 
     # If true, the graph will resize when the window is resized.
-    use_resize_handler: Var[bool]
+    # use_resize_handler: Var[bool]
 
     def _render(self):
         tag = super()._render()

--- a/reflex/components/plotly/plotly.py
+++ b/reflex/components/plotly/plotly.py
@@ -48,7 +48,7 @@ class Plotly(PlotlyLib):
         tag = super()._render()
         if self.layout is None:
             tag.remove_props("data", "layout")
-            tag.special_props.add(Var.create_safe(f"{{...{self.data}}}"))
+            tag.special_props.add(Var.create_safe(f"{{...{self.data._var_name_unwrapped}}}"))
         else:
             tag.add_props(data=self.data.to(dict)["data"])
         return tag

--- a/reflex/components/plotly/plotly.py
+++ b/reflex/components/plotly/plotly.py
@@ -43,3 +43,12 @@ class Plotly(PlotlyLib):
 
     # If true, the graph will resize when the window is resized.
     use_resize_handler: Var[bool]
+
+    def _render(self):
+        tag = super()._render()
+        if self.layout is None:
+            tag.remove_props("data", "layout")
+            tag.special_props.add(Var.create_safe(f"{{...{self.data}}}"))
+        else:
+            tag.add_props(data=self.data.to(dict)["data"])
+        return tag

--- a/reflex/components/plotly/plotly.py
+++ b/reflex/components/plotly/plotly.py
@@ -33,10 +33,10 @@ class Plotly(PlotlyLib):
     layout: Var[Dict]
 
     # The config of the graph.
-    # config: Var[Dict]
+    config: Var[Dict]
 
     # If true, the graph will resize when the window is resized.
-    # use_resize_handler: Var[bool]
+    use_resize_handler: Var[bool]
 
     def _render(self):
         tag = super()._render()

--- a/reflex/components/plotly/plotly.pyi
+++ b/reflex/components/plotly/plotly.pyi
@@ -101,8 +101,6 @@ class Plotly(PlotlyLib):
         data: Optional[Union[Var[Figure], Figure]] = None,  # type: ignore
         layout: Optional[Union[Var[Dict], Dict]] = None,
         config: Optional[Union[Var[Dict], Dict]] = None,
-        width: Optional[Union[Var[str], str]] = None,
-        height: Optional[Union[Var[str], str]] = None,
         use_resize_handler: Optional[Union[Var[bool], bool]] = None,
         style: Optional[Style] = None,
         key: Optional[Any] = None,
@@ -164,8 +162,6 @@ class Plotly(PlotlyLib):
             data: The figure to display. This can be a plotly figure or a plotly data json.
             layout: The layout of the graph.
             config: The config of the graph.
-            width: The width of the graph.
-            height: The height of the graph.
             use_resize_handler: If true, the graph will resize when the window is resized.
             style: The style of the component.
             key: A unique key for the component.

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -390,7 +390,6 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
         from reflex.utils.exceptions import ReflexRuntimeError
 
         if not _reflex_internal_init and not is_testing_env():
-            breakpoint()
             raise ReflexRuntimeError(
                 "State classes should not be instantiated directly in a Reflex app. "
                 "See https://reflex.dev/docs/state/ for further information."

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -390,6 +390,7 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
         from reflex.utils.exceptions import ReflexRuntimeError
 
         if not _reflex_internal_init and not is_testing_env():
+            breakpoint()
             raise ReflexRuntimeError(
                 "State classes should not be instantiated directly in a Reflex app. "
                 "See https://reflex.dev/docs/state/ for further information."

--- a/reflex/utils/serializers.py
+++ b/reflex/utils/serializers.py
@@ -255,7 +255,7 @@ def serialize_enum(en: Enum) -> str:
         en: The enum to serialize.
 
     Returns:
-         The serialized enum.
+        The serialized enum.
     """
     return en.value
 
@@ -313,7 +313,7 @@ try:
     from plotly.io import to_json
 
     @serializer
-    def serialize_figure(figure: Figure) -> list:
+    def serialize_figure(figure: Figure) -> dict:
         """Serialize a plotly figure.
 
         Args:
@@ -322,7 +322,7 @@ try:
         Returns:
             The serialized figure.
         """
-        return json.loads(str(to_json(figure)))["data"]
+        return json.loads(str(to_json(figure)))
 
 except ImportError:
     pass

--- a/tests/components/graphing/test_plotly.py
+++ b/tests/components/graphing/test_plotly.py
@@ -30,7 +30,7 @@ def test_serialize_plotly(plotly_fig: go.Figure):
         plotly_fig: The figure to serialize.
     """
     value = serialize(plotly_fig)
-    assert isinstance(value, list)
+    assert isinstance(value, dict)
     assert value == serialize_figure(plotly_fig)
 
 

--- a/tests/utils/test_format.py
+++ b/tests/utils/test_format.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import datetime
 from typing import Any, List
 
+import plotly.graph_objects as go
 import pytest
 
 from reflex.components.tags.tag import Tag
 from reflex.event import EventChain, EventHandler, EventSpec, FrontendEvent
 from reflex.style import Style
 from reflex.utils import format
+from reflex.utils.serializers import serialize_figure
 from reflex.vars import BaseVar, Var
 from tests.test_state import (
     ChildState,
@@ -661,7 +663,7 @@ formatted_router = {
                         2: {"prop1": 42, "prop2": "hello"},
                     },
                     "dt": "1989-11-09 18:53:00+01:00",
-                    "fig": [],
+                    "fig": serialize_figure(go.Figure()),
                     "key": "",
                     "map_key": "a",
                     "mapping": {"a": [1, 2, 3], "b": [4, 5, 6]},


### PR DESCRIPTION
Bug fix
Now both data and layout prop are supported in Plotly figures.