### PR TITLE
Handle props annotated as list/dict of EventHandler

### DIFF
--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -645,7 +645,7 @@ class Component(BaseComponent, ABC):
         # Look for component specific triggers,
         # e.g. variable declared as EventHandler types.
         for field in self.get_fields().values():
-            if types._issubclass(field.type_, EventHandler):
+            if types._issubclass(field.outer_type_, EventHandler):
                 args_spec = None
                 annotation = field.annotation
                 if (metadata := getattr(annotation, "__metadata__", None)) is not None:

--- a/reflex/event.py
+++ b/reflex/event.py
@@ -1491,6 +1491,11 @@ if sys.version_info >= (3, 10):
 
         @overload
         def __call__(
+            self: EventCallback[Q, T],
+        ) -> EventCallback[Q, T]: ...
+
+        @overload
+        def __call__(
             self: EventCallback[Concatenate[V, Q], T], value: V | Var[V]
         ) -> EventCallback[Q, T]: ...
 


### PR DESCRIPTION
These props are NOT event triggers themselves, but rather they are props that expect a list or dict of event handlers.

Additional fix for calling an `@rx.event` decorated event handler with no arguments.