### PR TITLE
Revert "[ENG-4100]reduce lock expiration time to 1s"

### DIFF
--- a/reflex/constants/config.py
+++ b/reflex/constants/config.py
@@ -26,7 +26,7 @@ class Expiration(SimpleNamespace):
     # Token expiration time in seconds
     TOKEN = 60 * 60
     # Maximum time in milliseconds that a state can be locked for exclusive access.
-    LOCK = 1000
+    LOCK = 10000
     # The PING timeout
     PING = 120
 


### PR DESCRIPTION
Reverts reflex-dev/reflex#4507

Expecting a followup PR that prints a warning instead when the operation holds the lock for "too long"