### PR TITLE
fix: allow replacing of _var_type in ComputedVar

### DIFF
--- a/reflex/vars/base.py
+++ b/reflex/vars/base.py
@@ -2088,14 +2088,12 @@ class ComputedVar(Var[RETURN_TYPE]):
     @override
     def _replace(
         self,
-        _var_type: Any = None,
         merge_var_data: VarData | None = None,
         **kwargs: Any,
     ) -> Self:
         """Replace the attributes of the ComputedVar.
 
         Args:
-            _var_type: ignored in ComputedVar.
             merge_var_data: VarData to merge into the existing VarData.
             **kwargs: Var fields to update.
 

--- a/tests/units/vars/test_base.py
+++ b/tests/units/vars/test_base.py
@@ -2,7 +2,8 @@ from typing import List, Mapping, Union
 
 import pytest
 
-from reflex.vars.base import figure_out_type
+from reflex.state import State
+from reflex.vars.base import computed_var, figure_out_type
 
 
 class CustomDict(dict[str, str]):
@@ -47,3 +48,16 @@ class ChildGenericDict(GenericDict):
 )
 def test_figure_out_type(value, expected):
     assert figure_out_type(value) == expected
+
+
+def test_computed_var_replace() -> None:
+    class StateTest(State):
+        @computed_var(cache=True)
+        def cv(self) -> int:
+            return 1
+
+    cv = StateTest.cv
+    assert cv._var_type is int
+
+    replaced = cv._replace(_var_type=float)
+    assert replaced._var_type is float


### PR DESCRIPTION
used to work in previous reflex versions