### PR TITLE
Improve Client-Side Routing on Page Not Found

### DIFF
--- a/reflex/.templates/web/utils/client_side_routing.js
+++ b/reflex/.templates/web/utils/client_side_routing.js
@@ -23,7 +23,12 @@ export const useClientSideRouting = () => {
       router.replace({
           pathname: window.location.pathname,
           query: window.location.search.slice(1),
-      })
+      }).then(()=>{
+          // Check if the current route is /404
+        if (router.pathname === '/404') {
+          setRouteNotFound(true); // Mark as an actual 404
+        }
+    })
       .catch((e) => {
         setRouteNotFound(true)  // navigation failed, so this is a real 404
       })


### PR DESCRIPTION
  ## Describe your changes.
  
The issue is well described in #3720 and also fixes it.

In the ```useClientSideRouting``` function, the ```routeNotFound``` state was incorrectly set to ```false``` even when the current route was actually not found. To address this, I added a hard check to verify the pathname after attempting a redirection. If the pathname remains ```/404``` after the redirection attempt, the ```routeNotFound``` state is correctly set to ```true```. This ensures that the correct 404 page is displayed when the route is genuinely not found.

Example is mentioned in the same issue's [thread](https://github.com/reflex-dev/reflex/issues/3720#issuecomment-2259891448)

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)


### New Feature Submission:

- [X] Does your submission pass the tests? 
- [X] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you successfully ran tests with your changes locally?