### PR TITLE
[ENG-4134]Allow specifying custom app module in rxconfig

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -33,7 +33,7 @@ env:
   PR_TITLE: ${{ github.event.pull_request.title }}
 
 jobs:
-  example-counter:
+  example-counter-and-nba-proxy:
     env:
       OUTPUT_FILE: import_benchmark.json
     timeout-minutes: 30
@@ -119,46 +119,6 @@ jobs:
           --benchmark-json "./reflex-examples/counter/${{ env.OUTPUT_FILE }}"
           --branch-name "${{ github.head_ref || github.ref_name }}" --pr-id "${{ github.event.pull_request.id }}"
           --app-name "counter"
-
-  example-nba-proxy:
-    timeout-minutes: 30
-    strategy:
-      # Prioritize getting more information out of the workflow (even if something fails)
-      fail-fast: false
-      matrix:
-        # Show OS combos first in GUI
-        os: [ ubuntu-latest, windows-latest ]
-        python-version: [ "3.9.21", "3.10.16", "3.11.11", "3.12.8", "3.13.1" ]
-        # Windows is a bit behind on Python version availability in Github
-        exclude:
-          - os: windows-latest
-            python-version: "3.11.11"
-          - os: windows-latest
-            python-version: "3.10.16"
-          - os: windows-latest
-            python-version: "3.9.21"
-        include:
-          - os: windows-latest
-            python-version: "3.11.9"
-          - os: windows-latest
-            python-version: "3.10.11"
-          - os: windows-latest
-            python-version: "3.9.13"
-
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup_build_env
-        with:
-          python-version: ${{ matrix.python-version }}
-          run-poetry-install: true
-          create-venv-at-path: .venv
-      - name: Clone Reflex Examples Repo
-        uses: actions/checkout@v4
-        with:
-          repository: reflex-dev/reflex-examples
-          ref: elijah/nba-proxy-app
-          path: reflex-examples
       - name: Install requirements for nba proxy example
         working-directory: ./reflex-examples/nba-proxy
         run: |
@@ -178,6 +138,7 @@ jobs:
           # Check that npm is home
           npm -v
           poetry run bash scripts/integration.sh ./reflex-examples/nba-proxy dev
+
 
   reflex-web:
     strategy:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -120,6 +120,65 @@ jobs:
           --branch-name "${{ github.head_ref || github.ref_name }}" --pr-id "${{ github.event.pull_request.id }}"
           --app-name "counter"
 
+  example-nba-proxy:
+    timeout-minutes: 30
+    strategy:
+      # Prioritize getting more information out of the workflow (even if something fails)
+      fail-fast: false
+      matrix:
+        # Show OS combos first in GUI
+        os: [ ubuntu-latest, windows-latest ]
+        python-version: [ "3.9.21", "3.10.16", "3.11.11", "3.12.8", "3.13.1" ]
+        # Windows is a bit behind on Python version availability in Github
+        exclude:
+          - os: windows-latest
+            python-version: "3.11.11"
+          - os: windows-latest
+            python-version: "3.10.16"
+          - os: windows-latest
+            python-version: "3.9.21"
+        include:
+          - os: windows-latest
+            python-version: "3.11.9"
+          - os: windows-latest
+            python-version: "3.10.11"
+          - os: windows-latest
+            python-version: "3.9.13"
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup_build_env
+        with:
+          python-version: ${{ matrix.python-version }}
+          run-poetry-install: true
+          create-venv-at-path: .venv
+      - name: Clone Reflex Examples Repo
+        uses: actions/checkout@v4
+        with:
+          repository: reflex-dev/reflex-examples
+          ref: elijah/nba-proxy-app
+          path: reflex-examples
+      - name: Install requirements for nba proxy example
+        working-directory: ./reflex-examples/nba-proxy
+        run: |
+          poetry run uv pip install -r requirements.txt
+      - name: Install additional dependencies for DB access
+        run: poetry run uv pip install psycopg
+      - name: Check export --backend-only before init for nba-proxy example
+        working-directory: ./reflex-examples/nba-proxy
+        run: |
+          poetry run reflex export --backend-only
+      - name: Init Website for nba-proxy example
+        working-directory: ./reflex-examples/nba-proxy
+        run: |
+          poetry run reflex init --loglevel debug
+      - name: Run Website and Check for errors
+        run: |
+          # Check that npm is home
+          npm -v
+          poetry run bash scripts/integration.sh ./reflex-examples/nba-proxy dev
+
   reflex-web:
     strategy:
       fail-fast: false

--- a/reflex/app_module_for_backend.py
+++ b/reflex/app_module_for_backend.py
@@ -7,14 +7,13 @@ from concurrent.futures import ThreadPoolExecutor
 from reflex import constants
 from reflex.utils import telemetry
 from reflex.utils.exec import is_prod_mode
-from reflex.utils.prerequisites import get_app
+from reflex.utils.prerequisites import get_and_validate_app
 
 if constants.CompileVars.APP != "app":
     raise AssertionError("unexpected variable name for 'app'")
 
 telemetry.send("compile")
-app_module = get_app(reload=False)
-app = getattr(app_module, constants.CompileVars.APP)
+app, app_module = get_and_validate_app(reload=False)
 # For py3.9 compatibility when redis is used, we MUST add any decorator pages
 # before compiling the app in a thread to avoid event loop error (REF-2172).
 app._apply_decorated_pages()
@@ -30,7 +29,7 @@ if is_prod_mode():
 # ensure only "app" is exposed.
 del app_module
 del compile_future
-del get_app
+del get_and_validate_app
 del is_prod_mode
 del telemetry
 del constants

--- a/reflex/config.py
+++ b/reflex/config.py
@@ -688,11 +688,11 @@ class Config(Base):
     # Maximum expiration lock time for redis state manager
     redis_lock_expiration: int = constants.Expiration.LOCK
 
-    # Token expiration time for redis state manager
-    redis_token_expiration: int = constants.Expiration.TOKEN
-
     # Maximum lock time before warning for redis state manager.
     redis_lock_warning_threshold: int = constants.Expiration.LOCK_WARNING_THRESHOLD
+
+    # Token expiration time for redis state manager
+    redis_token_expiration: int = constants.Expiration.TOKEN
 
     # Attributes that were explicitly set by the user.
     _non_default_attributes: Set[str] = pydantic.PrivateAttr(set())

--- a/reflex/config.py
+++ b/reflex/config.py
@@ -691,6 +691,9 @@ class Config(Base):
     # Token expiration time for redis state manager
     redis_token_expiration: int = constants.Expiration.TOKEN
 
+    # Maximum lock time before warning for redis state manager.
+    redis_lock_warning_threshold: int = constants.Expiration.LOCK_WARNING_THRESHOLD
+
     # Attributes that were explicitly set by the user.
     _non_default_attributes: Set[str] = pydantic.PrivateAttr(set())
 

--- a/reflex/config.py
+++ b/reflex/config.py
@@ -83,7 +83,7 @@ class DBConfig(Base):
         )
 
     @classmethod
-    def postgresql_psycopg2(
+    def postgresql_psycopg(
         cls,
         database: str,
         username: str,
@@ -91,7 +91,7 @@ class DBConfig(Base):
         host: str | None = None,
         port: int | None = 5432,
     ) -> DBConfig:
-        """Create an instance with postgresql+psycopg2 engine.
+        """Create an instance with postgresql+psycopg engine.
 
         Args:
             database: Database name.
@@ -104,7 +104,7 @@ class DBConfig(Base):
             DBConfig instance.
         """
         return cls(
-            engine="postgresql+psycopg2",
+            engine="postgresql+psycopg",
             username=username,
             password=password,
             host=host,

--- a/reflex/config.py
+++ b/reflex/config.py
@@ -746,9 +746,9 @@ class Config(Base):
         module_name = Path(path).stem
         module_path = Path(path).resolve()
         sys.path.insert(0, str(module_path.parent.parent))
-        spec = spec_from_file_location(module_name, path)
+        spec = spec_from_file_location(module_name, module_path)
         if not spec:
-            raise ConfigError(f"Could not load module from path: {path}")
+            raise ConfigError(f"Could not load module from path: {module_path}")
         module = module_from_spec(spec)
         # Set the package name to the parent directory of the module (for relative imports)
         module.__package__ = module_path.parent.name

--- a/reflex/config.py
+++ b/reflex/config.py
@@ -10,7 +10,7 @@ import os
 import sys
 import threading
 import urllib.parse
-from importlib.util import find_spec, module_from_spec, spec_from_file_location
+from importlib.util import find_spec
 from pathlib import Path
 from types import ModuleType
 from typing import (
@@ -606,7 +606,7 @@ class Config(Base):
     app_name: str
 
     # The path to the app module.
-    app_module_path: Optional[str] = None
+    app_module_import: Optional[str] = None
 
     # The log level to use.
     loglevel: constants.LogLevel = constants.LogLevel.DEFAULT
@@ -730,40 +730,17 @@ class Config(Base):
                 "REDIS_URL is required when using the redis state manager."
             )
 
-    @staticmethod
-    def _load_via_spec(path: str) -> ModuleType:
-        """Load a module dynamically using its file path.
-
-        Args:
-            path: The path to the module.
-
-        Returns:
-            The loaded module.
-
-        Raises:
-            ConfigError: If the module cannot be loaded.
-        """
-        module_name = Path(path).stem
-        module_path = Path(path).resolve()
-        sys.path.insert(0, str(module_path.parent.parent))
-        spec = spec_from_file_location(module_name, module_path)
-        if not spec:
-            raise ConfigError(f"Could not load module from path: {module_path}")
-        module = module_from_spec(spec)
-        # Set the package name to the parent directory of the module (for relative imports)
-        module.__package__ = module_path.parent.name
-        spec.loader.exec_module(module)  # type: ignore
-        return module
-
     @property
     def app_module(self) -> ModuleType | None:
-        """Return the app module if `app_module_path` is set.
+        """Return the app module if `app_module_import` is set.
 
         Returns:
             The app module.
         """
         return (
-            self._load_via_spec(self.app_module_path) if self.app_module_path else None
+            importlib.import_module(self.app_module_import)
+            if self.app_module_import
+            else None
         )
 
     @property
@@ -773,9 +750,8 @@ class Config(Base):
         Returns:
             The module name.
         """
-        if self.app_module and self.app_module.__file__:
-            module_file = Path(self.app_module.__file__)
-            return f"{module_file.parent.name}.{module_file.stem}"
+        if self.app_module is not None:
+            return self.app_module.__name__
         return ".".join([self.app_name, self.app_name])
 
     def update_from_env(self) -> dict[str, Any]:
@@ -914,7 +890,7 @@ def get_config(reload: bool = False) -> Config:
             return cached_rxconfig.config
 
     with _config_lock:
-        sys_path = sys.path.copy()
+        orig_sys_path = sys.path.copy()
         sys.path.clear()
         sys.path.append(str(Path.cwd()))
         try:
@@ -922,9 +898,14 @@ def get_config(reload: bool = False) -> Config:
             return _get_config()
         except Exception:
             # If the module import fails, try to import with the original sys.path.
-            sys.path.extend(sys_path)
+            sys.path.extend(orig_sys_path)
             return _get_config()
         finally:
+            # Find any entries added to sys.path by rxconfig.py itself.
+            extra_paths = [
+                p for p in sys.path if p not in orig_sys_path and p != str(Path.cwd())
+            ]
             # Restore the original sys.path.
             sys.path.clear()
-            sys.path.extend(sys_path)
+            sys.path.extend(extra_paths)
+            sys.path.extend(orig_sys_path)

--- a/reflex/event.py
+++ b/reflex/event.py
@@ -1591,7 +1591,7 @@ def get_handler_args(
 
 
 def fix_events(
-    events: list[IndividualEventType] | None,
+    events: list[EventSpec | EventHandler] | None,
     token: str,
     router_data: dict[str, Any] | None = None,
 ) -> list[Event]:

--- a/reflex/event.py
+++ b/reflex/event.py
@@ -1591,7 +1591,7 @@ def get_handler_args(
 
 
 def fix_events(
-    events: list[EventHandler | EventSpec] | None,
+    events: list[IndividualEventType] | None,
     token: str,
     router_data: dict[str, Any] | None = None,
 ) -> list[Event]:

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -2432,7 +2432,7 @@ class OnLoadInternalState(State):
         self.is_hydrated = False
         return [
             *fix_events(
-                load_events,
+                cast(list[EventSpec | EventHandler], load_events),
                 self.router.session.client_token,
                 router_data=self.router_data,
             ),

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -2432,7 +2432,7 @@ class OnLoadInternalState(State):
         self.is_hydrated = False
         return [
             *fix_events(
-                cast(list[EventSpec | EventHandler], load_events),
+                cast(list[Union[EventSpec, EventHandler]], load_events),
                 self.router.session.client_token,
                 router_data=self.router_data,
             ),

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1759,7 +1759,7 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
         except Exception as ex:
             state._clean()
 
-            app_instance = getattr(prerequisites.get_app(), constants.CompileVars.APP)
+            app_instance = prerequisites.get_and_validate_app().app
 
             event_specs = app_instance.backend_exception_handler(ex)
 
@@ -1871,7 +1871,7 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
         except Exception as ex:
             telemetry.send_error(ex, context="backend")
 
-            app_instance = getattr(prerequisites.get_app(), constants.CompileVars.APP)
+            app_instance = prerequisites.get_and_validate_app().app
 
             event_specs = app_instance.backend_exception_handler(ex)
 
@@ -2383,7 +2383,7 @@ class FrontendEventExceptionState(State):
             component_stack: The stack trace of the component where the exception occurred.
 
         """
-        app_instance = getattr(prerequisites.get_app(), constants.CompileVars.APP)
+        app_instance, _ = prerequisites.get_and_validate_app()
         app_instance.frontend_exception_handler(Exception(stack))
 
 
@@ -2422,7 +2422,7 @@ class OnLoadInternalState(State):
             The list of events to queue for on load handling.
         """
         # Do not app._compile()!  It should be already compiled by now.
-        app = getattr(prerequisites.get_app(), constants.CompileVars.APP)
+        app = prerequisites.get_and_validate_app().app
         load_events = app.get_load_events(self.router.page.path)
         if not load_events:
             self.is_hydrated = True
@@ -2589,7 +2589,7 @@ class StateProxy(wrapt.ObjectProxy):
         """
         super().__init__(state_instance)
         # compile is not relevant to backend logic
-        self._self_app = getattr(prerequisites.get_app(), constants.CompileVars.APP)
+        self._self_app = prerequisites.get_and_validate_app().app
         self._self_substate_path = tuple(state_instance.get_full_name().split("."))
         self._self_actx = None
         self._self_mutable = False
@@ -3682,7 +3682,7 @@ def get_state_manager() -> StateManager:
     Returns:
         The state manager.
     """
-    app = getattr(prerequisites.get_app(), constants.CompileVars.APP)
+    app = prerequisites.get_and_validate_app().app
     return app.state_manager
 
 

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1759,9 +1759,9 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
         except Exception as ex:
             state._clean()
 
-            app_instance = prerequisites.get_and_validate_app().app
-
-            event_specs = app_instance.backend_exception_handler(ex)
+            event_specs = (
+                prerequisites.get_and_validate_app().app.backend_exception_handler(ex)
+            )
 
             if event_specs is None:
                 return StateUpdate()
@@ -1871,9 +1871,9 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
         except Exception as ex:
             telemetry.send_error(ex, context="backend")
 
-            app_instance = prerequisites.get_and_validate_app().app
-
-            event_specs = app_instance.backend_exception_handler(ex)
+            event_specs = (
+                prerequisites.get_and_validate_app().app.backend_exception_handler(ex)
+            )
 
             yield state._as_state_update(
                 handler,
@@ -2383,8 +2383,9 @@ class FrontendEventExceptionState(State):
             component_stack: The stack trace of the component where the exception occurred.
 
         """
-        app_instance, _ = prerequisites.get_and_validate_app()
-        app_instance.frontend_exception_handler(Exception(stack))
+        prerequisites.get_and_validate_app().app.frontend_exception_handler(
+            Exception(stack)
+        )
 
 
 class UpdateVarsInternalState(State):
@@ -2422,8 +2423,9 @@ class OnLoadInternalState(State):
             The list of events to queue for on load handling.
         """
         # Do not app._compile()!  It should be already compiled by now.
-        app = prerequisites.get_and_validate_app().app
-        load_events = app.get_load_events(self.router.page.path)
+        load_events = prerequisites.get_and_validate_app().app.get_load_events(
+            self.router.page.path
+        )
         if not load_events:
             self.is_hydrated = True
             return  # Fast path for navigation with no on_load events defined.
@@ -3682,8 +3684,7 @@ def get_state_manager() -> StateManager:
     Returns:
         The state manager.
     """
-    app = prerequisites.get_and_validate_app().app
-    return app.state_manager
+    return prerequisites.get_and_validate_app().app.state_manager
 
 
 class MutableProxy(wrapt.ObjectProxy):

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -248,8 +248,17 @@ def get_reload_dirs() -> list[str]:
     """
     config = get_config()
     reload_dirs = [config.app_name]
-    if app_module_path := config.app_module_path:
-        reload_dirs.append(str(Path(app_module_path).resolve().parent.parent))
+    if config.app_module is not None and config.app_module.__file__:
+        module_path = Path(config.app_module.__file__).resolve().parent
+        while module_path.parent.name:
+            for parent_file in module_path.parent.iterdir():
+                if parent_file == "__init__.py":
+                    # go up a level to find dir without `__init__.py`
+                    module_path = module_path.parent
+                    break
+            else:
+                break
+        reload_dirs.append(str(module_path))
     return reload_dirs
 
 

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -240,6 +240,19 @@ def run_backend(
         run_uvicorn_backend(host, port, loglevel)
 
 
+def get_reload_dirs() -> list[str]:
+    """Get the reload directories for the backend.
+
+    Returns:
+        The reload directories for the backend.
+    """
+    config = get_config()
+    reload_dirs = [config.app_name]
+    if app_module_path := config.app_module_path:
+        reload_dirs.append(str(Path(app_module_path).resolve().parent.parent))
+    return reload_dirs
+
+
 def run_uvicorn_backend(host, port, loglevel: LogLevel):
     """Run the backend in development mode using Uvicorn.
 
@@ -256,7 +269,7 @@ def run_uvicorn_backend(host, port, loglevel: LogLevel):
         port=port,
         log_level=loglevel.value,
         reload=True,
-        reload_dirs=[get_config().app_name],
+        reload_dirs=get_reload_dirs(),
     )
 
 
@@ -281,7 +294,7 @@ def run_granian_backend(host, port, loglevel: LogLevel):
             interface=Interfaces.ASGI,
             log_level=LogLevels(loglevel.value),
             reload=True,
-            reload_paths=[Path(get_config().app_name)],
+            reload_paths=get_reload_dirs(),
             reload_ignore_dirs=[".web"],
         ).serve()
     except ImportError:

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -22,8 +22,7 @@ import zipfile
 from datetime import datetime
 from pathlib import Path
 from types import ModuleType
-from typing import Callable, List, Optional
-from collections import namedtuple
+from typing import Callable, List, NamedTuple, Optional
 
 import httpx
 import typer
@@ -49,7 +48,14 @@ if typing.TYPE_CHECKING:
 
 CURRENTLY_INSTALLING_NODE = False
 
-AppInfo = namedtuple("AppInfo", ["app", "module"])
+
+class AppInfo(NamedTuple):
+    """A tuple containing the app instance and module."""
+
+    app: App
+    module: ModuleType
+
+
 @dataclasses.dataclass(frozen=True)
 class Template:
     """A template for a Reflex app."""

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -330,6 +330,9 @@ def get_and_validate_app(reload: bool = False) -> AppInfo:
 
     Returns:
         The app instance and the app module.
+
+    Raises:
+        RuntimeError: If the app instance is not an instance of rx.App.
     """
     from reflex.app import App
 

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -340,7 +340,7 @@ def get_and_validate_app(reload: bool = False) -> AppInfo:
     app = getattr(app_module, constants.CompileVars.APP)
     if not isinstance(app, App):
         raise RuntimeError(
-            "The app instance in the specified app_module_path in rxconfig must be an instance of rx.App."
+            "The app instance in the specified app_module_import in rxconfig must be an instance of rx.App."
         )
     return AppInfo(app=app, module=app_module)
 


### PR DESCRIPTION
```python 

import sys
import reflex as rx
from pathlib import Path


sys.path.insert(0, str(Path("/path/to/app/foo/")))

config = rx.Config(
    app_name="my_project",
    app_module_path="foo.foo"
)
```

Assuming you have a reflex app `foo` with App instance living in `foo/foo/foo.py`

Example app: https://github.com/reflex-dev/reflex-examples/pull/291