### PR TITLE
implement _evaluate in state

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -24,7 +24,6 @@ from typing import (
     Dict,
     List,
     Optional,
-    Self,
     Sequence,
     Set,
     Tuple,
@@ -35,6 +34,7 @@ from typing import (
 
 import dill
 from sqlalchemy.orm import DeclarativeBase
+from typing_extensions import Self
 
 from reflex.config import get_config
 from reflex.vars.base import (

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -79,8 +79,8 @@ from reflex.utils.serializers import serializer
 from reflex.utils.types import override
 from reflex.vars import VarData
 
-# if TYPE_CHECKING:
-#     from reflex.components.component import Component
+if TYPE_CHECKING:
+    from reflex.components.component import Component
 
 
 Delta = Dict[str, Any]
@@ -697,6 +697,9 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
         Returns:
             The ComputedVar.
         """
+        console.warn(
+            "The _evaluate method is experimental and may be removed in future versions."
+        )
         from reflex.components.base.fragment import fragment
         from reflex.components.component import Component
 

--- a/reflex/vars/base.py
+++ b/reflex/vars/base.py
@@ -1559,8 +1559,9 @@ class ComputedVar(Var[RETURN_TYPE]):
         Raises:
             TypeError: If the computed var dependencies are not Var instances or var names.
         """
-        hints = get_type_hints(fget)
-        hint = hints.get("return", Any)
+        hint = kwargs.pop("return_type", None) or get_type_hints(fget).get(
+            "return", Any
+        )
 
         kwargs["_js_expr"] = kwargs.pop("_js_expr", fget.__name__)
         kwargs["_var_type"] = kwargs.pop("_var_type", hint)

--- a/tests/integration/test_dynamic_components.py
+++ b/tests/integration/test_dynamic_components.py
@@ -16,6 +16,8 @@ def DynamicComponents():
     import reflex as rx
 
     class DynamicComponentsState(rx.State):
+        value: int = 10
+
         button: rx.Component = rx.button(
             "Click me",
             custom_attrs={
@@ -52,11 +54,20 @@ def DynamicComponents():
 
     app = rx.App()
 
+    def factorial(n: int) -> int:
+        if n == 0:
+            return 1
+        return n * factorial(n - 1)
+
     @app.add_page
     def index():
         return rx.vstack(
             DynamicComponentsState.client_token_component,
             DynamicComponentsState.button,
+            rx.text(
+                DynamicComponentsState._evaluate(lambda state: factorial(state.value)),
+                id="factorial",
+            ),
         )
 
 
@@ -150,3 +161,7 @@ def test_dynamic_components(driver, dynamic_components: AppHarness):
         dynamic_components.poll_for_content(button, exp_not_equal="Click me")
         == "Clicked"
     )
+
+    factorial = poll_for_result(lambda: driver.find_element(By.ID, "factorial"))
+    assert factorial
+    assert factorial.text == "3628800"


### PR DESCRIPTION
Introduces experimental inline-way to define State components.

```py
"""This is a mockup example to demonstrate the usage of server_side function."""

import random

import reflex as rx


class State(rx.State):
    large_number: int = 100
    header_name: str = "Factorial Calculator"

    def randomize_number(self):
        self.large_number = random.randint(1, 900)


def factorial(n: int) -> int:
    """Return the factorial of n."""
    if n == 0:
        return 1
    return n * factorial(n - 1)


def is_prime(n: int) -> bool:
    """Return True if n is prime, False otherwise."""
    if n < 2:
        return False
    return all(n % i != 0 for i in range(2, n))


app = rx.App()


@app.add_page
def index():
    return rx.vstack(
        rx.text(
            f"factorial of {State.large_number} is ",
            State._evaluate(
                lambda state: str(factorial(state.large_number)),
            ),
            width="100%",
        ),
        rx.text(
            f"url-name of {State.header_name} is ",
            State._evaluate(lambda state: state.header_name.lower().replace(" ", "-")),
        ),
        rx.text(
            f"{State.large_number} is ",
            State._evaluate(
                lambda state: (
                    "prime" if is_prime(state.large_number) else "not prime"
                ),
            ),
        ),
        rx.button(
            "Randomize",
            on_click=lambda: State.randomize_number,
        ),
    )
```