### PR TITLE
Fix 'enter_key_submit=True' on 'rx.text_area' by disabling debounce if set

### DIFF
--- a/reflex/components/radix/themes/components/text_area.py
+++ b/reflex/components/radix/themes/components/text_area.py
@@ -108,8 +108,13 @@ class TextArea(RadixThemesComponent, elements.Textarea):
         Returns:
             The component.
         """
-        if props.get("value") is not None and props.get("on_change") is not None:
+        if (
+            props.get("value") is not None
+            and props.get("on_change") is not None
+            and props.get("enter_key_submit", False) is False
+        ):
             # create a debounced input if the user requests full control to avoid typing jank
+            # disabled when using `enter_key_submit`
             return DebounceInput.create(super().create(*children, **props))
         return super().create(*children, **props)
 


### PR DESCRIPTION
### All Submissions:

- [x ] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x ] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

### Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

### New Feature Submission:

- [x ] Does your submission pass the tests? 
- [x ] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable? -- no
- [x ] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.

    b. Describe your changes.
    
   Add additional constraint on whether to wrap rx.text_area in DebounceInput. Don't wrap if `enter_key_submit` is True.
   Without this, the enter_key_submit behaviour is ignored.
   
   Closes #4080
   
   Note: If there is a way to do this without having to remove the DebounceInput, that would be even better.