### PR TITLE
fix initial state without cv fallback

### DIFF
--- a/reflex/compiler/utils.py
+++ b/reflex/compiler/utils.py
@@ -152,7 +152,9 @@ def compile_state(state: Type[BaseState]) -> dict:
         console.warn(
             f"Failed to compile initial state with computed vars, excluding them: {e}"
         )
-        initial_state = state(_reflex_internal_init=True).dict(include_computed=False)
+        initial_state = state(_reflex_internal_init=True).dict(
+            initial=True, include_computed=False
+        )
     return format.format_state(initial_state)
 
 

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1761,7 +1761,7 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
             prop_name: self.get_value(getattr(self, prop_name))
             for prop_name in self.base_vars
         }
-        if initial:
+        if initial and include_computed:
             computed_vars = {
                 # Include initial computed vars.
                 prop_name: (


### PR DESCRIPTION
This does not actually fix a bug, because the initial argument was only used for initial values of computed vars. However, one of my following PRs will use the initial arg for smth else which requires the initial arg to be set properly