### PR TITLE
Override `react-is@19.0.0` for recharts compatibility

### DIFF
--- a/reflex/.templates/jinja/web/package.json.jinja2
+++ b/reflex/.templates/jinja/web/package.json.jinja2
@@ -15,7 +15,13 @@
   "devDependencies": {
     {% for package, version in dev_dependencies.items() %}
     "{{ package }}": "{{ version }}"{% if not loop.last %},{% endif %}
-    
+
+    {% endfor %}
+  },
+  "overrides": {
+    {% for package, version in overrides.items() %}
+    "{{ package }}": "{{ version }}"{% if not loop.last %},{% endif %}
+
     {% endfor %}
   }
 }

--- a/reflex/constants/installer.py
+++ b/reflex/constants/installer.py
@@ -195,3 +195,7 @@ class PackageJson(SimpleNamespace):
         "postcss": "8.5.1",
         "postcss-import": "16.1.0",
     }
+    OVERRIDES = {
+        # This should always match the `react` version in DEPENDENCIES for recharts compatibility.
+        "react-is": "19.0.0"
+    }

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -846,6 +846,7 @@ def _compile_package_json():
         },
         dependencies=constants.PackageJson.DEPENDENCIES,
         dev_dependencies=constants.PackageJson.DEV_DEPENDENCIES,
+        overrides=constants.PackageJson.OVERRIDES,
     )
 
 


### PR DESCRIPTION
See https://github.com/recharts/recharts/issues/4558 for details.