### PR TITLE
[REF-3006] Inline code rendered in rx.markdown has extra trailing space

### DIFF
--- a/reflex/components/markdown/markdown.py
+++ b/reflex/components/markdown/markdown.py
@@ -229,7 +229,7 @@ class Markdown(Component):
         Returns:
             The formatted component.
         """
-        return str(self.get_component(tag, **props)).replace("\n", " ")
+        return str(self.get_component(tag, **props)).replace("\n", "")
 
     def format_component_map(self) -> dict[str, str]:
         """Format the component map for rendering.


### PR DESCRIPTION
Avoid replacing newlines with whitespaces... these show up in the rendered output 😱

Fix #3425