### PR TITLE
Prepend hydrate event when connecting

### DIFF
--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -352,10 +352,17 @@ export const applyRestEvent = async (event, socket) => {
  * Queue events to be processed and trigger processing of queue.
  * @param events Array of events to queue.
  * @param socket The socket object to send the event on.
+ * @param prepend Whether to place the events at the beginning of the queue.
  */
-export const queueEvents = async (events, socket) => {
+export const queueEvents = async (events, socket, prepend) => {
+  if (prepend) {
+    // Drain the existing queue and place it after the given events.
+    events = [...events, ...Array.from({length: event_queue.length}).map(() => event_queue.pop())];
+  }
   event_queue.push(...events);
-  await processEvent(socket.current);
+  if (socket.current) {
+    await processEvent(socket.current);
+  }
 };
 
 /**
@@ -477,7 +484,7 @@ export const connect = async (
   });
   socket.current.on("reload", async (event) => {
     event_processing = false;
-    queueEvents([...initialEvents(), event], socket);
+    queueEvents([...initialEvents(), event], socket, true);
   });
 
   document.addEventListener("visibilitychange", checkVisibility);
@@ -773,9 +780,8 @@ export const useEventLoop = (
   const sentHydrate = useRef(false); // Avoid double-hydrate due to React strict-mode
   useEffect(() => {
     if (router.isReady && !sentHydrate.current) {
-      const events = initial_events();
-      addEvents(
-        events.map((e) => ({
+      queueEvents(
+        initial_events().map((e) => ({
           ...e,
           router_data: (({ pathname, query, asPath }) => ({
             pathname,
@@ -783,6 +789,8 @@ export const useEventLoop = (
             asPath,
           }))(router),
         })),
+        socket,
+        true,
       );
       sentHydrate.current = true;
     }

--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -360,9 +360,7 @@ export const queueEvents = async (events, socket, prepend) => {
     events = [...events, ...Array.from({length: event_queue.length}).map(() => event_queue.shift())];
   }
   event_queue.push(...events);
-  if (socket.current) {
-    await processEvent(socket.current);
-  }
+  await processEvent(socket.current);
 };
 
 /**

--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -357,7 +357,7 @@ export const applyRestEvent = async (event, socket) => {
 export const queueEvents = async (events, socket, prepend) => {
   if (prepend) {
     // Drain the existing queue and place it after the given events.
-    events = [...events, ...Array.from({length: event_queue.length}).map(() => event_queue.pop())];
+    events = [...events, ...Array.from({length: event_queue.length}).map(() => event_queue.shift())];
   }
   event_queue.push(...events);
   if (socket.current) {


### PR DESCRIPTION
Avoid backend on_mount events triggering a `reload` message, which ends up requeuing hydrate event.

```
import reflex as rx


class State(rx.State):
    def fooooooo(self):
        print("Foooo!")

    def on_load(self):
        print("on_load scrode")


def index() -> rx.Component:
    return rx.box("Hola Mundo", on_mount=[State.fooooooo, State.fooooooo, State.fooooooo])


app = rx.App()
app.add_page(index, on_load=State.on_load)
```

Before the fix, this code triggers on_load four times 🫨 