### PR TITLE
refactor: radix section default size

### DIFF
--- a/reflex/components/radix/themes/layout/section.py
+++ b/reflex/components/radix/themes/layout/section.py
@@ -16,5 +16,5 @@ class Section(el.Section, RadixThemesComponent):
 
     tag = "Section"
 
-    # The size of the section: "1" - "3" (default "3")
-    size: Var[LiteralSectionSize]
+    # The size of the section: "1" - "3" (default "2")
+    size: Var[LiteralSectionSize] = Var.create_safe("2")

--- a/reflex/components/radix/themes/layout/section.pyi
+++ b/reflex/components/radix/themes/layout/section.pyi
@@ -123,7 +123,7 @@ class Section(el.Section, RadixThemesComponent):
 
         Args:
             *children: Child components.
-            size: The size of the section: "1" - "3" (default "3")
+            size: The size of the section: "1" - "3" (default "2")
             access_key:  Provides a hint for generating a keyboard shortcut for the current element.
             auto_capitalize: Controls whether and how text input is automatically capitalized as it is entered/edited by the user.
             content_editable: Indicates whether the element's content is editable.


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

#3274 

Changed the default size of rx.section to "2" from "3" as mentioned.

