### PR TITLE
If we have `set_focus()` we need `blur_focus()`.

### DIFF
--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -299,7 +299,7 @@ export const applyEvent = async (event, socket, navigate, params) => {
     const ref =
       event.payload.ref in refs ? refs[event.payload.ref] : event.payload.ref;
     const current = ref?.current;
-    if (current === undefined || current?.focus === undefined) {
+    if (current === undefined || current?.blur === undefined) {
       console.error(
         `No element found for ref ${event.payload.ref} in _blur_focus`,
       );

--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -295,6 +295,20 @@ export const applyEvent = async (event, socket, navigate, params) => {
     return false;
   }
 
+  if (event.name == "_blur_focus") {
+    const ref =
+      event.payload.ref in refs ? refs[event.payload.ref] : event.payload.ref;
+    const current = ref?.current;
+    if (current === undefined || current?.focus === undefined) {
+      console.error(
+        `No element found for ref ${event.payload.ref} in _blur_focus`,
+      );
+    } else {
+      current.blur();
+    }
+    return false;
+  }
+
   if (event.name == "_set_value") {
     const ref =
       event.payload.ref in refs ? refs[event.payload.ref] : event.payload.ref;

--- a/reflex/event.py
+++ b/reflex/event.py
@@ -1025,6 +1025,22 @@ def set_focus(ref: str) -> EventSpec:
     )
 
 
+def blur_focus(ref: str) -> EventSpec:
+    """Blur focus of specified ref.
+
+    Args:
+        ref: The ref.
+
+    Returns:
+        An event to blur focus on the ref
+    """
+    return server_side(
+        "_blur_focus",
+        get_fn_signature(blur_focus),
+        ref=LiteralVar.create(format.format_ref(ref)),
+    )
+
+
 def scroll_to(elem_id: str, align_to_top: bool | Var[bool] = True) -> EventSpec:
     """Select the id of a html element for scrolling into view.
 
@@ -2293,6 +2309,7 @@ class EventNamespace:
     back = staticmethod(back)
     window_alert = staticmethod(window_alert)
     set_focus = staticmethod(set_focus)
+    blur_focus = staticmethod(blur_focus)
     scroll_to = staticmethod(scroll_to)
     set_value = staticmethod(set_value)
     remove_cookie = staticmethod(remove_cookie)

--- a/tests/units/test_event.py
+++ b/tests/units/test_event.py
@@ -262,16 +262,19 @@ def test_event_window_alert():
     )
 
 
-def test_set_focus():
+@pytest.mark.parametrize(
+    ("func", "qualname"), [("set_focus", "_set_focus"), ("blur_focus", "_blur_focus")]
+)
+def test_focus(func: str, qualname: str):
     """Test the event set focus function."""
-    spec = event.set_focus("input1")
+    spec = getattr(event, func)("input1")
     assert isinstance(spec, EventSpec)
-    assert spec.handler.fn.__qualname__ == "_set_focus"
+    assert spec.handler.fn.__qualname__ == qualname
     assert spec.args[0][0].equals(Var(_js_expr="ref"))
     assert spec.args[0][1].equals(LiteralVar.create("ref_input1"))
-    assert format.format_event(spec) == 'Event("_set_focus", {ref:"ref_input1"})'
-    spec = event.set_focus("input1")
-    assert format.format_event(spec) == 'Event("_set_focus", {ref:"ref_input1"})'
+    assert format.format_event(spec) == f'Event("{qualname}", {{ref:"ref_input1"}})'
+    spec = getattr(event, func)("input1")
+    assert format.format_event(spec) == f'Event("{qualname}", {{ref:"ref_input1"}})'
 
 
 def test_set_value():

--- a/tests/units/test_event.py
+++ b/tests/units/test_event.py
@@ -266,7 +266,12 @@ def test_event_window_alert():
     ("func", "qualname"), [("set_focus", "_set_focus"), ("blur_focus", "_blur_focus")]
 )
 def test_focus(func: str, qualname: str):
-    """Test the event set focus function."""
+    """Test the event set focus function.
+
+    Args:
+        func: The event function name.
+        qualname: The sig qual name passed to JS.
+    """
     spec = getattr(event, func)("input1")
     assert isinstance(spec, EventSpec)
     assert spec.handler.fn.__qualname__ == qualname


### PR DESCRIPTION
## Add's `blur_focus()` server-side event for it's `set_focus()` counterpart.

> Pretty self-explanatory. Updated tests to include new event.


### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### New Feature Submission:

- [x] Does your submission pass the tests?
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
