### PR TITLE
Add value and default_value to rx.el.select

### DIFF
--- a/pyi_hashes.json
+++ b/pyi_hashes.json
@@ -29,7 +29,7 @@
   "reflex/components/el/element.pyi": "06ac2213b062119323291fa66a1ac19e",
   "reflex/components/el/elements/__init__.pyi": "280ed457675f3720e34b560a3f617739",
   "reflex/components/el/elements/base.pyi": "6e533348b5e1a88cf62fbb5a38dbd795",
-  "reflex/components/el/elements/forms.pyi": "dca85624142e170709dbecdbffdff4ee",
+  "reflex/components/el/elements/forms.pyi": "e05f3ed762ea47f37f32550f8b9105e5",
   "reflex/components/el/elements/inline.pyi": "33d9d860e75dd8c4769825127ed363bb",
   "reflex/components/el/elements/media.pyi": "addd6872281d65d44a484358b895432f",
   "reflex/components/el/elements/metadata.pyi": "974a86d9f0662f6fc15a5bb4b3a87862",

--- a/reflex/components/el/elements/forms.py
+++ b/reflex/components/el/elements/forms.py
@@ -572,6 +572,12 @@ class Select(BaseHTML):
     # Fired when the select value changes
     on_change: EventHandler[input_event]
 
+    # The controlled value of the select, read only unless used with on_change
+    value: Var[str]
+
+    # The default value of the select when initially rendered
+    default_value: Var[str]
+
 
 AUTO_HEIGHT_JS = """
 const autoHeightOnInput = (e, is_enabled) => {


### PR DESCRIPTION
correcting an apparent miss from way back

(opening PR without `pyi_hashes.json` change to see if it catches the diff)