### PR TITLE
Fix code wrap in markdown

### DIFF
--- a/reflex/components/markdown/markdown.py
+++ b/reflex/components/markdown/markdown.py
@@ -70,7 +70,7 @@ def get_base_component_map() -> dict[str, Callable]:
         "a": lambda value: Link.create(value),
         "code": lambda value: Code.create(value),
         "codeblock": lambda value, **props: CodeBlock.create(
-            value, margin_y="1em", **props
+            value, margin_y="1em", wrap_long_lines=True, **props
         ),
     }
 


### PR DESCRIPTION
Related to #3721

Update `Markdown` component to wrap long lines in code blocks.

* Modify `reflex/components/markdown/markdown.py` to set the `wrap_long_lines` prop to `True` for the `CodeBlock` component in the `component_map`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/reflex-dev/reflex/issues/3721?shareId=de9535c6-3153-4dc7-ac4a-5067538449f5).