### PR TITLE
[ENG-3738] Revert "mixin computed vars should only be applied to highest level s…

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -431,9 +431,8 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
         return [
             v
             for mixin in cls._mixins() + [cls]
-            for name, v in mixin.__dict__.items()
+            for v in mixin.__dict__.values()
             if isinstance(v, (ComputedVar, ImmutableComputedVar))
-            and name not in cls.inherited_vars
         ]
 
     @classmethod
@@ -551,8 +550,6 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
 
         for mixin in cls._mixins():
             for name, value in mixin.__dict__.items():
-                if name in cls.inherited_vars:
-                    continue
                 if isinstance(value, (ComputedVar, ImmutableComputedVar)):
                     fget = cls._copy_fn(value.fget)
                     newcv = value._replace(

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -3211,24 +3211,9 @@ class MixinState(State, mixin=True):
     num: int = 0
     _backend: int = 0
 
-    @rx.var(cache=True)
-    def computed(self) -> str:
-        """A computed var on mixin state.
-
-        Returns:
-            A computed value.
-        """
-        return ""
-
 
 class UsesMixinState(MixinState, State):
     """A state that uses the mixin state."""
-
-    pass
-
-
-class ChildUsesMixinState(UsesMixinState):
-    """A child state that uses the mixin state."""
 
     pass
 
@@ -3238,15 +3223,3 @@ def test_mixin_state() -> None:
     assert "num" in UsesMixinState.base_vars
     assert "num" in UsesMixinState.vars
     assert UsesMixinState.backend_vars == {"_backend": 0}
-
-    assert "computed" in UsesMixinState.computed_vars
-    assert "computed" in UsesMixinState.vars
-
-
-def test_child_mixin_state() -> None:
-    """Test that mixin vars are only applied to the highest state in the hierarchy."""
-    assert "num" in ChildUsesMixinState.inherited_vars
-    assert "num" not in ChildUsesMixinState.base_vars
-
-    assert "computed" in ChildUsesMixinState.inherited_vars
-    assert "computed" not in ChildUsesMixinState.computed_vars


### PR DESCRIPTION
…tate (#3833)"

This reverts commit 477e1dece9166fb13825c4ae416b030d8f70ccb9.

`integration/test_state_inheritence.py` fails on py3.8 with this change. unclear what the root cause is.

cc @benedikt-bartscher 