### PR TITLE
[REF-3597]Type check Radio items

### DIFF
--- a/reflex/components/radix/themes/components/radio_group.py
+++ b/reflex/components/radix/themes/components/radio_group.py
@@ -12,6 +12,7 @@ from reflex.components.radix.themes.typography.text import Text
 from reflex.event import EventHandler
 from reflex.ivars.base import ImmutableVar, LiteralVar
 from reflex.ivars.sequence import StringVar
+from reflex.utils import types
 from reflex.vars import Var
 
 from ..base import (
@@ -133,6 +134,8 @@ class HighLevelRadioGroup(RadixThemesComponent):
 
         Returns:
             The created radio group component.
+
+        TypeError: If the type of items is invalid.
         """
         direction = props.pop("direction", "column")
         spacing = props.pop("spacing", "2")
@@ -140,6 +143,16 @@ class HighLevelRadioGroup(RadixThemesComponent):
         variant = props.pop("variant", "classic")
         color_scheme = props.pop("color_scheme", None)
         default_value = props.pop("default_value", "")
+
+        if (
+            not isinstance(items, (list, Var))
+            or isinstance(items, Var)
+            and not types._issubclass(items._var_type, list)
+        ):
+            items_type = type(items) if not isinstance(items, Var) else items._var_type
+            raise TypeError(
+                f"The radio group component takes in a list, got {items_type} instead"
+            )
 
         default_value = LiteralVar.create(default_value)
 

--- a/reflex/components/radix/themes/components/radio_group.py
+++ b/reflex/components/radix/themes/components/radio_group.py
@@ -135,7 +135,8 @@ class HighLevelRadioGroup(RadixThemesComponent):
         Returns:
             The created radio group component.
 
-        TypeError: If the type of items is invalid.
+        Raises:
+            TypeError: If the type of items is invalid.
         """
         direction = props.pop("direction", "column")
         spacing = props.pop("spacing", "2")

--- a/reflex/components/radix/themes/components/radio_group.pyi
+++ b/reflex/components/radix/themes/components/radio_group.pyi
@@ -419,6 +419,9 @@ class HighLevelRadioGroup(RadixThemesComponent):
 
         Returns:
             The created radio group component.
+
+        Raises:
+            TypeError: If the type of items is invalid.
         """
         ...
 
@@ -588,6 +591,9 @@ class RadioGroup(ComponentNamespace):
 
         Returns:
             The created radio group component.
+
+        Raises:
+            TypeError: If the type of items is invalid.
         """
         ...
 


### PR DESCRIPTION
Validate and throw an error if the items passed into `rx.radio` is not a list