### PR TITLE
allow for 'go.Figure | None' annotation in State

### DIFF
--- a/reflex/components/plotly/plotly.py
+++ b/reflex/components/plotly/plotly.py
@@ -255,7 +255,7 @@ const extractPoints = (points) => {
 
     def _render(self):
         tag = super()._render()
-        figure = self.data.to(dict)
+        figure = self.data.to(dict) if self.data is not None else {}
         merge_dicts = []  # Data will be merged and spread from these dict Vars
         if self.layout is not None:
             # Why is this not a literal dict? Great question... it didn't work


### PR DESCRIPTION
```python
import reflex as rx
import plotly.graph_objects as go

app = rx.App()

class State(rx.State):
    figure: go.Figure | None = None

    def create_figure(self):
        self.figure = go.Figure(
            data=[go.Bar(x=[1, 2, 3], y=[1, 3, 2])],
            layout=go.Layout(
                title=go.layout.Title(text="A Figure Specified By A Graph Object")
            ),
        )

@rx.page("/")
def index() -> rx.Component:
    return rx.cond(State.figure, rx.plotly(data=State.figure)), rx.button(
        "Init & Show Figure", on_click=State.create_figure
    )
```