### PR TITLE
Temporarily downpin @radix-ui/themes <3.1.5

### DIFF
--- a/reflex/components/radix/themes/base.py
+++ b/reflex/components/radix/themes/base.py
@@ -112,6 +112,9 @@ class RadixThemesComponent(Component):
 
     library = "@radix-ui/themes@^3.0.0"
 
+    # Temporary pin < 3.1.5 until radix-ui/themes#627 is resolved.
+    library = library + " && <3.1.5"
+
     # "Fake" prop color_scheme is used to avoid shadowing CSS prop "color".
     _rename_props: Dict[str, str] = {"colorScheme": "color"}
 

--- a/tests/units/components/core/test_banner.py
+++ b/tests/units/components/core/test_banner.py
@@ -4,6 +4,7 @@ from reflex.components.core.banner import (
     ConnectionPulser,
     WebsocketTargetURL,
 )
+from reflex.components.radix.themes.base import RadixThemesComponent
 from reflex.components.radix.themes.typography.text import Text
 
 
@@ -24,7 +25,7 @@ def test_connection_banner():
             "react",
             "$/utils/context",
             "$/utils/state",
-            "@radix-ui/themes@^3.0.0",
+            RadixThemesComponent().library or "",
             "$/env.json",
         )
     )
@@ -42,7 +43,7 @@ def test_connection_modal():
             "react",
             "$/utils/context",
             "$/utils/state",
-            "@radix-ui/themes@^3.0.0",
+            RadixThemesComponent().library or "",
             "$/env.json",
         )
     )


### PR DESCRIPTION
A visual/style regression was introduced in @radix-ui/themes 3.1.5 as described in radix-ui/themes#627 which reflex needs to avoid.