### PR TITLE
debounce: pass through key and special_props

### DIFF
--- a/reflex/components/core/debounce.py
+++ b/reflex/components/core/debounce.py
@@ -101,6 +101,9 @@ class DebounceInput(Component):
         props.setdefault("style", {}).update(child.style)
         if child.class_name is not None:
             props["class_name"] = f"{props.get('class_name', '')} {child.class_name}"
+        for field in ("key", "special_props"):
+            if getattr(child, field) is not None:
+                props[field] = getattr(child, field)
         child_ref = child.get_ref()
         if props.get("input_ref") is None and child_ref:
             props["input_ref"] = Var.create_safe(

--- a/tests/components/core/test_debounce.py
+++ b/tests/components/core/test_debounce.py
@@ -92,6 +92,29 @@ def test_render_with_ref():
     assert "foo_bar" in str(tag.props["inputRef"])
 
 
+def test_render_with_key():
+    tag = rx.debounce_input(
+        rx.input(
+            on_change=S.on_change,
+            key="foo_bar",
+        )
+    )._render()
+    assert isinstance(tag.props["key"], rx.Var)
+    assert "foo_bar" in str(tag.props["key"])
+
+
+def test_render_with_special_props():
+    special_prop = rx.Var.create_safe("{foo_bar}", _var_is_string=False)
+    tag = rx.debounce_input(
+        rx.input(
+            on_change=S.on_change,
+            special_props=[special_prop],
+        )
+    )._render()
+    assert len(tag.special_props) == 1
+    assert list(tag.special_props)[0].equals(special_prop)
+
+
 def test_event_triggers():
     debounced_input = rx.debounce_input(
         rx.input(


### PR DESCRIPTION
These fields on the base Component were not being carried onto the DebounceInput component (to be passed to the child).

Discovered while testing #3653