### PR TITLE
[ENG-3954] Treat ArrayVar.foreach index as int

### DIFF
--- a/reflex/vars/sequence.py
+++ b/reflex/vars/sequence.py
@@ -1167,7 +1167,10 @@ class ArrayVar(Var[ARRAY_VAR_TYPE]):
                 _var_type=first_arg_type,
             ).guess_type()
 
-            function_var = ArgsFunctionOperation.create((arg_name,), fn(first_arg))
+            function_var = ArgsFunctionOperation.create(
+                (arg_name,),
+                Var.create(fn(first_arg)),
+            )
 
         return map_array_operation(self, function_var)
 

--- a/reflex/vars/sequence.py
+++ b/reflex/vars/sequence.py
@@ -1155,7 +1155,7 @@ class ArrayVar(Var[ARRAY_VAR_TYPE]):
             function_var = ArgsFunctionOperation.create(tuple(), return_value)
         else:
             # generic number var
-            number_var = Var("").to(NumberVar)
+            number_var = Var("").to(NumberVar, int)
 
             first_arg_type = self[number_var]._var_type
 


### PR DESCRIPTION
```python
import reflex as rx

l = rx.Var.create(["a", "b"])
l_foo = l.foreach(lambda item: item + "_foo")
```