### PR TITLE
reflex/app.py - Update Import Statements

### DIFF
--- a/reflex/app.py
+++ b/reflex/app.py
@@ -14,11 +14,11 @@ import os
 import platform
 import sys
 import traceback
+from collections.abc import AsyncIterator
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 from typing import Any
-from typing import AsyncIterator
-from typing import Callable
 from typing import Coroutine
 from typing import Dict
 from typing import List


### PR DESCRIPTION
This PR adjusts the import statements in `reflex/app.py` to import `AsyncIterator` and `Callable` from `collections.abc` instead of `typing`. This change enhances compatibility with newer Python versions and aligns with best practices for future-proofing the codebase. The `datetime`, `pathlib.Path`, and `typing` imports remain unchanged.
