### PR TITLE
Path change after Astral 0.5.0 update

### DIFF
--- a/docker-example/production-app-platform/Dockerfile
+++ b/docker-example/production-app-platform/Dockerfile
@@ -25,7 +25,7 @@
 # Stage 1: init
 FROM python:3.11 as init
 
-ARG uv=/root/.cargo/bin/uv
+ARG uv=/root/.local/bin/uv
 
 # Install `uv` for faster package boostrapping
 ADD --chmod=755 https://astral.sh/uv/install.sh /install.sh

--- a/docker-example/production-compose/Dockerfile
+++ b/docker-example/production-compose/Dockerfile
@@ -4,7 +4,7 @@
 # Stage 1: init
 FROM python:3.11 as init
 
-ARG uv=/root/.cargo/bin/uv
+ARG uv=/root/.local/bin/uv
 
 # Install `uv` for faster package boostrapping
 ADD --chmod=755 https://astral.sh/uv/install.sh /install.sh


### PR DESCRIPTION
https://github.com/astral-sh/uv/releases
Use XDG (i.e. ~/.local/bin) instead of the Cargo home directory in the installer


### Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


