### PR TITLE
[ENG-3870] rx.call_script with f-string var produces incorrect code

### DIFF
--- a/reflex/event.py
+++ b/reflex/event.py
@@ -845,7 +845,7 @@ def call_script(
             LiteralVar.create(javascript_code),
             javascript_code,
         )
-        if javascript_code._get_all_var_data() is None:
+        if not javascript_code._get_all_var_data():
             # Without VarData, cast to string and eval the code in the event loop.
             javascript_code = str(Var(_js_expr=original_code))
 

--- a/reflex/event.py
+++ b/reflex/event.py
@@ -839,6 +839,16 @@ def call_script(
                 ),
             ),
         }
+    if isinstance(javascript_code, str):
+        # When there is VarData, include it and eval the JS code inline on the client.
+        javascript_code, original_code = (
+            LiteralVar.create(javascript_code),
+            javascript_code,
+        )
+        if javascript_code._get_all_var_data() is None:
+            # Without VarData, cast to string and eval the code in the event loop.
+            javascript_code = str(Var(_js_expr=original_code))
+
     return server_side(
         "_call_script",
         get_fn_signature(call_script),


### PR DESCRIPTION
Avoid casting javascript code with embedded Var as LiteralStringVar
    
There are two cases that need to be handled:
    
    1. The javascript code contains Vars with VarData, these can only be evaluated
       in the component context, since they may use hooks. Vars with VarData cannot be
       used from the backend. In this case, we cast the given code as a raw js
       expression and include the extracted VarData.
    
    2. The javascript code has no VarData. In this case, we pass the code as the
       raw js expression and cast to a python str to get a js literal string to eval.