### PR TITLE
BaseState.get_var_value helper to get a value from a Var

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -144,6 +144,9 @@ HANDLED_PICKLE_ERRORS = (
     ValueError,
 )
 
+# For BaseState.get_var_value
+VAR_TYPE = TypeVar("VAR_TYPE", bound=Var)
+
 
 def _no_chain_background_task(
     state_cls: Type["BaseState"], name: str, fn: Callable
@@ -1597,7 +1600,7 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
         # Slow case - fetch missing parent states from redis.
         return await self._get_state_from_redis(state_cls)
 
-    async def get_var_value(self, var: Var) -> Any:
+    async def get_var_value(self, var: Var[VAR_TYPE]) -> VAR_TYPE:
         """Get the value of an rx.Var from another state.
 
         Args:

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -107,6 +107,7 @@ from reflex.utils.exceptions import (
     StateSchemaMismatchError,
     StateSerializationError,
     StateTooLargeError,
+    UnretrievableVarValueError,
 )
 from reflex.utils.exec import is_testing_env
 from reflex.utils.serializers import serializer
@@ -1595,6 +1596,36 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
 
         # Slow case - fetch missing parent states from redis.
         return await self._get_state_from_redis(state_cls)
+
+    async def get_var_value(self, var: Var) -> Any:
+        """Get the value of an rx.Var from another state.
+
+        Args:
+            var: The var to get the value for.
+
+        Returns:
+            The value of the var.
+
+        Raises:
+            UnretrievableVarValueError: If the var does not have a literal value
+                or associated state.
+        """
+        # Fast case: this is a literal var and the value is known.
+        if hasattr(var, "_var_value"):
+            return var._var_value
+        var_data = var._get_all_var_data()
+        if var_data is None or not var_data.state:
+            raise UnretrievableVarValueError(
+                f"Unable to retrieve value for {var._js_expr}: not associated with any state."
+            )
+        # Fastish case: this var belongs to this state
+        if var_data.state == self.get_full_name():
+            return getattr(self, var_data.field_name)
+        # Slow case: this var belongs to another state
+        other_state = await self.get_state(
+            self._get_root_state().get_class_substate(var_data.state)
+        )
+        return getattr(other_state, var_data.field_name)
 
     def _get_event_handler(
         self, event: Event

--- a/reflex/utils/exceptions.py
+++ b/reflex/utils/exceptions.py
@@ -187,3 +187,7 @@ def raise_system_package_missing_error(package: str) -> NoReturn:
 
 class InvalidLockWarningThresholdError(ReflexError):
     """Raised when an invalid lock warning threshold is provided."""
+
+
+class UnretrievableVarValueError(ReflexError):
+    """Raised when the value of a var is not retrievable."""

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -116,7 +116,7 @@ class TestState(BaseState):
     # Set this class as not test one
     __test__ = False
 
-    num1: int
+    num1: rx.Field[int]
     num2: float = 3.14
     key: str
     map_key: str = "a"
@@ -164,7 +164,7 @@ class ChildState(TestState):
     """A child state fixture."""
 
     value: str
-    count: int = 23
+    count: rx.Field[int] = rx.field(23)
 
     def change_both(self, value: str, count: int):
         """Change both the value and count.
@@ -1664,7 +1664,7 @@ async def state_manager(request) -> AsyncGenerator[StateManager, None]:
 
 
 @pytest.fixture()
-def substate_token(state_manager, token):
+def substate_token(state_manager, token) -> str:
     """A token + substate name for looking up in state manager.
 
     Args:
@@ -3768,14 +3768,14 @@ async def test_upcast_event_handler_arg(handler, payload):
 
 
 @pytest.mark.asyncio
-async def test_get_var_value(state_manager, token):
+async def test_get_var_value(state_manager: StateManager, substate_token: str):
     """Test that get_var_value works correctly.
 
     Args:
         state_manager: The state manager to use.
-        token: A token.
+        substate_token: Token for the substate used by state_manager.
     """
-    state = await state_manager.get_state(_substate_key(token, TestState))
+    state = await state_manager.get_state(substate_token)
 
     # State Var from same state
     assert await state.get_var_value(TestState.num1) == 0


### PR DESCRIPTION
When given a state Var or a LiteralVar, retrieve the actual value associated with the Var.

For state Vars, the returned value is directly tied to the associated state and can be modified.

Modifying LiteralVar values or ComputedVar values will have no useful effect.

### Sample Code

```python
from typing import ClassVar
import reflex as rx


class DataState(rx.State):
    categories: list[dict] = [
        {"id": 1, "name": "Maquinaria Agricola", "order": 0},
        {"id": 2, "name": "Tractores", "order": 0},
    ]
    frameworks: list[dict] = [
        {"id": 6, "name": "Reflex", "order": 0},
        {"id": 9, "name": "NextJS", "order": 0},
        {"id": 10, "name": "FastAPI", "order": 0},
        {"id": 11, "name": "Django", "order": 0},
    ]
    candies: list[dict] = [
        {"id": 1, "name": "KitKat", "order": 0},
        {"id": 2, "name": "Snickers", "order": 0},
        {"id": 3, "name": "Butterfinger", "order": 0},
    ]


class CategoryCarousel(rx.ComponentState):
    _target_var: ClassVar[rx.Var]

    async def handle_click(self, cat_id):
        print(f"Category clicked: {cat_id}")
        categories = await self.get_var_value(self._target_var)
        for c in categories:
            if c["id"] == cat_id:
                c["order"] += 1
                break

    @classmethod
    def get_component(cls, target: rx.Var[list[dict]], **props) -> rx.Component:
        cls._target_var = target
        props.setdefault("columns", "2")
        props.setdefault("width", "100%")
        props.setdefault("spacing", "4")
        return rx.grid(
            rx.foreach(
                target,
                lambda cat: rx.box(
                    rx.heading(f"ID: {cat['id']}"),
                    rx.text(f"Name: {cat['name']} {cat['order']}"),
                    on_click=cls.handle_click(cat['id']),
                    padding="1rem",
                    border="1px solid",
                    border_radius="lg",
                    margin_y="2",
                    shadow="md",
                ),
            ),
            **props,
        )


def category_boxes():
    return rx.container(
        rx.vstack(
            CategoryCarousel.create(target=DataState.categories),
            rx.separator(),
            CategoryCarousel.create(target=DataState.frameworks),
            rx.separator(),
            CategoryCarousel.create(target=DataState.candies),
            rx.separator(),
            CategoryCarousel.create(target=rx.Var.create([
                {"id": 1, "name": "Can", "order": 0},
                {"id": 2, "name": "You", "order": 0},
                {"id": 3, "name": "Edit?", "order": 0},
            ])),
            spacing="4",
            width="100%",
        ),
    )


def prueba_carousel():
    return rx.flex(
        category_boxes(),
        width="100%",
        min_height="100vh",
        padding_y="4em",
    )


def index():
    return prueba_carousel()


app = rx.App()
app.add_page(index)
```