### PR TITLE
Include value._get_all_var_data when ClientStateVar.set_value is used

### DIFF
--- a/reflex/experimental/client_state.py
+++ b/reflex/experimental/client_state.py
@@ -178,9 +178,12 @@ class ClientStateVar(Var):
             if self._global_ref
             else self._setter_name
         )
+        _var_data = VarData(imports=_refs_import if self._global_ref else {})
         if value is not NoValue:
             # This is a hack to make it work like an EventSpec taking an arg
-            value_str = str(LiteralVar.create(value))
+            value_var = LiteralVar.create(value)
+            _var_data = _var_data.merge(value_var._get_all_var_data())
+            value_str = str(value_var)
 
             if value_str.startswith("_"):
                 # remove patterns of ["*"] from the value_str using regex
@@ -190,7 +193,7 @@ class ClientStateVar(Var):
                 setter = f"(() => {setter}({value_str}))"
         return Var(
             _js_expr=setter,
-            _var_data=VarData(imports=_refs_import if self._global_ref else {}),
+            _var_data=_var_data,
         ).to(FunctionVar, EventChain)
 
     @property


### PR DESCRIPTION
If `set_value` is called with a State var as the argument, ensure that its context is brought into scope.