### PR TITLE
[REF-3222] define new JS-type var classes

### DIFF
--- a/reflex/experimental/vars/__init__.py
+++ b/reflex/experimental/vars/__init__.py
@@ -1,3 +1,9 @@
 """Experimental Immutable-Based Var System."""
 
 from .base import ImmutableVar as ImmutableVar
+from .base import StringVar as StringVar
+from .base import NumberVar as NumberVar
+from .base import BooleanVar as BooleanVar
+from .base import ArrayVar as ArrayVar
+from .base import ObjectVar as ObjectVar
+from .base import FunctionVar as FunctionVar

--- a/reflex/experimental/vars/__init__.py
+++ b/reflex/experimental/vars/__init__.py
@@ -1,9 +1,9 @@
 """Experimental Immutable-Based Var System."""
 
-from .base import ImmutableVar as ImmutableVar
-from .base import StringVar as StringVar
-from .base import NumberVar as NumberVar
-from .base import BooleanVar as BooleanVar
 from .base import ArrayVar as ArrayVar
-from .base import ObjectVar as ObjectVar
+from .base import BooleanVar as BooleanVar
 from .base import FunctionVar as FunctionVar
+from .base import ImmutableVar as ImmutableVar
+from .base import NumberVar as NumberVar
+from .base import ObjectVar as ObjectVar
+from .base import StringVar as StringVar

--- a/reflex/experimental/vars/base.py
+++ b/reflex/experimental/vars/base.py
@@ -100,7 +100,7 @@ class ImmutableVar(Var):
                 kwargs.get("_var_data", self._var_data), merge_var_data
             ),
         )
-        return ImmutableVar(**field_values)
+        return type(self)(**field_values)
 
     @classmethod
     def create(
@@ -161,7 +161,7 @@ class ImmutableVar(Var):
             )
         name = name if isinstance(name, str) else format.json_dumps(name)
 
-        return ImmutableVar(
+        return cls(
             _var_name=name,
             _var_type=type_,
             _var_data=_var_data,
@@ -210,55 +210,25 @@ class ImmutableVar(Var):
         return f"{REFLEX_VAR_OPENING_TAG}{hash(self)}{REFLEX_VAR_CLOSING_TAG}{self._var_name}"
 
 
-@dataclasses.dataclass(
-    eq=False,
-    frozen=True,
-    **{"slots": True} if sys.version_info >= (3, 10) else {},
-)
 class StringVar(ImmutableVar):
     """Base class for immutable string vars."""
 
 
-@dataclasses.dataclass(
-    eq=False,
-    frozen=True,
-    **{"slots": True} if sys.version_info >= (3, 10) else {},
-)
 class NumberVar(ImmutableVar):
     """Base class for immutable number vars."""
 
 
-@dataclasses.dataclass(
-    eq=False,
-    frozen=True,
-    **{"slots": True} if sys.version_info >= (3, 10) else {},
-)
 class BooleanVar(ImmutableVar):
     """Base class for immutable boolean vars."""
 
 
-@dataclasses.dataclass(
-    eq=False,
-    frozen=True,
-    **{"slots": True} if sys.version_info >= (3, 10) else {},
-)
 class ObjectVar(ImmutableVar):
     """Base class for immutable object vars."""
 
 
-@dataclasses.dataclass(
-    eq=False,
-    frozen=True,
-    **{"slots": True} if sys.version_info >= (3, 10) else {},
-)
 class ArrayVar(ImmutableVar):
     """Base class for immutable array vars."""
 
 
-@dataclasses.dataclass(
-    eq=False,
-    frozen=True,
-    **{"slots": True} if sys.version_info >= (3, 10) else {},
-)
 class FunctionVar(ImmutableVar):
     """Base class for immutable function vars."""

--- a/reflex/experimental/vars/base.py
+++ b/reflex/experimental/vars/base.py
@@ -208,3 +208,51 @@ class ImmutableVar(Var):
 
         # Encode the _var_data into the formatted output for tracking purposes.
         return f"{REFLEX_VAR_OPENING_TAG}{hash(self)}{REFLEX_VAR_CLOSING_TAG}{self._var_name}"
+
+
+@dataclasses.dataclass(
+    eq=False,
+    frozen=True,
+    **{"slots": True} if sys.version_info >= (3, 10) else {},
+)
+class StringVar(ImmutableVar): ...
+
+
+@dataclasses.dataclass(
+    eq=False,
+    frozen=True,
+    **{"slots": True} if sys.version_info >= (3, 10) else {},
+)
+class NumberVar(ImmutableVar): ...
+
+
+@dataclasses.dataclass(
+    eq=False,
+    frozen=True,
+    **{"slots": True} if sys.version_info >= (3, 10) else {},
+)
+class BooleanVar(ImmutableVar): ...
+
+
+@dataclasses.dataclass(
+    eq=False,
+    frozen=True,
+    **{"slots": True} if sys.version_info >= (3, 10) else {},
+)
+class ObjectVar(ImmutableVar): ...
+
+
+@dataclasses.dataclass(
+    eq=False,
+    frozen=True,
+    **{"slots": True} if sys.version_info >= (3, 10) else {},
+)
+class ArrayVar(ImmutableVar): ...
+
+
+@dataclasses.dataclass(
+    eq=False,
+    frozen=True,
+    **{"slots": True} if sys.version_info >= (3, 10) else {},
+)
+class FunctionVar(ImmutableVar): ...

--- a/reflex/experimental/vars/base.py
+++ b/reflex/experimental/vars/base.py
@@ -204,10 +204,12 @@ class ImmutableVar(Var):
         Returns:
             The formatted var.
         """
-        _global_vars[hash(self)] = self
+        hashed_var = hash(self)
+
+        _global_vars[hashed_var] = self
 
         # Encode the _var_data into the formatted output for tracking purposes.
-        return f"{REFLEX_VAR_OPENING_TAG}{hash(self)}{REFLEX_VAR_CLOSING_TAG}{self._var_name}"
+        return f"{REFLEX_VAR_OPENING_TAG}{hashed_var}{REFLEX_VAR_CLOSING_TAG}{self._var_name}"
 
 
 class StringVar(ImmutableVar):

--- a/reflex/experimental/vars/base.py
+++ b/reflex/experimental/vars/base.py
@@ -215,7 +215,8 @@ class ImmutableVar(Var):
     frozen=True,
     **{"slots": True} if sys.version_info >= (3, 10) else {},
 )
-class StringVar(ImmutableVar): ...
+class StringVar(ImmutableVar):
+    """Base class for immutable string vars."""
 
 
 @dataclasses.dataclass(
@@ -223,7 +224,8 @@ class StringVar(ImmutableVar): ...
     frozen=True,
     **{"slots": True} if sys.version_info >= (3, 10) else {},
 )
-class NumberVar(ImmutableVar): ...
+class NumberVar(ImmutableVar):
+    """Base class for immutable number vars."""
 
 
 @dataclasses.dataclass(
@@ -231,7 +233,8 @@ class NumberVar(ImmutableVar): ...
     frozen=True,
     **{"slots": True} if sys.version_info >= (3, 10) else {},
 )
-class BooleanVar(ImmutableVar): ...
+class BooleanVar(ImmutableVar):
+    """Base class for immutable boolean vars."""
 
 
 @dataclasses.dataclass(
@@ -239,7 +242,8 @@ class BooleanVar(ImmutableVar): ...
     frozen=True,
     **{"slots": True} if sys.version_info >= (3, 10) else {},
 )
-class ObjectVar(ImmutableVar): ...
+class ObjectVar(ImmutableVar):
+    """Base class for immutable object vars."""
 
 
 @dataclasses.dataclass(
@@ -247,7 +251,8 @@ class ObjectVar(ImmutableVar): ...
     frozen=True,
     **{"slots": True} if sys.version_info >= (3, 10) else {},
 )
-class ArrayVar(ImmutableVar): ...
+class ArrayVar(ImmutableVar):
+    """Base class for immutable array vars."""
 
 
 @dataclasses.dataclass(
@@ -255,4 +260,5 @@ class ArrayVar(ImmutableVar): ...
     frozen=True,
     **{"slots": True} if sys.version_info >= (3, 10) else {},
 )
-class FunctionVar(ImmutableVar): ...
+class FunctionVar(ImmutableVar):
+    """Base class for immutable function vars."""


### PR DESCRIPTION
> All state vars and literal vars will inherit from one of the 6 fundamental Var types (based on the resulting type in generated JS code).
>
>These types will define the valid operations that are allowed.
>
>Each Var Operation class will also inherit from one of these types to define the result of evaluating the expression associated with the operation (for example, getting the length of an ArrayVar is an operation of type NumberVar)
>
>Because these classes will inherit from ImmutableVar, they will have the same fields that a Var currently has and they will already have all operations available at first. A subsequent stage of the project will move the operations from Var into modular VarOperations classes that will apply to one or more of these 6 types.
>
>StringVar
>
>NumberVar
>
>BooleanVar
>
>ObjectVar
>
>ArrayVar
>
>FunctionVar
>
>These types should be implemented in a new module reflex/experimental/vars/base.py (or js.py). Eventually the new experimental vars package will replace reflex.vars when everything is ready.
>
> This should allow us to incrementally merge and test the Var refactoring project in main without disrupting the current Var system.