### PR TITLE
Override _var_is_string when handling str literals

### DIFF
--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -352,7 +352,7 @@ class Component(BaseComponent, ABC):
             **{
                 prop: Var.create(
                     kwargs[prop],
-                    _var_is_string=False,
+                    _var_is_string=False if isinstance(kwargs[prop], str) else None,
                 )
                 for prop in self.get_initial_props()
                 if prop in kwargs
@@ -400,7 +400,10 @@ class Component(BaseComponent, ABC):
                 passed_types = None
                 try:
                     # Try to create a var from the value.
-                    kwargs[key] = Var.create(value, _var_is_string=False)
+                    kwargs[key] = Var.create(
+                        value,
+                        _var_is_string=False if isinstance(value, str) else None,
+                    )
 
                     # Check that the var type is not None.
                     if kwargs[key] is None:


### PR DESCRIPTION
Maintain the pre 0.5.4 behavior when dealing with string literal props, without displaying the deprecation warning.

Wait, isn't it weird to pass `_var_is_string=False` when the type is actually a str??

Yes, yes it is. However this is currently needed to avoid raising the DeprecationWarning internally. These str-type vars with _var_is_string set to false are handled by
`reflex.utils.format.format_prop`, but setting them to be _var_is_string=True causes them to get quoted twice, which is not what we want.

Var operations refactor will take care of cleaning this up, but for now, we will go with the hack.