### PR TITLE
[ENG-4351] Add mapping for lucide icons

### DIFF
--- a/reflex/components/lucide/icon.py
+++ b/reflex/components/lucide/icon.py
@@ -56,7 +56,12 @@ class Icon(LucideIconComponent):
                 "\nSee full list at https://lucide.dev/icons."
             )
 
-        props["tag"] = format.to_title_case(format.to_snake_case(props["tag"])) + "Icon"
+        if props["tag"] in LUCIDE_ICON_MAPPING_OVERRIDE:
+            props["tag"] = LUCIDE_ICON_MAPPING_OVERRIDE[props["tag"]]
+        else:
+            props["tag"] = (
+                format.to_title_case(format.to_snake_case(props["tag"])) + "Icon"
+            )
         props["alias"] = f"Lucide{props['tag']}"
         props.setdefault("color", "var(--current-color)")
         return super().create(*children, **props)
@@ -1634,3 +1639,10 @@ LUCIDE_ICON_LIST = [
     "zoom_in",
     "zoom_out",
 ]
+
+# The default transformation of some icon names doesn't match how the
+# icons are exported from Lucide. Manual overrides can go here.
+LUCIDE_ICON_MAPPING_OVERRIDE = {
+    "grid_2x_2_check": "Grid2x2Check",
+    "grid_2x_2_x": "Grid2x2X",
+}

--- a/reflex/components/lucide/icon.pyi
+++ b/reflex/components/lucide/icon.pyi
@@ -1682,3 +1682,7 @@ LUCIDE_ICON_LIST = [
     "zoom_in",
     "zoom_out",
 ]
+LUCIDE_ICON_MAPPING_OVERRIDE = {
+    "grid_2x_2_check": "Grid2x2Check",
+    "grid_2x_2_x": "Grid2x2X",
+}

--- a/tests/units/components/lucide/test_icon.py
+++ b/tests/units/components/lucide/test_icon.py
@@ -1,13 +1,19 @@
 import pytest
 
-from reflex.components.lucide.icon import LUCIDE_ICON_LIST, Icon
+from reflex.components.lucide.icon import (
+    LUCIDE_ICON_LIST,
+    LUCIDE_ICON_MAPPING_OVERRIDE,
+    Icon,
+)
 from reflex.utils import format
 
 
 @pytest.mark.parametrize("tag", LUCIDE_ICON_LIST)
 def test_icon(tag):
     icon = Icon.create(tag)
-    assert icon.alias == f"Lucide{format.to_title_case(tag)}Icon"
+    assert icon.alias == "Lucide" + LUCIDE_ICON_MAPPING_OVERRIDE.get(
+        tag, f"{format.to_title_case(tag)}Icon"
+    )
 
 
 def test_icon_missing_tag():


### PR DESCRIPTION
For icon names that don't auto-translate to the correct lucide tag name, provide manual override.

Fix #4621