### PR TITLE
Skip saving page components when skipping compile output

### DIFF
--- a/reflex/app.py
+++ b/reflex/app.py
@@ -564,11 +564,12 @@ class App(MiddlewareMixin, LifespanMixin):
             meta=meta,
         )
 
-    def _compile_page(self, route: str):
+    def _compile_page(self, route: str, save_page: bool = True):
         """Compile a page.
 
         Args:
             route: The route of the page to compile.
+            save_page: If True, the compiled page is saved to self.pages.
         """
         component, enable_state = compiler.compile_unevaluated_page(
             route, self.unevaluated_pages[route], self.state, self.style, self.theme
@@ -579,7 +580,8 @@ class App(MiddlewareMixin, LifespanMixin):
 
         # Add the page.
         self._check_routes_conflict(route)
-        self.pages[route] = component
+        if save_page:
+            self.pages[route] = component
 
     def get_load_events(self, route: str) -> list[IndividualEventType[[], Any]]:
         """Get the load events for a route.
@@ -879,14 +881,16 @@ class App(MiddlewareMixin, LifespanMixin):
             # If a theme component was provided, wrap the app with it
             app_wrappers[(20, "Theme")] = self.theme
 
+        should_compile = self._should_compile()
+
         for route in self.unevaluated_pages:
             console.debug(f"Evaluating page: {route}")
-            self._compile_page(route)
+            self._compile_page(route, save_page=should_compile)
 
         # Add the optional endpoints (_upload)
         self._add_optional_endpoints()
 
-        if not self._should_compile():
+        if not should_compile:
             return
 
         self._validate_var_dependencies()


### PR DESCRIPTION
Obviously we still have to evaluate the pages to make sure we know about all states, but not saving them to `App.pages` dict reduces high-line memory usage for backend-only process from ~900Mb to ~530Mb on reflex-web.