### PR TITLE
reflex init --ai fixups

### DIFF
--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -1598,3 +1598,15 @@ def is_windows_bun_supported() -> bool:
         and cpu_info.model_name is not None
         and "ARM" not in cpu_info.model_name
     )
+
+
+def is_generation_hash(template: str) -> bool:
+    """Check if the template looks like a generation hash.
+
+    Args:
+        template: The template name.
+
+    Returns:
+        True if the template is composed of 32 or more hex characters.
+    """
+    return re.match(r"^[0-9a-f]{32,}$", template) is not None

--- a/reflex/utils/redir.py
+++ b/reflex/utils/redir.py
@@ -11,7 +11,7 @@ from . import console
 
 
 def open_browser_and_wait(
-    target_url: str, poll_url: str, interval: int = 1
+    target_url: str, poll_url: str, interval: int = 2
 ) -> httpx.Response:
     """Open a browser window to target_url and request poll_url until it returns successfully.
 
@@ -27,10 +27,14 @@ def open_browser_and_wait(
         console.warn(
             f"Unable to automatically open the browser. Please navigate to {target_url} in your browser."
         )
-    console.info("Complete the workflow in the browser to continue.")
-    while response := httpx.get(poll_url, follow_redirects=True):
-        if response.is_success:
-            break
+    console.info("[b]Complete the workflow in the browser to continue.[/b]")
+    while True:
+        try:
+            response = httpx.get(poll_url, follow_redirects=True)
+            if response.is_success:
+                break
+        except httpx.RequestError as err:
+            console.info(f"Will retry after error occurred while polling: {err}.")
         time.sleep(interval)
     return response
 


### PR DESCRIPTION
* Catch exceptions while polling to avoid exiting the loop
* Increase polling interval to 2s
* Allow `--template` to be a generation hash when `--ai` is also specified