### PR TITLE
`State.get_var_value` should never return a Var

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1564,7 +1564,9 @@ class BaseState(Base, ABC, extra=pydantic.Extra.allow):
         unset = object()
 
         # Fast case: this is a literal var and the value is known.
-        if (var_value := getattr(var, "_var_value", unset)) is not unset:
+        if (
+            var_value := getattr(var, "_var_value", unset)
+        ) is not unset and not isinstance(var_value, Var):
             return var_value  # pyright: ignore [reportReturnType]
 
         var_data = var._get_all_var_data()

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -111,7 +111,7 @@ class TestState(BaseState):
     key: str
     map_key: str = "a"
     array: list[float] = [1, 2, 3.14]
-    mapping: dict[str, list[int]] = {"a": [1, 2, 3], "b": [4, 5, 6]}
+    mapping: rx.Field[dict[str, list[int]]] = rx.field({"a": [1, 2, 3], "b": [4, 5, 6]})
     obj: Object = Object()
     complex: dict[int, Object] = {1: Object(), 2: Object()}
     fig: Figure = Figure()
@@ -3868,6 +3868,12 @@ async def test_get_var_value(state_manager: StateManager, substate_token: str):
     # Generic Var with no state
     with pytest.raises(UnretrievableVarValueError):
         await state.get_var_value(rx.Var("undefined"))
+
+    # ObjectVar
+    assert await state.get_var_value(TestState.mapping) == {
+        "a": [1, 2, 3],
+        "b": [4, 5, 6],
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Because ObjectVar may support arbitrary attribute access, a non-Literal ObjectVar returns something for `getattr(var, _var_value)`, which isn't actually a dict value.