### PR TITLE
state.js: set event_processing = false when websocket connects

### DIFF
--- a/integration/test_connection_banner.py
+++ b/integration/test_connection_banner.py
@@ -11,13 +11,27 @@ from reflex.testing import AppHarness, WebDriver
 
 def ConnectionBanner():
     """App with a connection banner."""
+    import asyncio
+
     import reflex as rx
 
     class State(rx.State):
         foo: int = 0
 
+        async def delay(self):
+            await asyncio.sleep(2)
+
     def index():
-        return rx.text("Hello World")
+        return rx.vstack(
+            rx.text("Hello World"),
+            rx.input(value=State.foo, read_only=True, id="counter"),
+            rx.button(
+                "Increment",
+                id="increment",
+                on_click=State.set_foo(State.foo + 1),  # type: ignore
+            ),
+            rx.button("Delay", id="delay", on_click=State.delay),
+        )
 
     app = rx.App(state=rx.State)
     app.add_page(index)
@@ -40,7 +54,7 @@ def connection_banner(tmp_path) -> Generator[AppHarness, None, None]:
         yield harness
 
 
-CONNECTION_ERROR_XPATH = "//*[ text() = 'Connection Error' ]"
+CONNECTION_ERROR_XPATH = "//*[ contains(text(), 'Cannot connect to server') ]"
 
 
 def has_error_modal(driver: WebDriver) -> bool:
@@ -69,7 +83,18 @@ def test_connection_banner(connection_banner: AppHarness):
     assert connection_banner.backend is not None
     driver = connection_banner.frontend()
 
-    connection_banner._poll_for(lambda: not has_error_modal(driver))
+    assert connection_banner._poll_for(lambda: not has_error_modal(driver))
+
+    delay_button = driver.find_element(By.ID, "delay")
+    increment_button = driver.find_element(By.ID, "increment")
+    counter_element = driver.find_element(By.ID, "counter")
+
+    # Increment the counter
+    increment_button.click()
+    assert connection_banner.poll_for_value(counter_element, exp_not_equal="0") == "1"
+
+    # Start an long event before killing the backend, to mark event_processing=true
+    delay_button.click()
 
     # Get the backend port
     backend_port = connection_banner._poll_for_servers().getsockname()[1]
@@ -80,10 +105,17 @@ def test_connection_banner(connection_banner: AppHarness):
         connection_banner.backend_thread.join()
 
     # Error modal should now be displayed
-    connection_banner._poll_for(lambda: has_error_modal(driver))
+    assert connection_banner._poll_for(lambda: has_error_modal(driver))
+
+    # Increment the counter with backend down
+    increment_button.click()
+    assert connection_banner.poll_for_value(counter_element, exp_not_equal="0") == "1"
 
     # Bring the backend back up
     connection_banner._start_backend(port=backend_port)
 
     # Banner should be gone now
-    connection_banner._poll_for(lambda: not has_error_modal(driver))
+    assert connection_banner._poll_for(lambda: not has_error_modal(driver))
+
+    # Count should have incremented after coming back up
+    assert connection_banner.poll_for_value(counter_element, exp_not_equal="1") == "2"

--- a/integration/test_connection_banner.py
+++ b/integration/test_connection_banner.py
@@ -21,7 +21,7 @@ def ConnectionBanner():
         foo: int = 0
 
         async def delay(self):
-            await asyncio.sleep(2)
+            await asyncio.sleep(5)
 
     def index():
         return rx.vstack(

--- a/integration/test_connection_banner.py
+++ b/integration/test_connection_banner.py
@@ -75,7 +75,8 @@ def has_error_modal(driver: WebDriver) -> bool:
         return False
 
 
-def test_connection_banner(connection_banner: AppHarness):
+@pytest.mark.asyncio
+async def test_connection_banner(connection_banner: AppHarness):
     """Test that the connection banner is displayed when the websocket drops.
 
     Args:
@@ -120,6 +121,9 @@ def test_connection_banner(connection_banner: AppHarness):
 
     # Bring the backend back up
     connection_banner._start_backend(port=backend_port)
+
+    # Create a new StateManager to avoid async loop affinity issues w/ redis
+    await connection_banner._reset_backend_state_manager()
 
     # Banner should be gone now
     assert connection_banner._poll_for(lambda: not has_error_modal(driver))

--- a/integration/test_connection_banner.py
+++ b/integration/test_connection_banner.py
@@ -8,6 +8,8 @@ from selenium.webdriver.common.by import By
 
 from reflex.testing import AppHarness, WebDriver
 
+from .utils import SessionStorage
+
 
 def ConnectionBanner():
     """App with a connection banner."""
@@ -82,6 +84,11 @@ def test_connection_banner(connection_banner: AppHarness):
     assert connection_banner.app_instance is not None
     assert connection_banner.backend is not None
     driver = connection_banner.frontend()
+
+    ss = SessionStorage(driver)
+    assert connection_banner._poll_for(
+        lambda: ss.get("token") is not None
+    ), "token not found"
 
     assert connection_banner._poll_for(lambda: not has_error_modal(driver))
 

--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -353,6 +353,7 @@ export const connect = async (
   // Once the socket is open, hydrate the page.
   socket.current.on("connect", () => {
     setConnectErrors([]);
+    event_processing = false;
   });
 
   socket.current.on("connect_error", (error) => {

--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -353,12 +353,17 @@ export const connect = async (
   // Once the socket is open, hydrate the page.
   socket.current.on("connect", () => {
     setConnectErrors([]);
-    event_processing = false;
   });
 
   socket.current.on("connect_error", (error) => {
     setConnectErrors((connectErrors) => [connectErrors.slice(-9), error]);
   });
+
+  // When the socket disconnects reset the event_processing flag
+  socket.current.on("disconnect", () => {
+    event_processing = false;
+  });
+
   // On each received message, queue the updates and events.
   socket.current.on("event", (message) => {
     const update = JSON5.parse(message);


### PR DESCRIPTION
In case an event was pending when the websocket went down, allow further events to be processed when it comes back up.

Fix #3404 

Various improvements to `integration/test_connection_banner.py` to catch this issue and fix overall reliability of the test.