### PR TITLE
Improve ClientState compatibility with rx.input

### DIFF
--- a/reflex/components/chakra/forms/input.py
+++ b/reflex/components/chakra/forms/input.py
@@ -93,7 +93,7 @@ class Input(ChakraComponent):
         Returns:
             The component.
         """
-        if props.get("value") is not None and props.get("on_change"):
+        if props.get("value") is not None and props.get("on_change") is not None:
             # create a debounced input if the user requests full control to avoid typing jank
             return DebounceInput.create(super().create(*children, **props))
         return super().create(*children, **props)

--- a/reflex/components/chakra/forms/textarea.py
+++ b/reflex/components/chakra/forms/textarea.py
@@ -72,7 +72,7 @@ class TextArea(ChakraComponent):
         Returns:
             The component.
         """
-        if props.get("value") is not None and props.get("on_change"):
+        if props.get("value") is not None and props.get("on_change") is not None:
             # create a debounced input if the user requests full control to avoid typing jank
             return DebounceInput.create(super().create(*children, **props))
         return super().create(*children, **props)

--- a/reflex/components/radix/themes/components/text_area.py
+++ b/reflex/components/radix/themes/components/text_area.py
@@ -106,7 +106,7 @@ class TextArea(RadixThemesComponent, elements.Textarea):
         Returns:
             The component.
         """
-        if props.get("value") is not None and props.get("on_change"):
+        if props.get("value") is not None and props.get("on_change") is not None:
             # create a debounced input if the user requests full control to avoid typing jank
             return DebounceInput.create(super().create(*children, **props))
         return super().create(*children, **props)

--- a/reflex/components/radix/themes/components/text_field.py
+++ b/reflex/components/radix/themes/components/text_field.py
@@ -99,7 +99,7 @@ class TextFieldRoot(elements.Div, RadixThemesComponent):
             The component.
         """
         component = super().create(*children, **props)
-        if props.get("value") is not None and props.get("on_change"):
+        if props.get("value") is not None and props.get("on_change") is not None:
             # create a debounced input if the user requests full control to avoid typing jank
             return DebounceInput.create(component)
         return component

--- a/reflex/experimental/client_state.py
+++ b/reflex/experimental/client_state.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Optional, Type, Union
 from reflex import constants
 from reflex.event import EventChain, EventHandler, EventSpec, call_script
 from reflex.utils.imports import ImportVar
-from reflex.vars import Var, VarData
+from reflex.vars import Var, VarData, get_unique_variable_name
 
 NoValue = object()
 
@@ -74,7 +74,10 @@ class ClientStateVar(Var):
 
     @classmethod
     def create(
-        cls, var_name: str, default: Any = NoValue, global_ref: bool = True
+        cls,
+        var_name: str | None = None,
+        default: Any = NoValue,
+        global_ref: bool = True,
     ) -> "ClientStateVar":
         """Create a local_state Var that can be accessed and updated on the client.
 
@@ -101,6 +104,8 @@ class ClientStateVar(Var):
         Returns:
             ClientStateVar
         """
+        if var_name is None:
+            var_name = get_unique_variable_name()
         assert isinstance(var_name, str), "var_name must be a string."
         if default is NoValue:
             default_var = Var.create_safe("", _var_is_local=False, _var_is_string=False)

--- a/reflex/experimental/client_state.py
+++ b/reflex/experimental/client_state.py
@@ -193,7 +193,7 @@ class ClientStateVar(Var):
             # This is a hack to make it work like an EventSpec taking an arg
             value = Var.create_safe(value, _var_is_string=isinstance(value, str))
             if not value._var_is_string and value._var_full_name.startswith("_"):
-                arg = value._var_name_unwrapped
+                arg = value._var_name_unwrapped.partition(".")[0]
             else:
                 arg = ""
             setter = f"({arg}) => {setter}({value._var_name_unwrapped})"

--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -1792,18 +1792,16 @@ class Var:
         """
         from reflex.style import Style
 
-        type_ = (
-            get_origin(self._var_type)
-            if types.is_generic_alias(self._var_type)
-            else self._var_type
-        )
+        generic_alias = types.is_generic_alias(self._var_type)
+
+        type_ = get_origin(self._var_type) if generic_alias else self._var_type
         wrapped_var = str(self)
 
         return (
             wrapped_var
             if not self._var_state
-            and types._issubclass(type_, dict)
-            or types._issubclass(type_, Style)
+            and not generic_alias
+            and (types._issubclass(type_, dict) or types._issubclass(type_, Style))
             else wrapped_var.strip("{}")
         )
 


### PR DESCRIPTION
Tweaks to make the ClientState work better with text input fields

```python
import reflex as rx


class AppState(rx.State):
    items: list[str]

    def add_item(
        self,
        value: str,
    ):
        self.items.append(value)


def todo_list():
    ItemState = rx._x.client_state(default="")

    return rx.vstack(
        rx.unordered_list(
            rx.foreach(
                AppState.items,
                lambda item: rx.list_item(rx.text(item)),
            ),
        ),
        rx.hstack(
            ItemState,
            rx.input(
                placeholder="what to do",
                id="input",
                value=ItemState.value,
                on_change=ItemState.set_value,
            ),
            rx.button(
                "Add",
                on_click=AppState.add_item(ItemState.value),
            ),
        )
    )


def index() -> rx.Component:
    # Welcome Page (Index)
    return rx.container(
        rx.color_mode.button(position="top-right"),
        todo_list(),
        rx.logo(),
    )


app = rx.App()
app.add_page(index)
```