### PR TITLE
[REF-2602]Do not suppress import errors in rxconfig

### DIFF
--- a/reflex/config.py
+++ b/reflex/config.py
@@ -354,12 +354,12 @@ def get_config(reload: bool = False) -> Config:
     sys.path.insert(0, os.getcwd())
     # only import the module if it exists. If a module spec exists then
     # the module exists.
-    spec = importlib.util.find_spec(constants.Config.MODULE)
+    spec = importlib.util.find_spec(constants.Config.MODULE)  # type: ignore
     if not spec:
-        # we need this condition to ensure that an import error is not thrown when
+        # we need this condition to ensure that a ModuleNotFound error is not thrown when
         # running unit/integration tests.
         return Config(app_name="")
-    rxconfig = __import__(constants.Config.MODULE)
+    rxconfig = importlib.import_module(constants.Config.MODULE)
     if reload:
         importlib.reload(rxconfig)
     return rxconfig.config

--- a/reflex/config.py
+++ b/reflex/config.py
@@ -352,11 +352,14 @@ def get_config(reload: bool = False) -> Config:
         The app config.
     """
     sys.path.insert(0, os.getcwd())
-    try:
-        rxconfig = __import__(constants.Config.MODULE)
-        if reload:
-            importlib.reload(rxconfig)
-        return rxconfig.config
-
-    except ImportError:
-        return Config(app_name="")  # type: ignore
+    # only import the module if it exists. If a module spec exists then
+    # the module exists.
+    spec = importlib.util.find_spec(constants.Config.MODULE)
+    if not spec:
+        # we need this condition to ensure that an import error is not thrown when
+        # running unit/integration tests.
+        return Config(app_name="")
+    rxconfig = __import__(constants.Config.MODULE)
+    if reload:
+        importlib.reload(rxconfig)
+    return rxconfig.config


### PR DESCRIPTION
Errors in rxconfig should be allowed to bubble up. This PR fixes an issue where an import error in rxconfig throws an error which is hard to debug. The logic is to only import the module if a spec exists. For cases (unit tests, integration tests, running reflex init for the first time, etc) where an rxconfig does not exists yet, we return an empty Config 