### PR TITLE
[REF-3220] Fix rx.cancel_upload EventSpec

### DIFF
--- a/reflex/components/core/upload.py
+++ b/reflex/components/core/upload.py
@@ -107,7 +107,7 @@ def cancel_upload(upload_id: str) -> EventSpec:
         An event spec that cancels the upload when triggered.
     """
     return call_script(
-        f"upload_controllers[{Var.create_safe(upload_id, _var_is_string=True)._var_name_unwrapped!r}]?.abort()"
+        f"upload_controllers[{Var.create_safe(upload_id, _var_is_string=True)._var_name_unwrapped}]?.abort()"
     )
 
 


### PR DESCRIPTION
The formatting of the upload ID had extra single quotes that were not needed. Now that `_var_name_unwrapped` is used, any `str`-like Vars will automatically be formatted with backticks