### PR TITLE
Handle REFLEX_ENV_FILE at init time

### DIFF
--- a/reflex/config.py
+++ b/reflex/config.py
@@ -69,9 +69,27 @@ def _load_dotenv_from_str(env_files: str) -> None:
             load_dotenv(env_file_path, override=True)
 
 
+def _load_dotenv_from_env():
+    """Load environment variables from paths specified in REFLEX_ENV_FILE."""
+    show_deprecation = False
+    env_env_file = os.environ.get("REFLEX_ENV_FILE")
+    if not env_env_file:
+        env_env_file = os.environ.get("ENV_FILE")
+        if env_env_file:
+            show_deprecation = True
+    if show_deprecation:
+        console.deprecate(
+            "Usage of deprecated ENV_FILE env var detected.",
+            reason="Prefer `REFLEX_` prefix when setting env vars.",
+            deprecation_version="0.7.13",
+            removal_version="0.8.0",
+        )
+    if env_env_file:
+        _load_dotenv_from_str(env_env_file)
+
+
 # Load the env files at import time if they are set in the ENV_FILE environment variable.
-if env_files := os.getenv("ENV_FILE"):
-    _load_dotenv_from_str(env_files)
+_load_dotenv_from_env()
 
 
 class DBConfig(Base):

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -3321,7 +3321,10 @@ async def test_setvar_async_setter():
         TestState.setvar("asynctest", 42)
 
 
-@pytest.mark.skipif("REDIS_URL" not in os.environ, reason="Test requires redis")
+@pytest.mark.skipif(
+    "REDIS_URL" not in os.environ and "REFLEX_REDIS_URL" not in os.environ,
+    reason="Test requires redis",
+)
 @pytest.mark.parametrize(
     "expiration_kwargs, expected_values",
     [
@@ -3394,7 +3397,10 @@ config = rx.Config(
         assert state_manager.lock_warning_threshold == expected_values[2]  # pyright: ignore [reportAttributeAccessIssue]
 
 
-@pytest.mark.skipif("REDIS_URL" not in os.environ, reason="Test requires redis")
+@pytest.mark.skipif(
+    "REDIS_URL" not in os.environ and "REFLEX_REDIS_URL" not in os.environ,
+    reason="Test requires redis",
+)
 @pytest.mark.parametrize(
     "redis_lock_expiration, redis_lock_warning_threshold",
     [


### PR DESCRIPTION
This was missed when env vars were renamed to use the REFLEX_ prefix

Also fixes up a test miss where redis tests were skipped even when providing REFLEX_REDIS_URL.