### PR TITLE
Add toast.loading from the sonner package

### DIFF
--- a/reflex/components/sonner/toast.py
+++ b/reflex/components/sonner/toast.py
@@ -328,6 +328,19 @@ class Toaster(Component):
         return Toaster.send_toast(message, level="success", **kwargs)
 
     @staticmethod
+    def toast_loading(message: str | Var = "", **kwargs: Any):
+        """Display a loading toast message.
+
+        Args:
+            message: The message to display.
+            **kwargs: Additional toast props.
+
+        Returns:
+            The toast event.
+        """
+        return Toaster.send_toast(message, level="loading", **kwargs)
+
+    @staticmethod
     def toast_dismiss(id: Var | str | None = None):
         """Dismiss a toast.
 
@@ -378,6 +391,7 @@ class ToastNamespace(ComponentNamespace):
     warning = staticmethod(Toaster.toast_warning)
     error = staticmethod(Toaster.toast_error)
     success = staticmethod(Toaster.toast_success)
+    loading = staticmethod(Toaster.toast_loading)
     dismiss = staticmethod(Toaster.toast_dismiss)
     __call__ = staticmethod(Toaster.send_toast)
 

--- a/reflex/components/sonner/toast.pyi
+++ b/reflex/components/sonner/toast.pyi
@@ -70,6 +70,8 @@ class Toaster(Component):
     @staticmethod
     def toast_success(message: str | Var = "", **kwargs: Any): ...
     @staticmethod
+    def toast_loading(message: str | Var = "", **kwargs: Any): ...
+    @staticmethod
     def toast_dismiss(id: Var | str | None = None): ...
     @overload
     @classmethod
@@ -172,6 +174,7 @@ class ToastNamespace(ComponentNamespace):
     warning = staticmethod(Toaster.toast_warning)
     error = staticmethod(Toaster.toast_error)
     success = staticmethod(Toaster.toast_success)
+    loading = staticmethod(Toaster.toast_loading)
     dismiss = staticmethod(Toaster.toast_dismiss)
 
     @staticmethod


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls ) for the desired changed?

### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

### New Feature Submission:

- [x] Does your submission pass the tests? 
- [x] Have you linted your code locally prior to submission?

### Description
I added the ability to call `rx.toast.loading` as a toast function. Everything was already wired up, the function just had to be made.
