### PR TITLE
[ENG-2566] Fix accordion style without Tailwind

### DIFF
--- a/reflex/components/radix/primitives/accordion.py
+++ b/reflex/components/radix/primitives/accordion.py
@@ -334,7 +334,11 @@ class AccordionHeader(AccordionComponent):
         Returns:
             The style of the component.
         """
-        return {"display": "flex"}
+        return {
+            "display": "flex",
+            # Reset some values to ensure consistent styling without tailwind reset.
+            "margin": "0",
+        }
 
 
 class AccordionTrigger(AccordionComponent):
@@ -399,6 +403,9 @@ class AccordionTrigger(AccordionComponent):
                     "color": "var(--accent-contrast)",
                 },
             },
+            # Reset some values to ensure consistent styling without tailwind reset.
+            "background": "none",
+            "border": "none",
         }
 
 


### PR DESCRIPTION
Now that tailwind is a plugin and more likely to be disabled, it was time to fix this ugliness.

```python
from typing import TypedDict
import reflex as rx

from rxconfig import config


class AccordionStyle(TypedDict):
    variant: str
    radius: str
    color_scheme: str


class State(rx.State):
    items: dict[str, str] = {
        "Item 1": "This is the first content in the accordion.",
        "Second item": "This is the second content in the accordion.",
        "Item Three": "Sometimes you need a third item after all."
    }
    styles: list[AccordionStyle] = [
        {"variant": "outline", "radius": "small", "color_scheme": "green"},
        {"variant": "surface", "radius": "none", "color_scheme": "blue"},
        {"variant": "ghost", "radius": "large", "color_scheme": "red"},
        {"variant": "soft", "radius": "medium", "color_scheme": "purple"},
        {"variant": "classic", "radius": "full", "color_scheme": "orange"},
    ]
    


def index() -> rx.Component:
    return rx.container(
        rx.color_mode.button(position="top-right"),
        rx.vstack(
            rx.heading("Welcome to Accordion!", size="9"),
            rx.foreach(
                State.styles,
                lambda style: rx.box(
                    rx.text(f"Variant: {style['variant']}, Radius: {style['radius']}, Color Scheme: {style['color_scheme']}"),
                    rx.accordion.root(
                        rx.foreach(
                            State.items,
                            lambda item: rx.accordion.item(
                                header=item[0],
                                content=item[1],
                                value=f"{item[0]}-{style['variant']}-{style['radius']}-{style['color_scheme']}",
                            ),
                        ),
                        variant=style["variant"],
                        radius=style["radius"],
                        color_scheme=style["color_scheme"],
                        collapsible=True,
                        type="multiple",
                        width="100%",
                    ),
                    width="100%",
                ),
            ),
            spacing="9",
        ),
        rx.logo(),
        size="3",
    )


app = rx.App()
app.add_page(index)
```

rxconfig.py

```python
import reflex as rx

config = rx.Config(
    app_name="repro_accordion_style",
    plugins=[],
    tailwind=None,
)
```

## Before

![image](https://github.com/user-attachments/assets/6f0fe177-eddf-44e0-be45-99e761043d3c)


## After 

![image](https://github.com/user-attachments/assets/9a06a76d-a91b-4e01-9081-61952decaac6)

To be clear, i think there are still some issues with the accordion styling, but this addresses the main "they are ugly without tailwind" issue
