### PR TITLE
add __repr__ method to MutableProxy

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -3596,6 +3596,14 @@ class MutableProxy(wrapt.ObjectProxy):
         self._self_state = state
         self._self_field_name = field_name
 
+    def __repr__(self) -> str:
+        """Get the representation of the wrapped object.
+
+        Returns:
+            The representation of the wrapped object.
+        """
+        return f"{self.__class__.__name__}({self.__wrapped__})"
+
     def _mark_dirty(
         self,
         wrapped=None,


### PR DESCRIPTION
Needed for debugging, otherwise if you print a mutable value inside an event handler you will get output which is not useful at all.