### PR TITLE
[REF-3016]Allow special characters in upload ID

### DIFF
--- a/reflex/components/core/upload.py
+++ b/reflex/components/core/upload.py
@@ -96,9 +96,7 @@ def clear_selected_files(id_: str = DEFAULT_UPLOAD_ID) -> EventSpec:
     # UploadFilesProvider assigns a special function to clear selected files
     # into the shared global refs object to make it accessible outside a React
     # component via `call_script` (otherwise backend could never clear files).
-    return call_script(
-        f"refs['__clear_selected_files']({Var.create_safe(id_, _var_is_string=True)._var_name_unwrapped!r})"
-    )
+    return call_script(f"refs['__clear_selected_files']({id_!r})")
 
 
 def cancel_upload(upload_id: str) -> EventSpec:

--- a/reflex/components/core/upload.py
+++ b/reflex/components/core/upload.py
@@ -50,9 +50,10 @@ def upload_file(id_: str = DEFAULT_UPLOAD_ID) -> BaseVar:
     Returns:
         A var referencing the file upload drop trigger.
     """
+    id_var = Var.create_safe(id_, _var_is_string=True)
     var_name = f"""e => setFilesById(filesById => {{
     const updatedFilesById = Object.assign({{}}, filesById);
-    updatedFilesById[`{id_}`] = e;
+    updatedFilesById[{id_var._var_name_unwrapped}] = e;
     return updatedFilesById;
   }})
     """
@@ -60,7 +61,7 @@ def upload_file(id_: str = DEFAULT_UPLOAD_ID) -> BaseVar:
     return BaseVar(
         _var_name=var_name,
         _var_type=EventChain,
-        _var_data=upload_files_context_var_data,
+        _var_data=VarData.merge(upload_files_context_var_data, id_var._var_data),
     )
 
 
@@ -74,10 +75,11 @@ def selected_files(id_: str = DEFAULT_UPLOAD_ID) -> BaseVar:
     Returns:
         A var referencing the list of selected file paths.
     """
+    id_var = Var.create_safe(id_, _var_is_string=True)
     return BaseVar(
-        _var_name=f"(filesById[`{id_}`] ? filesById[`{id_}`].map((f) => (f.path || f.name)) : [])",
+        _var_name=f"(filesById[{id_var._var_name_unwrapped}] ? filesById[{id_var._var_name_unwrapped}].map((f) => (f.path || f.name)) : [])",
         _var_type=List[str],
-        _var_data=upload_files_context_var_data,
+        _var_data=VarData.merge(upload_files_context_var_data, id_var._var_data),
     )
 
 
@@ -94,7 +96,9 @@ def clear_selected_files(id_: str = DEFAULT_UPLOAD_ID) -> EventSpec:
     # UploadFilesProvider assigns a special function to clear selected files
     # into the shared global refs object to make it accessible outside a React
     # component via `call_script` (otherwise backend could never clear files).
-    return call_script(f"refs['__clear_selected_files']({id_!r})")
+    return call_script(
+        f"refs['__clear_selected_files']({Var.create_safe(id_, _var_is_string=True)._var_name_unwrapped!r})"
+    )
 
 
 def cancel_upload(upload_id: str) -> EventSpec:
@@ -106,7 +110,9 @@ def cancel_upload(upload_id: str) -> EventSpec:
     Returns:
         An event spec that cancels the upload when triggered.
     """
-    return call_script(f"upload_controllers[{upload_id!r}]?.abort()")
+    return call_script(
+        f"upload_controllers[{Var.create_safe(upload_id, _var_is_string=True)._var_name_unwrapped!r}]?.abort()"
+    )
 
 
 def get_upload_dir() -> Path:

--- a/reflex/components/core/upload.py
+++ b/reflex/components/core/upload.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 from typing import Any, Callable, ClassVar, Dict, List, Optional, Union
 
@@ -37,8 +38,25 @@ upload_files_context_var_data: VarData = VarData(
 )
 
 
+def validate_upload_id(id_: str, fn_name):
+    """Check that only alphanumeric characters and underscores are present in an upload id.
+
+    Args:
+        id_: The upload id.
+        fn_name: Name of caller to show when validation fails.
+
+    Raises:
+        ValueError: If the string is not valid.
+    """
+    pattern = re.compile(r"^[a-zA-Z0-9_]+$")
+    if not pattern.match(id_):
+        raise ValueError(
+            f"Invalid upload ID: '{id_}'. The upload id for `rx.{fn_name}` should contain only alphanumeric characters and underscores."
+        )
+
+
 @CallableVar
-def upload_file(id_: str = DEFAULT_UPLOAD_ID) -> BaseVar:
+def upload_file(id_: str = DEFAULT_UPLOAD_ID, fn_name: str = "upload_file") -> BaseVar:
     """Get the file upload drop trigger.
 
     This var is passed to the dropzone component to update the file list when a
@@ -46,10 +64,12 @@ def upload_file(id_: str = DEFAULT_UPLOAD_ID) -> BaseVar:
 
     Args:
         id_: The id of the upload to get the drop trigger for.
+        fn_name: Name of the caller to use in validation error message when the id string is invalid.
 
     Returns:
         A var referencing the file upload drop trigger.
     """
+    validate_upload_id(id_, fn_name)
     return BaseVar(
         _var_name=f"e => setFilesById(filesById => ({{...filesById, {id_}: e}}))",
         _var_type=EventChain,
@@ -67,8 +87,9 @@ def selected_files(id_: str = DEFAULT_UPLOAD_ID) -> BaseVar:
     Returns:
         A var referencing the list of selected file paths.
     """
+    validate_upload_id(id_, "selected_files")
     return BaseVar(
-        _var_name=f"(filesById.{id_} ? filesById.{id_}.map((f) => (f.path || f.name)) : [])",
+        _var_name=f"(filesById[`{id_}`] ? filesById[`{id_}`].map((f) => (f.path || f.name)) : [])",
         _var_type=List[str],
         _var_data=upload_files_context_var_data,
     )
@@ -84,6 +105,7 @@ def clear_selected_files(id_: str = DEFAULT_UPLOAD_ID) -> EventSpec:
     Returns:
         An event spec that clears the list of selected files when triggered.
     """
+    validate_upload_id(id_, "clear_selected_files")
     # UploadFilesProvider assigns a special function to clear selected files
     # into the shared global refs object to make it accessible outside a React
     # component via `call_script` (otherwise backend could never clear files).
@@ -99,6 +121,7 @@ def cancel_upload(upload_id: str) -> EventSpec:
     Returns:
         An event spec that cancels the upload when triggered.
     """
+    validate_upload_id(upload_id, "cancel_upload")
     return call_script(f"upload_controllers[{upload_id!r}]?.abort()")
 
 
@@ -249,7 +272,9 @@ class Upload(MemoizationLeaf):
 
         if upload_props.get("on_drop") is None:
             # If on_drop is not provided, save files to be uploaded later.
-            upload_props["on_drop"] = upload_file(upload_props["id"])
+            upload_props["on_drop"] = upload_file(
+                upload_props["id"], fn_name="upload_files"
+            )
         else:
             on_drop = upload_props["on_drop"]
             if isinstance(on_drop, Callable):

--- a/reflex/components/core/upload.pyi
+++ b/reflex/components/core/upload.pyi
@@ -8,7 +8,6 @@ from reflex.vars import Var, BaseVar, ComputedVar
 from reflex.event import EventChain, EventHandler, EventSpec
 from reflex.style import Style
 import os
-import re
 from pathlib import Path
 from typing import Any, Callable, ClassVar, Dict, List, Optional, Union
 from reflex import constants
@@ -30,11 +29,8 @@ from reflex.vars import BaseVar, CallableVar, Var, VarData
 DEFAULT_UPLOAD_ID: str
 upload_files_context_var_data: VarData
 
-def validate_upload_id(id_: str, fn_name): ...
 @CallableVar
-def upload_file(
-    id_: str = DEFAULT_UPLOAD_ID, fn_name: str = "upload_file"
-) -> BaseVar: ...
+def upload_file(id_: str = DEFAULT_UPLOAD_ID) -> BaseVar: ...
 @CallableVar
 def selected_files(id_: str = DEFAULT_UPLOAD_ID) -> BaseVar: ...
 @CallableEventSpec

--- a/reflex/components/core/upload.pyi
+++ b/reflex/components/core/upload.pyi
@@ -8,6 +8,7 @@ from reflex.vars import Var, BaseVar, ComputedVar
 from reflex.event import EventChain, EventHandler, EventSpec
 from reflex.style import Style
 import os
+import re
 from pathlib import Path
 from typing import Any, Callable, ClassVar, Dict, List, Optional, Union
 from reflex import constants
@@ -29,8 +30,11 @@ from reflex.vars import BaseVar, CallableVar, Var, VarData
 DEFAULT_UPLOAD_ID: str
 upload_files_context_var_data: VarData
 
+def validate_upload_id(id_: str, fn_name): ...
 @CallableVar
-def upload_file(id_: str = DEFAULT_UPLOAD_ID) -> BaseVar: ...
+def upload_file(
+    id_: str = DEFAULT_UPLOAD_ID, fn_name: str = "upload_file"
+) -> BaseVar: ...
 @CallableVar
 def selected_files(id_: str = DEFAULT_UPLOAD_ID) -> BaseVar: ...
 @CallableEventSpec

--- a/reflex/event.py
+++ b/reflex/event.py
@@ -390,7 +390,8 @@ class FileUpload(Base):
             (
                 Var.create_safe("files", _var_is_string=False),
                 Var.create_safe(
-                    f"filesById.{upload_id}", _var_is_string=False
+                    f"filesById[{Var.create_safe(upload_id, _var_is_string=True)._var_name_unwrapped}]",
+                    _var_is_string=False,
                 )._replace(_var_data=upload_files_context_var_data),
             ),
             (

--- a/reflex/event.py
+++ b/reflex/event.py
@@ -386,7 +386,6 @@ class FileUpload(Base):
         )
 
         upload_id = self.upload_id or DEFAULT_UPLOAD_ID
-
         spec_args = [
             (
                 Var.create_safe("files", _var_is_string=False),

--- a/tests/components/forms/test_uploads.py
+++ b/tests/components/forms/test_uploads.py
@@ -72,7 +72,12 @@ def test_upload_root_component_render(upload_root_component):
     assert upload["props"] == [
         "id={`default`}",
         "multiple={true}",
-        "onDrop={e => setFilesById(filesById => ({...filesById, default: e}))}",
+        "onDrop={e => setFilesById(filesById => {\n"
+        "    const updatedFilesById = Object.assign({}, filesById);\n"
+        "    updatedFilesById[`default`] = e;\n"
+        "    return updatedFilesById;\n"
+        "  })\n"
+        "    }",
         "ref={ref_default}",
     ]
     assert upload["args"] == ("getRootProps", "getInputProps")
@@ -114,7 +119,12 @@ def test_upload_component_render(upload_component):
     assert upload["props"] == [
         "id={`default`}",
         "multiple={true}",
-        "onDrop={e => setFilesById(filesById => ({...filesById, default: e}))}",
+        "onDrop={e => setFilesById(filesById => {\n"
+        "    const updatedFilesById = Object.assign({}, filesById);\n"
+        "    updatedFilesById[`default`] = e;\n"
+        "    return updatedFilesById;\n"
+        "  })\n"
+        "    }",
         "ref={ref_default}",
     ]
     assert upload["args"] == ("getRootProps", "getInputProps")
@@ -156,6 +166,11 @@ def test_upload_component_with_props_render(upload_component_with_props):
         "maxFiles={2}",
         "multiple={true}",
         "noDrag={true}",
-        "onDrop={e => setFilesById(filesById => ({...filesById, default: e}))}",
+        "onDrop={e => setFilesById(filesById => {\n"
+        "    const updatedFilesById = Object.assign({}, filesById);\n"
+        "    updatedFilesById[`default`] = e;\n"
+        "    return updatedFilesById;\n"
+        "  })\n"
+        "    }",
         "ref={ref_default}",
     ]

--- a/tests/components/forms/test_uploads.py
+++ b/tests/components/forms/test_uploads.py
@@ -46,7 +46,7 @@ def upload_component_id_special():
             rx.button("select file"),
             rx.text("Drag and drop files here or click to select files"),
             border="1px dotted black",
-            id="#spec!al-&%@)(*^&+_98ID",
+            id="#spec!`al-_98ID",
         )
 
     return upload_component()
@@ -193,11 +193,11 @@ def test_upload_component_id_with_special_chars(upload_component_id_special):
     upload = upload_component_id_special.render()
 
     assert upload["props"] == [
-        "id={`#spec!al-&%@)(*^&+_98ID`}",
+        r"id={`#spec!\`al-_98ID`}",
         "multiple={true}",
         "onDrop={e => setFilesById(filesById => {\n"
         "    const updatedFilesById = Object.assign({}, filesById);\n"
-        "    updatedFilesById[`#spec!al-&%@)(*^&+_98ID`] = e;\n"
+        "    updatedFilesById[`#spec!\\`al-_98ID`] = e;\n"
         "    return updatedFilesById;\n"
         "  })\n"
         "    }",

--- a/tests/components/forms/test_uploads.py
+++ b/tests/components/forms/test_uploads.py
@@ -40,6 +40,19 @@ def upload_component():
 
 
 @pytest.fixture
+def upload_component_id_special():
+    def upload_component():
+        return rx.upload(
+            rx.button("select file"),
+            rx.text("Drag and drop files here or click to select files"),
+            border="1px dotted black",
+            id="#spec!al-&%@)(*^&+_98ID",
+        )
+
+    return upload_component()
+
+
+@pytest.fixture
 def upload_component_with_props():
     """A test upload component with props function.
 
@@ -173,4 +186,20 @@ def test_upload_component_with_props_render(upload_component_with_props):
         "  })\n"
         "    }",
         "ref={ref_default}",
+    ]
+
+
+def test_upload_component_id_with_special_chars(upload_component_id_special):
+    upload = upload_component_id_special.render()
+
+    assert upload["props"] == [
+        "id={`#spec!al-&%@)(*^&+_98ID`}",
+        "multiple={true}",
+        "onDrop={e => setFilesById(filesById => {\n"
+        "    const updatedFilesById = Object.assign({}, filesById);\n"
+        "    updatedFilesById[`#spec!al-&%@)(*^&+_98ID`] = e;\n"
+        "    return updatedFilesById;\n"
+        "  })\n"
+        "    }",
+        "ref={ref__spec_al__98ID}",
     ]


### PR DESCRIPTION
We should allow special characters as upload id for the following:

```python
rx.upload(..., id=<upload_id>),
rx.selected_files(<upload_id>)
rx.upload_files(upload_id=<upload_id>)
rx.clear_selected_files(<upload_id>)
```

fixes #3444 