### PR TITLE
LiteralEventChainVar becomes an ArgsFunctionOperation

### DIFF
--- a/reflex/event.py
+++ b/reflex/event.py
@@ -1332,7 +1332,7 @@ class EventChainVar(FunctionVar):
     frozen=True,
     **{"slots": True} if sys.version_info >= (3, 10) else {},
 )
-class LiteralEventChainVar(ArgsFunctionOperation, EventChainVar, LiteralVar):
+class LiteralEventChainVar(LiteralVar, ArgsFunctionOperation, EventChainVar):
     """A literal event chain var."""
 
     _var_value: EventChain = dataclasses.field(default=None)  # type: ignore
@@ -1377,7 +1377,7 @@ class LiteralEventChainVar(ArgsFunctionOperation, EventChainVar, LiteralVar):
 
         return cls(
             _js_expr="",
-            _var_type=Callable,
+            _var_type=EventChain,
             _var_data=_var_data,
             _args_names=arg_def,
             _return_expr=invocation.call(

--- a/reflex/event.py
+++ b/reflex/event.py
@@ -22,6 +22,7 @@ from typing import (
     TypeVar,
     Union,
     get_type_hints,
+    overload,
 )
 
 from typing_extensions import ParamSpec, get_args, get_origin
@@ -1416,6 +1417,11 @@ EventType = Union[IndividualEventType[G], List[IndividualEventType[G]]]
 
 P = ParamSpec("P")
 T = TypeVar("T")
+V = TypeVar("V")
+V2 = TypeVar("V2")
+V3 = TypeVar("V3")
+V4 = TypeVar("V4")
+V5 = TypeVar("V5")
 
 if sys.version_info >= (3, 10):
     from typing import Concatenate
@@ -1430,6 +1436,54 @@ if sys.version_info >= (3, 10):
                 func: The function to be wrapped.
             """
             self.func = func
+
+        @overload
+        def __get__(
+            self: EventCallback[[V], T], instance: None, owner
+        ) -> Callable[[Union[Var[V], V]], T]: ...
+
+        @overload
+        def __get__(
+            self: EventCallback[[V, V2], T], instance: None, owner
+        ) -> Callable[[Union[Var[V], V], Union[Var[V2], V2]], T]: ...
+
+        @overload
+        def __get__(
+            self: EventCallback[[V, V2, V3], T], instance: None, owner
+        ) -> Callable[
+            [Union[Var[V], V], Union[Var[V2], V2], Union[Var[V3], V3]],
+            T,
+        ]: ...
+
+        @overload
+        def __get__(
+            self: EventCallback[[V, V2, V3, V4], T], instance: None, owner
+        ) -> Callable[
+            [
+                Union[Var[V], V],
+                Union[Var[V2], V2],
+                Union[Var[V3], V3],
+                Union[Var[V4], V4],
+            ],
+            T,
+        ]: ...
+
+        @overload
+        def __get__(
+            self: EventCallback[[V, V2, V3, V4, V5], T], instance: None, owner
+        ) -> Callable[
+            [
+                Union[Var[V], V],
+                Union[Var[V2], V2],
+                Union[Var[V3], V3],
+                Union[Var[V4], V4],
+                Union[Var[V5], V5],
+            ],
+            T,
+        ]: ...
+
+        @overload
+        def __get__(self, instance, owner) -> Callable[P, T]: ...
 
         def __get__(self, instance, owner) -> Callable[P, T]:
             """Get the function with the instance bound to it.

--- a/reflex/event.py
+++ b/reflex/event.py
@@ -1332,7 +1332,10 @@ class EventChainVar(FunctionVar):
     frozen=True,
     **{"slots": True} if sys.version_info >= (3, 10) else {},
 )
-class LiteralEventChainVar(LiteralVar, ArgsFunctionOperation, EventChainVar):
+# Note: LiteralVar is second in the inheritance list allowing it act like a
+# CachedVarOperation (ArgsFunctionOperation) and get the _js_expr from the
+# _cached_var_name property.
+class LiteralEventChainVar(ArgsFunctionOperation, LiteralVar, EventChainVar):
     """A literal event chain var."""
 
     _var_value: EventChain = dataclasses.field(default=None)  # type: ignore

--- a/reflex/event.py
+++ b/reflex/event.py
@@ -1440,19 +1440,19 @@ if sys.version_info >= (3, 10):
         @overload
         def __get__(
             self: EventCallback[[V], T], instance: None, owner
-        ) -> Callable[[Union[Var[V], V]], T]: ...
+        ) -> Callable[[Union[Var[V], V]], EventSpec]: ...
 
         @overload
         def __get__(
             self: EventCallback[[V, V2], T], instance: None, owner
-        ) -> Callable[[Union[Var[V], V], Union[Var[V2], V2]], T]: ...
+        ) -> Callable[[Union[Var[V], V], Union[Var[V2], V2]], EventSpec]: ...
 
         @overload
         def __get__(
             self: EventCallback[[V, V2, V3], T], instance: None, owner
         ) -> Callable[
             [Union[Var[V], V], Union[Var[V2], V2], Union[Var[V3], V3]],
-            T,
+            EventSpec,
         ]: ...
 
         @overload
@@ -1465,7 +1465,7 @@ if sys.version_info >= (3, 10):
                 Union[Var[V3], V3],
                 Union[Var[V4], V4],
             ],
-            T,
+            EventSpec,
         ]: ...
 
         @overload
@@ -1479,13 +1479,13 @@ if sys.version_info >= (3, 10):
                 Union[Var[V4], V4],
                 Union[Var[V5], V5],
             ],
-            T,
+            EventSpec,
         ]: ...
 
         @overload
         def __get__(self, instance, owner) -> Callable[P, T]: ...
 
-        def __get__(self, instance, owner) -> Callable[P, T]:
+        def __get__(self, instance, owner) -> Callable:
             """Get the function with the instance bound to it.
 
             Args:


### PR DESCRIPTION
Instead of using the ArgsFunctionOperation to create the string representation of the _js_expr, make the identity of the var an ArgsFunctionOperation so the _args_names and _return_expr remain accessible.

Rely on the default behavior of ArgsFunctionOperation to create the _cached_var_name / _js_expr value.

This allows the compat shim in `format_event_chain` to remain functional, as it does special handling for ArgsFunctionOperation to retain the previous behavior of that function (this was a regression introduced in 0.6.2).