### PR TITLE
add support for .f format

### DIFF
--- a/reflex/vars/number.py
+++ b/reflex/vars/number.py
@@ -542,6 +542,9 @@ class NumberVar(Var[NUMBER_T], python_types=(int, float)):
 
         Returns:
             The formatted number.
+
+        Raises:
+            VarValueError: If the format specifier is not supported.
         """
         if (
             format_spec


### PR DESCRIPTION
closes #2148

```py
from math import pi
import reflex as rx

app = rx.App()


class State(rx.State):
    field: float = pi


@app.add_page
def index():
    return rx.text(f"What {State.field:.2}")
```