### PR TITLE
improve dynamic route vars, no need to compute deps

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1193,6 +1193,8 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
                 continue
             dynamic_vars[param] = DynamicRouteVar(
                 fget=func,
+                auto_deps=False,
+                deps=["router"],
                 cache=True,
                 _js_expr=param,
                 _var_data=VarData.from_state(cls),


### PR DESCRIPTION
We do not need to compute deps for dynamic args. They are fixed anyway. Small performance improvement.