### PR TITLE
Fix runtime error on python 3.11.0

### DIFF
--- a/reflex/event.py
+++ b/reflex/event.py
@@ -1412,7 +1412,7 @@ class ToEventChainVarOperation(ToOperation, EventChainVar):
 
 G = ParamSpec("G")
 
-IndividualEventType = Union[EventSpec, EventHandler, Callable[G, Any], Var]
+IndividualEventType = Union[EventSpec, EventHandler, Callable[G, Any], Var[Any]]
 
 EventType = Union[IndividualEventType[G], List[IndividualEventType[G]]]
 


### PR DESCRIPTION
All generic types present in a Union must be parametrized on 3.11.0 if any other generic types in the union are parametrized.

This appears to be a bug in 3.11.0, as the behavior is not observed in 3.11.1 or 3.10; fixing here as this is technically more correct anyway and avoids a crash.