### PR TITLE
Fix grammatical error in README: correct 'Our DALL·E. app has an even…

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ def get_image(self):
 
 Within the state, we define functions called event handlers that change the state vars. Event handlers are the way that we can modify the state in Reflex. They can be called in response to user actions, such as clicking a button or typing in a text box. These actions are called events.
 
-Our DALL·E. app has an event handler, `get_image` to which get this image from the OpenAI API. Using `yield` in the middle of an event handler will cause the UI to update. Otherwise the UI will update at the end of the event handler.
+Our DALL·E app has an event handler, `get_image` which gets this image from the OpenAI API. Using `yield` in the middle of an event handler will cause the UI to update. Otherwise the UI will update at the end of the event handler.
 
 ### **Routing**
 


### PR DESCRIPTION
 ## Summary
  Fixed a grammatical error in the README.md file in the "Let's break this down" section.

  ## Changes
  - Changed "to get this image" to "gets this image" for grammatical correctness
  - Removed extra period after "DALL·E."

  ## Type of Change
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] Documentation update

  ## Checklist
  - [x] I have run the unit tests and they pass
  - [x] I have run linting checks (ruff check .)
  - [x] My changes follow the project's coding style
  - [x] This is a minor documentation fix that doesn't require additional testing