### PR TITLE
[ENG-4153]Use empty string for None values in `rx.input` and `rx.el.input`

### DIFF
--- a/reflex/components/el/elements/forms.py
+++ b/reflex/components/el/elements/forms.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, Iterator, Set, Tuple, Union
 
 from jinja2 import Environment
 
-from reflex.components.core.cond import cond
 from reflex.components.el.element import Element
 from reflex.components.tags.tag import Tag
 from reflex.constants import Dirs, EventTriggers
@@ -400,7 +399,7 @@ class Input(BaseHTML):
 
         # React expects an empty string(instead of null) for uncontrolled inputs.
         if value is not None:
-            props["value"] = cond(value, value, "")
+            props["value"] = Var(_js_expr=f"{value} ?? ''", _var_type=str)
         return super().create(*children, **props)
 
 

--- a/reflex/components/el/elements/forms.py
+++ b/reflex/components/el/elements/forms.py
@@ -400,7 +400,7 @@ class Input(BaseHTML):
 
         value = props.get("value")
 
-        # React expects an empty string(instead of null) for uncontrolled inputs.
+        # React expects an empty string(instead of null) for controlled inputs.
         if value is not None and is_optional(
             (value_var := Var.create(value))._var_type
         ):

--- a/reflex/components/el/elements/forms.py
+++ b/reflex/components/el/elements/forms.py
@@ -395,11 +395,18 @@ class Input(BaseHTML):
         Returns:
             The component.
         """
+        from reflex.vars.number import ternary_operation
+
         value = props.get("value")
 
         # React expects an empty string(instead of null) for uncontrolled inputs.
         if value is not None:
-            props["value"] = Var(_js_expr=f"{value} ?? ''", _var_type=str)
+            props["value"] = ternary_operation(
+                ((value_var := Var.create(value)) != Var.create(None))
+                & (value_var != Var(_js_expr="undefined")),
+                value,
+                "",
+            )
         return super().create(*children, **props)
 
 

--- a/reflex/components/el/elements/forms.py
+++ b/reflex/components/el/elements/forms.py
@@ -18,6 +18,7 @@ from reflex.event import (
     prevent_default,
 )
 from reflex.utils.imports import ImportDict
+from reflex.utils.types import is_optional
 from reflex.vars import VarData
 from reflex.vars.base import LiteralVar, Var
 
@@ -400,9 +401,11 @@ class Input(BaseHTML):
         value = props.get("value")
 
         # React expects an empty string(instead of null) for uncontrolled inputs.
-        if value is not None:
+        if value is not None and is_optional(
+            (value_var := Var.create(value))._var_type
+        ):
             props["value"] = ternary_operation(
-                ((value_var := Var.create(value)) != Var.create(None))
+                (value_var != Var.create(None))
                 & (value_var != Var(_js_expr="undefined")),
                 value,
                 "",

--- a/reflex/components/el/elements/forms.py
+++ b/reflex/components/el/elements/forms.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Iterator, Set, Tuple, Union
 
 from jinja2 import Environment
 
+from reflex.components.core.cond import cond
 from reflex.components.el.element import Element
 from reflex.components.tags.tag import Tag
 from reflex.constants import Dirs, EventTriggers
@@ -383,6 +384,24 @@ class Input(BaseHTML):
 
     # Fired when a key is released
     on_key_up: EventHandler[key_event]
+
+    @classmethod
+    def create(cls, *children, **props):
+        """Create an Input component.
+
+        Args:
+            *children: The children of the component.
+            **props: The properties of the component.
+
+        Returns:
+            The component.
+        """
+        value = props.get("value")
+
+        # React expects an empty string(instead of null) for uncontrolled inputs.
+        if value is not None:
+            props["value"] = cond(value, value, "")
+        return super().create(*children, **props)
 
 
 class Label(BaseHTML):

--- a/reflex/components/el/elements/forms.py
+++ b/reflex/components/el/elements/forms.py
@@ -405,10 +405,10 @@ class Input(BaseHTML):
             (value_var := Var.create(value))._var_type
         ):
             props["value"] = ternary_operation(
-                (value_var != Var.create(None))
+                (value_var != Var.create(None))  # pyright: ignore [reportGeneralTypeIssues]
                 & (value_var != Var(_js_expr="undefined")),
                 value,
-                "",
+                Var.create(""),
             )
         return super().create(*children, **props)
 

--- a/reflex/components/el/elements/forms.pyi
+++ b/reflex/components/el/elements/forms.pyi
@@ -512,7 +512,7 @@ class Input(BaseHTML):
         on_unmount: Optional[EventType[[], BASE_STATE]] = None,
         **props,
     ) -> "Input":
-        """Create the component.
+        """Create an Input component.
 
         Args:
             *children: The children of the component.
@@ -576,7 +576,7 @@ class Input(BaseHTML):
             class_name: The class name for the component.
             autofocus: Whether the component should take the focus once the page is loaded
             custom_attrs: custom attribute
-            **props: The props of the component.
+            **props: The properties of the component.
 
         Returns:
             The component.

--- a/reflex/components/radix/themes/components/text_field.py
+++ b/reflex/components/radix/themes/components/text_field.py
@@ -100,7 +100,7 @@ class TextFieldRoot(elements.Div, RadixThemesComponent):
         """
         value = props.get("value")
 
-        # React expects an empty string(instead of null) for uncontrolled inputs.
+        # React expects an empty string(instead of null) for controlled inputs.
         if value is not None and is_optional(
             (value_var := Var.create(value))._var_type
         ):

--- a/reflex/components/radix/themes/components/text_field.py
+++ b/reflex/components/radix/themes/components/text_field.py
@@ -6,7 +6,6 @@ from typing import Literal, Union
 
 from reflex.components.component import Component, ComponentNamespace
 from reflex.components.core.breakpoints import Responsive
-from reflex.components.core.cond import cond
 from reflex.components.core.debounce import DebounceInput
 from reflex.components.el import elements
 from reflex.event import EventHandler, input_event, key_event
@@ -101,7 +100,7 @@ class TextFieldRoot(elements.Div, RadixThemesComponent):
 
         # React expects an empty string(instead of null) for uncontrolled inputs.
         if value is not None:
-            props["value"] = cond(value, value, "")
+            props["value"] = Var(_js_expr=f"{value} ?? ''", _var_type=str)
 
         component = super().create(*children, **props)
         if props.get("value") is not None and props.get("on_change") is not None:

--- a/reflex/components/radix/themes/components/text_field.py
+++ b/reflex/components/radix/themes/components/text_field.py
@@ -6,6 +6,7 @@ from typing import Literal, Union
 
 from reflex.components.component import Component, ComponentNamespace
 from reflex.components.core.breakpoints import Responsive
+from reflex.components.core.cond import cond
 from reflex.components.core.debounce import DebounceInput
 from reflex.components.el import elements
 from reflex.event import EventHandler, input_event, key_event
@@ -96,6 +97,12 @@ class TextFieldRoot(elements.Div, RadixThemesComponent):
         Returns:
             The component.
         """
+        value = props.get("value")
+
+        # React expects an empty string(instead of null) for uncontrolled inputs.
+        if value is not None:
+            props["value"] = cond(value, value, "")
+
         component = super().create(*children, **props)
         if props.get("value") is not None and props.get("on_change") is not None:
             # create a debounced input if the user requests full control to avoid typing jank

--- a/reflex/components/radix/themes/components/text_field.py
+++ b/reflex/components/radix/themes/components/text_field.py
@@ -9,6 +9,7 @@ from reflex.components.core.breakpoints import Responsive
 from reflex.components.core.debounce import DebounceInput
 from reflex.components.el import elements
 from reflex.event import EventHandler, input_event, key_event
+from reflex.utils.types import is_optional
 from reflex.vars.base import Var
 from reflex.vars.number import ternary_operation
 
@@ -100,10 +101,11 @@ class TextFieldRoot(elements.Div, RadixThemesComponent):
         value = props.get("value")
 
         # React expects an empty string(instead of null) for uncontrolled inputs.
-        if value is not None:
-            # props["value"] = Var(_js_expr=f"{value} ?? ''", _var_type=str)
+        if value is not None and is_optional(
+            (value_var := Var.create(value))._var_type
+        ):
             props["value"] = ternary_operation(
-                ((value_var := Var.create(value)) != Var.create(None))
+                (value_var != Var.create(None))
                 & (value_var != Var(_js_expr="undefined")),
                 value,
                 "",

--- a/reflex/components/radix/themes/components/text_field.py
+++ b/reflex/components/radix/themes/components/text_field.py
@@ -105,10 +105,10 @@ class TextFieldRoot(elements.Div, RadixThemesComponent):
             (value_var := Var.create(value))._var_type
         ):
             props["value"] = ternary_operation(
-                (value_var != Var.create(None))
+                (value_var != Var.create(None))  # pyright: ignore [reportGeneralTypeIssues]
                 & (value_var != Var(_js_expr="undefined")),
                 value,
-                "",
+                Var.create(""),
             )
 
         component = super().create(*children, **props)

--- a/reflex/components/radix/themes/components/text_field.py
+++ b/reflex/components/radix/themes/components/text_field.py
@@ -10,6 +10,7 @@ from reflex.components.core.debounce import DebounceInput
 from reflex.components.el import elements
 from reflex.event import EventHandler, input_event, key_event
 from reflex.vars.base import Var
+from reflex.vars.number import ternary_operation
 
 from ..base import LiteralAccentColor, LiteralRadius, RadixThemesComponent
 
@@ -100,7 +101,13 @@ class TextFieldRoot(elements.Div, RadixThemesComponent):
 
         # React expects an empty string(instead of null) for uncontrolled inputs.
         if value is not None:
-            props["value"] = Var(_js_expr=f"{value} ?? ''", _var_type=str)
+            # props["value"] = Var(_js_expr=f"{value} ?? ''", _var_type=str)
+            props["value"] = ternary_operation(
+                ((value_var := Var.create(value)) != Var.create(None))
+                & (value_var != Var(_js_expr="undefined")),
+                value,
+                "",
+            )
 
         component = super().create(*children, **props)
         if props.get("value") is not None and props.get("on_change") is not None:

--- a/tests/units/components/core/test_debounce.py
+++ b/tests/units/components/core/test_debounce.py
@@ -6,6 +6,7 @@ import reflex as rx
 from reflex.components.core.debounce import DEFAULT_DEBOUNCE_TIMEOUT
 from reflex.state import BaseState
 from reflex.vars.base import LiteralVar, Var
+from reflex.vars.number import ternary_operation
 
 
 def test_create_no_child():
@@ -60,8 +61,13 @@ def test_render_child_props():
     assert "css" in tag.props and isinstance(tag.props["css"], rx.vars.Var)
     for prop in ["foo", "bar", "baz", "quuc"]:
         assert prop in str(tag.props["css"])
+    value_var = Var.create("real")
     assert tag.props["value"].equals(
-        Var(_js_expr="real ?? ''", _var_type=str)
+        ternary_operation(
+            (value_var != Var.create(None)) & (value_var != Var(_js_expr="undefined")),
+            "real",
+            "",
+        )
     )
     assert len(tag.props["onChange"].events) == 1
     assert tag.props["onChange"].events[0].handler == S.on_change

--- a/tests/units/components/core/test_debounce.py
+++ b/tests/units/components/core/test_debounce.py
@@ -6,7 +6,6 @@ import reflex as rx
 from reflex.components.core.debounce import DEFAULT_DEBOUNCE_TIMEOUT
 from reflex.state import BaseState
 from reflex.vars.base import LiteralVar, Var
-from reflex.vars.number import ternary_operation
 
 
 def test_create_no_child():
@@ -61,14 +60,7 @@ def test_render_child_props():
     assert "css" in tag.props and isinstance(tag.props["css"], rx.vars.Var)
     for prop in ["foo", "bar", "baz", "quuc"]:
         assert prop in str(tag.props["css"])
-    value_var = Var.create("real")
-    assert tag.props["value"].equals(
-        ternary_operation(
-            (value_var != Var.create(None)) & (value_var != Var(_js_expr="undefined")),
-            "real",
-            "",
-        )
-    )
+    assert tag.props["value"].equals(LiteralVar.create("real"))
     assert len(tag.props["onChange"].events) == 1
     assert tag.props["onChange"].events[0].handler == S.on_change
     assert tag.contents == ""

--- a/tests/units/components/core/test_debounce.py
+++ b/tests/units/components/core/test_debounce.py
@@ -61,7 +61,7 @@ def test_render_child_props():
     for prop in ["foo", "bar", "baz", "quuc"]:
         assert prop in str(tag.props["css"])
     assert tag.props["value"].equals(
-        rx.cond(real_var := LiteralVar.create("real"), real_var, "")
+        Var(_js_expr="real ?? ''", _var_type=str)
     )
     assert len(tag.props["onChange"].events) == 1
     assert tag.props["onChange"].events[0].handler == S.on_change

--- a/tests/units/components/core/test_debounce.py
+++ b/tests/units/components/core/test_debounce.py
@@ -60,7 +60,9 @@ def test_render_child_props():
     assert "css" in tag.props and isinstance(tag.props["css"], rx.vars.Var)
     for prop in ["foo", "bar", "baz", "quuc"]:
         assert prop in str(tag.props["css"])
-    assert tag.props["value"].equals(LiteralVar.create("real"))
+    assert tag.props["value"].equals(
+        rx.cond(real_var := LiteralVar.create("real"), real_var, "")
+    )
     assert len(tag.props["onChange"].events) == 1
     assert tag.props["onChange"].events[0].handler == S.on_change
     assert tag.contents == ""


### PR DESCRIPTION
React expects empty strings instead of `null` values for the `value` prop of the input component. putting this in a cond allows the input field to be updated when the `value` is `None`
