### PR TITLE
[ENG-4776] Write stateful pages marker earlier when should_compile is False

### DIFF
--- a/reflex/app.py
+++ b/reflex/app.py
@@ -1103,6 +1103,9 @@ class App(MiddlewareMixin, LifespanMixin):
                     console.debug(f"Evaluating page: {route}")
                     self._compile_page(route, save_page=should_compile)
 
+            # Save the pages which created new states at eval time.
+            self._write_stateful_pages_marker()
+
             # Add the optional endpoints (_upload)
             self._add_optional_endpoints()
 
@@ -1145,6 +1148,8 @@ class App(MiddlewareMixin, LifespanMixin):
                     )[:10]
                 )
             )
+            # Save the pages which created new states at eval time.
+            self._write_stateful_pages_marker()
 
         # Add the optional endpoints (_upload)
         self._add_optional_endpoints()
@@ -1366,7 +1371,8 @@ class App(MiddlewareMixin, LifespanMixin):
             for output_path, code in compile_results:
                 compiler_utils.write_page(output_path, code)
 
-        # Write list of routes that create dynamic states for backend to use.
+    def _write_stateful_pages_marker(self):
+        """Write list of routes that create dynamic states for the backend to use later."""
         if self._state is not None:
             stateful_pages_marker = (
                 prerequisites.get_backend_dir() / constants.Dirs.STATEFUL_PAGES


### PR DESCRIPTION
Fix issue where the presence of `.web/backend` without `.web/backend/stateful_pages.json` was breaking detection statefulness.