### PR TITLE
reduce badge perf impact on pages

### DIFF
--- a/reflex/app.py
+++ b/reflex/app.py
@@ -986,12 +986,15 @@ class App(MiddlewareMixin, LifespanMixin):
 
     def _setup_sticky_badge(self):
         """Add the sticky badge to the app."""
-        for k, component in self._pages.items():
-            # Would be nice to share single sticky_badge across all pages, but
-            # it bungles the StatefulComponent compile step.
+        from reflex.components.component import memo
+
+        @memo
+        def memoized_badge():
             sticky_badge = sticky()
             sticky_badge._add_style_recursive({})
-            self._pages[k] = Fragment.create(sticky_badge, component)
+            return sticky_badge
+
+        self.app_wraps[(0, "StickyBadge")] = lambda _: memoized_badge()
 
     def _apply_decorated_pages(self):
         """Add @rx.page decorated pages to the app.
@@ -1161,7 +1164,8 @@ class App(MiddlewareMixin, LifespanMixin):
             else:
                 config.show_built_with_reflex = True
 
-        if is_prod_mode() and config.show_built_with_reflex:
+        # if is_prod_mode() and
+        if config.show_built_with_reflex:
             self._setup_sticky_badge()
 
         progress.advance(task)


### PR DESCRIPTION
The sticky badge showing Built with Reflex is now added as an app_wrap instead of injected in each page, reducing the impact on compilation length.