### PR TITLE
require typing_extensions >= 4.6.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3050,4 +3050,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "937f0cadb1a4566117dad8d0be6018ad1a8fe9aeb19c499d2a010d36ef391ee1"
+content-hash = "8975c9e30cd8e1d1968f2344218ea4fa0548462edff4bee4046513882b7bad25"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ twine = ">=4.0.0,<6.0"
 tomlkit = ">=0.12.4,<1.0"
 lazy_loader = ">=0.4"
 reflex-chakra = ">=0.6.0"
+typing_extensions = ">=4.6.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.1.2,<9.0"


### PR DESCRIPTION
TypeAliasType was added in 4.6

https://github.com/python/typing_extensions/blob/main/CHANGELOG.md#release-460-may-22-2023