### PR TITLE
raise StateSerializationError if the state cannot be serialized

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -97,6 +97,7 @@ from reflex.utils.exceptions import (
     ReflexRuntimeError,
     SetUndefinedStateVarError,
     StateSchemaMismatchError,
+    StateSerializationError,
     StateTooLargeError,
 )
 from reflex.utils.exec import is_testing_env
@@ -2177,8 +2178,12 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
 
         Returns:
             The serialized state.
+
+        Raises:
+            StateSerializationError: If the state cannot be serialized.
         """
         payload = b""
+        error = ""
         try:
             payload = pickle.dumps((self._to_schema(), self))
         except HANDLED_PICKLE_ERRORS as og_pickle_error:
@@ -2198,8 +2203,13 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
             except HANDLED_PICKLE_ERRORS as ex:
                 error += f"Dill was also unable to pickle the state: {ex}"
             console.warn(error)
+
         if environment.REFLEX_PERF_MODE.get() != PerformanceMode.OFF:
             self._check_state_size(len(payload))
+
+        if not payload:
+            raise StateSerializationError(error)
+
         return payload
 
     @classmethod

--- a/reflex/utils/exceptions.py
+++ b/reflex/utils/exceptions.py
@@ -155,6 +155,10 @@ class StateTooLargeError(ReflexError):
     """Raised when the state is too large to be serialized."""
 
 
+class StateSerializationError(ReflexError):
+    """Raised when the state cannot be serialized."""
+
+
 class SystemPackageMissingError(ReflexError):
     """Raised when a system package is missing."""
 

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -55,7 +55,11 @@ from reflex.state import (
 )
 from reflex.testing import chdir
 from reflex.utils import format, prerequisites, types
-from reflex.utils.exceptions import ReflexRuntimeError, SetUndefinedStateVarError
+from reflex.utils.exceptions import (
+    ReflexRuntimeError,
+    SetUndefinedStateVarError,
+    StateSerializationError,
+)
 from reflex.utils.format import json_dumps
 from reflex.vars.base import Var, computed_var
 from tests.units.states.mutation import MutableSQLAModel, MutableTestState
@@ -3433,8 +3437,9 @@ def test_fallback_pickle():
     # Some object, like generator, are still unpicklable with dill.
     state3 = DillState(_reflex_internal_init=True)  # type: ignore
     state3._g = (i for i in range(10))
-    pk3 = state3._serialize()
-    assert len(pk3) == 0
+
+    with pytest.raises(StateSerializationError):
+        _ = state3._serialize()
 
 
 def test_typed_state() -> None:


### PR DESCRIPTION
Ignored errors during state serialize causing errors during deserialize
this can be hard to debug

```
Task exception was never retrieved
future: <Task finished name='Task-341' coro=<AsyncServer._handle_event_internal() done, defined at /app/.venv/lib/python3.13/site-packages/socketio/async_server.py:608> exception=EOFError('Ran out of input')>
```

if needed, I can make this an optional check which can be enabled via env