### PR TITLE
fix spelling mistakes

### DIFF
--- a/pyi_hashes.json
+++ b/pyi_hashes.json
@@ -81,7 +81,7 @@
   "reflex/components/radix/themes/components/scroll_area.pyi": "7cbfa553778dce45256e9530b0be883b",
   "reflex/components/radix/themes/components/segmented_control.pyi": "c23a595bfc16aaf4d479dfaaa92a3273",
   "reflex/components/radix/themes/components/select.pyi": "3703abe61e53cd619e0ea18da5003c44",
-  "reflex/components/radix/themes/components/separator.pyi": "e93e99178867d5846932161a6e8bf760",
+  "reflex/components/radix/themes/components/separator.pyi": "7459cd06701290fe96dd1c0e9ee74f3c",
   "reflex/components/radix/themes/components/skeleton.pyi": "f3f84004eb63983947393df976428ee3",
   "reflex/components/radix/themes/components/slider.pyi": "e31b84a6bdd286f25a5fa8f4bde95738",
   "reflex/components/radix/themes/components/spinner.pyi": "da0d693bf1b4e72d027a1c871850710e",

--- a/reflex/components/radix/themes/components/separator.py
+++ b/reflex/components/radix/themes/components/separator.py
@@ -6,7 +6,7 @@ from reflex.components.core.breakpoints import Responsive
 from reflex.components.radix.themes.base import LiteralAccentColor, RadixThemesComponent
 from reflex.vars.base import LiteralVar, Var
 
-LiteralSeperatorSize = Literal["1", "2", "3", "4"]
+LiteralSeparatorSize = Literal["1", "2", "3", "4"]
 
 
 class Separator(RadixThemesComponent):
@@ -15,7 +15,7 @@ class Separator(RadixThemesComponent):
     tag = "Separator"
 
     # The size of the select: "1" | "2" | "3" | "4"
-    size: Var[Responsive[LiteralSeperatorSize]] = LiteralVar.create("4")
+    size: Var[Responsive[LiteralSeparatorSize]] = LiteralVar.create("4")
 
     # The color of the select
     color_scheme: Var[LiteralAccentColor]

--- a/reflex/event.py
+++ b/reflex/event.py
@@ -577,7 +577,7 @@ class JavascriptInputEvent:
     init=True,
     frozen=True,
 )
-class JavasciptKeyboardEvent:
+class JavascriptKeyboardEvent:
     """Interface for a Javascript KeyboardEvent https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent."""
 
     key: str = ""
@@ -645,7 +645,7 @@ class KeyInputInfo(TypedDict):
 
 
 def key_event(
-    e: ObjectVar[JavasciptKeyboardEvent],
+    e: ObjectVar[JavascriptKeyboardEvent],
 ) -> tuple[Var[str], Var[KeyInputInfo]]:
     """Get the key from a keyboard event.
 

--- a/reflex/plugins/base.py
+++ b/reflex/plugins/base.py
@@ -17,7 +17,7 @@ class CommonContext(TypedDict):
 P = ParamSpec("P")
 
 
-class AddTaskProtcol(Protocol):
+class AddTaskProtocol(Protocol):
     """Protocol for adding a task to the pre-compile context."""
 
     def __call__(
@@ -39,7 +39,7 @@ class AddTaskProtcol(Protocol):
 class PreCompileContext(CommonContext):
     """Context for pre-compile hooks."""
 
-    add_save_task: AddTaskProtcol
+    add_save_task: AddTaskProtocol
     add_modify_task: Callable[[str, Callable[[str], str]], None]
     unevaluated_pages: Sequence["UnevaluatedPage"]
 

--- a/reflex/route.py
+++ b/reflex/route.py
@@ -131,7 +131,7 @@ def replace_brackets_with_keywords(input_string: str) -> str:
     )
 
 
-def route_specifity(keyworded_route: str) -> tuple[int, int, int]:
+def route_specificity(keyworded_route: str) -> tuple[int, int, int]:
     """Get the specificity of a route with keywords.
 
     The smaller the number, the more specific the route is.
@@ -193,13 +193,13 @@ def get_router(routes: list[str]) -> Callable[[str], str | None]:
     keyworded_routes = {
         replace_brackets_with_keywords(route): route for route in routes
     }
-    sorted_routes_by_specifity = sorted(
+    sorted_routes_by_specificity = sorted(
         keyworded_routes.items(),
-        key=lambda item: route_specifity(item[0]),
+        key=lambda item: route_specificity(item[0]),
     )
     regexed_routes = [
         (get_route_regex(keyworded_route), original_route)
-        for keyworded_route, original_route in sorted_routes_by_specifity
+        for keyworded_route, original_route in sorted_routes_by_specificity
     ]
 
     def get_route(path: str) -> str | None:

--- a/reflex/utils/console.py
+++ b/reflex/utils/console.py
@@ -31,7 +31,7 @@ _EMITTED_DEPRECATION_WARNINGS = set()
 _EMITTED_INFO = set()
 
 # Warnings which have been printed.
-_EMIITED_WARNINGS = set()
+_EMITTED_WARNINGS = set()
 
 # Errors which have been printed.
 _EMITTED_ERRORS = set()
@@ -250,9 +250,9 @@ def warn(msg: str, *, dedupe: bool = False, **kwargs):
     """
     if _LOG_LEVEL <= LogLevel.WARNING:
         if dedupe:
-            if msg in _EMIITED_WARNINGS:
+            if msg in _EMITTED_WARNINGS:
                 return
-            _EMIITED_WARNINGS.add(msg)
+            _EMITTED_WARNINGS.add(msg)
         print(f"[orange1]Warning: {msg}[/orange1]", **kwargs)
     if should_use_log_file_console():
         print_to_log_file(f"[orange1]Warning: {msg}[/orange1]", **kwargs)

--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -251,7 +251,7 @@ def _escape_js_string(string: str) -> str:
         The escaped string.
     """
 
-    # TODO: we may need to re-vist this logic after new Var API is implemented.
+    # TODO: we may need to re-visit this logic after new Var API is implemented.
     def escape_outside_segments(segment: str):
         """Escape backticks in segments outside of `${}`.
 

--- a/tests/integration/shared/state.py
+++ b/tests/integration/shared/state.py
@@ -4,4 +4,4 @@ import reflex as rx
 
 
 class SharedState(rx.State):
-    """Shared state class for reflexers using librarys."""
+    """Shared state class for reflexers using libraries."""

--- a/tests/integration/tests_playwright/test_table.py
+++ b/tests/integration/tests_playwright/test_table.py
@@ -11,7 +11,7 @@ expected_col_headers = ["Name", "Age", "Location"]
 expected_row_headers = ["John", "Jane", "Joe"]
 expected_cells_data = [
     ["30", "New York"],
-    ["31", "San Fransisco"],
+    ["31", "San Francisco"],
     ["32", "Los Angeles"],
 ]
 
@@ -42,7 +42,7 @@ def Table():
                     rx.table.row(
                         rx.table.row_header_cell("Jane"),
                         rx.table.cell(31),
-                        rx.table.cell("San Fransisco"),
+                        rx.table.cell("San Francisco"),
                     ),
                     rx.table.row(
                         rx.table.row_header_cell("Joe"),

--- a/tests/units/components/test_tag.py
+++ b/tests/units/components/test_tag.py
@@ -8,7 +8,7 @@ from reflex.vars.base import LiteralVar, Var
     ("props", "test_props"),
     [
         ({}, []),
-        ({"key-hypen": 1}, ['"key-hypen":1']),
+        ({"key-hyphen": 1}, ['"key-hyphen":1']),
         ({"key": 1}, ["key:1"]),
         ({"key": "value"}, ['key:"value"']),
         ({"key": True, "key2": "value2"}, ["key:true", 'key2:"value2"']),

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -837,7 +837,7 @@ async def test_process_event_substate(test_state, child_state, grandchild_state)
         }
         test_state._clean()
 
-    # Test with the granchild state.
+    # Test with the grandchild state.
     assert grandchild_state.value2 == ""
     event = Event(
         token="t",
@@ -3629,7 +3629,7 @@ def test_assignment_to_undeclared_vars():
         def handle_supported_regular_vars(self):
             self.val = "no underscore"
             self._val = "single leading underscore"
-            self.__val = "double leading undercore"
+            self.__val = "double leading underscore"
 
         def handle_regular_var(self):
             self.num = 5

--- a/tests/units/test_var.py
+++ b/tests/units/test_var.py
@@ -1168,7 +1168,7 @@ def nested_base():
     )
 
 
-def test_retrival():
+def test_retrieval():
     var_without_data = Var(_js_expr="test")
     assert var_without_data is not None
 


### PR DESCRIPTION
While reading the code I noticed a couple of spelling mistakes being highlighted by my [typos](https://github.com/crate-ci/typos) lsp. Running `typos` on the whole code base picked up some more. Hope this helps. :sweat_smile: 
