### PR TITLE
Revert "Do not mark unchanged backend var deps as dirty"

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1307,9 +1307,6 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
             return
 
         if name in self.backend_vars:
-            # abort if unchanged
-            if self._backend_vars.get(name) == value:
-                return
             self._backend_vars.__setitem__(name, value)
             self.dirty_vars.add(name)
             self._mark_dirty()


### PR DESCRIPTION
Reverts reflex-dev/reflex#4494

This `__eq__` check for pydantic v1 BaseModel triggers a call to `.dict()`, which for large models could be an expensive serialization. What's worse though is for database models, this can trigger infinite recursion if the relationships are circular, even for backend variables that are never intended to be rendered on the frontend.

@benedikt-bartscher we can probably bring this back in https://github.com/reflex-dev/reflex/issues/4487, but we'll need some guardrails in `rx.Model.dict` to avoid infinite recursion. And we should consider if serializing the model to `dict()` for every assignment of a backend var is worth it.