### PR TITLE
[REF-3589] raise EventHandlerArgMismatch when event handler args don't match spec

### DIFF
--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -527,15 +527,7 @@ class Component(BaseComponent, ABC):
             for v in value:
                 if isinstance(v, (EventHandler, EventSpec)):
                     # Call the event handler to get the event.
-                    try:
-                        event = call_event_handler(v, args_spec)
-                    except ValueError as err:
-                        raise ValueError(
-                            f" {err} defined in the `{type(self).__name__}` component"
-                        ) from err
-
-                    # Add the event to the chain.
-                    events.append(event)
+                    events.append(call_event_handler(v, args_spec))
                 elif isinstance(v, Callable):
                     # Call the lambda to get the event chain.
                     result = call_event_fn(v, args_spec)

--- a/reflex/event.py
+++ b/reflex/event.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import inspect
+import types
 import urllib.parse
 from base64 import b64encode
 from typing import (
@@ -903,6 +904,8 @@ def call_event_fn(fn: Callable, arg_spec: ArgsSpec) -> list[EventSpec] | Var:
     # Check that fn signature matches arg_spec
     fn_args = inspect.getfullargspec(fn).args
     n_fn_args = len(fn_args)
+    if isinstance(fn, types.MethodType):
+        n_fn_args -= 1  # subtract 1 for bound self arg
     parsed_args = parse_args_spec(arg_spec)
     if len(parsed_args) != n_fn_args:
         raise EventFnArgMismatch(

--- a/reflex/utils/exceptions.py
+++ b/reflex/utils/exceptions.py
@@ -79,3 +79,7 @@ class LockExpiredError(ReflexError):
 
 class MatchTypeError(ReflexError, TypeError):
     """Raised when the return types of match cases are different."""
+
+
+class EventHandlerArgMismatch(ReflexError, TypeError):
+    """Raised when the number of args accepted by an EventHandler is differs from that provided by the event trigger."""

--- a/reflex/utils/exceptions.py
+++ b/reflex/utils/exceptions.py
@@ -83,3 +83,7 @@ class MatchTypeError(ReflexError, TypeError):
 
 class EventHandlerArgMismatch(ReflexError, TypeError):
     """Raised when the number of args accepted by an EventHandler is differs from that provided by the event trigger."""
+
+
+class EventFnArgMismatch(ReflexError, TypeError):
+    """Raised when the number of args accepted by a lambda differs from that provided by the event trigger."""

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -79,6 +79,8 @@ def component2() -> Type[Component]:
         # A test list prop.
         arr: Var[List[str]]
 
+        on_prop_event: EventHandler[lambda e0: [e0]]
+
         def get_event_triggers(self) -> Dict[str, Any]:
             """Test controlled triggers.
 
@@ -496,7 +498,7 @@ def test_get_props(component1, component2):
         component2: A test component.
     """
     assert component1.get_props() == {"text", "number", "text_or_number"}
-    assert component2.get_props() == {"arr"}
+    assert component2.get_props() == {"arr", "on_prop_event"}
 
 
 @pytest.mark.parametrize(
@@ -574,7 +576,7 @@ def test_get_event_triggers(component1, component2):
     assert component1().get_event_triggers().keys() == default_triggers
     assert (
         component2().get_event_triggers().keys()
-        == {"on_open", "on_close"} | default_triggers
+        == {"on_open", "on_close", "on_prop_event"} | default_triggers
     )
 
 
@@ -888,18 +890,105 @@ def test_invalid_event_handler_args(component2, test_state):
         component2: A test component.
         test_state: A test state.
     """
-    # Uncontrolled event handlers should not take args.
-    # This is okay.
-    component2.create(on_click=test_state.do_something)
-    # This is not okay.
+    # EventHandler args must match
     with pytest.raises(ValueError):
         component2.create(on_click=test_state.do_something_arg)
+    with pytest.raises(ValueError):
         component2.create(on_open=test_state.do_something)
+    with pytest.raises(ValueError):
+        component2.create(on_prop_event=test_state.do_something)
+
+    # Multiple EventHandler args: all must match
+    with pytest.raises(ValueError):
+        component2.create(
+            on_click=[test_state.do_something_arg, test_state.do_something]
+        )
+    with pytest.raises(ValueError):
         component2.create(
             on_open=[test_state.do_something_arg, test_state.do_something]
         )
-    # However lambdas are okay.
+    with pytest.raises(ValueError):
+        component2.create(
+            on_prop_event=[test_state.do_something_arg, test_state.do_something]
+        )
+
+    # lambda cannot return weird values.
+    with pytest.raises(ValueError):
+        component2.create(on_click=lambda: 1)
+    with pytest.raises(ValueError):
+        component2.create(on_click=lambda: [1])
+    with pytest.raises(ValueError):
+        component2.create(
+            on_click=lambda: (test_state.do_something_arg(1), test_state.do_something)
+        )
+
+    # lambda signature must match event trigger.
+    with pytest.raises(ValueError):
+        component2.create(on_click=lambda _: test_state.do_something_arg(1))
+    with pytest.raises(ValueError):
+        component2.create(on_open=lambda: test_state.do_something)
+    with pytest.raises(ValueError):
+        component2.create(on_prop_event=lambda: test_state.do_something)
+
+    # lambda returning EventHandler must match spec
+    with pytest.raises(ValueError):
+        component2.create(on_click=lambda: test_state.do_something_arg)
+    with pytest.raises(ValueError):
+        component2.create(on_open=lambda _: test_state.do_something)
+    with pytest.raises(ValueError):
+        component2.create(on_prop_event=lambda _: test_state.do_something)
+
+    # Mixed EventSpec and EventHandler must match spec.
+    with pytest.raises(ValueError):
+        component2.create(
+            on_click=lambda: [
+                test_state.do_something_arg(1),
+                test_state.do_something_arg,
+            ]
+        )
+    with pytest.raises(ValueError):
+        component2.create(
+            on_open=lambda _: [test_state.do_something_arg(1), test_state.do_something]
+        )
+    with pytest.raises(ValueError):
+        component2.create(
+            on_prop_event=lambda _: [
+                test_state.do_something_arg(1),
+                test_state.do_something,
+            ]
+        )
+
+
+def test_valid_event_handler_args(component2, test_state):
+    """Test that an valid event handler args do not raise exception.
+
+    Args:
+        component2: A test component.
+        test_state: A test state.
+    """
+    # Uncontrolled event handlers should not take args.
+    component2.create(on_click=test_state.do_something)
+    component2.create(on_click=test_state.do_something_arg(1))
+
+    # Controlled event handlers should take args.
+    component2.create(on_open=test_state.do_something_arg)
+    component2.create(on_prop_event=test_state.do_something_arg)
+
+    # Using a partial event spec bypasses arg validation (ignoring the args).
+    component2.create(on_open=test_state.do_something())
+    component2.create(on_prop_event=test_state.do_something())
+
+    # lambda returning EventHandler is okay if the spec matches.
+    component2.create(on_click=lambda: test_state.do_something)
+    component2.create(on_open=lambda _: test_state.do_something_arg)
+    component2.create(on_prop_event=lambda _: test_state.do_something_arg)
+
+    # lambda can always return an EventSpec.
     component2.create(on_click=lambda: test_state.do_something_arg(1))
+    component2.create(on_open=lambda _: test_state.do_something_arg(1))
+    component2.create(on_prop_event=lambda _: test_state.do_something_arg(1))
+
+    # Return EventSpec and EventHandler (no arg).
     component2.create(
         on_click=lambda: [test_state.do_something_arg(1), test_state.do_something]
     )
@@ -907,9 +996,24 @@ def test_invalid_event_handler_args(component2, test_state):
         on_click=lambda: [test_state.do_something_arg(1), test_state.do_something()]
     )
 
-    # Controlled event handlers should take args.
-    # This is okay.
-    component2.create(on_open=test_state.do_something_arg)
+    # Return 2 EventSpec.
+    component2.create(
+        on_open=lambda _: [test_state.do_something_arg(1), test_state.do_something()]
+    )
+    component2.create(
+        on_prop_event=lambda _: [
+            test_state.do_something_arg(1),
+            test_state.do_something(),
+        ]
+    )
+
+    # Return EventHandler (1 arg) and EventSpec.
+    component2.create(
+        on_open=lambda _: [test_state.do_something_arg, test_state.do_something()]
+    )
+    component2.create(
+        on_prop_event=lambda _: [test_state.do_something_arg, test_state.do_something()]
+    )
 
 
 def test_get_hooks_nested(component1, component2, component3):

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -22,6 +22,7 @@ from reflex.ivars.base import LiteralVar
 from reflex.state import BaseState
 from reflex.style import Style
 from reflex.utils import imports
+from reflex.utils.exceptions import EventHandlerArgMismatch
 from reflex.utils.imports import ImportDict, ImportVar, ParsedImportDict, parse_imports
 from reflex.vars import BaseVar, Var, VarData
 
@@ -891,23 +892,23 @@ def test_invalid_event_handler_args(component2, test_state):
         test_state: A test state.
     """
     # EventHandler args must match
-    with pytest.raises(ValueError):
+    with pytest.raises(EventHandlerArgMismatch):
         component2.create(on_click=test_state.do_something_arg)
-    with pytest.raises(ValueError):
+    with pytest.raises(EventHandlerArgMismatch):
         component2.create(on_open=test_state.do_something)
-    with pytest.raises(ValueError):
+    with pytest.raises(EventHandlerArgMismatch):
         component2.create(on_prop_event=test_state.do_something)
 
     # Multiple EventHandler args: all must match
-    with pytest.raises(ValueError):
+    with pytest.raises(EventHandlerArgMismatch):
         component2.create(
             on_click=[test_state.do_something_arg, test_state.do_something]
         )
-    with pytest.raises(ValueError):
+    with pytest.raises(EventHandlerArgMismatch):
         component2.create(
             on_open=[test_state.do_something_arg, test_state.do_something]
         )
-    with pytest.raises(ValueError):
+    with pytest.raises(EventHandlerArgMismatch):
         component2.create(
             on_prop_event=[test_state.do_something_arg, test_state.do_something]
         )
@@ -931,26 +932,26 @@ def test_invalid_event_handler_args(component2, test_state):
         component2.create(on_prop_event=lambda: test_state.do_something)
 
     # lambda returning EventHandler must match spec
-    with pytest.raises(ValueError):
+    with pytest.raises(EventHandlerArgMismatch):
         component2.create(on_click=lambda: test_state.do_something_arg)
-    with pytest.raises(ValueError):
+    with pytest.raises(EventHandlerArgMismatch):
         component2.create(on_open=lambda _: test_state.do_something)
-    with pytest.raises(ValueError):
+    with pytest.raises(EventHandlerArgMismatch):
         component2.create(on_prop_event=lambda _: test_state.do_something)
 
     # Mixed EventSpec and EventHandler must match spec.
-    with pytest.raises(ValueError):
+    with pytest.raises(EventHandlerArgMismatch):
         component2.create(
             on_click=lambda: [
                 test_state.do_something_arg(1),
                 test_state.do_something_arg,
             ]
         )
-    with pytest.raises(ValueError):
+    with pytest.raises(EventHandlerArgMismatch):
         component2.create(
             on_open=lambda _: [test_state.do_something_arg(1), test_state.do_something]
         )
-    with pytest.raises(ValueError):
+    with pytest.raises(EventHandlerArgMismatch):
         component2.create(
             on_prop_event=lambda _: [
                 test_state.do_something_arg(1),

--- a/tests/components/test_component.py
+++ b/tests/components/test_component.py
@@ -22,7 +22,7 @@ from reflex.ivars.base import LiteralVar
 from reflex.state import BaseState
 from reflex.style import Style
 from reflex.utils import imports
-from reflex.utils.exceptions import EventHandlerArgMismatch
+from reflex.utils.exceptions import EventFnArgMismatch, EventHandlerArgMismatch
 from reflex.utils.imports import ImportDict, ImportVar, ParsedImportDict, parse_imports
 from reflex.vars import BaseVar, Var, VarData
 
@@ -924,11 +924,11 @@ def test_invalid_event_handler_args(component2, test_state):
         )
 
     # lambda signature must match event trigger.
-    with pytest.raises(ValueError):
+    with pytest.raises(EventFnArgMismatch):
         component2.create(on_click=lambda _: test_state.do_something_arg(1))
-    with pytest.raises(ValueError):
+    with pytest.raises(EventFnArgMismatch):
         component2.create(on_open=lambda: test_state.do_something)
-    with pytest.raises(ValueError):
+    with pytest.raises(EventFnArgMismatch):
         component2.create(on_prop_event=lambda: test_state.do_something)
 
     # lambda returning EventHandler must match spec


### PR DESCRIPTION
2 new error messages when the event trigger spec does not match the function definiton.

```
reflex.utils.exceptions.EventHandlerArgMismatch: The number of arguments accepted by State.no_arg (0) does not match the arguments passed by the event trigger: ['form_data']
See https://reflex.dev/docs/events/event-arguments/
```

```
reflex.utils.exceptions.EventFnArgMismatch: The number of arguments accepted by <function index.<locals>.<lambda> at 0x10c791ee0> (0) does not match the arguments passed by the event trigger: ['form_data']
See https://reflex.dev/docs/events/event-arguments/
```