### PR TITLE
Arbitrary arg access two levels deep for untyped handler

### DIFF
--- a/reflex/event.py
+++ b/reflex/event.py
@@ -1042,7 +1042,7 @@ def resolve_annotation(annotations: dict[str, Any], arg_name: str):
             removal_version="0.7.0",
         )
         # Allow arbitrary attribute access two levels deep until removed.
-        return dict[str, dict]
+        return Dict[str, dict]
     return annotation
 
 

--- a/reflex/event.py
+++ b/reflex/event.py
@@ -1041,7 +1041,8 @@ def resolve_annotation(annotations: dict[str, Any], arg_name: str):
             deprecation_version="0.6.3",
             removal_version="0.7.0",
         )
-        return JavascriptInputEvent
+        # Allow arbitrary attribute access two levels deep until removed.
+        return dict[str, dict]
     return annotation
 
 


### PR DESCRIPTION
Provide drop-in compatibility with existing component wrapping code that was accessing attributes on the default handler arg type.