### PR TITLE
Allow any user to set `show_built_with_reflex=False` in any mode

### DIFF
--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -23,8 +23,6 @@ typer.core.rich = None  # pyright: ignore [reportPrivateImportUsage]
 cli = typer.Typer(add_completion=False, pretty_exceptions_enable=False)
 
 
-SHOW_BUILT_WITH_REFLEX_INFO = "https://reflex.dev/docs/hosting/reflex-branding/"
-
 # Get the config.
 config = get_config()
 
@@ -193,15 +191,6 @@ def _run(
     prerequisites.check_latest_package_version(constants.Reflex.MODULE_NAME)
 
     if frontend:
-        if not config.show_built_with_reflex:
-            # The sticky badge may be disabled at runtime for team/enterprise tiers.
-            prerequisites.check_config_option_in_tier(
-                option_name="show_built_with_reflex",
-                allowed_tiers=["team", "enterprise"],
-                fallback_value=True,
-                help_link=SHOW_BUILT_WITH_REFLEX_INFO,
-            )
-
         # Get the app module.
         prerequisites.get_compiled_app()
 
@@ -353,15 +342,6 @@ def export(
 
     if prerequisites.needs_reinit(frontend=frontend or not backend):
         _init(name=config.app_name, loglevel=loglevel)
-
-    if frontend and not config.show_built_with_reflex:
-        # The sticky badge may be disabled on export for team/enterprise tiers.
-        prerequisites.check_config_option_in_tier(
-            option_name="show_built_with_reflex",
-            allowed_tiers=["team", "enterprise"],
-            fallback_value=False,
-            help_link=SHOW_BUILT_WITH_REFLEX_INFO,
-        )
 
     export_utils.export(
         zipping=zipping,
@@ -556,15 +536,6 @@ def deploy(
     from reflex.utils import prerequisites
 
     check_version()
-
-    if not config.show_built_with_reflex:
-        # The sticky badge may be disabled on deploy for pro/team/enterprise tiers.
-        prerequisites.check_config_option_in_tier(
-            option_name="show_built_with_reflex",
-            allowed_tiers=["pro", "team", "enterprise"],
-            fallback_value=True,
-            help_link=SHOW_BUILT_WITH_REFLEX_INFO,
-        )
 
     # Set the log level.
     console.set_log_level(loglevel)


### PR DESCRIPTION
Based on discussion with users and contributors, the team has decided not to restrict the `show_built_with_reflex` config option to paid subscribers.

By default, apps will show the branding when exported, but setting the config knob to false is sufficient for removing the badge from the exported app without logging in or subscribing.