### PR TITLE
Hanson/tooltip-improvement/props

### DIFF
--- a/reflex/components/recharts/general.py
+++ b/reflex/components/recharts/general.py
@@ -8,12 +8,12 @@ from reflex.event import EventHandler
 from reflex.vars import Var
 
 from .recharts import (
+    LiteralAnimationEasing,
     LiteralIconType,
     LiteralLayout,
     LiteralLegendAlign,
     LiteralPosition,
     LiteralVerticalAlign,
-    LiteralAnimationEasing,
     Recharts,
 )
 
@@ -155,7 +155,9 @@ class GraphingTooltip(Recharts):
     label_style: Var[Dict[str, Any]]
 
     # This option allows the tooltip to extend beyond the viewBox of the chart itself. DEFAULT: { x: false, y: false }
-    allow_escape_view_box: Var[Dict[str, bool]] = Var.create_safe({"x": False, "y": False})
+    allow_escape_view_box: Var[Dict[str, bool]] = Var.create_safe(
+        {"x": False, "y": False}
+    )
 
     # If set true, the tooltip is displayed. If set false, the tooltip is hidden, usually calculated internally.
     active: Var[bool]

--- a/reflex/components/recharts/general.py
+++ b/reflex/components/recharts/general.py
@@ -13,6 +13,7 @@ from .recharts import (
     LiteralLegendAlign,
     LiteralPosition,
     LiteralVerticalAlign,
+    LiteralAnimationEasing,
     Recharts,
 )
 
@@ -141,6 +142,21 @@ class GraphingTooltip(Recharts):
     # The box of viewing area, which has the shape of {x: someVal, y: someVal, width: someVal, height: someVal}, usually calculated internally.
     view_box: Var[Dict[str, Any]]
 
+    # The style of default tooltip content item which is a li element. DEFAULT: {}
+    item_style: Var[Dict[str, Any]]
+
+    # The style of tooltip wrapper which is a dom element. DEFAULT: {}
+    wrapper_style: Var[Dict[str, Any]]
+
+    # The style of tooltip content which is a dom element. DEFAULT: {}
+    content_style: Var[Dict[str, Any]]
+
+    # The style of default tooltip label which is a p element. DEFAULT: {}
+    label_style: Var[Dict[str, Any]]
+
+    # This option allows the tooltip to extend beyond the viewBox of the chart itself. DEFAULT: { x: false, y: false }
+    allow_escape_view_box: Var[Dict[str, bool]] = Var.create_safe({"x": False, "y": False})
+
     # If set true, the tooltip is displayed. If set false, the tooltip is hidden, usually calculated internally.
     active: Var[bool]
 
@@ -149,6 +165,15 @@ class GraphingTooltip(Recharts):
 
     # The coordinate of tooltip which is usually calculated internally.
     coordinate: Var[Dict[str, Any]]
+
+    # If set false, animation of tooltip will be disabled. DEFAULT: true in CSR, and false in SSR
+    is_animation_active: Var[bool]
+
+    # Specifies the duration of animation, the unit of this option is ms. DEFAULT: 1500
+    animation_duration: Var[int]
+
+    # The type of easing function. DEFAULT: 'ease'
+    animation_easing: Var[LiteralAnimationEasing]
 
 
 class Label(Recharts):

--- a/reflex/components/recharts/general.pyi
+++ b/reflex/components/recharts/general.pyi
@@ -9,9 +9,10 @@ from reflex.event import EventChain, EventHandler, EventSpec
 from reflex.style import Style
 from typing import Any, Dict, List, Union
 from reflex.components.component import MemoizationLeaf
-from reflex.constants import EventTriggers
+from reflex.event import EventHandler
 from reflex.vars import Var
 from .recharts import (
+    LiteralAnimationEasing,
     LiteralIconType,
     LiteralLayout,
     LiteralLegendAlign,
@@ -109,7 +110,6 @@ class ResponsiveContainer(Recharts, MemoizationLeaf):
         ...
 
 class Legend(Recharts):
-    def get_event_triggers(self) -> dict[str, Union[Var, Any]]: ...
     @overload
     @classmethod
     def create(  # type: ignore
@@ -175,7 +175,25 @@ class Legend(Recharts):
         class_name: Optional[Any] = None,
         autofocus: Optional[bool] = None,
         custom_attrs: Optional[Dict[str, Union[Var, str]]] = None,
+        on_blur: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
         on_click: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_context_menu: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_double_click: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_focus: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_mount: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_mouse_down: Optional[
             Union[EventHandler, EventSpec, list, function, BaseVar]
         ] = None,
         on_mouse_enter: Optional[
@@ -191,6 +209,15 @@ class Legend(Recharts):
             Union[EventHandler, EventSpec, list, function, BaseVar]
         ] = None,
         on_mouse_over: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_mouse_up: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_scroll: Optional[
+            Union[EventHandler, EventSpec, list, function, BaseVar]
+        ] = None,
+        on_unmount: Optional[
             Union[EventHandler, EventSpec, list, function, BaseVar]
         ] = None,
         **props
@@ -219,9 +246,6 @@ class Legend(Recharts):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -236,9 +260,24 @@ class GraphingTooltip(Recharts):
         filter_null: Optional[Union[Var[bool], bool]] = None,
         cursor: Optional[Union[Var[bool], bool]] = None,
         view_box: Optional[Union[Var[Dict[str, Any]], Dict[str, Any]]] = None,
+        item_style: Optional[Union[Var[Dict[str, Any]], Dict[str, Any]]] = None,
+        wrapper_style: Optional[Union[Var[Dict[str, Any]], Dict[str, Any]]] = None,
+        content_style: Optional[Union[Var[Dict[str, Any]], Dict[str, Any]]] = None,
+        label_style: Optional[Union[Var[Dict[str, Any]], Dict[str, Any]]] = None,
+        allow_escape_view_box: Optional[
+            Union[Var[Dict[str, bool]], Dict[str, bool]]
+        ] = None,
         active: Optional[Union[Var[bool], bool]] = None,
         position: Optional[Union[Var[Dict[str, Any]], Dict[str, Any]]] = None,
         coordinate: Optional[Union[Var[Dict[str, Any]], Dict[str, Any]]] = None,
+        is_animation_active: Optional[Union[Var[bool], bool]] = None,
+        animation_duration: Optional[Union[Var[int], int]] = None,
+        animation_easing: Optional[
+            Union[
+                Var[Literal["ease", "ease-in", "ease-out", "ease-in-out", "linear"]],
+                Literal["ease", "ease-in", "ease-out", "ease-in-out", "linear"],
+            ]
+        ] = None,
         style: Optional[Style] = None,
         key: Optional[Any] = None,
         id: Optional[Any] = None,
@@ -301,9 +340,17 @@ class GraphingTooltip(Recharts):
             filter_null: When an item of the payload has value null or undefined, this item won't be displayed.
             cursor: If set false, no cursor will be drawn when tooltip is active.
             view_box: The box of viewing area, which has the shape of {x: someVal, y: someVal, width: someVal, height: someVal}, usually calculated internally.
+            item_style: The style of default tooltip content item which is a li element. DEFAULT: {}
+            wrapper_style: The style of tooltip wrapper which is a dom element. DEFAULT: {}
+            content_style: The style of tooltip content which is a dom element. DEFAULT: {}
+            label_style: The style of default tooltip label which is a p element. DEFAULT: {}
+            allow_escape_view_box: This option allows the tooltip to extend beyond the viewBox of the chart itself. DEFAULT: { x: false, y: false }
             active: If set true, the tooltip is displayed. If set false, the tooltip is hidden, usually calculated internally.
             position: If this field is set, the tooltip position will be fixed and will not move anymore.
             coordinate: The coordinate of tooltip which is usually calculated internally.
+            is_animation_active: If set false, animation of tooltip will be disabled. DEFAULT: true in CSR, and false in SSR
+            animation_duration: Specifies the duration of animation, the unit of this option is ms. DEFAULT: 1500
+            animation_easing: The type of easing function. DEFAULT: 'ease'
             style: The style of the component.
             key: A unique key for the component.
             id: The id for the component.
@@ -314,9 +361,6 @@ class GraphingTooltip(Recharts):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -446,9 +490,6 @@ class Label(Recharts):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -506,8 +547,6 @@ class LabelList(Recharts):
             ]
         ] = None,
         offset: Optional[Union[Var[int], int]] = None,
-        fill: Optional[Union[Var[str], str]] = None,
-        stroke: Optional[Union[Var[str], str]] = None,
         style: Optional[Style] = None,
         key: Optional[Any] = None,
         id: Optional[Any] = None,
@@ -568,8 +607,6 @@ class LabelList(Recharts):
             data_key: The key of a group of label values in data.
             position: The position of each label relative to it view box。"Top" | "left" | "right" | "bottom" | "inside" | "outside" | "insideLeft" | "insideRight" | "insideTop" | "insideBottom" | "insideTopLeft" | "insideBottomLeft" | "insideTopRight" | "insideBottomRight" | "insideStart" | "insideEnd" | "end" | "center"
             offset: The offset to the specified "position"
-            fill: Color of the fill
-            stroke: Color of the stroke
             style: The style of the component.
             key: A unique key for the component.
             id: The id for the component.
@@ -580,8 +617,11 @@ class LabelList(Recharts):
 
         Returns:
             The component.
-
-        Raises:
-            TypeError: If an invalid child is passed.
         """
         ...
+
+responsive_container = ResponsiveContainer.create
+legend = Legend.create
+graphing_tooltip = GraphingTooltip.create
+label = Label.create
+label_list = LabelList.create

--- a/reflex/components/recharts/general.pyi
+++ b/reflex/components/recharts/general.pyi
@@ -9,7 +9,7 @@ from reflex.event import EventChain, EventHandler, EventSpec
 from reflex.style import Style
 from typing import Any, Dict, List, Union
 from reflex.components.component import MemoizationLeaf
-from reflex.event import EventHandler
+from reflex.constants import EventTriggers
 from reflex.vars import Var
 from .recharts import (
     LiteralIconType,
@@ -109,6 +109,7 @@ class ResponsiveContainer(Recharts, MemoizationLeaf):
         ...
 
 class Legend(Recharts):
+    def get_event_triggers(self) -> dict[str, Union[Var, Any]]: ...
     @overload
     @classmethod
     def create(  # type: ignore
@@ -174,25 +175,7 @@ class Legend(Recharts):
         class_name: Optional[Any] = None,
         autofocus: Optional[bool] = None,
         custom_attrs: Optional[Dict[str, Union[Var, str]]] = None,
-        on_blur: Optional[
-            Union[EventHandler, EventSpec, list, function, BaseVar]
-        ] = None,
         on_click: Optional[
-            Union[EventHandler, EventSpec, list, function, BaseVar]
-        ] = None,
-        on_context_menu: Optional[
-            Union[EventHandler, EventSpec, list, function, BaseVar]
-        ] = None,
-        on_double_click: Optional[
-            Union[EventHandler, EventSpec, list, function, BaseVar]
-        ] = None,
-        on_focus: Optional[
-            Union[EventHandler, EventSpec, list, function, BaseVar]
-        ] = None,
-        on_mount: Optional[
-            Union[EventHandler, EventSpec, list, function, BaseVar]
-        ] = None,
-        on_mouse_down: Optional[
             Union[EventHandler, EventSpec, list, function, BaseVar]
         ] = None,
         on_mouse_enter: Optional[
@@ -208,15 +191,6 @@ class Legend(Recharts):
             Union[EventHandler, EventSpec, list, function, BaseVar]
         ] = None,
         on_mouse_over: Optional[
-            Union[EventHandler, EventSpec, list, function, BaseVar]
-        ] = None,
-        on_mouse_up: Optional[
-            Union[EventHandler, EventSpec, list, function, BaseVar]
-        ] = None,
-        on_scroll: Optional[
-            Union[EventHandler, EventSpec, list, function, BaseVar]
-        ] = None,
-        on_unmount: Optional[
             Union[EventHandler, EventSpec, list, function, BaseVar]
         ] = None,
         **props
@@ -245,6 +219,9 @@ class Legend(Recharts):
 
         Returns:
             The component.
+
+        Raises:
+            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -337,6 +314,9 @@ class GraphingTooltip(Recharts):
 
         Returns:
             The component.
+
+        Raises:
+            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -466,6 +446,9 @@ class Label(Recharts):
 
         Returns:
             The component.
+
+        Raises:
+            TypeError: If an invalid child is passed.
         """
         ...
 
@@ -523,6 +506,8 @@ class LabelList(Recharts):
             ]
         ] = None,
         offset: Optional[Union[Var[int], int]] = None,
+        fill: Optional[Union[Var[str], str]] = None,
+        stroke: Optional[Union[Var[str], str]] = None,
         style: Optional[Style] = None,
         key: Optional[Any] = None,
         id: Optional[Any] = None,
@@ -583,6 +568,8 @@ class LabelList(Recharts):
             data_key: The key of a group of label values in data.
             position: The position of each label relative to it view box。"Top" | "left" | "right" | "bottom" | "inside" | "outside" | "insideLeft" | "insideRight" | "insideTop" | "insideBottom" | "insideTopLeft" | "insideBottomLeft" | "insideTopRight" | "insideBottomRight" | "insideStart" | "insideEnd" | "end" | "center"
             offset: The offset to the specified "position"
+            fill: Color of the fill
+            stroke: Color of the stroke
             style: The style of the component.
             key: A unique key for the component.
             id: The id for the component.
@@ -593,11 +580,8 @@ class LabelList(Recharts):
 
         Returns:
             The component.
+
+        Raises:
+            TypeError: If an invalid child is passed.
         """
         ...
-
-responsive_container = ResponsiveContainer.create
-legend = Legend.create
-graphing_tooltip = GraphingTooltip.create
-label = Label.create
-label_list = LabelList.create


### PR DESCRIPTION
Added missing props for tooltip 
`is_animation_active` `animation_duration` `animation_easing` `item_style` `wrapper_style` `content_style` `label_style` `allow_escape_view_box`