### PR TITLE
guess_type: if the type is optional, treat it like it's "not None"

### DIFF
--- a/reflex/ivars/base.py
+++ b/reflex/ivars/base.py
@@ -455,15 +455,15 @@ class ImmutableVar(Var, Generic[VAR_TYPE]):
             raise TypeError(f"Unsupported type {var_type} for guess_type.")
 
         if issubclass(fixed_type, (int, float)):
-            return self.to(NumberVar, self._var_type)
+            return self.to(NumberVar, var_type)
         if issubclass(fixed_type, dict):
-            return self.to(ObjectVar, self._var_type)
+            return self.to(ObjectVar, var_type)
         if issubclass(fixed_type, (list, tuple, set)):
-            return self.to(ArrayVar, self._var_type)
+            return self.to(ArrayVar, var_type)
         if issubclass(fixed_type, str):
             return self.to(StringVar)
         if issubclass(fixed_type, Base):
-            return self.to(ObjectVar, self._var_type)
+            return self.to(ObjectVar, var_type)
         return self
 
     def get_default_value(self) -> Any:

--- a/reflex/ivars/base.py
+++ b/reflex/ivars/base.py
@@ -362,7 +362,11 @@ class ImmutableVar(Var, Generic[VAR_TYPE]):
         from .object import ObjectVar, ToObjectOperation
         from .sequence import ArrayVar, StringVar, ToArrayOperation, ToStringOperation
 
-        fixed_type = get_origin(var_type) or var_type
+        base_type = var_type
+        if types.is_optional(base_type):
+            base_type = types.get_args(base_type)[0]
+
+        fixed_type = get_origin(base_type) or base_type
 
         fixed_output_type = get_origin(output) or output
 
@@ -455,15 +459,15 @@ class ImmutableVar(Var, Generic[VAR_TYPE]):
             raise TypeError(f"Unsupported type {var_type} for guess_type.")
 
         if issubclass(fixed_type, (int, float)):
-            return self.to(NumberVar, var_type)
+            return self.to(NumberVar, self._var_type)
         if issubclass(fixed_type, dict):
-            return self.to(ObjectVar, var_type)
+            return self.to(ObjectVar, self._var_type)
         if issubclass(fixed_type, (list, tuple, set)):
-            return self.to(ArrayVar, var_type)
+            return self.to(ArrayVar, self._var_type)
         if issubclass(fixed_type, str):
             return self.to(StringVar)
         if issubclass(fixed_type, Base):
-            return self.to(ObjectVar, var_type)
+            return self.to(ObjectVar, self._var_type)
         return self
 
     def get_default_value(self) -> Any:


### PR DESCRIPTION
When guessing the type for an Optional annotation, the Optional was already being stripped off, but this value was being ignored, except for error messages. So actually use the Optional-stripped value.