### PR TITLE
[0.9] remove ids refs from form_data

### DIFF
--- a/pyi_hashes.json
+++ b/pyi_hashes.json
@@ -29,7 +29,7 @@
   "reflex/components/el/element.pyi": "3519fdc9a74aab7b02f475568def5f95",
   "reflex/components/el/elements/__init__.pyi": "baeddd04d4d3a82799420b2a6df368f6",
   "reflex/components/el/elements/base.pyi": "2c962706dd6c28821497e9c8044cab4e",
-  "reflex/components/el/elements/forms.pyi": "0a75b05da0e53f581e356e464d3675d2",
+  "reflex/components/el/elements/forms.pyi": "7d96e23d763f4dcfc179a40fc205d895",
   "reflex/components/el/elements/inline.pyi": "523f3d432fb0daa21a4036bb37b4c8fa",
   "reflex/components/el/elements/media.pyi": "7d2f7996b2bbac9dff223e44e8c9b02d",
   "reflex/components/el/elements/metadata.pyi": "1591385cc150bf113b689bf4b58e67f2",

--- a/reflex/components/el/elements/forms.py
+++ b/reflex/components/el/elements/forms.py
@@ -34,7 +34,7 @@ HANDLE_SUBMIT_JS_JINJA2 = Environment().from_string(
     const handleSubmit_{{ handle_submit_unique_name }} = useCallback((ev) => {
         const $form = ev.target
         ev.preventDefault()
-        const {{ form_data }} = {...Object.fromEntries(new FormData($form).entries()), ...{{ field_ref_mapping }}};
+        const {{ form_data }} = {...Object.fromEntries(new FormData($form).entries())};
 
         ({{ on_submit_event_chain }}(ev));
 
@@ -217,7 +217,6 @@ class Form(BaseHTML):
             HANDLE_SUBMIT_JS_JINJA2.render(
                 handle_submit_unique_name=self.handle_submit_unique_name,
                 form_data=FORM_DATA,
-                field_ref_mapping=str(LiteralVar.create(self._get_form_refs())),
                 on_submit_event_chain=str(
                     LiteralVar.create(self.event_triggers[EventTriggers.ON_SUBMIT])
                 ),

--- a/tests/integration/test_form_submit.py
+++ b/tests/integration/test_form_submit.py
@@ -130,15 +130,11 @@ def FormSubmitName(form_component):
 @pytest.fixture(
     scope="module",
     params=[
-        functools.partial(FormSubmit, form_component="rx.form.root"),
         functools.partial(FormSubmitName, form_component="rx.form.root"),
-        functools.partial(FormSubmit, form_component="rx.el.form"),
         functools.partial(FormSubmitName, form_component="rx.el.form"),
     ],
     ids=[
-        "id-radix",
         "name-radix",
-        "id-html",
         "name-html",
     ],
 )


### PR DESCRIPTION
Passing both name and ids refs can lead to duplicate data, we should only pass form data by name.

Fix #5418 (when extracting hooks in stateful components, the form hook still refer `refs` but the import is removed, leading to the error)