### PR TITLE
feat: Added two more options to setvar.

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -295,13 +295,11 @@ class EventHandlerSetVar(EventHandler):
         from reflex.utils.exceptions import EventHandlerValueError
 
         if args:
-            var_name: Union[str, BaseVar] = args[0]
-            if not isinstance(args[0], str) and not isinstance(var_name, BaseVar):
+            var_name: str = args[0]
+            if not isinstance(args[0], str):
                 raise EventHandlerValueError(
                     f"Var name must be passed as a string, got {args[0]!r}"
                 )
-            if isinstance(var_name, BaseVar):
-                var_name = var_name._var_name
             fracs = var_name.split(".")
             # Check that the requested Var setter exists on the State at compile time.
             if (

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -259,19 +259,23 @@ class EventHandlerSetVar(EventHandler):
         Args:
             var_name: The name of the variable to set.
             value: The value to set the variable to.
+
+        Raises:
+            AttributeError: If the given Var name does not exist on the state.
         """
         var_name_fracs = var_name.split(".")
         if len(var_name_fracs) > 1:
-            if isinstance(getattr(self, var_name_fracs[0]), Base):
-                obj = initial_obj = getattr(self, var_name_fracs[0])
+            var_name_on_state = var_name_fracs[0]
+            if isinstance(getattr(self, var_name_on_state), Base):
+                obj = initial_obj = getattr(self, var_name_on_state)
                 for frac in var_name_fracs[1:-1]:
                     obj = getattr(obj, frac)
                 setattr(obj, var_name_fracs[-1], value)
-                getattr(self, constants.SETTER_PREFIX + var_name_fracs[0])(initial_obj)
+                getattr(self, constants.SETTER_PREFIX + var_name_on_state)(initial_obj)
                 return
             else:
                 raise AttributeError(
-                    f"Variable `{var_name}` of type {getattr(self, var_name_fracs[0])._var_type} cannot be set to `{value}`"
+                    f"Variable `{var_name}` of type {getattr(self, var_name_on_state)._var_type} cannot be set to `{value}`"
                 )
         getattr(self, constants.SETTER_PREFIX + var_name)(value)
 

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -2988,12 +2988,20 @@ async def test_setvar(mock_app: rx.App, token: str):
 
     # Set Var in same state (with Var type casting)
     for event in rx.event.fix_events(
-        [TestState.setvar("num1", 42), TestState.setvar("num2", "4.2")], token
+        [
+            TestState.setvar("num1", 42),
+            TestState.setvar("num2", "4.2"),
+            TestState.setvar(TestState.obj.prop1, 21),
+            TestState.setvar("obj.prop2", "world"),
+        ],
+        token,
     ):
         async for update in state._process(event):
             print(update)
     assert state.num1 == 42
     assert state.num2 == 4.2
+    assert state.obj.prop1 == 21
+    assert state.obj.prop2 == "world"
 
     # Set Var in parent state
     for event in rx.event.fix_events([GrandchildState.setvar("array", [43])], token):


### PR DESCRIPTION
Either provide a dot-separated string to access
fields on objects or use a var to describe which
value to set.

This enables you to write something like this:
```python
import reflex as rx

class Object(rx.Base):
    name: str = "1234"

class State(rx.State):
    message: str = "Default"
    object: Object = Object()

def index() -> rx.Component:
    return rx.container(
        rx.text(f"Object name: ", State.object.name),
        rx.input(value=State.object.name, on_change=State.setvar(State.object.name)),  # new syntax
        rx.input(value=State.object.name, on_change=State.setvar("object.name")),  #new syntax
        rx.text(f"Message: ", State.message),
        rx.input(value=State.message, on_change=State.setvar(State.message)),  # new syntax
        rx.input(value=State.message, on_change=State.setvar("message")),
    )

app = rx.App()
app.add_page(index)
```

It might need some polishing with regard to nonexisting fields on objects, which is not checked for now. 
But I want to share a first version to get feedback.
