### PR TITLE
[ENG-4100]reduce lock expiration time to 1s

### DIFF
--- a/reflex/constants/config.py
+++ b/reflex/constants/config.py
@@ -26,7 +26,7 @@ class Expiration(SimpleNamespace):
     # Token expiration time in seconds
     TOKEN = 60 * 60
     # Maximum time in milliseconds that a state can be locked for exclusive access.
-    LOCK = 10000
+    LOCK = 1000
     # The PING timeout
     PING = 120
 


### PR DESCRIPTION
Reduce the Redis lock expiration time to 1s so users are guaranteed to get the lock expiration error when they run processes that block the main thread. 