### PR TITLE
When merging hook VarData, include the hook's VarData first

### DIFF
--- a/reflex/vars/base.py
+++ b/reflex/vars/base.py
@@ -170,7 +170,8 @@ class VarData:
         object.__setattr__(self, "components", tuple(components or []))
 
         if hooks and any(hooks.values()):
-            merged_var_data = VarData.merge(self, *hooks.values())
+            # Merge our dependencies first, so they can be referenced.
+            merged_var_data = VarData.merge(*hooks.values(), self)
             if merged_var_data is not None:
                 object.__setattr__(self, "state", merged_var_data.state)
                 object.__setattr__(self, "field_name", merged_var_data.field_name)

--- a/tests/units/test_var.py
+++ b/tests/units/test_var.py
@@ -1896,7 +1896,7 @@ def test_var_data_hooks():
 
 def test_var_data_with_hooks_value():
     var_data = VarData(hooks={"what": VarData(hooks={"whot": VarData(hooks="whott")})})
-    assert var_data == VarData(hooks=["what", "whot", "whott"])
+    assert var_data == VarData(hooks=["whott", "whot", "what"])
 
 
 def test_str_var_in_components(mocker):


### PR DESCRIPTION
The hook's VarData might be referencing some earlier hooks that are needed, so include the dependent VarData first so the dependencies render earlier in the output and can be referenced.

Needed for reflex-enterprise / react-dnd