### PR TITLE
[bug] Avoid deleting endpoint port when running on Replit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,13 +80,13 @@ poetry run pyright reflex tests
 find reflex tests -name "*.py" -not -path reflex/reflex.py | xargs poetry run darglint
 ```
 
-Finally, run `black` to format your code.
+Finally, run `ruff` to format your code.
 
 ``` bash
-poetry run black reflex tests
+poetry run ruff format .
 ```
 
-Consider installing git pre-commit hooks so Ruff, Pyright, Darglint and Black will run automatically before each commit.
+Consider installing git pre-commit hooks so Ruff, Pyright, Darglint and `make_pyi` will run automatically before each commit.
 Note that pre-commit will only be installed when you use a Python version >= 3.8.
 
 ``` bash

--- a/reflex/config.py
+++ b/reflex/config.py
@@ -316,13 +316,13 @@ class Config(Base):
         ):
             self.deploy_url = f"http://localhost:{kwargs['frontend_port']}"
 
-        # If running in Github Codespaces, override API_URL
-        codespace_name = os.getenv("CODESPACE_NAME")
-        if "api_url" not in self._non_default_attributes and codespace_name:
+        if "api_url" not in self._non_default_attributes:
+            # If running in Github Codespaces, override API_URL
+            codespace_name = os.getenv("CODESPACE_NAME")
             GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN = os.getenv(
                 "GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN"
             )
-            if codespace_name:
+            if codespace_name and GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN:
                 self.api_url = (
                     f"https://{codespace_name}-{kwargs.get('backend_port', self.backend_port)}"
                     f".{GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}"

--- a/reflex/config.py
+++ b/reflex/config.py
@@ -322,11 +322,16 @@ class Config(Base):
             GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN = os.getenv(
                 "GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN"
             )
+            # If running on Replit.com interactively, override API_URL to ensure we maintain the backend_port
+            replit_dev_domain = os.getenv("REPLIT_DEV_DOMAIN")
+            backend_port = kwargs.get("backend_port", self.backend_port)
             if codespace_name and GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN:
                 self.api_url = (
                     f"https://{codespace_name}-{kwargs.get('backend_port', self.backend_port)}"
                     f".{GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}"
                 )
+            elif replit_dev_domain and backend_port:
+                self.api_url = f"https://{replit_dev_domain}:{backend_port}"
 
     def _set_persistent(self, **kwargs):
         """Set values in this config and in the environment so they persist into subprocess.


### PR DESCRIPTION
- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Does your submission pass the tests? 
- [x] Have you successfully ran tests with your changes locally?

This adds an additional gate to @cdmistman's original PR, to ensure that we do not thwart reverse-proxy setups.

Note, the original suggestion was to modify the backend, similar to how codespaces works, but I didn't realize I was attempting to test with @cdmistman's change directly applied to `.web/`. When I attempted to verify the fix in a fresh environment, the original issue popped up again, cementing in my mind that this is the correct fix.

Second attempt at #3441 