### PR TITLE
Update help text command for listing VM types

### DIFF
--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -647,7 +647,7 @@ def deployv2(
     vmtype: Optional[str] = typer.Option(
         None,
         "--vmtype",
-        help="Vm type id. Run reflex apps vmtypes list to get options.",
+        help="VM type id. Run `reflex apps vmtypes` to get options.",
     ),
     hostname: Optional[str] = typer.Option(
         None,


### PR DESCRIPTION
Not sure when the command changed, but in 0.1.16 the previous command errors out

```
(VENV-dev311) masen@asmbp21 form-designer % reflex apps vmtypes list
Usage: reflex apps vmtypes [OPTIONS]
Try 'reflex apps vmtypes --help' for help.

Error: Got unexpected extra argument (list)
```