### PR TITLE
compat: do not patch pydantic if the installed version starts with "1."

### DIFF
--- a/reflex/utils/compat.py
+++ b/reflex/utils/compat.py
@@ -21,6 +21,11 @@ def pydantic_v1_patch():
     try:
         import pydantic.v1  # type: ignore
 
+        if pydantic.__version__.startswith("1."):
+            # pydantic v1 is already installed
+            yield
+            return
+
         sys.modules["pydantic.fields"] = pydantic.v1.fields  # type: ignore
         sys.modules["pydantic.main"] = pydantic.v1.main  # type: ignore
         sys.modules["pydantic.errors"] = pydantic.v1.errors  # type: ignore


### PR DESCRIPTION
In pydantic 1.10.16 (hopefully the last version), they added the `pydantic.v1` namespace to make transitioning to the v2 package easier without changing code.

However, Reflex was depending on pydantic v1 NOT having `pydantic.v1` to skip patching names from `v1` into the top level `pydantic` (normally we do this to force sqlmodel to use v1, even when the v2 package is installed).

Unbreak CI
