### PR TITLE
Include child imports in markdown component_map

### DIFF
--- a/reflex/components/markdown/markdown.py
+++ b/reflex/components/markdown/markdown.py
@@ -170,7 +170,7 @@ class Markdown(Component):
                 ),
             },
             *[
-                component(_MOCK_ARG)._get_imports()  # type: ignore
+                component(_MOCK_ARG)._get_all_imports()  # type: ignore
                 for component in self.component_map.values()
             ],
             CodeBlock.create(theme="light")._get_imports(),  # type: ignore,


### PR DESCRIPTION
If a component in the markdown component_map contains children components, use `_get_all_imports` to recursively enumerate them.

Fix #3880