### PR TITLE
[REF-3185][REF-3180]Dont escape backticks in JS string interpolation

### DIFF
--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -211,6 +211,7 @@ def _escape_js_string(string: str) -> str:
         The escaped string.
     """
 
+    # TODO: we may need to re-vist this logic after new Var API is implemented.
     def escape_outside_segments(segment):
         """Escape backticks in segments outside of `${}`.
 

--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -210,10 +210,23 @@ def _escape_js_string(string: str) -> str:
     Returns:
         The escaped string.
     """
-    # Escape backticks.
-    string = string.replace(r"\`", "`")
-    string = string.replace("`", r"\`")
-    return string
+
+    def escape_outside_segments(segment):
+        """Escape backticks in segments outside of `${}`."""
+        if segment.startswith("${") and segment.endswith("}"):
+            # Return the `${}` segment unchanged
+            return segment
+        else:
+            # Escape backticks in the segment
+            segment = segment.replace(r"\`", "`")
+            segment = segment.replace("`", r"\`")
+            return segment
+
+    # Split the string into parts, keeping the `${}` segments
+    parts = re.split(r"(\$\{.*?\})", string)
+    escaped_parts = [escape_outside_segments(part) for part in parts]
+    escaped_string = "".join(escaped_parts)
+    return escaped_string
 
 
 def _wrap_js_string(string: str) -> str:

--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -212,7 +212,14 @@ def _escape_js_string(string: str) -> str:
     """
 
     def escape_outside_segments(segment):
-        """Escape backticks in segments outside of `${}`."""
+        """Escape backticks in segments outside of `${}`.
+
+        Args:
+            segment: The part of the string to escape.
+
+        Returns:
+            The escaped or unescaped segment.
+        """
         if segment.startswith("${") and segment.endswith("}"):
             # Return the `${}` segment unchanged
             return segment

--- a/tests/utils/test_format.py
+++ b/tests/utils/test_format.py
@@ -109,16 +109,16 @@ def test_wrap(text: str, open: str, expected: str, check_first: bool, num: int):
             "This is a random string with \\`backticks\\`",
         ),
         (
-            "This is a string with ${`string interpolation`} unescaped",
-            "This is a string with ${`string interpolation`} unescaped",
+            "This is a string with ${someValue[`string interpolation`]} unescaped",
+            "This is a string with ${someValue[`string interpolation`]} unescaped",
         ),
         (
-            "This is a string with `backticks` and ${`string interpolation`} unescaped",
-            "This is a string with \\`backticks\\` and ${`string interpolation`} unescaped",
+            "This is a string with `backticks` and ${someValue[`string interpolation`]} unescaped",
+            "This is a string with \\`backticks\\` and ${someValue[`string interpolation`]} unescaped",
         ),
         (
-            "This is a string with `backticks`, ${`the first string interpolation`} and ${`the second`}",
-            "This is a string with \\`backticks\\`, ${`the first string interpolation`} and ${`the second`}",
+            "This is a string with `backticks`, ${someValue[`the first string interpolation`]} and ${someValue[`the second`]}",
+            "This is a string with \\`backticks\\`, ${someValue[`the first string interpolation`]} and ${someValue[`the second`]}",
         ),
     ],
 )

--- a/tests/utils/test_format.py
+++ b/tests/utils/test_format.py
@@ -97,6 +97,36 @@ def test_wrap(text: str, open: str, expected: str, check_first: bool, num: int):
 
 
 @pytest.mark.parametrize(
+    "string,expected_output",
+    [
+        ("This is a random string", "This is a random string"),
+        (
+            "This is a random string with `backticks`",
+            "This is a random string with \\`backticks\\`",
+        ),
+        (
+            "This is a random string with `backticks`",
+            "This is a random string with \\`backticks\\`",
+        ),
+        (
+            "This is a string with ${`string interpolation`} unescaped",
+            "This is a string with ${`string interpolation`} unescaped",
+        ),
+        (
+            "This is a string with `backticks` and ${`string interpolation`} unescaped",
+            "This is a string with \\`backticks\\` and ${`string interpolation`} unescaped",
+        ),
+        (
+            "This is a string with `backticks`, ${`the first string interpolation`} and ${`the second`}",
+            "This is a string with \\`backticks\\`, ${`the first string interpolation`} and ${`the second`}",
+        ),
+    ],
+)
+def test_escape_js_string(string, expected_output):
+    assert format._escape_js_string(string) == expected_output
+
+
+@pytest.mark.parametrize(
     "text,indent_level,expected",
     [
         ("", 2, ""),


### PR DESCRIPTION
Javascript is not a happy person when you escape backticks in a string interpolation. Eg.

```js 
  const value = `Getting the value of ${ someValue[\`key\`]}`
``` 
when trying to format or escape strings with backticks, we want to exclude anything in `${}`.
