### PR TITLE
[REF-2978] Ignore Redis config_set for AWS ElastiCache

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -2654,7 +2654,10 @@ class StateManagerRedis(StateManager):
             )
         except ResponseError:
             # Some redis servers only allow out-of-band configuration, so ignore errors here.
-            ignore_config_error = os.environ.get("REFLEX_AWS_ELASTICACHE_REDIS", None)
+            ignore_config_error = os.environ.get(
+                "REFLEX_IGNORE_REDIS_CONFIG_ERROR",
+                None,
+            )
             if not ignore_config_error:
                 raise
         async with self.redis.pubsub() as pubsub:


### PR DESCRIPTION
AWS ElastiCache redis has out of band configuration and cannot call CONFIG commands, so allow the user to ignore errors as an escape hatch.

Fix #3371