### PR TITLE
Extract client_ip from x-forwarded-for header

### DIFF
--- a/reflex/app.py
+++ b/reflex/app.py
@@ -2087,8 +2087,19 @@ class EventNamespace(AsyncNamespace):
         # Get the client IP
         try:
             client_ip = environ["asgi.scope"]["client"][0]
+            headers["asgi-scope-client"] = client_ip
         except (KeyError, IndexError):
             client_ip = environ.get("REMOTE_ADDR", "0.0.0.0")
+
+        # Unroll reverse proxy forwarded headers.
+        client_ip = (
+            headers.get(
+                "x-forwarded-for",
+                client_ip,
+            )
+            .partition(",")[0]
+            .strip()
+        )
 
         async with contextlib.aclosing(
             process(self.app, event, sid, headers, client_ip)


### PR DESCRIPTION
Last week, a contributor opened a PR into one of my third party components https://github.com/masenf/reflex-magic-link-auth/pull/4

The intention was to fix how the `X-Forwarded-For` header is handled when a reverse proxy is used. The logic is relatively simple... but I realized there are at least 3 other projects that also need this same update, so it makes sense to bring it into the core such that accessing `State.router.session.client_ip` is correct in more instances automatically.

The other fixes will still be brought in to retain compatibility with older releases, but now reflex will use the most accurate client IP it can find for `client_ip`