### PR TITLE
fix get_uuid_string_var

### DIFF
--- a/reflex/vars.py
+++ b/reflex/vars.py
@@ -2588,15 +2588,17 @@ def get_uuid_string_var() -> Var:
     """
     from reflex.utils.imports import ImportVar
 
+    unique_uuid_var = get_unique_variable_name()
     unique_uuid_var_data = VarData(
         imports={
             f"/{constants.Dirs.STATE_PATH}": {ImportVar(tag="generateUUID")},  # type: ignore
             "react": "useMemo",
-        }
+        },
+        hooks={f"const {unique_uuid_var} = useMemo(generateUUID, [])": None},
     )
 
     return BaseVar(
-        _var_name="useMemo(generateUUID, [])",
+        _var_name=unique_uuid_var,
         _var_type=str,
         _var_data=unique_uuid_var_data,
     )


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.

While creating an accordion, the number of hook calls are not constant and it raises a runtime error.
This happens when a value is not provided to the accordion item, a simple fix is to move `get_uuid_string_val()` call out to a separate hook.

closes #3767 
