### PR TITLE
retain traceback of foreach untyped var error

### DIFF
--- a/reflex/components/core/foreach.py
+++ b/reflex/components/core/foreach.py
@@ -107,7 +107,7 @@ class Foreach(Component):
                 iterable,
                 "foreach",
                 "https://reflex.dev/docs/library/dynamic-rendering/foreach/",
-            ) from e
+            ).with_traceback(e.__traceback__) from None
         return component
 
     def _render(self) -> IterTag:


### PR DESCRIPTION
try with
```py
from typing import TypedDict
import reflex as rx

app = rx.App()


class MessageLine(TypedDict):
    index: int
    content: str


class Message(TypedDict):
    lines: list


class State(rx.State):
    messages: list[Message] = [
        {
            "lines": [
                {"index": 0, "content": "Hello"},
                {"index": 1, "content": "World"},
            ],
        }
    ]


def index():
    return rx.foreach(
        State.messages,
        lambda message: rx.vstack(
            rx.foreach(
                message["lines"],
                lambda line: rx.el.div(
                    f"{line['index']}: {line['content']}",
                    style={"color": "red"},
                ),
            )
        ),
    )


app.add_page(index, route="/")
```