### PR TITLE
Bugfix/leave gitignore as is

### DIFF
--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -446,7 +446,7 @@ def initialize_gitignore(
     if files_to_ignore == current_ignore:
         console.debug(f"{gitignore_file} already up to date.")
         return
-    files_to_ignore = [f for f in files_to_ignore if f not in current_ignore]
+    files_to_ignore = [ln for ln in files_to_ignore if ln not in current_ignore]
     files_to_ignore += current_ignore
 
     # Write files to the .gitignore file.

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -430,7 +430,7 @@ def create_config(app_name: str):
 
 def initialize_gitignore(
     gitignore_file: Path = constants.GitIgnore.FILE,
-    files_to_ignore: set[str] = constants.GitIgnore.DEFAULTS,
+    files_to_ignore: set[str] | list[str] = constants.GitIgnore.DEFAULTS,
 ):
     """Initialize the template .gitignore file.
 
@@ -439,23 +439,20 @@ def initialize_gitignore(
         files_to_ignore: The files to add to the .gitignore file.
     """
     # Combine with the current ignored files.
-    current_ignore: set[str] = set()
+    current_ignore: list[str] = []
     if gitignore_file.exists():
-        current_ignore |= set(
-            line.strip() for line in gitignore_file.read_text().splitlines()
-        )
+        current_ignore = [ln.strip() for ln in gitignore_file.read_text().splitlines()]
 
     if files_to_ignore == current_ignore:
         console.debug(f"{gitignore_file} already up to date.")
         return
-    files_to_ignore |= current_ignore
+    files_to_ignore = [f for f in files_to_ignore if f not in current_ignore]
+    files_to_ignore += current_ignore
 
     # Write files to the .gitignore file.
     gitignore_file.touch(exist_ok=True)
     console.debug(f"Creating {gitignore_file}")
-    gitignore_file.write_text(
-        "\n".join(sorted(files_to_ignore)) + "\n",
-    )
+    gitignore_file.write_text("\n".join(files_to_ignore) + "\n")
 
 
 def initialize_requirements_txt():


### PR DESCRIPTION
For #4285 

…e and improve current ignore handling.  Dont sort the gitignore file.

Added the list[str] type as annotation as seemed like the easiest way to fix linting error.

Was not sure if its preferable to have the current_ignore as is and then append the possible new ones or other way around but this seemed the nicest looking so just went with this one.  

### All Submissions:

- [ ] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?

nope :)

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?
