### PR TITLE
Wrap Checkbox component in Context Menu (partial fix for #4262)

### DIFF
--- a/reflex/components/radix/themes/components/context_menu.py
+++ b/reflex/components/radix/themes/components/context_menu.py
@@ -2,14 +2,13 @@
 
 from typing import Dict, List, Literal, Union
 
-from reflex.components.component import ComponentNamespace
+from reflex.components.component import Component, ComponentNamespace
 from reflex.components.core.breakpoints import Responsive
 from reflex.event import EventHandler, no_args_event_spec, passthrough_event_spec
 from reflex.vars.base import LiteralVar, Var
-from reflex.components.component import Component
-from .checkbox import HighLevelCheckbox
 
 from ..base import LiteralAccentColor, RadixThemesComponent
+from .checkbox import HighLevelCheckbox
 
 LiteralDirType = Literal["ltr", "rtl"]
 
@@ -29,6 +28,7 @@ LiteralStickyType = Literal[
 LiteralCheckboxSize = Literal["1", "2", "3"]
 
 LiteralCheckboxVariant = Literal["classic", "surface", "soft"]
+
 
 class ContextMenuRoot(RadixThemesComponent):
     """Menu representing a set of actions, displayed at the origin of a pointer right-click or long-press."""
@@ -236,11 +236,12 @@ class ContextMenuSeparator(RadixThemesComponent):
 
     tag = "ContextMenu.Separator"
 
+
 class ContextMenuCheckbox(RadixThemesComponent):
     """The component that contains the checkbox."""
-    
+
     tag = "ContextMenu.Checkbox"
-    
+
     def create(cls, text: Var[str] = LiteralVar.create(""), **props) -> Component:
         """Create a checkbox with a label.
 
@@ -252,6 +253,7 @@ class ContextMenuCheckbox(RadixThemesComponent):
             The checkbox component with a label.
         """
         return HighLevelCheckbox.create(cls, **props)
+
 
 class ContextMenu(ComponentNamespace):
     """Menu representing a set of actions, diplayed at the origin of a pointer right-click or long-press."""
@@ -265,5 +267,6 @@ class ContextMenu(ComponentNamespace):
     item = staticmethod(ContextMenuItem.create)
     separator = staticmethod(ContextMenuSeparator.create)
     checkbox = staticmethod(ContextMenuCheckbox.create)
+
 
 context_menu = ContextMenu()

--- a/reflex/components/radix/themes/components/context_menu.py
+++ b/reflex/components/radix/themes/components/context_menu.py
@@ -231,6 +231,24 @@ class ContextMenuSeparator(RadixThemesComponent):
 
     tag = "ContextMenu.Separator"
 
+class ContextMenuCheckBoxItem(RadixThemesComponent):
+    """The component that contains the context menu checkbox items."""
+    
+    tag = "ContextMenu.CheckboxItem"
+    
+    # Whether the checkbox is checked.
+    checked: Var[bool] 
+    
+    # Whether the checkbox is disabled.
+    disabled: Var[bool]
+    
+    # Event handler for when the checkbox state changes.
+    on_check_change: EventHandler[passthrough_event_spec(bool)]
+    
+    def toggle_state(self):
+        """Toggle the checked state dynamically."""
+        if self.checked is not None:
+            self.checked.set(not self.checked.get())
 
 class ContextMenu(ComponentNamespace):
     """Menu representing a set of actions, displayed at the origin of a pointer right-click or long-press."""
@@ -243,6 +261,7 @@ class ContextMenu(ComponentNamespace):
     sub_content = staticmethod(ContextMenuSubContent.create)
     item = staticmethod(ContextMenuItem.create)
     separator = staticmethod(ContextMenuSeparator.create)
+    checkbox_item = staticmethod(ContextMenuCheckBoxItem.create)
 
 
 context_menu = ContextMenu()

--- a/reflex/components/radix/themes/components/context_menu.py
+++ b/reflex/components/radix/themes/components/context_menu.py
@@ -5,7 +5,11 @@ from typing import Dict, List, Literal, Union
 from reflex.components.component import ComponentNamespace
 from reflex.components.core.breakpoints import Responsive
 from reflex.event import EventHandler, no_args_event_spec, passthrough_event_spec
-from reflex.vars.base import Var
+from reflex.vars.base import LiteralVar, Var
+from reflex.components.component import Component
+from reflex.components.radix.themes.typography.text import Text
+from reflex.components.radix.themes.layout.flex import Flex
+from .checkbox import HighLevelCheckbox
 
 from ..base import LiteralAccentColor, RadixThemesComponent
 
@@ -24,6 +28,9 @@ LiteralStickyType = Literal[
     "always",
 ]
 
+LiteralCheckboxSize = Literal["1", "2", "3"]
+
+LiteralCheckboxVariant = Literal["classic", "surface", "soft"]
 
 class ContextMenuRoot(RadixThemesComponent):
     """Menu representing a set of actions, displayed at the origin of a pointer right-click or long-press."""
@@ -231,22 +238,26 @@ class ContextMenuSeparator(RadixThemesComponent):
 
     tag = "ContextMenu.Separator"
 
-class ContextMenuCheckBoxItem(RadixThemesComponent):
-    """The component that contains the context menu checkbox items."""
+class ContextMenuCheckbox(RadixThemesComponent):
+    """The component that contains the checkbox."""
     
-    tag = "ContextMenu.CheckboxItem"
+    tag = "ContextMenu.Checkbox"
     
-    # Whether the checkbox is checked.
-    checked: Var[bool] 
-    
-    # Whether the checkbox is disabled.
-    disabled: Var[bool]
-    
-    # Fired when the checkbox state changes.
-    on_check_change: EventHandler[passthrough_event_spec(bool)]
+    @classmethod
+    def create(cls, text: Var[str] = LiteralVar.create(""), **props) -> Component:
+        """Create a checkbox with a label.
+
+        Args:
+            text: The text of the label.
+            **props: Additional properties to apply to the checkbox item.
+
+        Returns:
+            The checkbox component with a label.
+        """
+        return HighLevelCheckbox.create(text=text, **props)
 
 class ContextMenu(ComponentNamespace):
-    """Menu representing a set of actions, displayed at the origin of a pointer right-click or long-press."""
+    """Menu representing a set of actions, diplayed at the origin of a pointer right-click or long-press."""
 
     root = staticmethod(ContextMenuRoot.create)
     trigger = staticmethod(ContextMenuTrigger.create)
@@ -256,6 +267,6 @@ class ContextMenu(ComponentNamespace):
     sub_content = staticmethod(ContextMenuSubContent.create)
     item = staticmethod(ContextMenuItem.create)
     separator = staticmethod(ContextMenuSeparator.create)
-    checkbox_item = staticmethod(ContextMenuCheckBoxItem.create)
+    checkbox = staticmethod(ContextMenuCheckbox.create)
 
 context_menu = ContextMenu()

--- a/reflex/components/radix/themes/components/context_menu.py
+++ b/reflex/components/radix/themes/components/context_menu.py
@@ -7,8 +7,6 @@ from reflex.components.core.breakpoints import Responsive
 from reflex.event import EventHandler, no_args_event_spec, passthrough_event_spec
 from reflex.vars.base import LiteralVar, Var
 from reflex.components.component import Component
-from reflex.components.radix.themes.typography.text import Text
-from reflex.components.radix.themes.layout.flex import Flex
 from .checkbox import HighLevelCheckbox
 
 from ..base import LiteralAccentColor, RadixThemesComponent
@@ -243,7 +241,6 @@ class ContextMenuCheckbox(RadixThemesComponent):
     
     tag = "ContextMenu.Checkbox"
     
-    @classmethod
     def create(cls, text: Var[str] = LiteralVar.create(""), **props) -> Component:
         """Create a checkbox with a label.
 
@@ -254,7 +251,7 @@ class ContextMenuCheckbox(RadixThemesComponent):
         Returns:
             The checkbox component with a label.
         """
-        return HighLevelCheckbox.create(text=text, **props)
+        return HighLevelCheckbox.create(cls, **props)
 
 class ContextMenu(ComponentNamespace):
     """Menu representing a set of actions, diplayed at the origin of a pointer right-click or long-press."""

--- a/reflex/components/radix/themes/components/context_menu.py
+++ b/reflex/components/radix/themes/components/context_menu.py
@@ -242,13 +242,8 @@ class ContextMenuCheckBoxItem(RadixThemesComponent):
     # Whether the checkbox is disabled.
     disabled: Var[bool]
     
-    # Event handler for when the checkbox state changes.
+    # Fired when the checkbox state changes.
     on_check_change: EventHandler[passthrough_event_spec(bool)]
-    
-    def toggle_state(self):
-        """Toggle the checked state dynamically."""
-        if self.checked is not None:
-            self.checked.set(not self.checked.get())
 
 class ContextMenu(ComponentNamespace):
     """Menu representing a set of actions, displayed at the origin of a pointer right-click or long-press."""
@@ -262,6 +257,5 @@ class ContextMenu(ComponentNamespace):
     item = staticmethod(ContextMenuItem.create)
     separator = staticmethod(ContextMenuSeparator.create)
     checkbox_item = staticmethod(ContextMenuCheckBoxItem.create)
-
 
 context_menu = ContextMenu()


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### **After** these steps, you're ready to open a pull request.

    a. Give a descriptive title to your PR.

    b. Describe your changes.
In `context_menu.py`, I added a new `ContextMenuCheckbox` class and initialized `checkbox`. Users can now use the checkbox like this:

<img width="306" alt="checkbox-context-menu" src="https://github.com/user-attachments/assets/4eba7532-bee6-4ddd-8302-4852406fc0fc">

    c. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
This pull request only fixes part of issue #4262.

