### PR TITLE
New Event Action: temporal

### DIFF
--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -705,6 +705,11 @@ export const useEventLoop = (
       _e.stopPropagation();
     }
     const combined_name = events.map((e) => e.name).join("+++");
+    if (event_actions?.temporal) {
+      if (!socket.current || !socket.current.connected) {
+        return;  // don't queue when the backend is not connected
+      }
+    }
     if (event_actions?.throttle) {
       // If throttle returns false, the events are not added to the queue.
       if (!throttle(combined_name, event_actions.throttle)) {

--- a/reflex/event.py
+++ b/reflex/event.py
@@ -181,6 +181,18 @@ class EventActionsMixin:
             event_actions={"debounce": delay_ms, **self.event_actions},
         )
 
+    @property
+    def temporal(self):
+        """Do not queue the event if the backend is down.
+
+        Returns:
+            New EventHandler-like with temporal set to True.
+        """
+        return dataclasses.replace(
+            self,
+            event_actions={"temporal": True, **self.event_actions},
+        )
+
 
 @dataclasses.dataclass(
     init=True,


### PR DESCRIPTION
When an event/event spec is marked as "temporal", it will not be queued unless the backend is up. This can be used to prevent periodic events (like from `rx.moment`) from queueing up while the backend is down, and then stampeding when the backend comes up and the queue is drained. It can be used to avoid processing many periodic events at once when the app is only expecting to process such an event every so often.