### PR TITLE
Ensure rx.match gets memoized to avoid excessive re-rendering

### DIFF
--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -2038,6 +2038,7 @@ class StatefulComponent(BaseComponent):
         from reflex.components.base.bare import Bare
         from reflex.components.core.cond import Cond
         from reflex.components.core.foreach import Foreach
+        from reflex.components.core.match import Match
 
         if isinstance(child, Bare):
             return child.contents
@@ -2045,6 +2046,8 @@ class StatefulComponent(BaseComponent):
             return child.cond
         if isinstance(child, Foreach):
             return child.iterable
+        if isinstance(child, Match):
+            return child.cond
         return child
 
     @classmethod


### PR DESCRIPTION
Fix an issue where Component-returning `rx.match` components that depended on State were causing the entire page to re-render due to not being memoized into their own react component function.

To see the issue live, go to https://reflex.dev/docs/library/layout/match/

Change the select box and watch the inkeep search box in the navbar. Notice how it flickers whenever the select value changes. With this change, there is no more flicker.