### PR TITLE
Do not allow call_function `callback` argument to be added afterwards

### DIFF
--- a/reflex/event.py
+++ b/reflex/event.py
@@ -1100,7 +1100,7 @@ def call_function(
     Returns:
         EventSpec: An event that will execute the client side javascript.
     """
-    callback_kwargs = {}
+    callback_kwargs = {"callback": None}
     if callback is not None:
         callback_kwargs = {
             "callback": format.format_queue_events(

--- a/tests/units/test_event.py
+++ b/tests/units/test_event.py
@@ -223,12 +223,17 @@ def test_event_console_log():
     )
     assert (
         format.format_event(spec)
-        == 'Event("_call_function", {function:(() => (console["log"]("message")))})'
+        == 'Event("_call_function", {function:(() => (console["log"]("message"))),callback:null})'
     )
     spec = event.console_log(Var(_js_expr="message"))
     assert (
         format.format_event(spec)
-        == 'Event("_call_function", {function:(() => (console["log"](message)))})'
+        == 'Event("_call_function", {function:(() => (console["log"](message))),callback:null})'
+    )
+    spec2 = event.console_log(Var(_js_expr="message2")).add_args(Var("throwaway"))
+    assert (
+        format.format_event(spec2)
+        == 'Event("_call_function", {function:(() => (console["log"](message2))),callback:null})'
     )
 
 
@@ -243,12 +248,17 @@ def test_event_window_alert():
     )
     assert (
         format.format_event(spec)
-        == 'Event("_call_function", {function:(() => (window["alert"]("message")))})'
+        == 'Event("_call_function", {function:(() => (window["alert"]("message"))),callback:null})'
     )
     spec = event.window_alert(Var(_js_expr="message"))
     assert (
         format.format_event(spec)
-        == 'Event("_call_function", {function:(() => (window["alert"](message)))})'
+        == 'Event("_call_function", {function:(() => (window["alert"](message))),callback:null})'
+    )
+    spec2 = event.window_alert(Var(_js_expr="message2")).add_args(Var("throwaway"))
+    assert (
+        format.format_event(spec2)
+        == 'Event("_call_function", {function:(() => (window["alert"](message2))),callback:null})'
     )
 
 


### PR DESCRIPTION
The default behavior for EventSpec is to treat the spec as a partial, wherein if additional unfilled arguments are available, and the event trigger wants to pass additional arguments, they will be applied positionally.

However, it never makes sense to fill in `callback` with an event trigger arg. Therefore, if the callback is not provided initially, set it to None explicitly so that some invalid value cannot be added later.

Makes code like this work

```python
rx.input(on_blur=rx.console_log("Input blurred"))
```

Without this patch, the frontend raises exception:

```
[Reflex Frontend Exception]
 TypeError: event.payload.callback is not a function
    at applyEvent (webpack-internal:///./utils/state.js:246:35)
    at processEvent (webpack-internal:///./utils/state.js:344:27)
    at queueEvents (webpack-internal:///./utils/state.js:321:11)
    at addEvents (webpack-internal:///./utils/state.js:660:13)
    at eval (webpack-internal:///./pages/index.js:134:111)
    at HTMLUnknownElement.callCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4164:14)
    at Object.invokeGuardedCallbackDev (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4213:16)
    at invokeGuardedCallback (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4277:31)
    at invokeGuardedCallbackAndCatchFirstError (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:4291:25)
    at executeDispatch (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:9041:3)
    at processDispatchQueueItemsInOrder (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:9073:7)
    at processDispatchQueue (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:9086:5)
    at dispatchEventsForPlugins (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:9097:3)
    at eval (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:9288:12)
    at batchedUpdates$1 (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:26174:12)
    at batchedUpdates (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:3991:12)
    at dispatchEventForPluginEventSystem (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:9287:3)
    at dispatchEventWithEnableCapturePhaseSelectiveHydrationWithoutDiscreteEventReplay 
(webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:6465:5)
    at dispatchEvent (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:6457:5)
    at dispatchDiscreteEvent (webpack-internal:///./node_modules/react-dom/cjs/react-dom.development.js:6430:5)
```

