### PR TITLE
Downgrade syntax highlighter to fix `wrapLongLines` issue

### DIFF
--- a/reflex/components/datadisplay/code.py
+++ b/reflex/components/datadisplay/code.py
@@ -382,7 +382,7 @@ for theme_name in dir(Theme):
 class CodeBlock(Component, MarkdownComponentMap):
     """A code block."""
 
-    library = "react-syntax-highlighter@15.6.1"
+    library = "react-syntax-highlighter@15.6.0"
 
     tag = "PrismAsyncLight"
 


### PR DESCRIPTION
ReactSyntaxHighligter `v15.16.1` breaks the functionality of the `wrap_long_line` prop. Downgrading to `15.16.0` works.

Related upstream PR: https://github.com/react-syntax-highlighter/react-syntax-highlighter/pull/487