### PR TITLE
[ENG-4130] Disable typer/rich integration appropriately

### DIFF
--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -20,7 +20,7 @@ from reflex.state import reset_disk_state_manager
 from reflex.utils import console, redir, telemetry
 
 # Disable typer+rich integration for help panels
-typer.core.rich = False  # type: ignore
+typer.core.rich = None  # type: ignore
 
 # Create the app.
 try:


### PR DESCRIPTION
The `rich` module should be set to `None`, indicating that rich should not be used.

Setting it to `False` worked before, but recently added code in typer fails when checking `if rich is not None`.

ref: https://github.com/fastapi/typer/pull/847
fix #4400