### PR TITLE
Remove token check in reflex deploy

### DIFF
--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -503,13 +503,6 @@ def deploy(
     # Set the log level.
     console.set_log_level(loglevel)
 
-    if not token:
-        # make sure user is logged in.
-        if interactive:
-            hosting_cli.login()
-        else:
-            raise SystemExit("Token is required for non-interactive mode.")
-
     # Only check requirements if interactive.
     # There is user interaction for requirements update.
     if interactive:


### PR DESCRIPTION
This logic has been moved upstream to reflex-hosting-cli (via https://github.com/reflex-dev/reflex-hosting-cli/pull/102)

