### PR TITLE
make computed var generic over mapping

### DIFF
--- a/reflex/vars/base.py
+++ b/reflex/vars/base.py
@@ -2219,10 +2219,10 @@ class ComputedVar(Var[RETURN_TYPE]):
 
     @overload
     def __get__(
-        self: ComputedVar[Mapping[DICT_KEY, DICT_VAL]],
+        self: ComputedVar[MAPPING_TYPE],
         instance: None,
         owner: Type,
-    ) -> ObjectVar[Mapping[DICT_KEY, DICT_VAL]]: ...
+    ) -> ObjectVar[MAPPING_TYPE]: ...
 
     @overload
     def __get__(
@@ -2465,10 +2465,10 @@ class AsyncComputedVar(ComputedVar[RETURN_TYPE]):
 
     @overload
     def __get__(
-        self: AsyncComputedVar[Mapping[DICT_KEY, DICT_VAL]],
+        self: AsyncComputedVar[MAPPING_TYPE],
         instance: None,
         owner: Type,
-    ) -> ObjectVar[Mapping[DICT_KEY, DICT_VAL]]: ...
+    ) -> ObjectVar[MAPPING_TYPE]: ...
 
     @overload
     def __get__(


### PR DESCRIPTION
```py
import reflex as rx


class State(rx.State):
    @rx.var
    def foo(self) -> int:
        return 42

    @rx.var(cache=True)
    def bar(self) -> dict:
        return {"foo": 42}


def fancy_number(n: rx.vars.NumberVar) -> rx.Component:
    return rx.text(n)


def fancy_object(o: rx.vars.ObjectVar) -> rx.Component:
    return rx.text(o.to_string())


def index() -> rx.Component:
    return rx.fragment(
        fancy_number(State.foo),
        fancy_object(State.bar),
    )


app = rx.App()
app.add_page(index)
```