### PR TITLE
[ENG-4012]Fix shiki copy button animation firing off after clicking copy button

### DIFF
--- a/reflex/components/datadisplay/shiki_code_block.py
+++ b/reflex/components/datadisplay/shiki_code_block.py
@@ -33,8 +33,8 @@ def copy_script() -> Any:
         f"""
 // Event listener for the parent click
 document.addEventListener('click', function(event) {{
-    // Find the closest div (parent element)
-    const parent = event.target.closest('div');
+    // Find the closest button (parent element)
+    const parent = event.target.closest('button');
     // If the parent is found
     if (parent) {{
         // Find the SVG element within the parent


### PR DESCRIPTION
Fix the issue where, after clicking the copy button on the Shiki code block, clicking anywhere else triggers the copy animation