### PR TITLE
notifying frontend about backend error looks better

### DIFF
--- a/reflex/components/core/banner.py
+++ b/reflex/components/core/banner.py
@@ -153,6 +153,20 @@ useEffect(() => {{
             hook,
         ]
 
+    @classmethod
+    def create(cls, *children, **props) -> Component:
+        """Create a connection toaster component.
+
+        Args:
+            *children: The children of the component.
+            **props: The properties of the component.
+
+        Returns:
+            The connection toaster component.
+        """
+        Toaster.is_used = True
+        return super().create(*children, **props)
+
 
 class ConnectionBanner(Component):
     """A connection banner component."""

--- a/reflex/components/core/banner.pyi
+++ b/reflex/components/core/banner.pyi
@@ -199,7 +199,7 @@ class ConnectionToaster(Toaster):
         ] = None,
         **props
     ) -> "ConnectionToaster":
-        """Create the component.
+        """Create a connection toaster component.
 
         Args:
             *children: The children of the component.
@@ -223,10 +223,10 @@ class ConnectionToaster(Toaster):
             class_name: The class name for the component.
             autofocus: Whether the component should take the focus once the page is loaded
             custom_attrs: custom attribute
-            **props: The props of the component.
+            **props: The properties of the component.
 
         Returns:
-            The component.
+            The connection toaster component.
         """
         ...
 

--- a/reflex/components/sonner/toast.py
+++ b/reflex/components/sonner/toast.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal, Optional, Union
+from typing import Any, ClassVar, Literal, Optional, Union
 
 from reflex.base import Base
 from reflex.components.component import Component, ComponentNamespace
@@ -211,6 +211,9 @@ class Toaster(Component):
     # Pauses toast timers when the page is hidden, e.g., when the tab is backgrounded, the browser is minimized, or the OS is locked.
     pause_when_page_is_hidden: Var[bool]
 
+    # Marked True when any Toast component is created.
+    is_used: ClassVar[bool] = False
+
     def add_hooks(self) -> list[Var | str]:
         """Add hooks for the toaster component.
 
@@ -231,7 +234,7 @@ class Toaster(Component):
         return [hook]
 
     @staticmethod
-    def send_toast(message: str, level: str | None = None, **props) -> EventSpec:
+    def send_toast(message: str = "", level: str | None = None, **props) -> EventSpec:
         """Send a toast message.
 
         Args:
@@ -239,10 +242,19 @@ class Toaster(Component):
             level: The level of the toast.
             **props: The options for the toast.
 
+        Raises:
+            ValueError: If the Toaster component is not created.
+
         Returns:
             The toast event.
         """
+        if not Toaster.is_used:
+            raise ValueError(
+                "Toaster component must be created before sending a toast. (use `rx.toast.provider()`)"
+            )
         toast_command = f"{toast_ref}.{level}" if level is not None else toast_ref
+        if message == "" and ("title" not in props or "description" not in props):
+            raise ValueError("Toast message or title or descrition must be provided.")
         if props:
             args = serialize(ToastProps(**props))  # type: ignore
             toast = f"{toast_command}(`{message}`, {args})"
@@ -330,6 +342,20 @@ class Toaster(Component):
             _var_data=dismiss_var_data,
         )
         return call_script(dismiss_action)
+
+    @classmethod
+    def create(cls, *children, **props) -> Component:
+        """Create a toaster component.
+
+        Args:
+            *children: The children of the toaster.
+            **props: The properties of the toaster.
+
+        Returns:
+            The toaster component.
+        """
+        cls.is_used = True
+        return super().create(*children, **props)
 
 
 # TODO: figure out why loading toast stay open forever

--- a/reflex/components/sonner/toast.pyi
+++ b/reflex/components/sonner/toast.pyi
@@ -7,7 +7,7 @@ from typing import Any, Dict, Literal, Optional, Union, overload
 from reflex.vars import Var, BaseVar, ComputedVar
 from reflex.event import EventChain, EventHandler, EventSpec
 from reflex.style import Style
-from typing import Any, Literal, Optional, Union
+from typing import Any, ClassVar, Literal, Optional, Union
 from reflex.base import Base
 from reflex.components.component import Component, ComponentNamespace
 from reflex.components.lucide.icon import Icon
@@ -57,9 +57,13 @@ class ToastProps(PropsBase):
     def dict(self, *args, **kwargs) -> dict[str, Any]: ...
 
 class Toaster(Component):
+    is_used: ClassVar[bool] = False
+
     def add_hooks(self) -> list[Var | str]: ...
     @staticmethod
-    def send_toast(message: str, level: str | None = None, **props) -> EventSpec: ...
+    def send_toast(
+        message: str = "", level: str | None = None, **props
+    ) -> EventSpec: ...
     @staticmethod
     def toast_info(message: str, **kwargs): ...
     @staticmethod
@@ -163,10 +167,10 @@ class Toaster(Component):
         ] = None,
         **props
     ) -> "Toaster":
-        """Create the component.
+        """Create a toaster component.
 
         Args:
-            *children: The children of the component.
+            *children: The children of the toaster.
             theme: the theme of the toast
             rich_colors: whether to show rich colors
             expand: whether to expand the toast
@@ -187,10 +191,10 @@ class Toaster(Component):
             class_name: The class name for the component.
             autofocus: Whether the component should take the focus once the page is loaded
             custom_attrs: custom attribute
-            **props: The props of the component.
+            **props: The properties of the toaster.
 
         Returns:
-            The component.
+            The toaster component.
         """
         ...
 
@@ -205,7 +209,7 @@ class ToastNamespace(ComponentNamespace):
 
     @staticmethod
     def __call__(
-        message: str, level: Optional[str] = None, **props
+        message: str = "", level: Optional[str] = None, **props
     ) -> "Optional[EventSpec]":
         """Send a toast message.
 
@@ -213,6 +217,9 @@ class ToastNamespace(ComponentNamespace):
             message: The message to display.
             level: The level of the toast.
             **props: The options for the toast.
+
+        Raises:
+            ValueError: If the Toaster component is not created.
 
         Returns:
             The toast event.

--- a/reflex/config.py
+++ b/reflex/config.py
@@ -219,6 +219,9 @@ class Config(Base):
     # Number of gunicorn workers from user
     gunicorn_workers: Optional[int] = None
 
+    # Whether to
+    debug: bool = False
+
     # Attributes that were explicitly set by the user.
     _non_default_attributes: Set[str] = pydantic.PrivateAttr(set())
 


### PR DESCRIPTION
Use toast as the default for notifying about backend errors.

Can set `debug=True` in the config or the env var `REFLEX_DEBUG=True` to have a more helpful message in the frontend.

Will fallback to the old window_alert if the toast provider has been removed.