### PR TITLE
fix silly bug when style is set directly to breakpoints

### DIFF
--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -469,6 +469,7 @@ class Component(BaseComponent, ABC):
 
         if isinstance(style, Breakpoints):
             style = {
+                # Assign the Breakpoints to the self-referential selector to avoid squashing down to a regular dict.
                 "&": style,
             }
 

--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -24,6 +24,7 @@ from typing import (
 import reflex.state
 from reflex.base import Base
 from reflex.compiler.templates import STATEFUL_COMPONENT
+from reflex.components.core.breakpoints import Breakpoints
 from reflex.components.tags import Tag
 from reflex.constants import (
     Dirs,
@@ -465,6 +466,11 @@ class Component(BaseComponent, ABC):
         if isinstance(style, List):
             # Merge styles, the later ones overriding keys in the earlier ones.
             style = {k: v for style_dict in style for k, v in style_dict.items()}
+
+        if isinstance(style, Breakpoints):
+            style = {
+                "&": style,
+            }
 
         kwargs["style"] = Style(
             {


### PR DESCRIPTION
```py
def index() -> rx.Component:
    return rx.text(
        "Hello, World!",
        style=rx.breakpoints(
            md={"color": "blue"},
            lg={"color": "green"},
        ),
        color="red",
        font_weight="bold",
    )
```