### PR TITLE
Reduce pickle size

### DIFF
--- a/tests/integration/test_dynamic_routes.py
+++ b/tests/integration/test_dynamic_routes.py
@@ -41,13 +41,13 @@ def DynamicRoute():
         return rx.fragment(
             rx.input(
                 value=DynamicState.router.session.client_token,
-                is_read_only=True,
+                read_only=True,
                 id="token",
             ),
-            rx.input(value=rx.State.page_id, is_read_only=True, id="page_id"),  # type: ignore
+            rx.input(value=rx.State.page_id, read_only=True, id="page_id"),  # type: ignore
             rx.input(
                 value=DynamicState.router.page.raw_path,
-                is_read_only=True,
+                read_only=True,
                 id="raw_path",
             ),
             rx.link("index", href="/", id="link_index"),


### PR DESCRIPTION
* Only serialize base vars
* Never serialize router/router_data in substates
* Hash the schema to reduce serialized size
* lru_cache the schema to avoid recomputing it