### PR TITLE
add overload for typeddict mapping since their value type is any

### DIFF
--- a/reflex/vars/object.py
+++ b/reflex/vars/object.py
@@ -202,6 +202,12 @@ class ObjectVar(Var[OBJECT_TYPE], python_types=Mapping):
         key: Var | Any,
     ) -> ObjectVar[Mapping[OTHER_KEY_TYPE, VALUE_TYPE]]: ...
 
+    @overload
+    def __getitem__(
+        self: ObjectVar[Mapping[Any, VALUE_TYPE]],
+        key: Var | Any,
+    ) -> Var[VALUE_TYPE]: ...
+
     def __getitem__(self, key: Var | Any) -> Var:
         """Get an item from the object.
 


### PR DESCRIPTION
closes #4948
happens because https://github.com/microsoft/pyright/issues/9903 because https://peps.python.org/pep-0728/ is still a draft