### PR TITLE
[REF-3056]Config knob for redis StateManager expiration times

### DIFF
--- a/reflex/config.py
+++ b/reflex/config.py
@@ -219,6 +219,12 @@ class Config(Base):
     # Number of gunicorn workers from user
     gunicorn_workers: Optional[int] = None
 
+    # Maximum expiration lock time for redis state manager
+    redis_state_manager_lock_expiration: int = constants.Expiration.LOCK
+
+    # Token expiration time for redis state manager
+    redis_state_manager_token_expiration: int = constants.Expiration.TOKEN
+
     # Attributes that were explicitly set by the user.
     _non_default_attributes: Set[str] = pydantic.PrivateAttr(set())
 

--- a/reflex/config.py
+++ b/reflex/config.py
@@ -220,10 +220,10 @@ class Config(Base):
     gunicorn_workers: Optional[int] = None
 
     # Maximum expiration lock time for redis state manager
-    redis_state_manager_lock_expiration: int = constants.Expiration.LOCK
+    redis_lock_expiration: int = constants.Expiration.LOCK
 
     # Token expiration time for redis state manager
-    redis_state_manager_token_expiration: int = constants.Expiration.TOKEN
+    redis_token_expiration: int = constants.Expiration.TOKEN
 
     # Attributes that were explicitly set by the user.
     _non_default_attributes: Set[str] = pydantic.PrivateAttr(set())

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -2204,7 +2204,14 @@ class StateManager(Base, ABC):
         """
         redis = prerequisites.get_redis()
         if redis is not None:
-            return StateManagerRedis(state=state, redis=redis)
+            # make sure expiration values are obtained only from the config object on creation
+            config = get_config()
+            return StateManagerRedis(
+                state=state,
+                redis=redis,
+                token_expiration=config.redis_token_expiration,
+                lock_expiration=config.redis_lock_expiration,
+            )
         return StateManagerMemory(state=state)
 
     @abstractmethod

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -53,6 +53,7 @@ from reflex.utils.exceptions import ImmutableStateError, LockExpiredError
 from reflex.utils.exec import is_testing_env
 from reflex.utils.serializers import SerializedType, serialize, serializer
 from reflex.vars import BaseVar, ComputedVar, Var, computed_var
+from reflex.config import get_config
 
 if TYPE_CHECKING:
     from reflex.components.component import Component
@@ -60,6 +61,7 @@ if TYPE_CHECKING:
 
 Delta = Dict[str, Any]
 var = computed_var
+config = get_config()
 
 
 # If the state is this large, it's considered a performance issue.
@@ -2316,7 +2318,6 @@ if not isinstance(State.validate.__func__, FunctionType):
         # Ignore cython function when pickling.
         pass
 
-
 @dill.register(type(State))
 def _dill_reduce_state(pickler, obj):
     if obj is not State and issubclass(obj, State):
@@ -2333,10 +2334,10 @@ class StateManagerRedis(StateManager):
     redis: Redis
 
     # The token expiration time (s).
-    token_expiration: int = constants.Expiration.TOKEN
+    token_expiration: int = config.redis_state_manager_token_expiration
 
     # The maximum time to hold a lock (ms).
-    lock_expiration: int = constants.Expiration.LOCK
+    lock_expiration: int = config.redis_state_manager_lock_expiration
 
     # The keyspace subscription string when redis is waiting for lock to be released
     _redis_notify_keyspace_events: str = (

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -2335,10 +2335,10 @@ class StateManagerRedis(StateManager):
     redis: Redis
 
     # The token expiration time (s).
-    token_expiration: int = config.redis_state_manager_token_expiration
+    token_expiration: int = config.redis_token_expiration
 
     # The maximum time to hold a lock (ms).
-    lock_expiration: int = config.redis_state_manager_lock_expiration
+    lock_expiration: int = config.redis_lock_expiration
 
     # The keyspace subscription string when redis is waiting for lock to be released
     _redis_notify_keyspace_events: str = (

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -40,6 +40,7 @@ from redis.exceptions import ResponseError
 
 from reflex import constants
 from reflex.base import Base
+from reflex.config import get_config
 from reflex.event import (
     BACKGROUND_TASK_MARKER,
     Event,
@@ -53,7 +54,6 @@ from reflex.utils.exceptions import ImmutableStateError, LockExpiredError
 from reflex.utils.exec import is_testing_env
 from reflex.utils.serializers import SerializedType, serialize, serializer
 from reflex.vars import BaseVar, ComputedVar, Var, computed_var
-from reflex.config import get_config
 
 if TYPE_CHECKING:
     from reflex.components.component import Component
@@ -2317,6 +2317,7 @@ if not isinstance(State.validate.__func__, FunctionType):
     def _dill_reduce_cython_function_or_method(pickler, obj):
         # Ignore cython function when pickling.
         pass
+
 
 @dill.register(type(State))
 def _dill_reduce_state(pickler, obj):

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -2931,6 +2931,7 @@ async def test_setvar(mock_app: rx.App, token: str):
         TestState.setvar(42, 42)
 
 
+@pytest.mark.skipif("REDIS_URL" not in os.environ, reason="Test requires redis")
 @pytest.mark.parametrize(
     "expiration_kwargs, expected_values",
     [
@@ -2954,11 +2955,12 @@ def test_redis_state_manager_config_knobs(tmp_path, expiration_kwargs, expected_
 import reflex as rx     
 config = rx.Config(
     app_name="project1",
-    redis_url="localhost",
+    redis_url="redis://localhost:6379",
     {config_items}
 )
 """
     (proj_root / "rxconfig.py").write_text(dedent(config_string))
+
     with chdir(proj_root):
         # reload config for each parameter to avoid stale values
         reflex.config.get_config(reload=True)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -7,6 +7,7 @@ import functools
 import json
 import os
 import sys
+from textwrap import dedent
 from typing import Any, Dict, Generator, List, Optional, Union
 from unittest.mock import AsyncMock, Mock
 
@@ -14,6 +15,8 @@ import pytest
 from plotly.graph_objects import Figure
 
 import reflex as rx
+import reflex.config
+from reflex import constants
 from reflex.app import App
 from reflex.base import Base
 from reflex.constants import CompileVars, RouteVar, SocketEvent
@@ -33,6 +36,7 @@ from reflex.state import (
     StateUpdate,
     _substate_key,
 )
+from reflex.testing import chdir
 from reflex.utils import format, prerequisites, types
 from reflex.utils.format import json_dumps
 from reflex.vars import BaseVar, ComputedVar
@@ -2925,3 +2929,41 @@ async def test_setvar(mock_app: rx.App, token: str):
     # Cannot setvar with non-string
     with pytest.raises(ValueError):
         TestState.setvar(42, 42)
+
+
+@pytest.mark.parametrize(
+    "expiration_kwargs, expected_values",
+    [
+        ({"redis_lock_expiration": 20000}, (20000, constants.Expiration.TOKEN)),
+        (
+            {"redis_lock_expiration": 50000, "redis_token_expiration": 5600},
+            (50000, 5600),
+        ),
+        ({"redis_token_expiration": 7600}, (constants.Expiration.LOCK, 7600)),
+    ],
+)
+def test_redis_state_manager_config_knobs(tmp_path, expiration_kwargs, expected_values):
+    proj_root = tmp_path / "project1"
+    proj_root.mkdir()
+
+    config_items = ",\n    ".join(
+        f"{key} = {value}" for key, value in expiration_kwargs.items()
+    )
+
+    config_string = f"""
+import reflex as rx     
+config = rx.Config(
+    app_name="project1",
+    redis_url="localhost",
+    {config_items}
+)
+"""
+    (proj_root / "rxconfig.py").write_text(dedent(config_string))
+    with chdir(proj_root):
+        # reload config for each parameter to avoid stale values
+        reflex.config.get_config(reload=True)
+        from reflex.state import State, StateManager
+
+        state_manager = StateManager.create(state=State)
+        assert state_manager.lock_expiration == expected_values[0]
+        assert state_manager.token_expiration == expected_values[1]

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -2952,7 +2952,7 @@ def test_redis_state_manager_config_knobs(tmp_path, expiration_kwargs, expected_
     )
 
     config_string = f"""
-import reflex as rx     
+import reflex as rx
 config = rx.Config(
     app_name="project1",
     redis_url="redis://localhost:6379",

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -2967,5 +2967,5 @@ config = rx.Config(
         from reflex.state import State, StateManager
 
         state_manager = StateManager.create(state=State)
-        assert state_manager.lock_expiration == expected_values[0]
-        assert state_manager.token_expiration == expected_values[1]
+        assert state_manager.lock_expiration == expected_values[0]  # type: ignore
+        assert state_manager.token_expiration == expected_values[1]  # type: ignore


### PR DESCRIPTION
Allow state manager expiration attributes(lock expiration and token expiration) to be overridden in the config when running with redis.

rxconfig.py
```python
import reflex as rx
config = rx.Config(
    app_name="project_name",
    redis_url="redis url",
    redis_lock_expiration=20000,
    redis_token_expiration=4800,
)

```