### PR TITLE
[REF-3184] [REF-3339] Background task locking improvements

### DIFF
--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1806,7 +1806,7 @@ async def test_state_proxy(grandchild_state: GrandchildState, mock_app: rx.App):
 
     sp = StateProxy(grandchild_state)
     assert sp.__wrapped__ == grandchild_state
-    assert sp._self_substate_path == grandchild_state.get_full_name().split(".")
+    assert sp._self_substate_path == tuple(grandchild_state.get_full_name().split("."))
     assert sp._self_app is mock_app
     assert not sp._self_mutable
     assert sp._self_actx is None


### PR DESCRIPTION
* Raise ImmutableStateError if attempting to enter `async with self` while the lock is already held
* When accessing other states via `get_state`, share the same StateProxy context, lock, and mutability flag. (If a coroutine in the other state attempts `async with self` this will now fail due to the change above.

Due to how locking is implemented in redis, modifying a substate separately from the entire state tree is not possible, because there is a single lock for a given client_token state and all substates.

Fix #3554 