### PR TITLE
[REF-2830] server side events and stateless components should not require not require a  backend

### DIFF
--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -281,6 +281,12 @@ export const applyRestEvent = async (event, socket) => {
  * @param socket The socket object to send the event on.
  */
 export const queueEvents = async (events, socket) => {
+
+  // Only proceed if the socket is up, otherwise we throw the event into the void
+  if (!socket) {
+    return;
+  }
+
   event_queue.push(...events);
   await processEvent(socket.current);
 };

--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -169,19 +169,19 @@ export const applyEvent = async (event, socket) => {
 
   if (event.name == "_remove_cookie") {
     cookies.remove(event.payload.key, { ...event.payload.options });
-    await queueEventIfSocketExists(initialEvents(), socket);
+    queueEventIfSocketExists(initialEvents(), socket);
     return false;
   }
 
   if (event.name == "_clear_local_storage") {
     localStorage.clear();
-    await queueEventIfSocketExists(initialEvents(), socket);
+    queueEventIfSocketExists(initialEvents(), socket);
     return false;
   }
 
   if (event.name == "_remove_local_storage") {
     localStorage.removeItem(event.payload.key);
-    await queueEventIfSocketExists(initialEvents(), socket);
+    queueEventIfSocketExists(initialEvents(), socket);
     return false;
   }
 

--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -135,11 +135,11 @@ export const applyDelta = (state, delta) => {
  *
  * @returns Adds event to queue and processes it if websocket exits, does nothing otherwise.
  */
-export const queueEventIfSocketExists = (events, socket) => {
+export const queueEventIfSocketExists = async (events, socket) => {
   if (!socket) {
     return;
   }
-  queueEvents(events, socket);
+  await queueEvents(events, socket);
 }
 
 /**

--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -169,19 +169,19 @@ export const applyEvent = async (event, socket) => {
 
   if (event.name == "_remove_cookie") {
     cookies.remove(event.payload.key, { ...event.payload.options });
-    queueEventIfSocketExists(initialEvents(), socket);
+    await queueEventIfSocketExists(initialEvents(), socket);
     return false;
   }
 
   if (event.name == "_clear_local_storage") {
     localStorage.clear();
-    queueEventIfSocketExists(initialEvents(), socket);
+    await queueEventIfSocketExists(initialEvents(), socket);
     return false;
   }
 
   if (event.name == "_remove_local_storage") {
     localStorage.removeItem(event.payload.key);
-    queueEventIfSocketExists(initialEvents(), socket);
+    await queueEventIfSocketExists(initialEvents(), socket);
     return false;
   }
 

--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -213,6 +213,10 @@ export const applyEvent = async (event, socket) => {
     return false;
   }
 
+   // Only proceed if the socket is up, otherwise we throw the event into the void
+   if (!socket) {
+    return false;
+  }
   // Update token and router data (if missing).
   event.token = getToken();
   if (
@@ -246,6 +250,10 @@ export const applyEvent = async (event, socket) => {
  * @returns Whether the event was sent.
  */
 export const applyRestEvent = async (event, socket) => {
+   // Only proceed if the socket is up, otherwise we throw the event into the void
+   if (!socket) {
+    return false;
+  }
   let eventSent = false;
   if (event.handler === "uploadFiles") {
 
@@ -282,11 +290,6 @@ export const queueEvents = async (events, socket) => {
  * @param socket The socket object to send the event on.
  */
 export const processEvent = async (socket) => {
-  // Only proceed if the socket is up, otherwise we throw the event into the void
-  if (!socket) {
-    return;
-  }
-
   // Only proceed if we're not already processing an event.
   if (event_queue.length === 0 || event_processing) {
     return;

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -541,9 +541,7 @@ class App(LifespanMixin, Base):
 
         # Ensure state is enabled if this page uses state.
         if self.state is None:
-            if on_load or component._has_event_triggers(
-                exclude_event_trigger_values=[constants.ColorMode.TOGGLE]
-            ):
+            if on_load or component._has_stateful_event_triggers():
                 self._enable_state()
             else:
                 for var in component._get_vars(include_children=True):

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -541,7 +541,9 @@ class App(LifespanMixin, Base):
 
         # Ensure state is enabled if this page uses state.
         if self.state is None:
-            if on_load or component._has_event_triggers():
+            if on_load or component._has_event_triggers(
+                exclude_event_trigger_values=[constants.ColorMode.TOGGLE]
+            ):
                 self._enable_state()
             else:
                 for var in component._get_vars(include_children=True):
@@ -1117,6 +1119,7 @@ async def process(
     """
     from reflex.utils import telemetry
 
+    print(f"Event: {event}\n ==================\n")
     try:
         # Add request data to the state.
         router_data = event.router_data

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -1119,7 +1119,6 @@ async def process(
     """
     from reflex.utils import telemetry
 
-    print(f"Event: {event}\n ==================\n")
     try:
         # Add request data to the state.
         router_data = event.router_data

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -7,7 +7,7 @@ import typing
 from abc import ABC, abstractmethod
 from functools import lru_cache, wraps
 from hashlib import md5
-from types import SimpleNamespace, LambdaType
+from types import SimpleNamespace
 from typing import (
     Any,
     Callable,
@@ -1113,38 +1113,35 @@ class Component(BaseComponent, ABC):
 
         return vars
 
-
     def _event_trigger_values_use_state(self) -> bool:
+        """Check if the values of a component's event trigger use state.
+
+        Returns:
+            True if any of the component's event trigger values uses State.
+        """
         for trigger in self.event_triggers.values():
             if isinstance(trigger, EventChain):
                 for event in trigger.events:
-                    if event.handler.state_full_name or isinstance(event.handler.fn, LambdaType) and event.handler.fn.__name__== (lambda: None).__name__:
+                    if event.handler.state_full_name:
                         return True
             elif isinstance(trigger, Var) and trigger._var_state:
                 return True
         return False
 
     def _has_stateful_event_triggers(self):
+        """Check if component or children have any event triggers that use state.
 
+        Returns:
+            True if the component or children have any event triggers that uses state.
+        """
         if self.event_triggers and self._event_trigger_values_use_state():
             return True
         else:
             for child in self.children:
-                if isinstance(child, Component) and child._has_stateful_event_triggers():
-                    return True
-        return False
-
-    def _has_event_triggers(self) -> bool:
-        """Check if the component or children have any event triggers.
-
-        Returns:
-            True if the component or children have any event triggers.
-        """
-        if self.event_triggers:
-            return True
-        else:
-            for child in self.children:
-                if isinstance(child, Component) and child._has_event_triggers():
+                if (
+                    isinstance(child, Component)
+                    and child._has_stateful_event_triggers()
+                ):
                     return True
         return False
 

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -1113,17 +1113,31 @@ class Component(BaseComponent, ABC):
 
         return vars
 
-    def _has_event_triggers(self) -> bool:
+    def _has_event_triggers(
+        self, exclude_event_trigger_values: list[str] | None = None
+    ) -> bool:
         """Check if the component or children have any event triggers.
+
+        Args:
+            exclude_event_trigger_values: Event trigger var names to exclude from this check.
 
         Returns:
             True if the component or children have any event triggers.
         """
-        if self.event_triggers:
+        if exclude_event_trigger_values is None:
+            exclude_event_trigger_values = []
+        if self.event_triggers and not any(
+            [
+                trigger_value._var_name in exclude_event_trigger_values
+                for trigger_value in self.event_triggers.values()
+            ]
+        ):
             return True
         else:
             for child in self.children:
-                if isinstance(child, Component) and child._has_event_triggers():
+                if isinstance(child, Component) and child._has_event_triggers(
+                    exclude_event_trigger_values
+                ):
                     return True
         return False
 

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -1128,7 +1128,7 @@ class Component(BaseComponent, ABC):
             exclude_event_trigger_values = []
         if self.event_triggers and not any(
             [
-                trigger_value._var_name in exclude_event_trigger_values
+                Var.create_safe(trigger_value)._var_name in exclude_event_trigger_values
                 for trigger_value in self.event_triggers.values()
             ]
         ):

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -2082,37 +2082,27 @@ class TriggerState(rx.State):
         """Sample event handler."""
         pass
 
+    def do_another_thing(self, value):
+        """Sample event handler with arg."""
+        pass
+
 
 @pytest.mark.parametrize(
-    "component, exclude_event_trigger_values, output",
+    "component, output",
     [
-        (rx.box(rx.text("random text")), None, False),
-        (rx.box(rx.text("random text", on_click=rx.console_log("log"))), None, True),
+        (rx.box(rx.text("random text")), False),
         (
             rx.box(rx.text("random text", on_click=rx.console_log("log"))),
-            ["_console"],
             False,
         ),
         (
             rx.box(
-                rx.text("random text", on_click=rx.console_log("log")),
+                rx.text("random text", on_click=TriggerState.do_something),
                 rx.text(
                     "random text",
                     on_click=BaseVar(_var_name="toggleColorMode", _var_type=EventChain),
                 ),
             ),
-            ["_console", "toggleColorMode"],
-            False,
-        ),
-        (
-            rx.box(
-                rx.text("random text", on_click=rx.console_log("log")),
-                rx.text(
-                    "random text",
-                    on_click=BaseVar(_var_name="toggleColorMode", _var_type=EventChain),
-                ),
-            ),
-            ["_console"],
             True,
         ),
         (
@@ -2123,17 +2113,10 @@ class TriggerState(rx.State):
                     on_click=BaseVar(_var_name="toggleColorMode", _var_type=EventChain),
                 ),
             ),
-            ["toggleColorMode"],
-            True,
-        ),
-        (
-            rx.box(rx.text("random text", on_click=TriggerState.do_something)),
-            ["do_something"],
             False,
         ),
         (
             rx.box(rx.text("random text", on_click=TriggerState.do_something)),
-            ["non_existent"],
             True,
         ),
         (
@@ -2143,26 +2126,27 @@ class TriggerState(rx.State):
                     on_click=[rx.console_log("log"), rx.window_alert("alert")],
                 ),
             ),
-            ["_console", "_alert"],
             False,
         ),
-(
+        (
             rx.box(
                 rx.text(
                     "random text",
-                    on_click=lambda x: x,
+                    on_click=[rx.console_log("log"), TriggerState.do_something],
                 ),
             ),
-            ["_console", "_alert"],
-            False,
+            True,
         ),
-
+        (
+            rx.box(
+                rx.text(
+                    "random text",
+                    on_click=lambda val: TriggerState.do_another_thing(val),  # type: ignore
+                ),
+            ),
+            True,
+        ),
     ],
 )
-def test_has_event_triggers(component, exclude_event_trigger_values, output):
-    assert (
-        component._has_event_triggers(
-            exclude_event_trigger_values=exclude_event_trigger_values
-        )
-        == output
-    )
+def test_has_state_event_triggers(component, output):
+    assert component._has_stateful_event_triggers() == output

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -2146,6 +2146,17 @@ class TriggerState(rx.State):
             ["_console", "_alert"],
             False,
         ),
+(
+            rx.box(
+                rx.text(
+                    "random text",
+                    on_click=lambda x: x,
+                ),
+            ),
+            ["_console", "_alert"],
+            False,
+        ),
+
     ],
 )
 def test_has_event_triggers(component, exclude_event_trigger_values, output):

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -2082,10 +2082,6 @@ class TriggerState(rx.State):
         """Sample event handler."""
         pass
 
-    def do_another_thing(self, value):
-        """Sample event handler with arg."""
-        pass
-
 
 @pytest.mark.parametrize(
     "component, output",
@@ -2141,7 +2137,7 @@ class TriggerState(rx.State):
             rx.box(
                 rx.text(
                     "random text",
-                    on_click=lambda val: TriggerState.do_another_thing(val),  # type: ignore
+                    on_blur=lambda: TriggerState.do_something,
                 ),
             ),
             True,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1392,8 +1392,12 @@ def test_app_state_determination():
     a4 = App()
     assert a4.state is None
 
-    # Referencing an event handler enables state.
     a4.add_page(rx.box(rx.button("Click", on_click=rx.console_log(""))), route="/")
+    assert a4.state is None
+
+    a4.add_page(
+        rx.box(rx.button("Click", on_click=DynamicState.on_counter)), route="/page2"
+    )
     assert a4.state is not None
 
 


### PR DESCRIPTION
We previously classified anything that uses an eventhandler as stateful. However this is not always true and ended up considering server-side events like `rx.console_log`, etc as stateful when they actually do not require state. With this PR, we make modifications to this logic ensuring that stateless components or server side events arent treated as stateful.

Stateless app
```python
import reflex as rx

def index():
   return rx.vstack(
      rx.button("click to log", on_click=rx.console("log a message")),
      rx.color_mode.button(),
   )
...
```

Stateful app
```python
import reflex as rx

Class State(rx.State):

    def do_something(self):
         ...

def index():
   return rx.vstack(
      rx.button("click ", on_click=State.do_something),
   )
...
```

fixes #3295 