### PR TITLE
Enabled Fallback for Images

### DIFF
--- a/reflex/components/next/image.py
+++ b/reflex/components/next/image.py
@@ -6,13 +6,8 @@ from reflex.event import EventHandler
 from reflex.utils import types
 from reflex.vars import Var
 
-from pathlib import Path
-from constants.base import Dirs
-
-import requests
-import os
-
 from .base import NextComponent
+
 
 # implementing image call back technique here
 class Image(NextComponent):
@@ -67,9 +62,6 @@ class Image(NextComponent):
     # Fires when the image has an error.
     on_error: EventHandler[lambda: []]
 
-    # Fires when the src image is not provided.
-    fallback: Var[str]
-
     @classmethod
     def create(
         cls,
@@ -92,42 +84,6 @@ class Image(NextComponent):
         style = props.get("style", {})
         DEFAULT_W_H = "100%"
 
-        def validate_src_image(src):
-            """
-            Validates the 'src' parameter for the Image component.
-            Args:
-                src: The source parameter (local file path, web URL, or Pillow Image).
-            Returns:
-                Valid source (src) or raises an error.
-            """
-            try:
-                if isinstance(src, str):
-                    if src.startswith("/"):
-                        full_path = Path.cwd() / Dirs.APP_ASSETS / src.strip("/")
-                        if os.path.exists(full_path):
-                            return True
-                        else:
-                            raise FileNotFoundError(f"Local image not found: {full_path}")
-                    elif src.startswith("http"):
-                        try:
-                            response = requests.head(src)
-                            if response.status_code == 200:
-                                return True
-                            else:
-                                raise ValueError(f"Invalid web URL: {src}")
-                        except requests.RequestException:
-                            raise ValueError(f"Failed to validate web URL: {src}")
-                    else:
-                        raise ValueError(f"Unsupported src format: {src}")
-                elif isinstance(src, Image.Image):
-                    return True
-                else:
-                    raise ValueError(f"Invalid src type: {type(src)}")
-            except Exception as e:
-                print(f"Error: {e}")
-                return False
-                                
-
         def check_prop_type(prop_name, prop_value):
             if types.check_prop_in_allowed_types(prop_value, allowed_types=[int]):
                 props[prop_name] = prop_value
@@ -138,17 +94,6 @@ class Image(NextComponent):
             else:
                 props[prop_name] = 0
                 style[prop_name] = DEFAULT_W_H
-
-
-        src = props.get("src", "")
-        if not validate_src_image(src):
-            if props.get("fallback"):
-                if validate_src_image(props.get("fallback")):
-                    props["src"] = props.get("fallback")
-                else:
-                    raise ValueError(f"Invalid fallback image: {props.get('fallback')}")
-            else:
-                raise ValueError(f"Invalid src image: {src}")
 
         check_prop_type("width", width)
         check_prop_type("height", height)


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update


### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.

    a. Enabled Fallback for Images
    b.  This pull request enables the “fallback” for rx.image(). The src parameter can accept local file paths, web URLs, or Pillow image objects as per the documentation of Reflex. When the specified image is unavailable or the URL is invalid, the fallback URL (if provided) is used as an alternative. The fallback URL undergoes the same checks as the original src. Currently, this feature is implemented in the base HTML image section, with the possibility of extending it to the next/image component.



closes #3838 