### PR TITLE
Include required `jsx` and `Fragment` imports in ComponentVar

### DIFF
--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -2647,6 +2647,12 @@ class LiteralComponentVar(CachedVarOperation, LiteralVar, ComponentVar):
         return VarData.merge(
             self._var_data,
             VarData(
+                imports={
+                    "@emotion/react": ["jsx"],
+                    "react": ["Fragment"],
+                },
+            ),
+            VarData(
                 imports=self._var_value._get_all_imports(),
             ),
         )


### PR DESCRIPTION
This allows code using component vars outside of the context of the compiler to properly resolve the required imports