### PR TITLE
fixes #4578 - correct the way dim_props created

### DIFF
--- a/reflex/components/recharts/charts.py
+++ b/reflex/components/recharts/charts.py
@@ -85,8 +85,8 @@ class ChartBase(RechartsCharts):
         cls._ensure_valid_dimension("height", height)
 
         dim_props = {
-            "width": width or "100%",
-            "height": height or "100%",
+            "width": width if width is not None else "100%",
+            "height": height if height is not None else "100%",
         }
         # Provide min dimensions so the graph always appears, even if the outer container is zero-size.
         if width is None:


### PR DESCRIPTION
Fixes #4578 
instead of using the following -
```python
dim_props = {
    "width": width or "100%",
    "height": height or "100%",
}
```
changing it to the following works
```python
dim_props = {
    "width": width if width is not None else "100%",
    "height": height if height is not None else "100%",
}
```
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


### Bug fix Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

