### PR TITLE
added domain for XAxis used by recharts

### DIFF
--- a/reflex/components/recharts/cartesian.py
+++ b/reflex/components/recharts/cartesian.py
@@ -138,6 +138,9 @@ class XAxis(Axis):
     # Ensures that all datapoints within a chart contribute to its domain calculation, even when they are hidden
     include_hidden: Var[bool] = Var.create_safe(False)
 
+    # The range of the axis. Work best in conjuction with allow_data_overflow.
+    domain: Var[List]
+
 
 class YAxis(Axis):
     """A YAxis component in Recharts."""
@@ -152,8 +155,8 @@ class YAxis(Axis):
     # The id of y-axis which is corresponding to the data.
     y_axis_id: Var[Union[str, int]]
 
-    # The range of the axis. Work best in conjuction with allow_data_overflow.
-    domain: Var[List]
+    # # The range of the axis. Work best in conjuction with allow_data_overflow.
+    # domain: Var[List]
 
 
 class ZAxis(Recharts):

--- a/reflex/components/recharts/cartesian.pyi
+++ b/reflex/components/recharts/cartesian.pyi
@@ -192,6 +192,7 @@ class XAxis(Axis):
         ] = None,
         x_axis_id: Optional[Union[Var[Union[int, str]], str, int]] = None,
         include_hidden: Optional[Union[Var[bool], bool]] = None,
+        domain: Optional[Union[Var[List], List]] = None,
         data_key: Optional[Union[Var[Union[int, str]], str, int]] = None,
         hide: Optional[Union[Var[bool], bool]] = None,
         width: Optional[Union[Var[Union[int, str]], str, int]] = None,
@@ -320,6 +321,7 @@ class XAxis(Axis):
             orientation: The orientation of axis 'top' | 'bottom'
             x_axis_id: The id of x-axis which is corresponding to the data.
             include_hidden: Ensures that all datapoints within a chart contribute to its domain calculation, even when they are hidden
+            domain: The range of the axis. Work best in conjuction with allow_data_overflow.
             data_key: The key of data displayed in the axis.
             hide: If set true, the axis do not display in the chart.
             width: The width of axis which is usually calculated internally.
@@ -366,7 +368,6 @@ class YAxis(Axis):
             Union[Var[Literal["left", "right"]], Literal["left", "right"]]
         ] = None,
         y_axis_id: Optional[Union[Var[Union[int, str]], str, int]] = None,
-        domain: Optional[Union[Var[List], List]] = None,
         data_key: Optional[Union[Var[Union[int, str]], str, int]] = None,
         hide: Optional[Union[Var[bool], bool]] = None,
         width: Optional[Union[Var[Union[int, str]], str, int]] = None,
@@ -494,8 +495,7 @@ class YAxis(Axis):
             *children: The children of the component.
             orientation: The orientation of axis 'left' | 'right'
             y_axis_id: The id of y-axis which is corresponding to the data.
-            domain: The range of the axis. Work best in conjuction with allow_data_overflow.
-            data_key: The key of data displayed in the axis.
+            data_key: # The range of the axis. Work best in conjuction with allow_data_overflow.  domain: Var[List]  The key of data displayed in the axis.
             hide: If set true, the axis do not display in the chart.
             width: The width of axis which is usually calculated internally.
             height: The height of axis, which can be setted by user.


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.

 Recharts uses domain to modify the min, max values on an Axis. This is missing from Reflex implementation for XAxis.
Although there is another bug which is in the core recharts.js library which doesn't respect allow_decimals prop if domain is being used. This fix would still work for integer values.

Closes #3752 

