### PR TITLE
If a Var is Optional, iterate over it as if it is not

### DIFF
--- a/reflex/components/core/foreach.py
+++ b/reflex/components/core/foreach.py
@@ -129,7 +129,7 @@ class Foreach(Component):
             iterable_state=str(tag.iterable),
             arg_name=tag.arg_var_name,
             arg_index=tag.get_index_var_arg(),
-            iterable_type=tag.iterable._var_type.mro()[0].__name__,
+            iterable_type=tag.get_iterable_var_type().__name__,
         )
 
 

--- a/reflex/components/tags/iter_tag.py
+++ b/reflex/components/tags/iter_tag.py
@@ -7,6 +7,7 @@ import inspect
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Tuple, Type, Union, get_args
 
 from reflex.components.tags.tag import Tag
+from reflex.utils.types import is_optional
 from reflex.vars import LiteralArrayVar, Var, get_unique_variable_name
 
 if TYPE_CHECKING:
@@ -38,15 +39,18 @@ class IterTag(Tag):
             The type of the iterable var.
         """
         iterable = self.iterable
+        var_type = iterable._var_type
+        if is_optional(var_type):
+            var_type = get_args(var_type)[0]
         try:
-            if iterable._var_type.mro()[0] is dict:
+            if var_type.mro()[0] is dict:
                 # Arg is a tuple of (key, value).
-                return Tuple[get_args(iterable._var_type)]  # type: ignore
-            elif iterable._var_type.mro()[0] is tuple:
+                return Tuple[get_args(var_type)]  # type: ignore
+            elif var_type.mro()[0] is tuple:
                 # Arg is a union of any possible values in the tuple.
-                return Union[get_args(iterable._var_type)]  # type: ignore
+                return Union[get_args(var_type)]  # type: ignore
             else:
-                return get_args(iterable._var_type)[0]
+                return get_args(var_type)[0]
         except Exception:
             return Any
 


### PR DESCRIPTION
This is potentially dangerous because it will cause frontend exception if the value actually is null.

I originally wrote this up to address #4471, but then I realized the problem was not iterating over an Optional, but that the field shouldn't have been optional to begin with. Posting this in case it is something we eventually want.