### PR TITLE
run get_app before checking for schema updates

### DIFF
--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -218,6 +218,7 @@ def _run(
         raise click.exceptions.Exit(1)
 
     # Warn if schema is not up to date.
+    prerequisites.get_app()
     prerequisites.check_schema_up_to_date()
 
     # Get the frontend and backend commands, based on the environment.


### PR DESCRIPTION
This change ensures `prerequisites` has access to the application models before checking for schema changes. 

Since version 0.7.9, I've been getting spurious "Detected database changes..." warnings when starting up my app, However, when I run `reflex db makemigrations`, nothing is produced.  I tweaked the code to show the phantom migration it was warning me and, to my surprise, it wanted to delete all the objects in my database.   I believe this is because the prerequisites code could not see the app's models when checking for migrations.  This PR resolve that, but it may not be the most sensible approach. :sweat_smile: 

This may be related to and fix #5301
