### PR TITLE
[ENG-5696] unwrap Var-typed annotations in @rx.memo signature

### DIFF
--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -43,6 +43,7 @@ from reflex.event import (
     no_args_event_spec,
     parse_args_spec,
     run_script,
+    unwrap_var_annotation,
 )
 from reflex.style import Style, format_as_emotion
 from reflex.utils import console, format, imports, types
@@ -1936,8 +1937,8 @@ def _register_custom_component(
         prop: (
             Var(
                 "",
-                _var_type=annotation,
-            )
+                _var_type=unwrap_var_annotation(annotation),
+            ).guess_type()
             if not types.safe_issubclass(annotation, EventHandler)
             else EventSpec(handler=EventHandler(fn=lambda: []))
         )


### PR DESCRIPTION
Annotating the function arguments as `Var` might lead to more accurate type hinting, but this breaks because the annotation was being unconditionally wrapped in a Var.

With this change, if the annotation is already a Var, then the inner type is used when constructing the dummy var that will be passed to the function for evaluation.

Fix #5217