### PR TITLE
Always treat the call_script callback as a string of JS code

### DIFF
--- a/integration/test_call_script.py
+++ b/integration/test_call_script.py
@@ -43,6 +43,7 @@ def CallScript():
         results: List[Optional[Union[str, Dict, List]]] = []
         inline_counter: int = 0
         external_counter: int = 0
+        value: str = "Initial"
 
         def call_script_callback(self, result):
             self.results.append(result)
@@ -227,6 +228,14 @@ def CallScript():
                 on_click=CallScriptState.get_external_counter,
                 id="update_external_counter",
             ),
+            rx.button(
+                CallScriptState.value,
+                on_click=rx.call_script(
+                    "'updated'",
+                    callback=CallScriptState.set_value,  # type: ignore
+                ),
+                id="update_value",
+            ),
             rx.button("Reset", id="reset", on_click=CallScriptState.reset_),
         )
 
@@ -355,3 +364,12 @@ def test_call_script(
     )
     reset_button.click()
     assert call_script.poll_for_value(counter, exp_not_equal="1") == "0"
+
+    # Check that triggering script from event trigger calls callback
+    update_value_button = driver.find_element(By.ID, "update_value")
+    update_value_button.click()
+
+    assert (
+        call_script.poll_for_content(update_value_button, exp_not_equal="Initial")
+        == "updated"
+    )

--- a/reflex/event.py
+++ b/reflex/event.py
@@ -766,10 +766,12 @@ def call_script(
     callback_kwargs = {}
     if callback is not None:
         callback_kwargs = {
-            "callback": format.format_queue_events(
-                callback,
-                args_spec=lambda result: [result],
-            )
+            "callback": str(
+                format.format_queue_events(
+                    callback,
+                    args_spec=lambda result: [result],
+                ),
+            ),
         }
     return server_side(
         "_call_script",


### PR DESCRIPTION
The handler for _call_script always calls `eval` on the `callback` string anyway, and this allows the callback to be specified for backend-originated call_script as well as frontend (triggered) call_script.

Fix https://github.com/reflex-dev/reflex/issues/3520

Update test cases to catch this issue.

General clean up of test_call_script