### PR TITLE
Change the defalut direction of radio group

### DIFF
--- a/reflex/components/radix/themes/components/radio_group.py
+++ b/reflex/components/radix/themes/components/radio_group.py
@@ -84,7 +84,7 @@ class HighLevelRadioGroup(RadixThemesComponent):
     items: Var[List[str]]
 
     # The direction of the radio group.
-    direction: Var[LiteralFlexDirection] = LiteralVar.create("column")
+    direction: Var[LiteralFlexDirection] = LiteralVar.create("row")
 
     # The gap between the items of the radio group.
     spacing: Var[LiteralSpacing] = LiteralVar.create("2")
@@ -137,7 +137,7 @@ class HighLevelRadioGroup(RadixThemesComponent):
         Raises:
             TypeError: If the type of items is invalid.
         """
-        direction = props.pop("direction", "column")
+        direction = props.pop("direction", "row")
         spacing = props.pop("spacing", "2")
         size = props.pop("size", "2")
         variant = props.pop("variant", "classic")


### PR DESCRIPTION
## Change the default direction of the radio group to horizontal.
- The default direction of radio groups is column.
- Since most use cases are horizontal, change the default direction from column to row.
-  This change requires change in documentation as well.
- Fixes #4070

### All Submissions:

- [ ✅ ] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [ ✅ ] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [ ✅ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [✅  ] This change requires a documentation update


### New Feature Submission:

- [✅  ] Does your submission pass the tests? 
- [✅  ] Have you linted your code locally prior to submission?

