### PR TITLE
[ENG-6295] missing stylesheet issue

### DIFF
--- a/reflex/compiler/utils.py
+++ b/reflex/compiler/utils.py
@@ -346,9 +346,18 @@ def create_document_root(
     Returns:
         The document root.
     """
-    head_components = head_components or [
-        Meta.create(char_set="utf-8"),
-        Meta.create(name="viewport", content="width=device-width, initial-scale=1"),
+    head_components = [
+        *(
+            head_components
+            or [
+                # Default meta tags if user does not provide.
+                Meta.create(char_set="utf-8"),
+                Meta.create(
+                    name="viewport", content="width=device-width, initial-scale=1"
+                ),
+            ]
+        ),
+        # Always include the framework meta and link tags.
         ReactMeta.create(),
         Links.create(),
     ]


### PR DESCRIPTION
When the app specified custom `head_components`, the default meta was not being included.