### PR TITLE
raise error when get package manager is not found

### DIFF
--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -467,9 +467,11 @@ def output_system_info():
         console.debug(f"{dep}")
 
     console.debug(
-        f"Using package installer at: {prerequisites.get_install_package_manager()}"  # type: ignore
+        f"Using package installer at: {prerequisites.get_install_package_manager(on_failure_return_none=True)}"  # type: ignore
     )
-    console.debug(f"Using package executer at: {prerequisites.get_package_manager()}")  # type: ignore
+    console.debug(
+        f"Using package executer at: {prerequisites.get_package_manager(on_failure_return_none=True)}"
+    )  # type: ignore
     if system != "Windows":
         console.debug(f"Unzip path: {path_ops.which('unzip')}")
 

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -204,7 +204,7 @@ def get_bun_version() -> version.Version | None:
         return None
 
 
-def get_install_package_manager() -> str | None:
+def get_install_package_manager() -> str:
     """Get the package manager executable for installation.
       Currently, bun is used for installation only.
 
@@ -221,17 +221,20 @@ def get_install_package_manager() -> str | None:
     return str(get_config().bun_path)
 
 
-def get_package_manager() -> str | None:
+def get_package_manager() -> str:
     """Get the package manager executable for running app.
       Currently on unix systems, npm is used for running the app only.
 
     Returns:
         The path to the package manager.
+
+    Raises:
+        FileNotFoundError: If the package manager is not found.
     """
     npm_path = path_ops.get_npm_path()
     if npm_path is not None:
         npm_path = str(Path(npm_path).resolve())
-    return npm_path
+    raise FileNotFoundError("NPM not found. You may need to run `reflex init`.")
 
 
 def windows_check_onedrive_in_path() -> bool:

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -233,7 +233,7 @@ def get_package_manager(on_failure_return_none: bool = False) -> str | None:
     """
     npm_path = path_ops.get_npm_path()
     if npm_path is not None:
-        npm_path = str(Path(npm_path).resolve())
+        return str(Path(npm_path).resolve())
     if on_failure_return_none:
         return None
     raise FileNotFoundError("NPM not found. You may need to run `reflex init`.")

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -208,6 +208,9 @@ def get_install_package_manager(on_failure_return_none: bool = False) -> str | N
     """Get the package manager executable for installation.
       Currently, bun is used for installation only.
 
+    Args:
+        on_failure_return_none: Whether to return None on failure.
+
     Returns:
         The path to the package manager.
     """
@@ -224,6 +227,9 @@ def get_install_package_manager(on_failure_return_none: bool = False) -> str | N
 def get_package_manager(on_failure_return_none: bool = False) -> str | None:
     """Get the package manager executable for running app.
       Currently on unix systems, npm is used for running the app only.
+
+    Args:
+        on_failure_return_none: Whether to return None on failure.
 
     Returns:
         The path to the package manager.
@@ -924,6 +930,9 @@ def install_frontend_packages(packages: set[str], config: Config):
     Args:
         packages: A list of package names to be installed.
         config: The config object.
+
+    Raises:
+        FileNotFoundError: If the package manager is not found.
 
     Example:
         >>> install_frontend_packages(["react", "react-dom"], get_config())

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -204,7 +204,7 @@ def get_bun_version() -> version.Version | None:
         return None
 
 
-def get_install_package_manager() -> str:
+def get_install_package_manager(on_failure_return_none: bool = False) -> str | None:
     """Get the package manager executable for installation.
       Currently, bun is used for installation only.
 
@@ -217,11 +217,11 @@ def get_install_package_manager() -> str:
         or windows_check_onedrive_in_path()
         or windows_npm_escape_hatch()
     ):
-        return get_package_manager()
+        return get_package_manager(on_failure_return_none)
     return str(get_config().bun_path)
 
 
-def get_package_manager() -> str:
+def get_package_manager(on_failure_return_none: bool = False) -> str | None:
     """Get the package manager executable for running app.
       Currently on unix systems, npm is used for running the app only.
 
@@ -234,6 +234,8 @@ def get_package_manager() -> str:
     npm_path = path_ops.get_npm_path()
     if npm_path is not None:
         npm_path = str(Path(npm_path).resolve())
+    if on_failure_return_none:
+        return None
     raise FileNotFoundError("NPM not found. You may need to run `reflex init`.")
 
 


### PR DESCRIPTION
Prevent errors like:
```
Invalid command: [None, 'run', 'next', 'telemetry', 'disable']
Warning: Unable to export due to: 1
```