### PR TITLE
benchmarks.yml: use node 18.x with reflex-web@main

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -30,7 +30,7 @@ jobs:
         # Show OS combos first in GUI
         os: [ubuntu-latest]
         python-version: ['3.11.4']
-        node-version: ['16.x']
+        node-version: ['18.x']
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: reflex-dev/reflex-web
-          ref: reflex-ci
+          ref: main
           path: reflex-web
 
       - name: Install Requirements for reflex-web


### PR DESCRIPTION
* Lighthouse requires node 18.x

* Target the reflex-web main branch for better tracking of lighthouse scores over time.

👉 Test run: https://github.com/reflex-dev/reflex/actions/runs/9882217403/job/27294653882

------------------

_Sidenote_

We actually haven't passed lighthouse benchmarking since late April 2024, but almost no one notices because it runs _on the PR_ after the PR is _closed_. So only the submitter or the merger will get an email notification about the benchmarking failures so basically it fails silently. If you check the merged PR list lately, all of them have ❌ even though they were ✅ when we merged them.

Today i got sick of getting these failure emails, and lighthouse benchmarking per-pr is probably something we _do_ want, so... here we are.