### PR TITLE
gitignore external assets by default

### DIFF
--- a/reflex/constants/config.py
+++ b/reflex/constants/config.py
@@ -39,7 +39,7 @@ class GitIgnore(SimpleNamespace):
     # The gitignore file.
     FILE = ".gitignore"
     # Files to gitignore.
-    DEFAULTS = {Dirs.WEB, "*.db", "__pycache__/", "*.py[cod]"}
+    DEFAULTS = {Dirs.WEB, "*.db", "__pycache__/", "*.py[cod]", "assets/external/"}
 
 
 class RequirementsTxt(SimpleNamespace):


### PR DESCRIPTION
External assets are contained in the python distributions and should not be tracked in git by the projects which are using them