### PR TITLE
Get default for backend var defined in mixin

### DIFF
--- a/tests/integration/test_component_state.py
+++ b/tests/integration/test_component_state.py
@@ -12,13 +12,21 @@ from . import utils
 
 def ComponentStateApp():
     """App using per component state."""
+    from typing import Generic, TypeVar
+
     import reflex as rx
 
-    class MultiCounter(rx.ComponentState):
+    E = TypeVar("E")
+
+    class MultiCounter(rx.ComponentState, Generic[E]):
         count: int = 0
+        _be: E
+        _be_int: int
+        _be_str: str = "42"
 
         def increment(self):
             self.count += 1
+            self._be = self.count  # type: ignore
 
         @classmethod
         def get_component(cls, *children, **props):
@@ -47,6 +55,14 @@ def ComponentStateApp():
                 "Inc A",
                 on_click=mc_a.State.increment,  # type: ignore
                 id="inc-a",
+            ),
+            rx.text(
+                mc_a.State.get_name() if mc_a.State is not None else "",
+                id="a_state_name",
+            ),
+            rx.text(
+                mc_b.State.get_name() if mc_b.State is not None else "",
+                id="b_state_name",
             ),
         )
 
@@ -87,6 +103,18 @@ async def test_component_state_app(component_state_app: AppHarness):
     button_b = driver.find_element(By.ID, "button-b")
     button_inc_a = driver.find_element(By.ID, "inc-a")
 
+    # Check that backend vars in mixins are okay
+    a_state_name = driver.find_element(By.ID, "a_state_name").text
+    b_state_name = driver.find_element(By.ID, "b_state_name").text
+    root_state = await component_state_app.get_state(ss.get("token"))
+    a_state = root_state.substates[a_state_name]
+    b_state = root_state.substates[b_state_name]
+    assert a_state._backend_vars == a_state.backend_vars
+    assert a_state._backend_vars == b_state._backend_vars
+    assert a_state._backend_vars["_be"] is None
+    assert a_state._backend_vars["_be_int"] == 0
+    assert a_state._backend_vars["_be_str"] == "42"
+
     assert count_a.text == "0"
 
     button_a.click()
@@ -98,6 +126,14 @@ async def test_component_state_app(component_state_app: AppHarness):
     button_inc_a.click()
     assert component_state_app.poll_for_content(count_a, exp_not_equal="2") == "3"
 
+    root_state = await component_state_app.get_state(ss.get("token"))
+    a_state = root_state.substates[a_state_name]
+    b_state = root_state.substates[b_state_name]
+    assert a_state._backend_vars != a_state.backend_vars
+    assert a_state._be == a_state._backend_vars["_be"] == 3
+    assert b_state._be is None
+    assert b_state._backend_vars["_be"] is None
+
     assert count_b.text == "0"
 
     button_b.click()
@@ -105,3 +141,9 @@ async def test_component_state_app(component_state_app: AppHarness):
 
     button_b.click()
     assert component_state_app.poll_for_content(count_b, exp_not_equal="1") == "2"
+
+    root_state = await component_state_app.get_state(ss.get("token"))
+    a_state = root_state.substates[a_state_name]
+    b_state = root_state.substates[b_state_name]
+    assert b_state._backend_vars != b_state.backend_vars
+    assert b_state._be == b_state._backend_vars["_be"] == 2


### PR DESCRIPTION
If the backend var is defined in a mixin class, it won't appear in `cls.__dict__`, but the value is still retrievable via `getattr` on `cls`. Prefer to use the actual defined default before using `Var.get_default_value()`.

If `Var.get_default_value()` fails, set the default to `None` such that the backend var still gets recognized as a backend var when it is used on `self`.

----

Update test_component_state to include backend vars

Extra coverage for backend vars with and without defaults, defined in a ComponentState/mixin class.
