### PR TITLE
raise_console_error during integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+import reflex.app
 from reflex.config import environment
 from reflex.testing import AppHarness, AppHarnessProd
 
@@ -76,3 +77,25 @@ def app_harness_env(request):
         The AppHarness class to use for the test.
     """
     return request.param
+
+
+@pytest.fixture(autouse=True)
+def raise_console_error(request, mocker):
+    """Spy on calls to `console.error` used by the framework.
+
+    Help catch spurious error conditions that might otherwise go unnoticed.
+
+    If a test is marked with `ignore_console_error`, the spy will be ignored
+    after the test.
+
+    Args:
+        request: The pytest request object.
+        mocker: The pytest mocker object.
+
+    Yields:
+        control to the test function.
+    """
+    spy = mocker.spy(reflex.app.console, "error")
+    yield
+    if "ignore_console_error" not in request.keywords:
+        spy.assert_not_called()

--- a/tests/integration/test_exception_handlers.py
+++ b/tests/integration/test_exception_handlers.py
@@ -13,6 +13,8 @@ from selenium.webdriver.support.ui import WebDriverWait
 
 from reflex.testing import AppHarness, AppHarnessProd
 
+pytestmark = [pytest.mark.ignore_console_error]
+
 
 def TestApp():
     """A test app for event exception handler integration."""


### PR DESCRIPTION
assert that the framework does not log at `console.error` during an integration test, this helps catch spurious issues that may arise which aren't being explicitly checked for and may not cause the test to fail otherwise.

per-test opt out via `ignore_console_error` mark.