### PR TITLE
fix: add missing size property to DynamicIcon class

### DIFF
--- a/pyi_hashes.json
+++ b/pyi_hashes.json
@@ -40,7 +40,7 @@
   "reflex/components/el/elements/tables.pyi": "e3f299e59bb8ff87aa949c6b606551c9",
   "reflex/components/el/elements/typography.pyi": "b4ec4ffb448f7a9b5f94712404448d9e",
   "reflex/components/gridjs/datatable.pyi": "98a7e1b3f3b60cafcdfcd8879750ee42",
-  "reflex/components/lucide/icon.pyi": "c1090e2c68a5d7653584dd74e8b8f1cf",
+  "reflex/components/lucide/icon.pyi": "91ccfd65214b968f1b18caba58a872ed",
   "reflex/components/markdown/markdown.pyi": "2f84254a548e908020949564fc289339",
   "reflex/components/moment/moment.pyi": "93fa4c6009390fe9400197ab52735b84",
   "reflex/components/plotly/plotly.pyi": "4311a0aae2abcc9226abb6a273f96372",

--- a/pyi_hashes.json
+++ b/pyi_hashes.json
@@ -40,7 +40,7 @@
   "reflex/components/el/elements/tables.pyi": "e3f299e59bb8ff87aa949c6b606551c9",
   "reflex/components/el/elements/typography.pyi": "b4ec4ffb448f7a9b5f94712404448d9e",
   "reflex/components/gridjs/datatable.pyi": "98a7e1b3f3b60cafcdfcd8879750ee42",
-  "reflex/components/lucide/icon.pyi": "91ccfd65214b968f1b18caba58a872ed",
+  "reflex/components/lucide/icon.pyi": "b69b861d50bbaecf0e0fde600192ed18",
   "reflex/components/markdown/markdown.pyi": "2f84254a548e908020949564fc289339",
   "reflex/components/moment/moment.pyi": "93fa4c6009390fe9400197ab52735b84",
   "reflex/components/plotly/plotly.pyi": "4311a0aae2abcc9226abb6a273f96372",

--- a/reflex/components/lucide/icon.py
+++ b/reflex/components/lucide/icon.py
@@ -93,6 +93,7 @@ class DynamicIcon(LucideIconComponent):
     tag = "DynamicIcon"
 
     name: Var[str]
+    size: Var[int]
 
     def _get_imports(self):
         _imports = super()._get_imports()


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran tests with your changes locally?

## Description

Fixes #5660 where `rx.icon` size attribute was ignored when using dynamic state variables vs static strings.
The DynamicIcon class was missing the size: Var[int] property definition, causing size to be treated as CSS style instead of a direct component prop. This resulted in dynamic icons falling back to Lucide React's default size of 24px instead of using the specified size.

### Problem
- `rx.icon("home", size=16)` worked correctly (16x16 pixels)
- `rx.icon(State.icon, size=16)` was broken (fell back to Lucide's default 24px)

### Root Cause
The `DynamicIcon` class was missing the `size: Var[int]` property definition, causing the size parameter to be treated as a CSS style instead of a direct component       
prop.

### Solution
Added the missing `size: Var[int]` property to the `DynamicIcon` class, ensuring consistent size handling between static and dynamic icons.

### Testing
- Verified both static and dynamic icons now render with proper component props
- All existing icon tests pass

closes #5660