### PR TITLE
Revert Markdown-related frontend dep bumps

### DIFF
--- a/.github/workflows/check_outdated_dependencies.yml
+++ b/.github/workflows/check_outdated_dependencies.yml
@@ -74,7 +74,7 @@ jobs:
         echo "$outdated"
 
         # Ignore 3rd party dependencies that are not updated.
-        filtered_outdated=$(echo "$outdated" | grep -vE 'Package|@chakra-ui|lucide-react|@splinetool/runtime|ag-grid-react|framer-motion' || true)
+        filtered_outdated=$(echo "$outdated" | grep -vE 'Package|@chakra-ui|lucide-react|@splinetool/runtime|ag-grid-react|framer-motion|react-markdown|remark-math|remark-gfm|rehype-katex|rehype-raw' || true)
         no_extra=$(echo "$filtered_outdated" | grep -vE '\|\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-' || true)
 
 

--- a/reflex/components/markdown/markdown.py
+++ b/reflex/components/markdown/markdown.py
@@ -75,7 +75,7 @@ def get_base_component_map() -> dict[str, Callable]:
 class Markdown(Component):
     """A markdown component."""
 
-    library = "react-markdown@9.0.1"
+    library = "react-markdown@8.0.7"
 
     tag = "ReactMarkdown"
 
@@ -157,19 +157,19 @@ class Markdown(Component):
         return [
             {
                 "": "katex/dist/katex.min.css",
-                "remark-math@6.0.0": ImportVar(
+                "remark-math@5.1.1": ImportVar(
                     tag=_REMARK_MATH._js_expr, is_default=True
                 ),
-                "remark-gfm@4.0.0": ImportVar(
+                "remark-gfm@3.0.1": ImportVar(
                     tag=_REMARK_GFM._js_expr, is_default=True
                 ),
                 "remark-unwrap-images@4.0.0": ImportVar(
                     tag=_REMARK_UNWRAP_IMAGES._js_expr, is_default=True
                 ),
-                "rehype-katex@7.0.1": ImportVar(
+                "rehype-katex@6.0.3": ImportVar(
                     tag=_REHYPE_KATEX._js_expr, is_default=True
                 ),
-                "rehype-raw@7.0.0": ImportVar(
+                "rehype-raw@6.1.1": ImportVar(
                     tag=_REHYPE_RAW._js_expr, is_default=True
                 ),
             },


### PR DESCRIPTION
The api in `react-markdown` 9.0.0 changes significantly, breaking the reflex internal component map. The plugins cannot be bumped because they depend on the newer version.

So keep these locked where they were, and ignore them in the out-of-date dep check.