### PR TITLE
Remove Fragment wrapper from `foreach` output to support iterable children in components like carousels

### DIFF
--- a/reflex/.templates/jinja/web/pages/utils.js.jinja2
+++ b/reflex/.templates/jinja/web/pages/utils.js.jinja2
@@ -60,11 +60,11 @@
 {# Args: #}
 {#     component: component dictionary #}
 {% macro render_iterable_tag(component) %}
-<>{ {{ component.iterable_state }}.map(({{ component.arg_name }}, {{ component.arg_index }}) => (
+{ {{ component.iterable_state }}.map(({{ component.arg_name }}, {{ component.arg_index }}) => (
   {% for child in component.children %}
   {{ render(child) }}
   {% endfor %}
-))}</>
+))}
 {%- endmacro %}
 
 


### PR DESCRIPTION

### All Submissions:

* [x] Have you followed the guidelines stated in [[CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md)](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
* [x] Have you checked to ensure there aren't any other open [[Pull Requests](https://github.com/reflex-dev/reflex/pulls)](https://github.com/reflex-dev/reflex/pulls) for the desired changes?

---

### Type of change

* [x] Bug fix (non-breaking change which fixes an issue)

---

### New Feature Submission:

* [x] Does your submission pass the tests?
* [x] Have you linted your code locally prior to submission?

---

### Changes To Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

---

### Description

This PR modifies the code generation logic for the `foreach` function in Reflex. Previously, elements generated by `foreach` were wrapped in a React Fragment (`<>...</>`), which breaks compatibility with components like `react-multi-carousel` or `react-responsive-carousel` that expect a flat iterable of children elements.

This change removes the Fragment wrapper in these cases, allowing iterable children to be passed correctly.

---

### Related Issue

Closes #5248

