### PR TITLE
bump CI runners to `macos-latest`

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -80,7 +80,7 @@ jobs:
       fail-fast: false
       matrix:
         # Show OS combos first in GUI
-        os: [ubuntu-latest, windows-latest, macos-12]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.9.18', '3.10.13', '3.11.5', '3.12.0']
         exclude:
           - os: windows-latest
@@ -92,7 +92,7 @@ jobs:
             python-version: '3.9.18'
           - os: macos-latest
             python-version: '3.10.13'
-          - os: macos-12
+          - os: macos-latest
             python-version: '3.12.0'
         include:
           - os: windows-latest
@@ -155,7 +155,7 @@ jobs:
       fail-fast: false
       matrix:
         # Show OS combos first in GUI
-        os: [ubuntu-latest, windows-latest, macos-12]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.11.5']
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -198,7 +198,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.11.5', '3.12.0']
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup_build_env

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -88,7 +88,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9.18', '3.10.13', '3.11.5', '3.12.0']
+        # Note: py39, py310 versions chosen due to available arm64 darwin builds.
+        python-version: ['3.9.13', '3.10.11', '3.11.5', '3.12.0']
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -89,7 +89,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9.18', '3.10.13', '3.11.5', '3.12.0']
-    runs-on: macos-12
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup_build_env


### PR DESCRIPTION
🤞

Tests passing on this commit https://github.com/reflex-dev/reflex/pull/4526/commits/cd9e729a8108bdf652c57197b6e33259e973626b

Branch rebased to remove the XXX commit https://github.com/reflex-dev/reflex/pull/4526/commits/718285ea959973ce6f2a270a2e8209605e2ae71b