### PR TITLE
Make domain props work for `y_axis`

### DIFF
--- a/reflex/components/recharts/cartesian.py
+++ b/reflex/components/recharts/cartesian.py
@@ -152,6 +152,7 @@ class YAxis(Axis):
     # The id of y-axis which is corresponding to the data.
     y_axis_id: Var[Union[str, int]]
 
+    # The range of the axis. Work best in conjuction with allow_data_overflow.
     domain: Var[List]
 
 

--- a/reflex/components/recharts/cartesian.py
+++ b/reflex/components/recharts/cartesian.py
@@ -152,6 +152,8 @@ class YAxis(Axis):
     # The id of y-axis which is corresponding to the data.
     y_axis_id: Var[Union[str, int]]
 
+    domain: Var[List]
+
 
 class ZAxis(Recharts):
     """A ZAxis component in Recharts."""

--- a/reflex/components/recharts/cartesian.pyi
+++ b/reflex/components/recharts/cartesian.pyi
@@ -494,6 +494,7 @@ class YAxis(Axis):
             *children: The children of the component.
             orientation: The orientation of axis 'left' | 'right'
             y_axis_id: The id of y-axis which is corresponding to the data.
+            domain: The range of the axis. Work best in conjuction with allow_data_overflow.
             data_key: The key of data displayed in the axis.
             hide: If set true, the axis do not display in the chart.
             width: The width of axis which is usually calculated internally.

--- a/reflex/components/recharts/cartesian.pyi
+++ b/reflex/components/recharts/cartesian.pyi
@@ -366,6 +366,7 @@ class YAxis(Axis):
             Union[Var[Literal["left", "right"]], Literal["left", "right"]]
         ] = None,
         y_axis_id: Optional[Union[Var[Union[int, str]], str, int]] = None,
+        domain: Optional[Union[Var[List], List]] = None,
         data_key: Optional[Union[Var[Union[int, str]], str, int]] = None,
         hide: Optional[Union[Var[bool], bool]] = None,
         width: Optional[Union[Var[Union[int, str]], str, int]] = None,


### PR DESCRIPTION
Assuming we have data going from 0 to 100, using the code below will only display the range 25,50 on the charts

```python
rx.recharts.y_axis(
    domain=[25, 50],
    allow_data_overflow=True,
),
```

Fix #3083