### PR TITLE
fix: allow specifying websocket port

### DIFF
--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -101,7 +101,6 @@ export const getBackendURL = (url_str) => {
       } else if (endpoint.protocol === "http:") {
         endpoint.protocol = "https:";
       }
-      endpoint.port = ""; // Assume websocket is on https port via load balancer.
     }
   }
   return endpoint;


### PR DESCRIPTION
A [Replit](https://replit.com) user reached out with pain getting a Reflex app set up on Replit. After some digging, this change seems to make the pain vanish

As a short explanation of why:
- all Replit projects are Docker containers
- we have reverse proxies set up to route traffic to repls given some URL, eg `https://f3ea4bab-7ba5-4eb2-9ad4-9ec4f3702158-00-1squ4svnaus5u.infra-staging.replit.dev/`
- we may also do port mapping to make the experience as pleasant as possible, eg 3000->80 for http ports
- because this is happening over the internet, we do also support auto tls promotion, which means that content being served from a project running in dev mode (eg `reflex dev`) will probably be accessed via `https://`
- all of this results in the next server being served over :443, but the web socket still being provided via `wss` on :8080 (note that we had to tell reflex's backend to bind to port :8080 due to a bug in our reverse proxying)

this change allows the next server's client to connect to the `wss` websocket on :8080 as expected