### PR TITLE
[ENG-3817] deprecate _var_name_unwrapped (instead of removing it)

### DIFF
--- a/reflex/vars/base.py
+++ b/reflex/vars/base.py
@@ -117,6 +117,16 @@ class Var(Generic[VAR_TYPE]):
         return self._js_expr
 
     @property
+    @deprecated("Use `_js_expr` instead.")
+    def _var_name_unwrapped(self) -> str:
+        """The name of the var without extra curly braces.
+
+        Returns:
+            The name of the var.
+        """
+        return self._js_expr
+
+    @property
     def _var_is_string(self) -> bool:
         """Whether the var is a string literal.
 


### PR DESCRIPTION
some components and code examples used `_var_name_unwrapped`, so map this property back to `_js_expr` and deprecate it.
