### PR TITLE
pin AppHarness tests to ubuntu-22.04 runner

### DIFF
--- a/.github/workflows/check_node_latest.yml
+++ b/.github/workflows/check_node_latest.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
     check_latest_node:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         strategy:
             matrix:
                 python-version: ['3.12']

--- a/.github/workflows/integration_app_harness.yml
+++ b/.github/workflows/integration_app_harness.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         state_manager: ['redis', 'memory']
         python-version: ['3.11.5', '3.12.0']
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     services:
       # Label used to access the service container
       redis:


### PR DESCRIPTION
integration_app_harness tests have been getting stuck and timing out, while check_node_latest has been straight up failing.

[github is rolling out ubuntu 24.04 as `ubuntu-latest` starting a few weeks ago](https://github.com/actions/runner-images/issues/10636)... seems that over the weekend, our workflows may have moved over since we're now experiencing unusual failures, even on old PRs that passed CI last week.

trying to pin the runner images to the previous 22.04 in an attempt to confirm or rule out this hypothesis