### PR TITLE
[REF-3101] `rx.list` Dont set/hardcode `list_style_position` css prop

### DIFF
--- a/reflex/components/radix/themes/layout/list.py
+++ b/reflex/components/radix/themes/layout/list.py
@@ -70,7 +70,6 @@ class BaseList(Component):
                 children = [Foreach.create(items, ListItem.create)]
             else:
                 children = [ListItem.create(item) for item in items]  # type: ignore
-        props["list_style_position"] = "outside"
         props["direction"] = "column"
         style = props.setdefault("style", {})
         style["list_style_type"] = list_style_type
@@ -86,7 +85,6 @@ class BaseList(Component):
         """
         return {
             "direction": "column",
-            "list_style_position": "inside",
         }
 
 


### PR DESCRIPTION

This should allow setting `list_style_postion`(which was previously hard-coded to `outside`) css prop to take effect:

```python
import reflex as rx

def index():
   return rx.vstack(
       rx.list.unordered(
            rx.list.item("Example 1"),
            rx.list.item("Example 2"),
            rx.list.item("Example 3"),
            list_style_position="outside"
        ),
        rx.list.unordered(
            rx.list.item("Example 4"),
            rx.list.item("Example 5"),
            rx.list.item("Example 6"),
            list_style_position="inside",
        ),
)

app = rx.App()
app.add_page(index)
```

Also for some reason, the original issue(https://github.com/reflex-dev/reflex/issues/2934) which prompted setting the `list_style_position` prop among others  in the pr (https://github.com/reflex-dev/reflex/pull/2936) renders fine without setting the prop