### PR TITLE
Added fill color for progress

### DIFF
--- a/reflex/components/radix/themes/components/progress.py
+++ b/reflex/components/radix/themes/components/progress.py
@@ -4,6 +4,7 @@ from typing import Literal
 
 from reflex.components.component import Component
 from reflex.components.core.breakpoints import Responsive
+from reflex.style import Style
 from reflex.vars.base import Var
 
 from ..base import LiteralAccentColor, RadixThemesComponent
@@ -38,6 +39,21 @@ class Progress(RadixThemesComponent):
     # The duration of the progress bar animation. Once the duration times out, the progress bar will start an indeterminate animation.
     duration: Var[str]
 
+    # The color of the progress bar fill animation.
+    fill_color: Var[str]
+
+    @staticmethod
+    def _color_selector(color: str) -> Style:
+        """Return a style object with the correct color and css selector.
+
+        Args:
+            color: Color of the fill part.
+
+        Returns:
+            Style: Style object with the correct css selector and color.
+        """
+        return Style({".rt-ProgressIndicator": {"background_color": color}})
+
     @classmethod
     def create(cls, *children, **props) -> Component:
         """Create a Progress component.
@@ -50,6 +66,12 @@ class Progress(RadixThemesComponent):
             The Progress Component.
         """
         props.setdefault("width", "100%")
+        if "fill_color" in props:
+            color = props.get("fill_color", "")
+            style = props.get("style", {})
+            style = style | cls._color_selector(color)
+            props["style"] = style
+
         return super().create(*children, **props)
 
 

--- a/reflex/components/radix/themes/components/progress.pyi
+++ b/reflex/components/radix/themes/components/progress.pyi
@@ -107,6 +107,7 @@ class Progress(RadixThemesComponent):
             ]
         ] = None,
         duration: Optional[Union[Var[str], str]] = None,
+        fill_color: Optional[Union[Var[str], str]] = None,
         style: Optional[Style] = None,
         key: Optional[Any] = None,
         id: Optional[Any] = None,
@@ -162,6 +163,7 @@ class Progress(RadixThemesComponent):
             high_contrast: Whether to render the progress bar with higher contrast color against background
             radius: Override theme radius for progress bar: "none" | "small" | "medium" | "large" | "full"
             duration: The duration of the progress bar animation. Once the duration times out, the progress bar will start an indeterminate animation.
+            fill_color: The color of the progress bar fill animation.
             style: The style of the component.
             key: A unique key for the component.
             id: The id for the component.


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


### New Feature Submission:

- [ ] Does your submission pass the tests? 
- [ ] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.

### Description
Added a fill_color  property to update the background style of the fill in progress bar. Since we do not expose the Progress.Root and Progress.Indicator components of radix ui. I updated the indicator class directly.
