### PR TITLE
improve rx.Field ObjectVar typing for sqlalchemy and dataclasses

### DIFF
--- a/reflex/vars/base.py
+++ b/reflex/vars/base.py
@@ -3239,11 +3239,6 @@ class Field(Generic[FIELD_TYPE]):
 
     @overload
     def __get__(
-        self: Field[BASE_TYPE], instance: None, owner: Any
-    ) -> ObjectVar[BASE_TYPE]: ...
-
-    @overload
-    def __get__(
         self: Field[SQLA_TYPE], instance: None, owner: Any
     ) -> ObjectVar[SQLA_TYPE]: ...
 

--- a/reflex/vars/base.py
+++ b/reflex/vars/base.py
@@ -40,6 +40,7 @@ from typing import (
     overload,
 )
 
+from sqlalchemy.orm import DeclarativeBase
 from typing_extensions import ParamSpec, TypeGuard, deprecated, get_type_hints, override
 
 from reflex import constants
@@ -3183,6 +3184,12 @@ def dispatch(
 V = TypeVar("V")
 
 BASE_TYPE = TypeVar("BASE_TYPE", bound=Base)
+SQLA_TYPE = TypeVar("SQLA_TYPE", bound=DeclarativeBase)
+
+if TYPE_CHECKING:
+    from _typeshed import DataclassInstance
+
+    DATACLASS_TYPE = TypeVar("DATACLASS_TYPE", bound=DataclassInstance)
 
 FIELD_TYPE = TypeVar("FIELD_TYPE")
 MAPPING_TYPE = TypeVar("MAPPING_TYPE", bound=Mapping)
@@ -3229,6 +3236,23 @@ class Field(Generic[FIELD_TYPE]):
     def __get__(
         self: Field[BASE_TYPE], instance: None, owner: Any
     ) -> ObjectVar[BASE_TYPE]: ...
+
+    @overload
+    def __get__(
+        self: Field[BASE_TYPE], instance: None, owner: Any
+    ) -> ObjectVar[BASE_TYPE]: ...
+
+    @overload
+    def __get__(
+        self: Field[SQLA_TYPE], instance: None, owner: Any
+    ) -> ObjectVar[SQLA_TYPE]: ...
+
+    if TYPE_CHECKING:
+
+        @overload
+        def __get__(
+            self: Field[DATACLASS_TYPE], instance: None, owner: Any
+        ) -> ObjectVar[DATACLASS_TYPE]: ...
 
     @overload
     def __get__(self, instance: None, owner: Any) -> Var[FIELD_TYPE]: ...

--- a/reflex/vars/base.py
+++ b/reflex/vars/base.py
@@ -574,7 +574,7 @@ class Var(Generic[VAR_TYPE]):
 
     @overload
     @classmethod
-    def create(  # type: ignore[override]
+    def create(  # pyright: ignore[reportOverlappingOverload]
         cls,
         value: bool,
         _var_data: VarData | None = None,
@@ -582,7 +582,7 @@ class Var(Generic[VAR_TYPE]):
 
     @overload
     @classmethod
-    def create(  # type: ignore[override]
+    def create(
         cls,
         value: int,
         _var_data: VarData | None = None,
@@ -606,7 +606,7 @@ class Var(Generic[VAR_TYPE]):
 
     @overload
     @classmethod
-    def create(
+    def create(  # pyright: ignore[reportOverlappingOverload]
         cls,
         value: None,
         _var_data: VarData | None = None,
@@ -3183,16 +3183,16 @@ def dispatch(
 
 V = TypeVar("V")
 
-BASE_TYPE = TypeVar("BASE_TYPE", bound=Base)
-SQLA_TYPE = TypeVar("SQLA_TYPE", bound=DeclarativeBase)
+BASE_TYPE = TypeVar("BASE_TYPE", bound=Base | None)
+SQLA_TYPE = TypeVar("SQLA_TYPE", bound=DeclarativeBase | None)
 
 if TYPE_CHECKING:
     from _typeshed import DataclassInstance
 
-    DATACLASS_TYPE = TypeVar("DATACLASS_TYPE", bound=DataclassInstance)
+    DATACLASS_TYPE = TypeVar("DATACLASS_TYPE", bound=DataclassInstance | None)
 
 FIELD_TYPE = TypeVar("FIELD_TYPE")
-MAPPING_TYPE = TypeVar("MAPPING_TYPE", bound=Mapping)
+MAPPING_TYPE = TypeVar("MAPPING_TYPE", bound=Mapping | None)
 
 
 class Field(Generic[FIELD_TYPE]):

--- a/reflex/vars/sequence.py
+++ b/reflex/vars/sequence.py
@@ -21,9 +21,11 @@ from typing import (
     overload,
 )
 
+from sqlalchemy.orm import DeclarativeBase
 from typing_extensions import TypeVar
 
 from reflex import constants
+from reflex.base import Base
 from reflex.constants.base import REFLEX_VAR_OPENING_TAG
 from reflex.constants.colors import Color
 from reflex.utils.exceptions import VarTypeError
@@ -53,7 +55,10 @@ from .number import (
 )
 
 if TYPE_CHECKING:
+    from .base import BASE_TYPE, DATACLASS_TYPE, SQLA_TYPE, ObjectVar
+    from .function import FunctionVar
     from .object import ObjectVar
+
 
 STRING_TYPE = TypeVar("STRING_TYPE", default=str)
 
@@ -962,6 +967,24 @@ class ArrayVar(Var[ARRAY_VAR_TYPE], python_types=(list, tuple, set)):
     ) -> ObjectVar[Dict[KEY_TYPE, VALUE_TYPE]]: ...
 
     @overload
+    def __getitem__(
+        self: ARRAY_VAR_OF_LIST_ELEMENT[BASE_TYPE],
+        i: int | NumberVar,
+    ) -> ObjectVar[BASE_TYPE]: ...
+
+    @overload
+    def __getitem__(
+        self: ARRAY_VAR_OF_LIST_ELEMENT[SQLA_TYPE],
+        i: int | NumberVar,
+    ) -> ObjectVar[SQLA_TYPE]: ...
+
+    @overload
+    def __getitem__(
+        self: ARRAY_VAR_OF_LIST_ELEMENT[DATACLASS_TYPE],
+        i: int | NumberVar,
+    ) -> ObjectVar[DATACLASS_TYPE]: ...
+
+    @overload
     def __getitem__(self, i: int | NumberVar) -> Var: ...
 
     def __getitem__(self, i: Any) -> ArrayVar[ARRAY_VAR_TYPE] | Var:
@@ -1646,10 +1669,6 @@ def repeat_array_operation(
         js_expression=f"Array.from({{ length: {count} }}).flatMap(() => {array})",
         var_type=array._var_type,
     )
-
-
-if TYPE_CHECKING:
-    from .function import FunctionVar
 
 
 @var_operation

--- a/reflex/vars/sequence.py
+++ b/reflex/vars/sequence.py
@@ -21,11 +21,9 @@ from typing import (
     overload,
 )
 
-from sqlalchemy.orm import DeclarativeBase
 from typing_extensions import TypeVar
 
 from reflex import constants
-from reflex.base import Base
 from reflex.constants.base import REFLEX_VAR_OPENING_TAG
 from reflex.constants.colors import Color
 from reflex.utils.exceptions import VarTypeError

--- a/reflex/vars/sequence.py
+++ b/reflex/vars/sequence.py
@@ -53,7 +53,7 @@ from .number import (
 )
 
 if TYPE_CHECKING:
-    from .base import BASE_TYPE, DATACLASS_TYPE, SQLA_TYPE, ObjectVar
+    from .base import BASE_TYPE, DATACLASS_TYPE, SQLA_TYPE
     from .function import FunctionVar
     from .object import ObjectVar
 

--- a/tests/units/vars/test_object.py
+++ b/tests/units/vars/test_object.py
@@ -8,6 +8,7 @@ import reflex as rx
 from reflex.utils.types import GenericType
 from reflex.vars.base import Var
 from reflex.vars.object import LiteralObjectVar, ObjectVar
+from reflex.vars.sequence import ArrayVar
 
 
 class Bare:
@@ -64,6 +65,8 @@ class ObjectState(rx.State):
     base: rx.Field[Base] = rx.field(Base())
     sqlamodel: rx.Field[SqlaModel] = rx.field(SqlaModel())
     dataclass: rx.Field[Dataclass] = rx.field(Dataclass())
+
+    base_list: rx.Field[list[Base]] = rx.field([Base()])
 
 
 @pytest.mark.parametrize("type_", [Base, Bare, SqlaModel, Dataclass])
@@ -127,11 +130,23 @@ def test_typing() -> None:
     # Base
     var = ObjectState.base
     _ = assert_type(var, ObjectVar[Base])
+    list_var = ObjectState.base_list
+    _ = assert_type(list_var, ArrayVar[list[Base]])
+    list_var_0 = list_var[0]
+    _ = assert_type(list_var_0, ObjectVar[Base])
 
     # Sqla
     var = ObjectState.sqlamodel
     _ = assert_type(var, ObjectVar[SqlaModel])
+    list_var = ObjectState.base_list
+    _ = assert_type(list_var, ArrayVar[list[Base]])
+    list_var_0 = list_var[0]
+    _ = assert_type(list_var_0, ObjectVar[Base])
 
     # Dataclass
     var = ObjectState.dataclass
     _ = assert_type(var, ObjectVar[Dataclass])
+    list_var = ObjectState.base_list
+    _ = assert_type(list_var, ArrayVar[list[Base]])
+    list_var_0 = list_var[0]
+    _ = assert_type(list_var_0, ObjectVar[Base])

--- a/tests/units/vars/test_object.py
+++ b/tests/units/vars/test_object.py
@@ -1,4 +1,7 @@
+import dataclasses
+
 import pytest
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 from typing_extensions import assert_type
 
 import reflex as rx
@@ -32,11 +35,32 @@ class Base(rx.Base):
     quantity: int = 0
 
 
+class SqlaBase(DeclarativeBase):
+    """Sqlalchemy declarative mapping base class."""
+
+    pass
+
+
+class SqlaModel(SqlaBase):
+    """A sqlalchemy model with a single attribute."""
+
+    quantity: Mapped[int] = mapped_column()
+
+
+@dataclasses.dataclass
+class Dataclass:
+    """A dataclass with a single attribute."""
+
+    quantity: int = 0
+
+
 class ObjectState(rx.State):
-    """A reflex state with bare and base objects."""
+    """A reflex state with bare, base and sqlalchemy base vars."""
 
     bare: rx.Field[Bare] = rx.field(Bare())
     base: rx.Field[Base] = rx.field(Base())
+    sqla: rx.Field[SqlaModel] = rx.field(SqlaModel())
+    dataclass: rx.Field[Dataclass] = rx.field(Dataclass())
 
 
 @pytest.mark.parametrize("type_", [Base, Bare])
@@ -100,3 +124,11 @@ def test_typing() -> None:
     # Base
     var = ObjectState.base
     _ = assert_type(var, ObjectVar[Base])
+
+    # Sqla
+    var = ObjectState.sqla
+    _ = assert_type(var, ObjectVar[SqlaModel])
+
+    # Dataclass
+    var = ObjectState.dataclass
+    _ = assert_type(var, ObjectVar[Dataclass])

--- a/tests/units/vars/test_object.py
+++ b/tests/units/vars/test_object.py
@@ -62,9 +62,13 @@ class ObjectState(rx.State):
     """A reflex state with bare, base and sqlalchemy base vars."""
 
     bare: rx.Field[Bare] = rx.field(Bare())
+    bare_optional: rx.Field[Bare | None] = rx.field(None)
     base: rx.Field[Base] = rx.field(Base())
+    base_optional: rx.Field[Base | None] = rx.field(None)
     sqlamodel: rx.Field[SqlaModel] = rx.field(SqlaModel())
+    sqlamodel_optional: rx.Field[SqlaModel | None] = rx.field(None)
     dataclass: rx.Field[Dataclass] = rx.field(Dataclass())
+    dataclass_optional: rx.Field[Dataclass | None] = rx.field(None)
 
     base_list: rx.Field[list[Base]] = rx.field([Base()])
 
@@ -130,6 +134,8 @@ def test_typing() -> None:
     # Base
     var = ObjectState.base
     _ = assert_type(var, ObjectVar[Base])
+    optional_var = ObjectState.base_optional
+    _ = assert_type(optional_var, ObjectVar[Base | None])
     list_var = ObjectState.base_list
     _ = assert_type(list_var, ArrayVar[list[Base]])
     list_var_0 = list_var[0]
@@ -138,6 +144,8 @@ def test_typing() -> None:
     # Sqla
     var = ObjectState.sqlamodel
     _ = assert_type(var, ObjectVar[SqlaModel])
+    optional_var = ObjectState.sqlamodel_optional
+    _ = assert_type(optional_var, ObjectVar[SqlaModel | None])
     list_var = ObjectState.base_list
     _ = assert_type(list_var, ArrayVar[list[Base]])
     list_var_0 = list_var[0]
@@ -146,6 +154,8 @@ def test_typing() -> None:
     # Dataclass
     var = ObjectState.dataclass
     _ = assert_type(var, ObjectVar[Dataclass])
+    optional_var = ObjectState.dataclass_optional
+    _ = assert_type(optional_var, ObjectVar[Dataclass | None])
     list_var = ObjectState.base_list
     _ = assert_type(list_var, ArrayVar[list[Base]])
     list_var_0 = list_var[0]


### PR DESCRIPTION
- improve rx.Field ObjectVar typing for sqlalchemy and dataclasses
- allow optional values in `rx.Field` annotations to resolve to the correct var type
- Also fixes typing for ObjectVars in ArrayVars