### PR TITLE
Add `endswith` method to String class

### DIFF
--- a/reflex/vars/sequence.py
+++ b/reflex/vars/sequence.py
@@ -272,6 +272,25 @@ class StringVar(Var[STRING_TYPE], python_types=str):
         return string_starts_with_operation(self, prefix)
 
     @overload
+    def endswith(self, suffix: StringVar | str) -> BooleanVar: ...
+
+    @overload
+    def endswith(self, suffix: NoReturn) -> NoReturn: ...
+
+    def endswith(self, suffix: Any) -> BooleanVar:
+        """Check if the string ends with a suffix.
+
+        Args:
+            suffix: The suffix.
+
+        Returns:
+            The string ends with operation.
+        """
+        if not isinstance(suffix, (StringVar, str)):
+            raise_unsupported_operand_types("endswith", (type(self), type(suffix)))
+        return string_ends_with_operation(self, suffix)
+
+    @overload
     def __lt__(self, other: StringVar | str) -> BooleanVar: ...
 
     @overload
@@ -498,6 +517,24 @@ def string_starts_with_operation(
     """
     return var_operation_return(
         js_expression=f"{full_string}.startsWith({prefix})", var_type=bool
+    )
+
+
+@var_operation
+def string_ends_with_operation(
+    full_string: StringVar[Any], suffix: StringVar[Any] | str
+):
+    """Check if a string ends with a suffix.
+
+    Args:
+        full_string: The full string.
+        suffix: The suffix.
+
+    Returns:
+        Whether the string ends with the suffix.
+    """
+    return var_operation_return(
+        js_expression=f"{full_string}.endsWith({suffix})", var_type=bool
     )
 
 


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?



As the title suggests, there's already a `startswith` method, but no `endswith`. This PR simply adds that method.