### PR TITLE
Use bun run when supported

### DIFF
--- a/reflex/constants/installer.py
+++ b/reflex/constants/installer.py
@@ -36,9 +36,9 @@ class Bun(SimpleNamespace):
     """Bun constants."""
 
     # The Bun version.
-    VERSION = "1.1.10"
+    VERSION = "1.1.26"
     # Min Bun Version
-    MIN_VERSION = "0.7.0"
+    MIN_VERSION = "1.1.26"
     # The directory to store the bun.
     ROOT_PATH = os.path.join(Reflex.DIR, "bun")
     # Default bun path.

--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -211,18 +211,11 @@ def _run(
     # Warn if schema is not up to date.
     prerequisites.check_schema_up_to_date()
 
-    # Get the frontend and backend commands, based on the environment.
-    setup_frontend = backend_cmd = None
+    # Get the backend command based on the environment.
     if env == constants.Env.DEV:
-        setup_frontend, backend_cmd = (
-            build.setup_frontend,
-            exec.run_backend,
-        )
+        backend_cmd = exec.run_backend
     elif env == constants.Env.PROD:
-        setup_frontend, backend_cmd = (
-            build.setup_frontend_prod,
-            exec.run_backend_prod,
-        )
+        backend_cmd = exec.run_backend_prod
     else:
         raise ValueError(f"Invalid env: {env}")
 
@@ -237,7 +230,7 @@ def _run(
 
     # Run the frontend on a separate thread.
     if frontend:
-        setup_frontend(Path.cwd())
+        build.setup_frontend(Path.cwd(), env)
         commands.append((exec.run_frontend, Path.cwd(), frontend_port, backend, env))
 
     # In prod mode, run the backend on a separate thread.

--- a/reflex/utils/build.py
+++ b/reflex/utils/build.py
@@ -216,13 +216,13 @@ def build(
 
 def setup_frontend(
     root: Path,
-    disable_telemetry: bool = True,
+    env: constants.Env = constants.Env.DEV,
 ):
     """Set up the frontend to run the app.
 
     Args:
         root: The root path of the project.
-        disable_telemetry: Whether to disable the Next telemetry.
+        env: The environment to set up the frontend for.
     """
     # Create the assets dir if it doesn't exist.
     path_ops.mkdir(constants.Dirs.APP_ASSETS)
@@ -237,27 +237,16 @@ def setup_frontend(
     set_env_json()
 
     # Disable the Next telemetry.
-    if disable_telemetry:
-        processes.new_process(
-            prerequisites.get_run_command("next", "telemetry", "disable"),
-            cwd=prerequisites.get_web_dir(),
-            stdout=subprocess.DEVNULL,
-            shell=constants.IS_WINDOWS,
-        )
+    processes.new_process(
+        prerequisites.get_run_command("next", "telemetry", "disable"),
+        cwd=prerequisites.get_web_dir(),
+        stdout=subprocess.DEVNULL,
+        shell=constants.IS_WINDOWS,
+    )
 
-
-def setup_frontend_prod(
-    root: Path,
-    disable_telemetry: bool = True,
-):
-    """Set up the frontend for prod mode.
-
-    Args:
-        root: The root path of the project.
-        disable_telemetry: Whether to disable the Next telemetry.
-    """
-    setup_frontend(root, disable_telemetry)
-    build(deploy_url=get_config().deploy_url)
+    # In production, build the frontend.
+    if env == constants.Env.PROD:
+        build(deploy_url=get_config().deploy_url)
 
 
 def _looks_like_venv_dir(dir_to_check: str) -> bool:

--- a/reflex/utils/build.py
+++ b/reflex/utils/build.py
@@ -207,7 +207,7 @@ def build(
 
     # Start the subprocess with the progress bar.
     process = processes.new_process(
-        [prerequisites.get_package_manager(), "run", command],
+        prerequisites.get_run_command(command),
         cwd=wdir,
         shell=constants.IS_WINDOWS,
     )
@@ -239,13 +239,7 @@ def setup_frontend(
     # Disable the Next telemetry.
     if disable_telemetry:
         processes.new_process(
-            [
-                prerequisites.get_package_manager(),
-                "run",
-                "next",
-                "telemetry",
-                "disable",
-            ],
+            prerequisites.get_run_command("next", "telemetry", "disable"),
             cwd=prerequisites.get_web_dir(),
             stdout=subprocess.DEVNULL,
             shell=constants.IS_WINDOWS,

--- a/reflex/utils/export.py
+++ b/reflex/utils/export.py
@@ -55,9 +55,6 @@ def export(
         prerequisites.get_compiled_app(export=True)
         # Set up .web directory and install frontend dependencies.
         build.setup_frontend(Path.cwd())
-
-    # Build the static app.
-    if frontend:
         build.build(deploy_url=config.deploy_url, for_export=True)
 
     # Zip up the app.

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -140,7 +140,7 @@ def test_setup_frontend(tmp_path, mocker):
     mocker.patch("reflex.utils.prerequisites.install_frontend_packages")
     mocker.patch("reflex.utils.build.set_env_json")
 
-    build.setup_frontend(tmp_path, disable_telemetry=False)
+    build.setup_frontend(tmp_path)
     assert web_public_folder.exists()
     assert (web_public_folder / "favicon.ico").exists()
 


### PR DESCRIPTION
Remove dependency on FNM + Node on supported operating systems as it seems bun can now run and export the apps well. For unsupported systems, we fallback to use NPM for everything.