### PR TITLE
dedupe windowed libraries at the end

### DIFF
--- a/reflex/compiler/compiler.py
+++ b/reflex/compiler/compiler.py
@@ -86,6 +86,12 @@ def _compile_app(app_root: Component) -> str:
         (_normalize_library_name(name), name) for name in bundled_libraries
     ]
 
+    window_libraries_deduped = [
+        window_library
+        for i, window_library in enumerate(window_libraries)
+        if window_libraries.index(window_library) == i
+    ]
+
     app_root_imports = app_root._get_all_imports()
     _apply_common_imports(app_root_imports)
 
@@ -93,7 +99,7 @@ def _compile_app(app_root: Component) -> str:
         imports=utils.compile_imports(app_root_imports),
         custom_codes=app_root._get_all_custom_code(),
         hooks=app_root._get_all_hooks(),
-        window_libraries=window_libraries,
+        window_libraries=window_libraries_deduped,
         render=app_root.render(),
         dynamic_imports=app_root._get_all_dynamic_imports(),
     )


### PR DESCRIPTION
i'm using index == index because the list is typically short