### PR TITLE
Default `rx.link` href to `#` so underline prop works

### DIFF
--- a/reflex/components/radix/themes/typography/link.py
+++ b/reflex/components/radix/themes/typography/link.py
@@ -77,13 +77,14 @@ class Link(RadixThemesComponent, A, MemoizationLeaf, MarkdownComponentMap):
             Component: The link component
         """
         props.setdefault(":hover", {"color": color("accent", 8)})
+        href = props.get("href")
 
         is_external = props.pop("is_external", None)
 
         if is_external is not None:
             props["target"] = cond(is_external, "_blank", "")
 
-        if props.get("href") is not None:
+        if href is not None:
             if not len(children):
                 raise ValueError("Link without a child will not display")
 
@@ -101,6 +102,9 @@ class Link(RadixThemesComponent, A, MemoizationLeaf, MarkdownComponentMap):
                     as_child=True,
                     **props,
                 )
+        else:
+            props["href"] = "#"
+
         return super().create(*children, **props)
 
 


### PR DESCRIPTION
`underline`  prop doesn't work when `href` prop is not set. To avoid this confusion, we default the href prop to `#`