### PR TITLE
[ENG-3989] Ensure non-serialized states are present in StateManagerDisk

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -2895,9 +2895,13 @@ class StateManagerDisk(StateManager):
         for substate in state.get_substates():
             substate_token = _substate_key(client_token, substate)
 
+            fresh_instance = await root_state.get_state(substate)
             instance = await self.load_state(substate_token)
-            if instance is None:
-                instance = await root_state.get_state(substate)
+            if instance is not None:
+                # Ensure all substates exist, even if they weren't serialized previously.
+                instance.substates = fresh_instance.substates
+            else:
+                instance = fresh_instance
             state.substates[substate.get_name()] = instance
             instance.parent_state = state
 


### PR DESCRIPTION
If a non-root state was serialized, but its substates were not, then these would not be populated when reloading the pickled state, because only substates from the root were being populated with fresh versions.

Now, capture the substates from all fresh states and apply them to the deserialized state for each substate to ensure that the entire state tree has all substates instantiated after deserializing, even substates that were never serialized originally.

Fixes #4227 