### PR TITLE
First use environment variable as npm registry

### DIFF
--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -37,7 +37,7 @@ from reflex.config import Config, get_config
 from reflex.utils import console, net, path_ops, processes
 from reflex.utils.exceptions import GeneratedCodeHasNoFunctionDefs
 from reflex.utils.format import format_library_name
-from reflex.utils.registry import _get_best_registry
+from reflex.utils.registry import _get_npm_registry
 
 CURRENTLY_INSTALLING_NODE = False
 
@@ -620,7 +620,7 @@ def initialize_package_json():
     code = _compile_package_json()
     output_path.write_text(code)
 
-    best_registry = _get_best_registry()
+    best_registry = _get_npm_registry()
     bun_config_path = get_web_dir() / constants.Bun.CONFIG_PATH
     bun_config_path.write_text(
         f"""

--- a/reflex/utils/registry.py
+++ b/reflex/utils/registry.py
@@ -1,8 +1,10 @@
 """Utilities for working with registries."""
 
+import os
+
 import httpx
 
-from reflex.utils import console
+from reflex.utils import console, net
 
 
 def latency(registry: str) -> int:
@@ -15,7 +17,7 @@ def latency(registry: str) -> int:
         int: The latency of the registry in microseconds.
     """
     try:
-        return httpx.get(registry).elapsed.microseconds
+        return net.get(registry).elapsed.microseconds
     except httpx.HTTPError:
         console.info(f"Failed to connect to {registry}.")
         return 10_000_000
@@ -34,7 +36,7 @@ def average_latency(registry, attempts: int = 3) -> int:
     return sum(latency(registry) for _ in range(attempts)) // attempts
 
 
-def _get_best_registry() -> str:
+def get_best_registry() -> str:
     """Get the best registry based on latency.
 
     Returns:
@@ -46,3 +48,15 @@ def _get_best_registry() -> str:
     ]
 
     return min(registries, key=average_latency)
+
+
+def _get_npm_registry() -> str:
+    """Get npm registry. If environment variable is set, use it first.
+
+    Returns:
+        str:
+    """
+    if npm_registry := os.environ.get("NPM_REGISTRY", ""):
+        return npm_registry
+    else:
+        return get_best_registry()

--- a/reflex/utils/registry.py
+++ b/reflex/utils/registry.py
@@ -56,7 +56,7 @@ def _get_npm_registry() -> str:
     Returns:
         str:
     """
-    if npm_registry := os.environ.get("NPM_REGISTRY", ""):
+    if npm_registry := os.environ.get("NPM_CONFIG_REGISTRY", ""):
         return npm_registry
     else:
         return get_best_registry()


### PR DESCRIPTION
### Type of change
- Bug fix (non-breaking change which fixes an issue)
close #4028 

When running `reflex init`, I have made adjustments to allow more flexible npm configurations, especially for environments where SSL verification is challenging or when using proxy remote repositories.

1. If the NPM_REGISTRY environment variable is set, the specified path will be used first.(If it is not set, the existing logic based on latency will apply.)
2. Instead of using httpx, we now use utilities implemented in net.

