### PR TITLE
[ENG-4406] cell component wrapper

### DIFF
--- a/reflex/components/recharts/__init__.py
+++ b/reflex/components/recharts/__init__.py
@@ -70,6 +70,8 @@ _SUBMOD_ATTRS: dict = {
         "Label",
         "label_list",
         "LabelList",
+        "cell",
+        "Cell"
     ],
     "polar": [
         "pie",

--- a/reflex/components/recharts/__init__.py
+++ b/reflex/components/recharts/__init__.py
@@ -71,7 +71,7 @@ _SUBMOD_ATTRS: dict = {
         "label_list",
         "LabelList",
         "cell",
-        "Cell"
+        "Cell",
     ],
     "polar": [
         "pie",

--- a/reflex/components/recharts/__init__.pyi
+++ b/reflex/components/recharts/__init__.pyi
@@ -53,11 +53,13 @@ from .charts import radar_chart as radar_chart
 from .charts import radial_bar_chart as radial_bar_chart
 from .charts import scatter_chart as scatter_chart
 from .charts import treemap as treemap
+from .general import Cell as Cell
 from .general import GraphingTooltip as GraphingTooltip
 from .general import Label as Label
 from .general import LabelList as LabelList
 from .general import Legend as Legend
 from .general import ResponsiveContainer as ResponsiveContainer
+from .general import cell as cell
 from .general import graphing_tooltip as graphing_tooltip
 from .general import label as label
 from .general import label_list as label_list

--- a/reflex/components/recharts/general.py
+++ b/reflex/components/recharts/general.py
@@ -241,9 +241,23 @@ class LabelList(Recharts):
     # The stroke color of each label. Default: "none"
     stroke: Var[Union[str, Color]] = LiteralVar.create("none")
 
+class Cell(Recharts):
+    """A Cell component in Recharts."""
+
+    tag = "Cell"
+
+    alias = "RechartsCell"
+
+    # The presentation attribute of a rectangle in bar or a sector in pie.
+    fill: Var[str]
+
+    # The presentation attribute of a rectangle in bar or a sector in pie.
+    stroke: Var[str]
+
 
 responsive_container = ResponsiveContainer.create
 legend = Legend.create
 graphing_tooltip = GraphingTooltip.create
 label = Label.create
 label_list = LabelList.create
+cell = Cell.create

--- a/reflex/components/recharts/general.py
+++ b/reflex/components/recharts/general.py
@@ -241,6 +241,7 @@ class LabelList(Recharts):
     # The stroke color of each label. Default: "none"
     stroke: Var[Union[str, Color]] = LiteralVar.create("none")
 
+
 class Cell(Recharts):
     """A Cell component in Recharts."""
 

--- a/reflex/components/recharts/general.pyi
+++ b/reflex/components/recharts/general.pyi
@@ -482,8 +482,59 @@ class LabelList(Recharts):
         """
         ...
 
+class Cell(Recharts):
+    @overload
+    @classmethod
+    def create(  # type: ignore
+        cls,
+        *children,
+        fill: Optional[Union[Var[str], str]] = None,
+        stroke: Optional[Union[Var[str], str]] = None,
+        style: Optional[Style] = None,
+        key: Optional[Any] = None,
+        id: Optional[Any] = None,
+        class_name: Optional[Any] = None,
+        autofocus: Optional[bool] = None,
+        custom_attrs: Optional[Dict[str, Union[Var, Any]]] = None,
+        on_blur: Optional[EventType[[], BASE_STATE]] = None,
+        on_click: Optional[EventType[[], BASE_STATE]] = None,
+        on_context_menu: Optional[EventType[[], BASE_STATE]] = None,
+        on_double_click: Optional[EventType[[], BASE_STATE]] = None,
+        on_focus: Optional[EventType[[], BASE_STATE]] = None,
+        on_mount: Optional[EventType[[], BASE_STATE]] = None,
+        on_mouse_down: Optional[EventType[[], BASE_STATE]] = None,
+        on_mouse_enter: Optional[EventType[[], BASE_STATE]] = None,
+        on_mouse_leave: Optional[EventType[[], BASE_STATE]] = None,
+        on_mouse_move: Optional[EventType[[], BASE_STATE]] = None,
+        on_mouse_out: Optional[EventType[[], BASE_STATE]] = None,
+        on_mouse_over: Optional[EventType[[], BASE_STATE]] = None,
+        on_mouse_up: Optional[EventType[[], BASE_STATE]] = None,
+        on_scroll: Optional[EventType[[], BASE_STATE]] = None,
+        on_unmount: Optional[EventType[[], BASE_STATE]] = None,
+        **props,
+    ) -> "Cell":
+        """Create the component.
+
+        Args:
+            *children: The children of the component.
+            fill: The presentation attribute of a rectangle in bar or a sector in pie.
+            stroke: The presentation attribute of a rectangle in bar or a sector in pie.
+            style: The style of the component.
+            key: A unique key for the component.
+            id: The id for the component.
+            class_name: The class name for the component.
+            autofocus: Whether the component should take the focus once the page is loaded
+            custom_attrs: custom attribute
+            **props: The props of the component.
+
+        Returns:
+            The component.
+        """
+        ...
+
 responsive_container = ResponsiveContainer.create
 legend = Legend.create
 graphing_tooltip = GraphingTooltip.create
 label = Label.create
 label_list = LabelList.create
+cell = Cell.create


### PR DESCRIPTION
@Lendemor 

```py
import reflex as rx
from reflex import Var, Color

from reflex.components.recharts.recharts import Recharts


class Cell(Recharts):
    """A Cell component in Recharts."""

    tag = "Cell"

    alias = "RechartsCell"

    # The presentation attribute of a rectangle in bar or a sector in pie.
    fill: Var[str | Color]

    # The presentation attribute of a rectangle in bar or a sector in pie.
    stroke: Var[str]


cell = Cell.create



class State:
    data: list[dict[str, int]] = [
        {"browser": "chrome", "visitors": 275},
        {"browser": "safari", "visitors": 200},
        {"browser": "firefox", "visitors": 187},
        {"browser": "edge", "visitors": 173},
        {"browser": "other", "visitors": 90},
    ]


def piechart_v1():
    return rx.vstack(
        rx.recharts.pie_chart(
            rx.recharts.pie(
                rx.foreach(
                    State.data,
                    lambda item, index: cell(
                        fill=rx.color('red', index + 4)
                    )
                ),
                data=State.data,
                data_key="visitors",
                name_key="browser",
                stroke="0",
                is_animation_active=False,
            ),
            width="100%",
            height=250,
        ),
        width="100%",
        align="center",
        padding="0.5em",
    )


app = rx.App()
app.add_page(piechart_v1(), "/")


```