### PR TITLE
[REF-2710]Recommend Running with `REFLEX_USE_NPM=1` if npm run fails after installing packages with bun.

### DIFF
--- a/reflex/constants/installer.py
+++ b/reflex/constants/installer.py
@@ -35,7 +35,7 @@ class Bun(SimpleNamespace):
     """Bun constants."""
 
     # The Bun version.
-    VERSION = "1.1.8"
+    VERSION = "1.1.10"
     # Min Bun Version
     MIN_VERSION = "0.7.0"
     # The directory to store the bun.

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -113,6 +113,14 @@ def run_process_and_launch_url(run_command: list[str], backend_present=True):
                     else:
                         console.print("New packages detected: Updating app...")
                 else:
+                    if any(
+                        [x in line for x in ("bin executable does not exist on disk",)]
+                    ):
+                        console.error(
+                            "Try setting `REFLEX_USE_NPM=1` and re-running `reflex init` and `reflex run` to use npm instead of bun:\n"
+                            "`REFLEX_USE_NPM=1 reflex init`\n"
+                            "`REFLEX_USE_NPM=1 reflex run`"
+                        )
                     new_hash = detect_package_change(json_file_path)
                     if new_hash != last_hash:
                         last_hash = new_hash


### PR DESCRIPTION
For errors that happen when running `npm run` if bun was used as a package manager(example below).

```shell
Debug: Running command: ['C:\\Users\\serrap\\AppData\\Local\\reflex\\fnm\\node-versions\\v18.17.0\\installation\\npm', 'run', 'dev']
Debug: Starting frontend
Debug: 
Debug: > dev
Debug: > next dev
Debug:
Debug: error: bin executable does not exist on disk
Debug:
Debug: Bun failed to remap this bin to its proper location within node_modules.
Debug: This is an indication of a corrupted node_modules directory.
Debug:
Debug: Please run 'bun install --force' in the project root and try
Debug: it again. If this message persists, please open an issue:
Debug: https://github.com/oven-sh/bun/issues
Debug:
Starting frontend failed with exit code 255
> dev
> next dev
error: bin executable does not exist on disk
Bun failed to remap this bin to its proper location within node_modules.
This is an indication of a corrupted node_modules directory.
Please run 'bun install --force' in the project root and try
it again. If this message persists, please open an issue:
https://github.com/oven-sh/bun/issues
Run with --loglevel debug  for the full log.
```
We should detect these and recommend users run reflex with `REFLEX_USE_NPM` to use npm only
