### PR TITLE
Add support for recursive datatypes checking

### DIFF
--- a/reflex/vars/base.py
+++ b/reflex/vars/base.py
@@ -30,6 +30,7 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    ForwardRef,
     Type,
     TypeVar,
     Union,
@@ -759,6 +760,12 @@ class Var(Generic[VAR_TYPE]):
             return self
 
         fixed_type = get_origin(var_type) or var_type
+
+        if isinstance(fixed_type, ForwardRef):
+            try:
+                fixed_type = fixed_type._evaluate(globals(), locals(), set())
+            except Exception:
+                raise TypeError(f"Could not resolve ForwardRef: {fixed_type}")
 
         if fixed_type in types.UnionTypes:
             inner_types = get_args(var_type)


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

### New Feature Submission:

- [ ] Does your submission pass the tests? 
- [ ] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.

    a. Give a descriptive title to your PR.
    
    b. Describe your changes.
    
    
    I did not added full test because I just wanted to fix it on my local enviroment...
    but i hope it helps 
    
    Recursive datatypes or ForwardRefs are detected as invalid 
    ```
    from typing import Dict, List, Optional, ForwardRef, get_type_hints
    DataType = List[Dict[str, Optional["DataType"]]]
    ```
    example error:
    ```
    web-app_1  |   File "/src/web_app/components/logSettings/tree.py", line 80, in _form_item
    web-app_1  |     rx.text(   data_["title"]    ),
    web-app_1  |                ~~~~~^^^^^^^^^
    web-app_1  |   File "/src/.venv/lib/python3.11/site-packages/reflex/vars/object.py", line 193, in __getitem__
    web-app_1  |     return ObjectItemOperation.create(self, key).guess_type()
    web-app_1  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    web-app_1  |   File "/src/.venv/lib/python3.11/site-packages/reflex/vars/base.py", line 781, in guess_type
    web-app_1  |     raise TypeError(f"Unsupported type {var_type} for guess_type.")
    web-app_1  | TypeError: Unsupported type ForwardRef('DataType') for guess_type.
    ```

    c. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).

