### PR TITLE
make vardata merge not use classmethod

### DIFF
--- a/reflex/vars/base.py
+++ b/reflex/vars/base.py
@@ -160,9 +160,13 @@ class VarData:
         Returns:
             The merged var data object.
         """
-        all_var_datas = [self] + [
-            var_data for var_data in others if var_data is not None
-        ]
+        all_var_datas = list(filter(None, (self, *others)))
+
+        if not all_var_datas:
+            return None
+
+        if len(all_var_datas) == 1:
+            return all_var_datas[0]
 
         # Get the first non-empty field name or default to empty string.
         field_name = next(

--- a/reflex/vars/base.py
+++ b/reflex/vars/base.py
@@ -151,16 +151,16 @@ class VarData:
         """
         return dict((k, list(v)) for k, v in self.imports)
 
-    def merge(self: VarData | None, *others: VarData | None) -> VarData | None:
+    def merge(*all: VarData | None) -> VarData | None:
         """Merge multiple var data objects.
 
         Args:
-            *others: The var data objects to merge.
+            *all: The var data objects to merge.
 
         Returns:
             The merged var data object.
         """
-        all_var_datas = list(filter(None, (self, *others)))
+        all_var_datas = list(filter(None, all))
 
         if not all_var_datas:
             return None

--- a/reflex/vars/base.py
+++ b/reflex/vars/base.py
@@ -151,7 +151,7 @@ class VarData:
         """
         return dict((k, list(v)) for k, v in self.imports)
 
-    def merge(self, *others: VarData | None) -> VarData | None:
+    def merge(self: VarData | None, *others: VarData | None) -> VarData | None:
         """Merge multiple var data objects.
 
         Args:

--- a/reflex/vars/base.py
+++ b/reflex/vars/base.py
@@ -164,11 +164,13 @@ class VarData:
             var_data for var_data in others if var_data is not None
         ]
 
+        # Get the first non-empty field name or default to empty string.
         field_name = next(
             (var_data.field_name for var_data in all_var_datas if var_data.field_name),
             "",
         )
 
+        # Get the first non-empty state or default to empty string.
         state = next(
             (var_data.state for var_data in all_var_datas if var_data.state), ""
         )

--- a/reflex/vars/base.py
+++ b/reflex/vars/base.py
@@ -159,6 +159,8 @@ class VarData:
 
         Returns:
             The merged var data object.
+
+        # noqa: DAR102 *all
         """
         all_var_datas = list(filter(None, all))
 


### PR DESCRIPTION
fixes:
```py
var_data.merge(...)
```
which was not equivalent to:
```py
VarData.merge(var_data, ...)
```