### PR TITLE
[REF-3266] Check for pydantic v1 outside of try/except

### DIFF
--- a/reflex/utils/compat.py
+++ b/reflex/utils/compat.py
@@ -32,6 +32,13 @@ def pydantic_v1_patch():
     Yields:
         None when the Pydantic module is patched.
     """
+    import pydantic
+
+    if pydantic.__version__.startswith("1."):
+        # pydantic v1 is already installed
+        yield
+        return
+
     patched_modules = [
         "pydantic",
         "pydantic.fields",
@@ -41,11 +48,6 @@ def pydantic_v1_patch():
     originals = {module: sys.modules.get(module) for module in patched_modules}
     try:
         import pydantic.v1  # type: ignore
-
-        if pydantic.__version__.startswith("1."):
-            # pydantic v1 is already installed
-            yield
-            return
 
         sys.modules["pydantic.fields"] = pydantic.v1.fields  # type: ignore
         sys.modules["pydantic.main"] = pydantic.v1.main  # type: ignore


### PR DESCRIPTION
If pydantic v1 is already installed, there is no reason to restore the original pydantic modules, which seems to introduce subtle incompatibilities with some pydantic versions.

Perform the pydantic version check early on and exit for v1 before doing anything with the sys.modules.

Fix #3642