### PR TITLE
Use cached_var_no_lock to avoid ImmutableVar deadlocks

### DIFF
--- a/reflex/ivars/base.py
+++ b/reflex/ivars/base.py
@@ -1011,9 +1011,6 @@ def figure_out_type(value: Any) -> types.GenericType:
     return type(value)
 
 
-_NOT_FOUND = object()
-
-
 class cached_property_no_lock(functools.cached_property):
     """A special version of functools.cached_property that does not use a lock."""
 

--- a/reflex/ivars/base.py
+++ b/reflex/ivars/base.py
@@ -1011,6 +1011,22 @@ def figure_out_type(value: Any) -> types.GenericType:
     return type(value)
 
 
+_NOT_FOUND = object()
+
+
+class cached_property_no_lock(functools.cached_property):
+    """A special version of functools.cached_property that does not use a lock."""
+
+    def __init__(self, func):
+        """Initialize the cached_property_no_lock.
+
+        Args:
+            func: The function to cache.
+        """
+        super().__init__(func)
+        self.lock = contextlib.nullcontext()
+
+
 class CachedVarOperation:
     """Base class for cached var operations to lower boilerplate code."""
 
@@ -1044,7 +1060,7 @@ class CachedVarOperation:
         """
         return self._cached_get_all_var_data
 
-    @functools.cached_property
+    @cached_property_no_lock
     def _cached_get_all_var_data(self) -> ImmutableVarData | None:
         """Get the cached VarData.
 
@@ -1096,7 +1112,7 @@ class AndOperation(CachedVarOperation, ImmutableVar):
     # The second var.
     _var2: Var = dataclasses.field(default_factory=lambda: LiteralVar.create(None))
 
-    @functools.cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """Get the cached var name.
 
@@ -1151,7 +1167,7 @@ class OrOperation(CachedVarOperation, ImmutableVar):
     # The second var.
     _var2: Var = dataclasses.field(default_factory=lambda: LiteralVar.create(None))
 
-    @functools.cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """Get the cached var name.
 

--- a/reflex/ivars/function.py
+++ b/reflex/ivars/function.py
@@ -4,13 +4,12 @@ from __future__ import annotations
 
 import dataclasses
 import sys
-from functools import cached_property
 from typing import Any, Callable, Optional, Tuple, Type, Union
 
 from reflex.utils.types import GenericType
 from reflex.vars import ImmutableVarData, Var, VarData
 
-from .base import CachedVarOperation, ImmutableVar, LiteralVar
+from .base import CachedVarOperation, ImmutableVar, LiteralVar, cached_property_no_lock
 
 
 class FunctionVar(ImmutableVar[Callable]):
@@ -79,7 +78,7 @@ class VarOperationCall(CachedVarOperation, ImmutableVar):
     _func: Optional[FunctionVar] = dataclasses.field(default=None)
     _args: Tuple[Union[Var, Any], ...] = dataclasses.field(default_factory=tuple)
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -88,7 +87,7 @@ class VarOperationCall(CachedVarOperation, ImmutableVar):
         """
         return f"({str(self._func)}({', '.join([str(LiteralVar.create(arg)) for arg in self._args])}))"
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_get_all_var_data(self) -> ImmutableVarData | None:
         """Get all the var data associated with the var.
 
@@ -139,7 +138,7 @@ class ArgsFunctionOperation(CachedVarOperation, FunctionVar):
     _args_names: Tuple[str, ...] = dataclasses.field(default_factory=tuple)
     _return_expr: Union[Var, Any] = dataclasses.field(default=None)
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -187,7 +186,7 @@ class ToFunctionOperation(CachedVarOperation, FunctionVar):
         default_factory=lambda: LiteralVar.create(None)
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 

--- a/reflex/ivars/number.py
+++ b/reflex/ivars/number.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import dataclasses
 import json
 import sys
-from functools import cached_property
 from typing import Any, Union
 
 from reflex.vars import ImmutableVarData, Var, VarData
@@ -14,6 +13,7 @@ from .base import (
     CachedVarOperation,
     ImmutableVar,
     LiteralVar,
+    cached_property_no_lock,
     unionize,
 )
 
@@ -341,7 +341,7 @@ class BinaryNumberOperation(CachedVarOperation, NumberVar):
         default_factory=lambda: LiteralNumberVar.create(0)
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -391,7 +391,7 @@ class UnaryNumberOperation(CachedVarOperation, NumberVar):
         default_factory=lambda: LiteralNumberVar.create(0)
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -424,7 +424,7 @@ class UnaryNumberOperation(CachedVarOperation, NumberVar):
 class NumberAddOperation(BinaryNumberOperation):
     """Base class for immutable number vars that are the result of an addition operation."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -437,7 +437,7 @@ class NumberAddOperation(BinaryNumberOperation):
 class NumberSubtractOperation(BinaryNumberOperation):
     """Base class for immutable number vars that are the result of a subtraction operation."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -450,7 +450,7 @@ class NumberSubtractOperation(BinaryNumberOperation):
 class NumberAbsoluteOperation(UnaryNumberOperation):
     """Base class for immutable number vars that are the result of an absolute operation."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -463,7 +463,7 @@ class NumberAbsoluteOperation(UnaryNumberOperation):
 class NumberMultiplyOperation(BinaryNumberOperation):
     """Base class for immutable number vars that are the result of a multiplication operation."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -476,7 +476,7 @@ class NumberMultiplyOperation(BinaryNumberOperation):
 class NumberNegateOperation(UnaryNumberOperation):
     """Base class for immutable number vars that are the result of a negation operation."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -489,7 +489,7 @@ class NumberNegateOperation(UnaryNumberOperation):
 class NumberTrueDivision(BinaryNumberOperation):
     """Base class for immutable number vars that are the result of a true division operation."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -502,7 +502,7 @@ class NumberTrueDivision(BinaryNumberOperation):
 class NumberFloorDivision(BinaryNumberOperation):
     """Base class for immutable number vars that are the result of a floor division operation."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -515,7 +515,7 @@ class NumberFloorDivision(BinaryNumberOperation):
 class NumberModuloOperation(BinaryNumberOperation):
     """Base class for immutable number vars that are the result of a modulo operation."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -528,7 +528,7 @@ class NumberModuloOperation(BinaryNumberOperation):
 class NumberExponentOperation(BinaryNumberOperation):
     """Base class for immutable number vars that are the result of an exponent operation."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -541,7 +541,7 @@ class NumberExponentOperation(BinaryNumberOperation):
 class NumberRoundOperation(UnaryNumberOperation):
     """Base class for immutable number vars that are the result of a round operation."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -554,7 +554,7 @@ class NumberRoundOperation(UnaryNumberOperation):
 class NumberCeilOperation(UnaryNumberOperation):
     """Base class for immutable number vars that are the result of a ceil operation."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -567,7 +567,7 @@ class NumberCeilOperation(UnaryNumberOperation):
 class NumberFloorOperation(UnaryNumberOperation):
     """Base class for immutable number vars that are the result of a floor operation."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -580,7 +580,7 @@ class NumberFloorOperation(UnaryNumberOperation):
 class NumberTruncOperation(UnaryNumberOperation):
     """Base class for immutable number vars that are the result of a trunc operation."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -706,7 +706,7 @@ class BooleanToIntOperation(CachedVarOperation, NumberVar):
         default_factory=lambda: LiteralBooleanVar.create(False)
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -749,7 +749,7 @@ class ComparisonOperation(CachedVarOperation, BooleanVar):
         default_factory=lambda: LiteralBooleanVar.create(False)
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -783,7 +783,7 @@ class ComparisonOperation(CachedVarOperation, BooleanVar):
 class GreaterThanOperation(ComparisonOperation):
     """Base class for immutable boolean vars that are the result of a greater than operation."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -796,7 +796,7 @@ class GreaterThanOperation(ComparisonOperation):
 class GreaterThanOrEqualOperation(ComparisonOperation):
     """Base class for immutable boolean vars that are the result of a greater than or equal operation."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -809,7 +809,7 @@ class GreaterThanOrEqualOperation(ComparisonOperation):
 class LessThanOperation(ComparisonOperation):
     """Base class for immutable boolean vars that are the result of a less than operation."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -822,7 +822,7 @@ class LessThanOperation(ComparisonOperation):
 class LessThanOrEqualOperation(ComparisonOperation):
     """Base class for immutable boolean vars that are the result of a less than or equal operation."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -835,7 +835,7 @@ class LessThanOrEqualOperation(ComparisonOperation):
 class EqualOperation(ComparisonOperation):
     """Base class for immutable boolean vars that are the result of an equal operation."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -848,7 +848,7 @@ class EqualOperation(ComparisonOperation):
 class NotEqualOperation(ComparisonOperation):
     """Base class for immutable boolean vars that are the result of a not equal operation."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -873,7 +873,7 @@ class LogicalOperation(CachedVarOperation, BooleanVar):
         default_factory=lambda: LiteralBooleanVar.create(False)
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -923,7 +923,7 @@ class BooleanNotOperation(CachedVarOperation, BooleanVar):
         default_factory=lambda: LiteralBooleanVar.create(False)
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -1058,7 +1058,7 @@ class ToNumberVarOperation(CachedVarOperation, NumberVar):
         default_factory=lambda: LiteralNumberVar.create(0)
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -1104,7 +1104,7 @@ class ToBooleanVarOperation(CachedVarOperation, BooleanVar):
         default_factory=lambda: LiteralBooleanVar.create(False)
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -1154,7 +1154,7 @@ class TernaryOperator(CachedVarOperation, ImmutableVar):
         default_factory=lambda: LiteralNumberVar.create(0)
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 

--- a/reflex/ivars/object.py
+++ b/reflex/ivars/object.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import dataclasses
-import functools
 import sys
 import typing
-from functools import cached_property
 from inspect import isclass
 from typing import (
     Any,
@@ -32,6 +30,7 @@ from .base import (
     CachedVarOperation,
     ImmutableVar,
     LiteralVar,
+    cached_property_no_lock,
     figure_out_type,
 )
 from .number import BooleanVar, NumberVar
@@ -306,7 +305,7 @@ class LiteralObjectVar(CachedVarOperation, ObjectVar[OBJECT_TYPE], LiteralVar):
         args_list = typing.get_args(self._var_type)
         return args_list[1] if args_list else Any
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -349,7 +348,7 @@ class LiteralObjectVar(CachedVarOperation, ObjectVar[OBJECT_TYPE], LiteralVar):
         """
         return hash((self.__class__.__name__, self._var_name))
 
-    @functools.cached_property
+    @cached_property_no_lock
     def _cached_get_all_var_data(self) -> ImmutableVarData | None:
         """Get all the var data.
 
@@ -402,7 +401,7 @@ class ObjectToArrayOperation(CachedVarOperation, ArrayVar):
         default_factory=lambda: LiteralObjectVar.create({})
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the operation.
 
@@ -440,7 +439,7 @@ class ObjectToArrayOperation(CachedVarOperation, ArrayVar):
 class ObjectKeysOperation(ObjectToArrayOperation):
     """Operation to get the keys of an object."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the operation.
 
@@ -475,7 +474,7 @@ class ObjectKeysOperation(ObjectToArrayOperation):
 class ObjectValuesOperation(ObjectToArrayOperation):
     """Operation to get the values of an object."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the operation.
 
@@ -510,7 +509,7 @@ class ObjectValuesOperation(ObjectToArrayOperation):
 class ObjectEntriesOperation(ObjectToArrayOperation):
     """Operation to get the entries of an object."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the operation.
 
@@ -557,7 +556,7 @@ class ObjectMergeOperation(CachedVarOperation, ObjectVar):
         default_factory=lambda: LiteralObjectVar.create({})
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the operation.
 
@@ -606,7 +605,7 @@ class ObjectItemOperation(CachedVarOperation, ImmutableVar):
     )
     _key: Var | Any = dataclasses.field(default_factory=lambda: LiteralVar.create(None))
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the operation.
 
@@ -657,7 +656,7 @@ class ToObjectOperation(CachedVarOperation, ObjectVar):
         default_factory=lambda: LiteralObjectVar.create({})
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the operation.
 
@@ -704,7 +703,7 @@ class ObjectHasOwnProperty(CachedVarOperation, BooleanVar):
     )
     _key: Var | Any = dataclasses.field(default_factory=lambda: LiteralVar.create(None))
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the operation.
 

--- a/reflex/ivars/sequence.py
+++ b/reflex/ivars/sequence.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 import dataclasses
-import functools
 import inspect
 import json
 import re
 import sys
 import typing
-from functools import cached_property
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -40,6 +38,7 @@ from .base import (
     CachedVarOperation,
     ImmutableVar,
     LiteralVar,
+    cached_property_no_lock,
     figure_out_type,
     unionize,
 )
@@ -216,7 +215,7 @@ class StringToStringOperation(CachedVarOperation, StringVar):
         default_factory=lambda: LiteralStringVar.create("")
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -253,7 +252,7 @@ class StringToStringOperation(CachedVarOperation, StringVar):
 class StringLowerOperation(StringToStringOperation):
     """Base class for immutable string vars that are the result of a string lower operation."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -266,7 +265,7 @@ class StringLowerOperation(StringToStringOperation):
 class StringUpperOperation(StringToStringOperation):
     """Base class for immutable string vars that are the result of a string upper operation."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -279,7 +278,7 @@ class StringUpperOperation(StringToStringOperation):
 class StringStripOperation(StringToStringOperation):
     """Base class for immutable string vars that are the result of a string strip operation."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -304,7 +303,7 @@ class StringContainsOperation(CachedVarOperation, BooleanVar):
         default_factory=lambda: LiteralStringVar.create("")
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -360,7 +359,7 @@ class StringStartsWithOperation(CachedVarOperation, BooleanVar):
         default_factory=lambda: LiteralStringVar.create("")
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -416,7 +415,7 @@ class StringItemOperation(CachedVarOperation, StringVar):
         default_factory=lambda: LiteralNumberVar.create(0)
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -470,7 +469,7 @@ class ArrayJoinOperation(CachedVarOperation, StringVar):
         default_factory=lambda: LiteralStringVar.create("")
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -642,7 +641,7 @@ class ConcatVarOperation(CachedVarOperation, StringVar):
 
     _var_value: Tuple[Var, ...] = dataclasses.field(default_factory=tuple)
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -672,7 +671,7 @@ class ConcatVarOperation(CachedVarOperation, StringVar):
 
         return "(" + "+".join(list_of_strs_filtered) + ")"
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_get_all_var_data(self) -> ImmutableVarData | None:
         """Get all the VarData associated with the Var.
 
@@ -953,7 +952,7 @@ class LiteralArrayVar(CachedVarOperation, LiteralVar, ArrayVar[ARRAY_VAR_TYPE]):
         List[Union[Var, Any]], Set[Union[Var, Any]], Tuple[Union[Var, Any], ...]
     ] = dataclasses.field(default_factory=list)
 
-    @functools.cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -968,7 +967,7 @@ class LiteralArrayVar(CachedVarOperation, LiteralVar, ArrayVar[ARRAY_VAR_TYPE]):
             + "]"
         )
 
-    @functools.cached_property
+    @cached_property_no_lock
     def _cached_get_all_var_data(self) -> ImmutableVarData | None:
         """Get all the VarData associated with the Var.
 
@@ -1044,7 +1043,7 @@ class StringSplitOperation(CachedVarOperation, ArrayVar):
         default_factory=lambda: LiteralStringVar.create("")
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -1093,7 +1092,7 @@ class ArrayToArrayOperation(CachedVarOperation, ArrayVar):
         default_factory=lambda: LiteralArrayVar.create([])
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -1140,7 +1139,7 @@ class ArraySliceOperation(CachedVarOperation, ArrayVar):
     )
     _slice: slice = dataclasses.field(default_factory=lambda: slice(None, None, None))
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -1216,7 +1215,7 @@ class ArraySliceOperation(CachedVarOperation, ArrayVar):
 class ArrayReverseOperation(ArrayToArrayOperation):
     """Base class for immutable string vars that are the result of a string reverse operation."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -1238,7 +1237,7 @@ class ArrayToNumberOperation(CachedVarOperation, NumberVar):
         default_factory=lambda: LiteralArrayVar.create([]),
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -1275,7 +1274,7 @@ class ArrayToNumberOperation(CachedVarOperation, NumberVar):
 class ArrayLengthOperation(ArrayToNumberOperation):
     """Base class for immutable number vars that are the result of an array length operation."""
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -1314,7 +1313,7 @@ class ArrayItemOperation(CachedVarOperation, ImmutableVar):
         default_factory=lambda: LiteralNumberVar.create(0)
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -1374,7 +1373,7 @@ class RangeOperation(CachedVarOperation, ArrayVar):
         default_factory=lambda: LiteralNumberVar.create(1)
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -1426,7 +1425,7 @@ class ArrayContainsOperation(CachedVarOperation, BooleanVar):
     )
     _needle: Var = dataclasses.field(default_factory=lambda: LiteralVar.create(None))
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -1473,7 +1472,7 @@ class ToStringOperation(CachedVarOperation, StringVar):
         default_factory=lambda: LiteralStringVar.create("")
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -1517,7 +1516,7 @@ class ToArrayOperation(CachedVarOperation, ArrayVar):
         default_factory=lambda: LiteralArrayVar.create([])
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -1565,7 +1564,7 @@ class ArrayRepeatOperation(CachedVarOperation, ArrayVar):
         default_factory=lambda: LiteralNumberVar.create(0)
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 
@@ -1615,7 +1614,7 @@ class ArrayConcatOperation(CachedVarOperation, ArrayVar):
         default_factory=lambda: LiteralArrayVar.create([])
     )
 
-    @cached_property
+    @cached_property_no_lock
     def _cached_var_name(self) -> str:
         """The name of the var.
 


### PR DESCRIPTION
ImmutableVar subclasses will always return the same value for a _var_name or _get_all_var_data so there is no need to use a per-class lock to protect a cached attribute on an instance, and doing so actually is observed to cause deadlocks when a particular _cached_var_name creates new LiteralVar instances and attempts to serialize them.