### PR TITLE
.gitmodules and .trunk/config Submodule Addition

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".trunk/config"]
+	path = .trunk/config
+	url = git@github.com:reflex-dev/oss-trunk-linter-config.git


### PR DESCRIPTION
This pull request adds two new files:

a) .gitmodules: This file has been created to include a submodule located at .trunk/config. The submodule is pointing to the repository git@github.com:reflex-dev/oss-trunk-linter-config.git.

b) .trunk/config: This is a submodule commit (f46ec9e2bc0619f4d9b10c496425eae5f3491009) referencing the external repository mentioned above.
