### PR TITLE
Add `expire_on_commit=False` for async sessions

### DIFF
--- a/reflex/model.py
+++ b/reflex/model.py
@@ -533,6 +533,7 @@ def asession(url: str | None = None) -> AsyncSession:
         _AsyncSessionLocal[url] = sqlalchemy.ext.asyncio.async_sessionmaker(
             bind=get_async_engine(url),
             class_=AsyncSession,
+            expire_on_commit=False,
             autocommit=False,
             autoflush=False,
         )


### PR DESCRIPTION
Avoid marking Model instances as expired after calling `.commit()`. This is considered fairly standard for asynchronous mode, as lazy loading on demand essentially does not work.