### PR TITLE
do not fallback to key name and print tracebacks properly in compile

### DIFF
--- a/reflex/base.py
+++ b/reflex/base.py
@@ -128,5 +128,5 @@ class Base(BaseModel):
         if isinstance(key, str):
             # Seems like this function signature was wrong all along?
             # If the user wants a field that we know of, get it and pass it off to _get_value
-            return getattr(self, key, key)
+            return getattr(self, key)
         return key

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -8,6 +8,7 @@ import functools
 import importlib
 import importlib.metadata
 import importlib.util
+import io
 import json
 import os
 import platform
@@ -447,6 +448,76 @@ def compile_app(reload: bool = False, export: bool = False) -> None:
         export: Compile the app for export
     """
     get_compiled_app(reload=reload, export=export)
+
+
+def _can_colorize() -> bool:
+    """Check if the output can be colorized.
+
+    Copied from _colorize.can_colorize.
+
+    https://raw.githubusercontent.com/python/cpython/refs/heads/main/Lib/_colorize.py
+
+    Returns:
+        If the output can be colorized
+    """
+    file = sys.stdout
+
+    if not sys.flags.ignore_environment:
+        if os.environ.get("PYTHON_COLORS") == "0":
+            return False
+        if os.environ.get("PYTHON_COLORS") == "1":
+            return True
+    if os.environ.get("NO_COLOR"):
+        return False
+    if os.environ.get("FORCE_COLOR"):
+        return True
+    if os.environ.get("TERM") == "dumb":
+        return False
+
+    if not hasattr(file, "fileno"):
+        return False
+
+    if sys.platform == "win32":
+        try:
+            import nt
+
+            if not nt._supports_virtual_terminal():
+                return False
+        except (ImportError, AttributeError):
+            return False
+
+    try:
+        return os.isatty(file.fileno())
+    except io.UnsupportedOperation:
+        return file.isatty()
+
+
+def compile_or_validate_app(compile: bool = False) -> bool:
+    """Compile or validate the app module based on the default config.
+
+    Args:
+        compile: Whether to compile the app.
+
+    Returns:
+        If the app is compiled successfully.
+    """
+    try:
+        if compile:
+            compile_app()
+        else:
+            validate_app()
+    except Exception as e:
+        import traceback
+
+        sys_exception = sys.exception()
+
+        try:
+            colorize = _can_colorize()
+            traceback.print_exception(e, colorize=colorize)  # pyright: ignore[reportCallIssue]
+        except Exception:
+            traceback.print_exception(sys_exception)
+        return False
+    return True
 
 
 def get_redis() -> Redis | None:


### PR DESCRIPTION
this errors fine (aside from mysterious traceback because we're running in a different process, that's also fixed in this pr):
```py
import reflex as rx


class State(rx.State):
    @rx.var
    def color_mode(self) -> str:
        return 1 / 0


def index() -> rx.Component:
    return rx.text(State.color_mode)


app = rx.App()
app.add_page(index)
```

this doesn't
```py
import reflex as rx


class State(rx.State):
    @rx.var
    def color_mode(self) -> str:
        return rx.wiojiaosdjsa


def index() -> rx.Component:
    return rx.text(State.color_mode)


app = rx.App()
app.add_page(index)
```

we're doing somewhere: `return getattr(self, key, key)`, which catches all `AttributeError`s, even ones that are deeper within the stack