### PR TITLE
Allow deploy with project name and app id

### DIFF
--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -440,7 +440,6 @@ def deploy(
         config.app_name,
         "--app-name",
         help="The name of the App to deploy under.",
-        hidden=True,
     ),
     app_id: str = typer.Option(
         None,

--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -480,6 +480,11 @@ def deploy(
         "--project",
         help="project id to deploy to",
     ),
+    project_name: Optional[str] = typer.Option(
+        None,
+        "--project-name",
+        help="The name of the project to deploy under.",
+    ),
     token: Optional[str] = typer.Option(
         None,
         "--token",
@@ -547,6 +552,8 @@ def deploy(
         loglevel=type(loglevel).INFO,  # type: ignore
         token=token,
         project=project,
+        config_path=config_path,
+        project_name=project_name,
         **extra,
     )
 

--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -442,6 +442,11 @@ def deploy(
         help="The name of the App to deploy under.",
         hidden=True,
     ),
+    app_id: str = typer.Option(
+        None,
+        "--app-id",
+        help="The ID of the App to deploy under.",
+    ),
     regions: List[str] = typer.Option(
         [],
         "-r",
@@ -529,6 +534,7 @@ def deploy(
     )
     hosting_cli.deploy(
         app_name=app_name,
+        app_id=app_id,
         export_fn=lambda zip_dest_dir,
         api_url,
         deploy_url,

--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -444,7 +444,7 @@ def deploy(
     app_id: str = typer.Option(
         None,
         "--app-id",
-        help="The ID of the App to deploy under.",
+        help="The ID of the App to deploy over.",
     ),
     regions: List[str] = typer.Option(
         [],

--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -487,7 +487,7 @@ def deploy(
     project_name: Optional[str] = typer.Option(
         None,
         "--project-name",
-        help="The name of the project to deploy under.",
+        help="The name of the project to deploy to.",
     ),
     token: Optional[str] = typer.Option(
         None,


### PR DESCRIPTION
Add command to deploy to a project by specifying the project name or app id

```
reflex deploy --project-name
```

```
reflex deploy --app-id
```
