### PR TITLE
[ENG-3476]Setting State Vars that are not defined should raise an error

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1282,10 +1282,9 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
             and name not in self.vars
             and name not in self.get_skip_vars()
         ):
-            available_vars = ", ".join(self.vars) or "None"
             raise AttributeError(
                 f"The state variable '{name}' has not been defined in '{type(self).__name__}'. "
-                f"All state variables must be declared before they can be set. Available vars: {available_vars}"
+                f"All state variables must be declared before they can be set."
             )
 
         # Set the attribute.

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1277,8 +1277,10 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
             self._mark_dirty()
             return
 
-        if not name in self.vars and not name in self._computed_var_dependencies and not name in self.get_skip_vars():
-            raise AttributeError(f"The state var '{name}' has not been defined in '{type(self).__name__}'. All state vars must be declared before they can be set.")
+        if name not in self.vars and name not in self.get_skip_vars():
+            raise AttributeError(
+                f"The state var '{name}' has not been defined in '{type(self).__name__}'. All state vars must be declared before they can be set."
+            )
 
         # Set the attribute.
         super().__setattr__(name, value)

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1282,9 +1282,9 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
             return
 
         if (
-            not name.startswith("__")
+            name not in self.vars
+            and not name.startswith("__")
             and not name.startswith(f"_{type(self).__name__}__")
-            and name not in self.vars
             and name not in self.get_skip_vars()
         ):
             raise SetUndefinedStateVarError(

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1277,9 +1277,15 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
             self._mark_dirty()
             return
 
-        if name not in self.vars and name not in self.get_skip_vars():
+        if (
+            not name.startswith("__")
+            and name not in self.vars
+            and name not in self.get_skip_vars()
+        ):
+            available_vars = ", ".join(self.vars) or "None"
             raise AttributeError(
-                f"The state var '{name}' has not been defined in '{type(self).__name__}'. All state vars must be declared before they can be set."
+                f"The state variable '{name}' has not been defined in '{type(self).__name__}'. "
+                f"All state variables must be declared before they can be set. Available vars: {available_vars}"
             )
 
         # Set the attribute.

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -74,6 +74,7 @@ from reflex.utils.exceptions import (
     EventHandlerShadowsBuiltInStateMethod,
     ImmutableStateError,
     LockExpiredError,
+    SetUndefinedStateVarError,
 )
 from reflex.utils.exec import is_testing_env
 from reflex.utils.serializers import serializer
@@ -1262,7 +1263,7 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
             value: The value of the attribute.
 
         Raises:
-            AttributeError: If a value of a var is set without first defining it.
+            SetUndefinedStateVar: If a value of a var is set without first defining it.
         """
         if isinstance(value, MutableProxy):
             # unwrap proxy objects when assigning back to the state
@@ -1287,7 +1288,7 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
             and name not in self.vars
             and name not in self.get_skip_vars()
         ):
-            raise AttributeError(
+            raise SetUndefinedStateVarError(
                 f"The state variable '{name}' has not been defined in '{type(self).__name__}'. "
                 f"All state variables must be declared before they can be set."
             )

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1281,7 +1281,9 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
             return
 
         if (
-            not name.startswith("__")
+            not name.startswith(
+                "_"
+            )  # TODO: skipping backend vars and vars with double leading underscores for now. They should be supported, however.
             and name not in self.vars
             and name not in self.get_skip_vars()
         ):

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1282,9 +1282,8 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
             return
 
         if (
-            not name.startswith(
-                "_"
-            )  # TODO: skipping backend vars and vars with double leading underscores for now. They should be supported, however.
+            not name.startswith("__")
+            and not name.startswith(f"_{type(self).__name__}__")
             and name not in self.vars
             and name not in self.get_skip_vars()
         ):

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1277,6 +1277,9 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
             self._mark_dirty()
             return
 
+        if not name in self.vars and not name in self._computed_var_dependencies and not name in self.get_skip_vars():
+            raise AttributeError(f"The state var '{name}' has not been defined in '{type(self).__name__}'. All state vars must be declared before they can be set.")
+
         # Set the attribute.
         super().__setattr__(name, value)
 

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1263,7 +1263,7 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
             value: The value of the attribute.
 
         Raises:
-            SetUndefinedStateVar: If a value of a var is set without first defining it.
+            SetUndefinedStateVarError: If a value of a var is set without first defining it.
         """
         if isinstance(value, MutableProxy):
             # unwrap proxy objects when assigning back to the state

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1283,9 +1283,9 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
 
         if (
             name not in self.vars
+            and name not in self.get_skip_vars()
             and not name.startswith("__")
             and not name.startswith(f"_{type(self).__name__}__")
-            and name not in self.get_skip_vars()
         ):
             raise SetUndefinedStateVarError(
                 f"The state variable '{name}' has not been defined in '{type(self).__name__}'. "

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1260,6 +1260,9 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
         Args:
             name: The name of the attribute.
             value: The value of the attribute.
+
+        Raises:
+            AttributeError: If a value of a var is set without first defining it.
         """
         if isinstance(value, MutableProxy):
             # unwrap proxy objects when assigning back to the state

--- a/reflex/utils/exceptions.py
+++ b/reflex/utils/exceptions.py
@@ -115,3 +115,7 @@ class PrimitiveUnserializableToJSON(ReflexError, ValueError):
 
 class InvalidLifespanTaskType(ReflexError, TypeError):
     """Raised when an invalid task type is registered as a lifespan task."""
+
+
+class SetUndefinedStateVarError(ReflexError, AttributeError):
+    """Raised when setting the value of a var without first declaring it."""

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -3262,3 +3262,26 @@ def test_child_mixin_state() -> None:
 
     assert "computed" in ChildUsesMixinState.inherited_vars
     assert "computed" not in ChildUsesMixinState.computed_vars
+
+
+def test_assignment_to_undeclared_vars():
+    """Test that an attribute error is thrown when undeclared vars are set"""
+    class State(BaseState):
+        val: str
+
+        def handle(self):
+            self.num = 5
+
+    class Substate(State):
+
+        def handle_var(self):
+            self.value = 20
+
+    state = State()
+    sub_state = Substate()
+
+    with pytest.raises(AttributeError):
+        state.handle()
+
+    with pytest.raises(AttributeError):
+        sub_state.handle()

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -3269,9 +3269,22 @@ def test_assignment_to_undeclared_vars():
 
     class State(BaseState):
         val: str
+        _val: str
+        __val: str
 
-        def handle(self):
+        def handle_supported_regular_vars(self):
+            self.val = "no underscore"
+            self._val = "single leading underscore"
+            self.__val = "double leading undercore"
+
+        def handle_regular_var(self):
             self.num = 5
+
+        def handle_backend_var(self):
+            self._num = 5
+
+        def handle_non_var(self):
+            self.__num = 5
 
     class Substate(State):
         def handle_var(self):
@@ -3281,7 +3294,16 @@ def test_assignment_to_undeclared_vars():
     sub_state = Substate()  # type: ignore
 
     with pytest.raises(AttributeError):
-        state.handle()
+        state.handle_regular_var()
 
     with pytest.raises(AttributeError):
         sub_state.handle_var()
+
+    # TODO: uncomment this if the case of backend vars are supported.
+    # with pytest.raises(AttributeError):
+    #     state.handle_backend_var()
+    #
+    # with pytest.raises(AttributeError):
+    #     state.handle_non_var()
+
+    state.handle_supported_regular_vars()

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -3270,7 +3270,7 @@ def test_assignment_to_undeclared_vars():
     class State(BaseState):
         val: str
         _val: str
-        __val: str
+        __val: str  # type: ignore
 
         def handle_supported_regular_vars(self):
             self.val = "no underscore"

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -3277,14 +3277,11 @@ def test_assignment_to_undeclared_vars():
         def handle_var(self):
             self.value = 20
 
-    state = State()
-    sub_state = Substate()
+    state = State()  # type: ignore
+    sub_state = Substate()  # type: ignore
 
     with pytest.raises(AttributeError):
         state.handle()
-
-    with pytest.raises(AttributeError):
-        sub_state.handle()
 
     with pytest.raises(AttributeError):
         sub_state.handle_var()

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -3265,7 +3265,8 @@ def test_child_mixin_state() -> None:
 
 
 def test_assignment_to_undeclared_vars():
-    """Test that an attribute error is thrown when undeclared vars are set"""
+    """Test that an attribute error is thrown when undeclared vars are set."""
+
     class State(BaseState):
         val: str
 
@@ -3273,7 +3274,6 @@ def test_assignment_to_undeclared_vars():
             self.num = 5
 
     class Substate(State):
-
         def handle_var(self):
             self.value = 20
 
@@ -3285,3 +3285,6 @@ def test_assignment_to_undeclared_vars():
 
     with pytest.raises(AttributeError):
         sub_state.handle()
+
+    with pytest.raises(AttributeError):
+        sub_state.handle_var()

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -41,6 +41,7 @@ from reflex.state import (
 )
 from reflex.testing import chdir
 from reflex.utils import format, prerequisites, types
+from reflex.utils.exceptions import SetUndefinedStateVarError
 from reflex.utils.format import json_dumps
 from reflex.vars.base import ComputedVar, Var
 from tests.units.states.mutation import MutableSQLAModel, MutableTestState
@@ -3293,17 +3294,14 @@ def test_assignment_to_undeclared_vars():
     state = State()  # type: ignore
     sub_state = Substate()  # type: ignore
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(SetUndefinedStateVarError):
         state.handle_regular_var()
 
-    with pytest.raises(AttributeError):
+    with pytest.raises(SetUndefinedStateVarError):
         sub_state.handle_var()
 
-    # TODO: uncomment this if the case of backend vars are supported.
-    # with pytest.raises(AttributeError):
-    #     state.handle_backend_var()
-    #
-    # with pytest.raises(AttributeError):
-    #     state.handle_non_var()
+    with pytest.raises(SetUndefinedStateVarError):
+        state.handle_backend_var()
 
     state.handle_supported_regular_vars()
+    state.handle_non_var()


### PR DESCRIPTION
```python
import reflex as rx

class State(rx.State):
   value: int = 0
   def change_value(self):
       self.value = 10 # valid
       self.num = 5   # error
       self._num = 10 # error
       self.__num = 10 # valid
```

