### PR TITLE
Allow nested responsive container

### DIFF
--- a/reflex/components/recharts/general.py
+++ b/reflex/components/recharts/general.py
@@ -56,6 +56,7 @@ class ResponsiveContainer(Recharts, MemoizationLeaf):
         "PieChart",
         "RadarChart",
         "RadialBarChart",
+        "ResponsiveContainer",
         "ScatterChart",
         "Treemap",
         "ComposedChart",


### PR DESCRIPTION
outer container will take precedence this is the expected behavior as this is the one if wrapper the user will pass

below code used to error 
```python
x.recharts.responsive_container(
                    rx.recharts.pie_chart(
                        rx.recharts.pie(
                            rx.foreach(
                                DashboardState.ticket_priorities,
                                lambda item: rx.recharts.cell(
                                    value=item["count"],
                                    name=item["priority"],
                                    fill=item["color"]
                                )
                            ),
                            data_key="count",
                            name_key="priority",
                            cx="50%",
                            cy="50%",
                            inner_radius="50%",
                            outer_radius="70%"
                        ),
                        rx.recharts.graphing_tooltip(
                            cursor=False,
                            is_animation_active=False,
                        ),
                        rx.recharts.legend(
                            layout="horizontal",
                            align="center",
                            vertical_align="bottom"
                        ),
                        data=DashboardState.ticket_priorities,
                    ),
                    width="100%",
                    height=250,
                    margin={
                        "top": 20,
                        "right": 20,
                        "left": 20,
                        "bottom": 20
                    }
                )

```