### PR TITLE
unionize base var fields types

### DIFF
--- a/reflex/utils/types.py
+++ b/reflex/utils/types.py
@@ -195,8 +195,6 @@ def unionize(*args: GenericType) -> Type:
         return Any
     if len(args) == 1:
         return args[0]
-    if sys.version_info >= (3, 11):
-        return Union[*args]  # type: ignore
     # We are bisecting the args list here to avoid hitting the recursion limit
     # In Python versions >= 3.11, we can simply do `return Union[*args]`
     midpoint = len(args) // 2

--- a/reflex/utils/types.py
+++ b/reflex/utils/types.py
@@ -195,6 +195,8 @@ def unionize(*args: GenericType) -> Type:
         return Any
     if len(args) == 1:
         return args[0]
+    if sys.version_info >= (3, 11):
+        return Union[*args]  # type: ignore
     # We are bisecting the args list here to avoid hitting the recursion limit
     # In Python versions >= 3.11, we can simply do `return Union[*args]`
     midpoint = len(args) // 2

--- a/reflex/vars/base.py
+++ b/reflex/vars/base.py
@@ -56,7 +56,7 @@ from reflex.utils.imports import (
     ParsedImportDict,
     parse_imports,
 )
-from reflex.utils.types import GenericType, Self, get_origin
+from reflex.utils.types import GenericType, Self, get_origin, unionize
 
 if TYPE_CHECKING:
     from reflex.state import BaseState
@@ -1235,26 +1235,6 @@ def var_operation(
         ).guess_type()
 
     return wrapper
-
-
-def unionize(*args: Type) -> Type:
-    """Unionize the types.
-
-    Args:
-        args: The types to unionize.
-
-    Returns:
-        The unionized types.
-    """
-    if not args:
-        return Any
-    if len(args) == 1:
-        return args[0]
-    # We are bisecting the args list here to avoid hitting the recursion limit
-    # In Python versions >= 3.11, we can simply do `return Union[*args]`
-    midpoint = len(args) // 2
-    first_half, second_half = args[:midpoint], args[midpoint:]
-    return Union[unionize(*first_half), unionize(*second_half)]
 
 
 def figure_out_type(value: Any) -> types.GenericType:

--- a/reflex/vars/base.py
+++ b/reflex/vars/base.py
@@ -441,7 +441,7 @@ class Var(Generic[VAR_TYPE]):
 
         if issubclass(output, NumberVar):
             if fixed_type is not None:
-                if fixed_type is Union:
+                if fixed_type in types.UnionTypes:
                     inner_types = get_args(base_type)
                     if not all(issubclass(t, (int, float)) for t in inner_types):
                         raise TypeError(
@@ -530,7 +530,7 @@ class Var(Generic[VAR_TYPE]):
 
         fixed_type = get_origin(var_type) or var_type
 
-        if fixed_type is Union:
+        if fixed_type in types.UnionTypes:
             inner_types = get_args(var_type)
 
             if all(

--- a/reflex/vars/object.py
+++ b/reflex/vars/object.py
@@ -262,7 +262,9 @@ class ObjectVar(Var[OBJECT_TYPE]):
             var_type = get_args(var_type)[0]
 
         fixed_type = var_type if isclass(var_type) else get_origin(var_type)
-        if isclass(fixed_type) and not issubclass(fixed_type, dict):
+        if (isclass(fixed_type) and not issubclass(fixed_type, dict)) or (
+            fixed_type in types.UnionTypes
+        ):
             attribute_type = get_attribute_access_type(var_type, name)
             if attribute_type is None:
                 raise VarAttributeError(

--- a/tests/units/test_var.py
+++ b/tests/units/test_var.py
@@ -398,6 +398,31 @@ def test_list_tuple_contains(var, expected):
     assert str(var.contains(other_var)) == f"{expected}.includes(other)"
 
 
+class Foo(rx.Base):
+    bar: int
+    baz: str
+
+
+class Bar(rx.Base):
+    bar: str
+    baz: str
+    foo: int
+
+
+@pytest.mark.parametrize(
+    ("var", "var_type"),
+    [
+        (Var(_js_expr="", _var_type=Foo | Bar).guess_type(), Foo | Bar),
+        (Var(_js_expr="", _var_type=Union[Foo, Bar]).guess_type(), Union[Foo, Bar]),
+        (Var(_js_expr="", _var_type=Union[Foo, Bar]).guess_type().bar, Union[int, str]),
+        (Var(_js_expr="", _var_type=Union[Foo, Bar]).guess_type().baz, str),
+        (Var(_js_expr="", _var_type=Union[Foo, Bar]).guess_type().foo, Union[int, None]),
+    ],
+)
+def test_var_types(var, var_type):
+    assert var._var_type == var_type
+
+
 @pytest.mark.parametrize(
     "var, expected",
     [

--- a/tests/units/test_var.py
+++ b/tests/units/test_var.py
@@ -1,5 +1,6 @@
 import json
 import math
+import sys
 import typing
 from typing import Dict, List, Optional, Set, Tuple, Union, cast
 
@@ -415,10 +416,16 @@ class Bar(rx.Base):
 
 @pytest.mark.parametrize(
     ("var", "var_type"),
-    [
-        (Var(_js_expr="", _var_type=Foo | Bar).guess_type(), Foo | Bar),
+    (
+        [
+            (Var(_js_expr="", _var_type=Foo | Bar).guess_type(), Foo | Bar),
+            (Var(_js_expr="", _var_type=Foo | Bar).guess_type().bar, Union[int, str]),
+        ]
+        if sys.version_info >= (3, 10)
+        else []
+    )
+    + [
         (Var(_js_expr="", _var_type=Union[Foo, Bar]).guess_type(), Union[Foo, Bar]),
-        (Var(_js_expr="", _var_type=Union[Foo, Bar]).guess_type().bar, Union[int, str]),
         (Var(_js_expr="", _var_type=Union[Foo, Bar]).guess_type().baz, str),
         (
             Var(_js_expr="", _var_type=Union[Foo, Bar]).guess_type().foo,

--- a/tests/units/test_var.py
+++ b/tests/units/test_var.py
@@ -399,11 +399,15 @@ def test_list_tuple_contains(var, expected):
 
 
 class Foo(rx.Base):
+    """Foo class."""
+
     bar: int
     baz: str
 
 
 class Bar(rx.Base):
+    """Bar class."""
+
     bar: str
     baz: str
     foo: int
@@ -416,7 +420,10 @@ class Bar(rx.Base):
         (Var(_js_expr="", _var_type=Union[Foo, Bar]).guess_type(), Union[Foo, Bar]),
         (Var(_js_expr="", _var_type=Union[Foo, Bar]).guess_type().bar, Union[int, str]),
         (Var(_js_expr="", _var_type=Union[Foo, Bar]).guess_type().baz, str),
-        (Var(_js_expr="", _var_type=Union[Foo, Bar]).guess_type().foo, Union[int, None]),
+        (
+            Var(_js_expr="", _var_type=Union[Foo, Bar]).guess_type().foo,
+            Union[int, None],
+        ),
     ],
 )
 def test_var_types(var, var_type):


### PR DESCRIPTION
```py
class Foo(rx.Base):
    name: str = "foo"


class Bar(rx.Base):
    field: str = "bar"


class State(rx.State):
    @rx.var
    def something(self) -> Foo | Bar:
        return Bar()


print(get_attribute_access_type(Foo | Bar, "name"))

print(State.something.name._var_type)
```