### PR TITLE
Add connection arguments to db config

### DIFF
--- a/reflex/config.py
+++ b/reflex/config.py
@@ -29,6 +29,7 @@ class DBConfig(Base):
     host: Optional[str] = ""
     port: Optional[int] = None
     database: str
+    options: Optional[Dict[str, Any]] = None
 
     @classmethod
     def postgresql(
@@ -38,6 +39,7 @@ class DBConfig(Base):
         password: str | None = None,
         host: str | None = None,
         port: int | None = 5432,
+        options: Optional[Dict[str, Any]] = None,
     ) -> DBConfig:
         """Create an instance with postgresql engine.
 
@@ -47,6 +49,7 @@ class DBConfig(Base):
             password: Database password.
             host: Database host.
             port: Database port.
+            options: Additional connection options.
 
         Returns:
             DBConfig instance.
@@ -58,6 +61,7 @@ class DBConfig(Base):
             host=host,
             port=port,
             database=database,
+            options=options,
         )
 
     @classmethod
@@ -68,6 +72,7 @@ class DBConfig(Base):
         password: str | None = None,
         host: str | None = None,
         port: int | None = 5432,
+        options: Optional[Dict[str, Any]] = None,
     ) -> DBConfig:
         """Create an instance with postgresql+psycopg2 engine.
 
@@ -77,6 +82,7 @@ class DBConfig(Base):
             password: Database password.
             host: Database host.
             port: Database port.
+            options: Additional connection options.
 
         Returns:
             DBConfig instance.
@@ -88,17 +94,20 @@ class DBConfig(Base):
             host=host,
             port=port,
             database=database,
+            options=options,
         )
 
     @classmethod
     def sqlite(
         cls,
         database: str,
+        options: Optional[Dict[str, Any]] = None,
     ) -> DBConfig:
         """Create an instance with sqlite engine.
 
         Args:
             database: Database name.
+            options: Additional connection options.
 
         Returns:
             DBConfig instance.
@@ -106,6 +115,7 @@ class DBConfig(Base):
         return cls(
             engine="sqlite",
             database=database,
+            options=options,
         )
 
     def get_url(self) -> str:
@@ -125,7 +135,11 @@ class DBConfig(Base):
         else:
             path = f"{host}"
 
-        return f"{self.engine}://{path}/{self.database}"
+        options = (
+            f"?{urllib.parse.urlencode(self.options)}" if self.options else ""
+        )
+
+        return f"{self.engine}://{path}/{self.database}{options}"
 
 
 class Config(Base):
@@ -361,7 +375,7 @@ def get_config(reload: bool = False) -> Config:
         reload: Re-import the rxconfig module from disk
 
     Returns:
-        The app config.
+            The app config.
     """
     sys.path.insert(0, os.getcwd())
     # only import the module if it exists. If a module spec exists then

--- a/reflex/model.py
+++ b/reflex/model.py
@@ -46,8 +46,11 @@ def get_engine(url: str | None = None) -> sqlalchemy.engine.Engine:
         )
     # Print the SQL queries if the log level is INFO or lower.
     echo_db_query = os.environ.get("SQLALCHEMY_ECHO") == "True"
+    # Get the connection arguments from the config.
+    connect_args = conf.db_config.options if conf.db_config and conf.db_config.options else {}
     # Needed for the admin dash on sqlite.
-    connect_args = {"check_same_thread": False} if url.startswith("sqlite") else {}
+    if url.startswith("sqlite"):
+        connect_args.update({"check_same_thread": False})
     return sqlmodel.create_engine(url, echo=echo_db_query, connect_args=connect_args)
 
 

--- a/tests/test_db_config.py
+++ b/tests/test_db_config.py
@@ -202,3 +202,105 @@ def test_constructor_postgresql_psycopg2(
     assert db_config.port == port
     assert db_config.database == database
     assert db_config.get_url() == expected_url
+
+
+@pytest.mark.parametrize(
+    "engine,username,password,host,port,database,options,expected_url",
+    [
+        (
+            "postgresql",
+            "user",
+            "pass",
+            "localhost",
+            5432,
+            "db",
+            {"connect_timeout": 10},
+            "postgresql://user:pass@localhost:5432/db?connect_timeout=10",
+        ),
+        (
+            "postgresql",
+            "user",
+            "pass",
+            "localhost",
+            None,
+            "db",
+            {"connect_timeout": 10},
+            "postgresql://user:pass@localhost/db?connect_timeout=10",
+        ),
+        (
+            "postgresql",
+            "user",
+            None,
+            "localhost",
+            None,
+            "db",
+            {"connect_timeout": 10},
+            "postgresql://user@localhost/db?connect_timeout=10",
+        ),
+        (
+            "postgresql",
+            "user",
+            None,
+            None,
+            None,
+            "db",
+            {"connect_timeout": 10},
+            "postgresql://user@/db?connect_timeout=10",
+        ),
+        (
+            "postgresql",
+            "user",
+            None,
+            None,
+            5432,
+            "db",
+            {"connect_timeout": 10},
+            "postgresql://user@/db?connect_timeout=10",
+        ),
+        (
+            "postgresql",
+            None,
+            None,
+            "localhost",
+            5432,
+            "db",
+            {"connect_timeout": 10},
+            "postgresql://localhost:5432/db?connect_timeout=10",
+        ),
+        (
+            "sqlite",
+            None,
+            None,
+            None,
+            None,
+            "db.sqlite",
+            {"timeout": 10},
+            "sqlite:///db.sqlite?timeout=10",
+        ),
+    ],
+)
+def test_get_url_with_options(
+    engine, username, password, host, port, database, options, expected_url
+):
+    """Test generation of URL with options.
+
+    Args:
+        engine: Database engine.
+        username: Database username.
+        password: Database password.
+        host: Database host.
+        port: Database port.
+        database: Database name.
+        options: Additional connection options.
+        expected_url: Expected database URL generated.
+    """
+    db_config = DBConfig(
+        engine=engine,
+        username=username,
+        password=password,
+        host=host,
+        port=port,
+        database=database,
+        options=options,
+    )
+    assert db_config.get_url() == expected_url


### PR DESCRIPTION
Related to #3751

Add support for specifying connection arguments in the config file for the db connection.

* **reflex/config.py**:
  - Add `options` attribute to the `DBConfig` class.
  - Update `get_url` method to include the `options` attribute in the URL.
  - Update `DBConfig` class methods (`postgresql`, `postgresql_psycopg2`, `sqlite`) to accept `options` parameter.
* **reflex/model.py**:
  - Update `get_engine` function to use the `options` attribute from `DBConfig` for connection arguments.
* **tests/test_db_config.py**:
  - Add test cases to verify that connection arguments can be specified in the config file.
  - Ensure test cases cover different database engines and connection arguments.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/reflex-dev/reflex/issues/3751?shareId=df914e8d-7b72-43c5-b62c-fba2af43b088).