### PR TITLE
fix checkbox_group component

### DIFF
--- a/reflex/components/el/elements/__init__.pyi
+++ b/reflex/components/el/elements/__init__.pyi
@@ -338,5 +338,5 @@ _MAPPING = {
     ],
 }
 EXCLUDE = ["del_", "Del", "image"]
-for _, v in _MAPPING.items():
+for (_, v) in _MAPPING.items():
     v.extend([mod.capitalize() for mod in v if mod not in EXCLUDE])

--- a/reflex/components/el/elements/__init__.pyi
+++ b/reflex/components/el/elements/__init__.pyi
@@ -338,5 +338,5 @@ _MAPPING = {
     ],
 }
 EXCLUDE = ["del_", "Del", "image"]
-for (_, v) in _MAPPING.items():
+for _, v in _MAPPING.items():
     v.extend([mod.capitalize() for mod in v if mod not in EXCLUDE])

--- a/reflex/components/radix/themes/components/checkbox_group.py
+++ b/reflex/components/radix/themes/components/checkbox_group.py
@@ -1,7 +1,7 @@
 """Components for the CheckboxGroup component of Radix Themes."""
 
 from types import SimpleNamespace
-from typing import Literal
+from typing import List, Literal
 
 from reflex.vars import Var
 
@@ -11,9 +11,9 @@ from ..base import LiteralAccentColor, RadixThemesComponent
 class CheckboxGroupRoot(RadixThemesComponent):
     """Root element for a CheckboxGroup component."""
 
-    tag = "CheckboxGroup"
+    tag = "CheckboxGroup.Root"
 
-    #
+    # Use the size prop to control the checkbox size.
     size: Var[Literal["1", "2", "3"]]
 
     # Variant of button: "classic" | "surface" | "soft"
@@ -25,11 +25,23 @@ class CheckboxGroupRoot(RadixThemesComponent):
     # Uses a higher contrast color for the component.
     high_contrast: Var[bool]
 
+    # determines which checkboxes, if any, are checked by default.
+    default_value: Var[List[str]]
+
+    # used to assign a name to the entire group of checkboxes
+    name: Var[str]
+
 
 class CheckboxGroupItem(RadixThemesComponent):
     """An item in the CheckboxGroup component."""
 
     tag = "CheckboxGroup.Item"
+
+    # specifies the value associated with a particular checkbox option.
+    value: Var[str]
+
+    # Use the native disabled attribute to create a disabled checkbox.
+    disabled: Var[bool]
 
 
 class CheckboxGroup(SimpleNamespace):

--- a/reflex/components/radix/themes/components/checkbox_group.pyi
+++ b/reflex/components/radix/themes/components/checkbox_group.pyi
@@ -8,7 +8,7 @@ from reflex.vars import Var, BaseVar, ComputedVar
 from reflex.event import EventChain, EventHandler, EventSpec
 from reflex.style import Style
 from types import SimpleNamespace
-from typing import Literal
+from typing import List, Literal
 from reflex.vars import Var
 from ..base import LiteralAccentColor, RadixThemesComponent
 
@@ -90,6 +90,8 @@ class CheckboxGroupRoot(RadixThemesComponent):
             ]
         ] = None,
         high_contrast: Optional[Union[Var[bool], bool]] = None,
+        default_value: Optional[Union[Var[List[str]], List[str]]] = None,
+        name: Optional[Union[Var[str], str]] = None,
         style: Optional[Style] = None,
         key: Optional[Any] = None,
         id: Optional[Any] = None,
@@ -150,10 +152,12 @@ class CheckboxGroupRoot(RadixThemesComponent):
 
         Args:
             *children: Child components.
-            size:
+            size: Use the size prop to control the checkbox size.
             variant: Variant of button: "classic" | "surface" | "soft"
             color_scheme: Override theme color for button
             high_contrast: Uses a higher contrast color for the component.
+            default_value: determines which checkboxes, if any, are checked by default.
+            name: used to assign a name to the entire group of checkboxes
             style: The style of the component.
             key: A unique key for the component.
             id: The id for the component.
@@ -173,6 +177,8 @@ class CheckboxGroupItem(RadixThemesComponent):
     def create(  # type: ignore
         cls,
         *children,
+        value: Optional[Union[Var[str], str]] = None,
+        disabled: Optional[Union[Var[bool], bool]] = None,
         style: Optional[Style] = None,
         key: Optional[Any] = None,
         id: Optional[Any] = None,
@@ -233,6 +239,8 @@ class CheckboxGroupItem(RadixThemesComponent):
 
         Args:
             *children: Child components.
+            value: specifies the value associated with a particular checkbox option.
+            disabled: Use the native disabled attribute to create a disabled checkbox.
             style: The style of the component.
             key: A unique key for the component.
             id: The id for the component.


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you successfully ran tests with your changes locally?

### Commit Description

Fix checkbox_group component

- corrected the tag of `CheckboxGroup` to `CheckboxGroup.Root`
- added `default_value` and `name` props to `CheckboxGroup.Root`
- added `value` and `disabled` props to `CheckboxGroupItem`
Fixes #3412

Here is a working code of the component:
```
        rx.checkbox_group.root(
            rx.checkbox_group.item(
                rx.text("Fun"),
                value="1",
                disabled=True
            ),
            rx.checkbox_group.item(
                rx.text("Serious"),
                value="2"
            ),
            rx.checkbox_group.item(
                rx.text("Smart"),
                value="3"
            ),
            default_value=["2"], name="example", size="3", variant="classic", color="crimson"
        )
```
![image](https://github.com/reflex-dev/reflex/assets/34986076/b1552cc9-d1bf-46e2-b912-ecd6bafb2eed)
