### PR TITLE
Raise TypeError when `ComputedVar.__init__` gets bad kwargs

### DIFF
--- a/reflex/vars/base.py
+++ b/reflex/vars/base.py
@@ -1557,8 +1557,8 @@ class ComputedVar(Var[RETURN_TYPE]):
             "return", Any
         )
 
-        kwargs["_js_expr"] = kwargs.pop("_js_expr", fget.__name__)
-        kwargs["_var_type"] = kwargs.pop("_var_type", hint)
+        kwargs.setdefault("_js_expr", fget.__name__)
+        kwargs.setdefault("_var_type", hint)
 
         Var.__init__(
             self,
@@ -1566,6 +1566,9 @@ class ComputedVar(Var[RETURN_TYPE]):
             _var_type=kwargs.pop("_var_type"),
             _var_data=kwargs.pop("_var_data", None),
         )
+
+        if kwargs:
+            raise TypeError(f"Unexpected keyword arguments: {tuple(kwargs)}")
 
         if backend is None:
             backend = fget.__name__.startswith("_")


### PR DESCRIPTION
It's easy to mis-spell `rx.var(cached=True)` instead of `rx.var(cache=True)`, and in 0.6.3, this doesn't actual raise an error... the bad value is silently discarded and the var is NOT marked as being cached.

Now the error clearly indicates what the problem is and where it was introduced

```console
...
  File "/Users/masenf/code/reflex-dev/repro-sqlalchemy-association-proxy/repro_sqlalchemy_association_proxy/repro_sqlalchemy_association_proxy.py", line 9, in <module>
    class State(rx.State):
  File "/Users/masenf/code/reflex-dev/repro-sqlalchemy-association-proxy/repro_sqlalchemy_association_proxy/repro_sqlalchemy_association_proxy.py", line 27, in State
    @rx.var(cached=True)
     ^^^^^^^^^^^^^^^^^^^
  File "/Users/masenf/code/reflex-dev/reflex/reflex/vars/base.py", line 1991, in wrapper
    return ComputedVar(
           ^^^^^^^^^^^^
  File "/Users/masenf/code/reflex-dev/reflex/reflex/vars/base.py", line 1571, in __init__
    raise TypeError(f"Unexpected keyword arguments: {tuple(kwargs)}")
TypeError: Unexpected keyword arguments: ('cached',)
```