### PR TITLE
Use the new state name when setting `is_hydrated` to false

### DIFF
--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -782,7 +782,7 @@ export const useEventLoop = (
   // Route after the initial page hydration.
   useEffect(() => {
     const change_start = () => {
-      const main_state_dispatch = dispatch["state"]
+      const main_state_dispatch = dispatch["reflex___state____state"]
       if (main_state_dispatch !== undefined) {
         main_state_dispatch({ is_hydrated: false })
       }


### PR DESCRIPTION
This change ensures that `is_hydrated` is reset to `false` when navigating between pages to avoid the "flicker" that shows incorrect data during navigation events.