### PR TITLE
poetry 2.0.0 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ repository = "https://github.com/reflex-dev/reflex"
 documentation = "https://reflex.dev/docs/getting-started/introduction"
 keywords = ["web", "framework"]
 classifiers = ["Development Status :: 4 - Beta"]
-packages = [{ include = "reflex" }]
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
Remove `packages` key, since this project uses the "default" package layout, so this key isn't needed.