### PR TITLE
allow event handlers to be turned into vars

### DIFF
--- a/reflex/event.py
+++ b/reflex/event.py
@@ -1607,7 +1607,7 @@ def get_fn_signature(fn: Callable) -> inspect.Signature:
     return signature.replace(parameters=(new_param, *signature.parameters.values()))
 
 
-class EventVar(ObjectVar, python_types=EventSpec):
+class EventVar(ObjectVar, python_types=(EventSpec, EventHandler)):
     """Base class for event vars."""
 
 
@@ -1632,7 +1632,7 @@ class LiteralEventVar(VarOperationCall, LiteralVar, EventVar):
     @classmethod
     def create(
         cls,
-        value: EventSpec,
+        value: EventSpec | EventHandler,
         _var_data: VarData | None = None,
     ) -> LiteralEventVar:
         """Create a new LiteralEventVar instance.
@@ -1644,6 +1644,18 @@ class LiteralEventVar(VarOperationCall, LiteralVar, EventVar):
         Returns:
             The created LiteralEventVar instance.
         """
+        if isinstance(value, EventHandler):
+
+            def no_args():
+                return ()
+
+            try:
+                value = call_event_handler(value, no_args)
+            except EventFnArgMismatchError:
+                raise ValueError(
+                    f"Event handler {value.fn.__qualname__} used inside of a rx.cond() must not take any arguments."
+                ) from None
+
         return cls(
             _js_expr="",
             _var_type=EventSpec,

--- a/reflex/event.py
+++ b/reflex/event.py
@@ -1643,6 +1643,9 @@ class LiteralEventVar(VarOperationCall, LiteralVar, EventVar):
 
         Returns:
             The created LiteralEventVar instance.
+
+        Raises:
+            EventFnArgMismatchError: If the event handler takes arguments.
         """
         if isinstance(value, EventHandler):
 
@@ -1652,7 +1655,7 @@ class LiteralEventVar(VarOperationCall, LiteralVar, EventVar):
             try:
                 value = call_event_handler(value, no_args)
             except EventFnArgMismatchError:
-                raise ValueError(
+                raise EventFnArgMismatchError(
                     f"Event handler {value.fn.__qualname__} used inside of a rx.cond() must not take any arguments."
                 ) from None
 

--- a/tests/units/test_event.py
+++ b/tests/units/test_event.py
@@ -431,8 +431,12 @@ def test_event_var_data():
         def s(self, value: int):
             pass
 
+        @event
+        def s2(self):
+            pass
+
     # Handler doesn't have any _var_data because it's just a str
-    handler_var = Var.create(S.s)
+    handler_var = Var.create(S.s2)
     assert handler_var._get_all_var_data() is None
 
     # Ensure spec carries _var_data


### PR DESCRIPTION
```py
import reflex as rx


class SnakeState(rx.State):
    game_over = False

    @rx.event
    def start_game(self):
        self.game_over = False

    @rx.event
    def pause_game(self):
        self.game_over = True


def index():
    return rx.el.button(
        rx.cond(
            SnakeState.game_over,
            "Start Game",
            "Pause Game",
        ),
        on_change=rx.cond(
            SnakeState.game_over, SnakeState.start_game, SnakeState.pause_game
        ),
    )


app = rx.App()

app.add_page(index, route="/")
```