### PR TITLE
ObjectVar __getitem__ typing issues

### DIFF
--- a/tests/units/vars/test_object.py
+++ b/tests/units/vars/test_object.py
@@ -26,10 +26,17 @@ def serialize_bare(obj: Bare) -> dict:
     return {"quantity": obj.quantity}
 
 
+class Tag(rx.Base):
+    """A Tag for testing."""
+
+    pass
+
+
 class Base(rx.Base):
     """A reflex base class with a single attribute."""
 
     quantity: int = 0
+    collection: list[Tag] = []
 
 
 class ObjectState(rx.State):
@@ -100,3 +107,6 @@ def test_typing() -> None:
     # Base
     var = ObjectState.base
     _ = assert_type(var, ObjectVar[Base])
+
+    # Collection
+    ObjectState.base.collection[0]

--- a/tests/units/vars/test_object.py
+++ b/tests/units/vars/test_object.py
@@ -44,6 +44,16 @@ class ObjectState(rx.State):
 
     bare: rx.Field[Bare] = rx.field(Bare())
     base: rx.Field[Base] = rx.field(Base())
+    d: rx.Field[dict[str, str]] = rx.field({})
+    d_bool: rx.Field[dict[str, bool]] = rx.field({})
+
+    @rx.var
+    def computed_d(self) -> dict[str, str]:
+        return self.d
+
+    @rx.var
+    def computed_d_bool(self) -> dict[str, bool]:
+        return self.d_bool
 
 
 @pytest.mark.parametrize("type_", [Base, Bare])
@@ -109,4 +119,8 @@ def test_typing() -> None:
     _ = assert_type(var, ObjectVar[Base])
 
     # Collection
+    ObjectState.d["key"]
+    ObjectState.computed_d["key"]
+    ObjectState.d_bool["key"]
+    ObjectState.computed_d_bool["key"]
     ObjectState.base.collection[0]


### PR DESCRIPTION
@adhami3310 do you have any idea on how to fix the typing test?

`reflex/tests/units/vars/test_object.py:112:5 - error: "__getitem__" method not defined on type "ObjectItemOperation" (reportGeneralTypeIssues)`