### PR TITLE
fix prevent AutoScroll hook name collision with unique ID

### DIFF
--- a/reflex/components/core/auto_scroll.py
+++ b/reflex/components/core/auto_scroll.py
@@ -52,11 +52,12 @@ class AutoScroll(Div):
             The hooks required for the component.
         """
         ref_name = self.get_ref()
+        unique_id = ref_name
         return [
             "const wasNearBottom = useRef(false);",
             "const hadScrollbar = useRef(false);",
             f"""
-const checkIfNearBottom = () => {{
+const checkIfNearBottom_{unique_id} = () => {{
     if (!{ref_name}.current) return;
 
     const container = {ref_name}.current;
@@ -71,7 +72,7 @@ const checkIfNearBottom = () => {{
 }};
 """,
             f"""
-const scrollToBottomIfNeeded = () => {{
+const scrollToBottomIfNeeded_{unique_id} = () => {{
     if (!{ref_name}.current) return;
 
     const container = {ref_name}.current;
@@ -93,24 +94,24 @@ useEffect(() => {{
     const container = {ref_name}.current;
     if (!container) return;
 
-    scrollToBottomIfNeeded();
+    scrollToBottomIfNeeded_{unique_id}();
 
     // Create ResizeObserver to detect height changes
     const resizeObserver = new ResizeObserver(() => {{
-        scrollToBottomIfNeeded();
+        scrollToBottomIfNeeded_{unique_id}();
     }});
 
     // Track scroll position before height changes
-    container.addEventListener('scroll', checkIfNearBottom);
+    container.addEventListener('scroll', checkIfNearBottom_{unique_id});
 
     // Initial check
-    checkIfNearBottom();
+    checkIfNearBottom_{unique_id}();
 
     // Observe container for size changes
     resizeObserver.observe(container);
 
     return () => {{
-        container.removeEventListener('scroll', checkIfNearBottom);
+        container.removeEventListener('scroll', checkIfNearBottom_{unique_id});
         resizeObserver.disconnect();
     }};
 }});


### PR DESCRIPTION
**Summary**
This PR adds a unique identifier (unique_id) as a suffix to dynamically generated hook function names, preventing naming collisions when multiple instances of the component are mounted.

**Changes**

- Introduced unique_id suffix to:
  - checkIfNearBottom_<unique_id>
  - scrollToBottomIfNeeded_<unique_id>
  - corresponding useEffect cleanup handlers
- Ensures scroll behavior remains scoped to each component instance
- Avoids potential conflicts from duplicated hook names

**Context**
Hook function names were previously shared across instances, which could lead to incorrect behavior or conflicts in shared DOM references. This update scopes those functions using a component-specific unique_id.

**Notes**
This version keeps the original structure and logic, and only appends unique_id to ensure safe multi-instance usage. No refactoring or naming convention changes were introduced beyond that.

closes #5648 