### PR TITLE
[ENG-4165] Consider default and default_factory for state vars

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1081,6 +1081,7 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
         if (
             not field.required
             and field.default is None
+            and field.default_factory is None
             and not types.is_optional(prop._var_type)
         ):
             # Ensure frontend uses null coalescing when accessing.

--- a/tests/units/components/core/test_foreach.py
+++ b/tests/units/components/core/test_foreach.py
@@ -1,8 +1,10 @@
 from typing import Dict, List, Set, Tuple, Union
 
+import pydantic.v1
 import pytest
 
 from reflex import el
+from reflex.base import Base
 from reflex.components.component import Component
 from reflex.components.core.foreach import (
     Foreach,
@@ -16,6 +18,12 @@ from reflex.state import BaseState, ComponentState
 from reflex.vars.base import Var
 from reflex.vars.number import NumberVar
 from reflex.vars.sequence import ArrayVar
+
+
+class ForEachTag(Base):
+    """A tag for testing the ForEach component."""
+
+    name: str = ""
 
 
 class ForEachState(BaseState):
@@ -45,6 +53,8 @@ class ForEachState(BaseState):
     colors_set: Set[str] = {"red", "green"}
     bad_annotation_list: list = [["red", "orange"], ["yellow", "blue"]]
     color_index_tuple: Tuple[int, str] = (0, "red")
+
+    default_factory_list: list[ForEachTag] = pydantic.v1.Field(default_factory=list)
 
 
 class ComponentStateTest(ComponentState):
@@ -290,3 +300,11 @@ def test_foreach_component_state():
             ForEachState.colors_list,
             ComponentStateTest.create,
         )
+
+
+def test_foreach_default_factory():
+    """Test that the default factory is called."""
+    _ = Foreach.create(
+        ForEachState.default_factory_list,
+        lambda tag: text(tag.name),
+    )


### PR DESCRIPTION
When determining whether a state var should be marked as optional, check that it is missing both default and default_factory and is not required.

Fix #4471