### PR TITLE
ENG-6769: Fix module app.app not found during on_load

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -2463,16 +2463,20 @@ class OnLoadInternalState(State):
     This is a separate substate to avoid deserializing the entire state tree for every page navigation.
     """
 
+    # Cannot properly annotate this as `App` due to circular import issues.
+    _app_ref: ClassVar = None
+
     def on_load_internal(self) -> list[Event | EventSpec | event.EventCallback] | None:
         """Queue on_load handlers for the current page.
 
         Returns:
             The list of events to queue for on load handling.
         """
-        # Do not app._compile()!  It should be already compiled by now.
-        load_events = prerequisites.get_and_validate_app().app.get_load_events(
-            self.router._page.path
-        )
+        app = type(self)._app_ref or prerequisites.get_and_validate_app().app
+        # Cache the app reference for subsequent calls.
+        if type(self)._app_ref is None:
+            type(self)._app_ref = app
+        load_events = app.get_load_events(self.router._page.path)
         if not load_events:
             self.is_hydrated = True
             return None  # Fast path for navigation with no on_load events defined.
@@ -2646,6 +2650,9 @@ def reload_state_module(
         state: Recursive argument for the state class to reload.
 
     """
+    # Reset the _app_ref of OnLoadInternalState to avoid stale references.
+    if state is OnLoadInternalState:
+        state._app_ref = None
     # Clean out all potentially dirty states of reloaded modules.
     for pd_state in tuple(state._potentially_dirty_states):
         with contextlib.suppress(ValueError):

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -2464,15 +2464,25 @@ class OnLoadInternalState(State):
     """
 
     # Cannot properly annotate this as `App` due to circular import issues.
-    _app_ref: ClassVar = None
+    _app_ref: ClassVar[Any] = None
 
     def on_load_internal(self) -> list[Event | EventSpec | event.EventCallback] | None:
         """Queue on_load handlers for the current page.
 
         Returns:
             The list of events to queue for on load handling.
+
+        Raises:
+            TypeError: If the app reference is not of type App.
         """
+        from reflex.app import App
+
         app = type(self)._app_ref or prerequisites.get_and_validate_app().app
+        if not isinstance(app, App):
+            msg = (
+                f"Expected app to be of type {App.__name__}, got {type(app).__name__}."
+            )
+            raise TypeError(msg)
         # Cache the app reference for subsequent calls.
         if type(self)._app_ref is None:
             type(self)._app_ref = app

--- a/tests/units/test_app.py
+++ b/tests/units/test_app.py
@@ -7,6 +7,7 @@ import uuid
 from collections.abc import Generator
 from contextlib import nullcontext as does_not_raise
 from pathlib import Path
+from typing import ClassVar
 from unittest.mock import AsyncMock
 
 import pytest
@@ -945,6 +946,7 @@ class DynamicState(BaseState):
     is_hydrated: bool = False
     loaded: int = 0
     counter: int = 0
+    _app_ref: ClassVar = None
 
     @rx.event
     def on_load(self):
@@ -982,6 +984,7 @@ def test_dynamic_arg_shadow(
         app_module_mock: Mocked app module.
         mocker: pytest mocker object.
     """
+    DynamicState._app_ref = None
     arg_name = "counter"
     route = f"/test/[{arg_name}]"
     app = app_module_mock.app = App(_state=DynamicState)
@@ -1030,6 +1033,7 @@ async def test_dynamic_route_var_route_change_completed_on_load(
         app_module_mock: Mocked app module.
         mocker: pytest mocker object.
     """
+    DynamicState._app_ref = None
     arg_name = "dynamic"
     route = f"test/[{arg_name}]"
     app = app_module_mock.app = App(_state=DynamicState)

--- a/tests/units/test_app.py
+++ b/tests/units/test_app.py
@@ -7,7 +7,7 @@ import uuid
 from collections.abc import Generator
 from contextlib import nullcontext as does_not_raise
 from pathlib import Path
-from typing import ClassVar
+from typing import Any, ClassVar
 from unittest.mock import AsyncMock
 
 import pytest
@@ -946,7 +946,7 @@ class DynamicState(BaseState):
     is_hydrated: bool = False
     loaded: int = 0
     counter: int = 0
-    _app_ref: ClassVar = None
+    _app_ref: ClassVar[Any] = None
 
     @rx.event
     def on_load(self):

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -2948,6 +2948,7 @@ async def test_preprocess(
         expected: Expected delta.
         mocker: pytest mock object.
     """
+    OnLoadInternalState._app_ref = None
     mocker.patch(
         "reflex.state.State.class_subclasses", {test_state, OnLoadInternalState}
     )
@@ -3002,6 +3003,7 @@ async def test_preprocess_multiple_load_events(
         token: A token.
         mocker: pytest mock object.
     """
+    OnLoadInternalState._app_ref = None
     mocker.patch(
         "reflex.state.State.class_subclasses", {OnLoadState, OnLoadInternalState}
     )


### PR DESCRIPTION
# Repro

```python
import reflex as rx


class State(rx.State):
    """The app state."""
    loaded: int = 0

    def on_load(self):
        self.loaded += 1


def index() -> rx.Component:
    return rx.container(
        rx.text(State.loaded),
        rx.moment(
            interval=300,
            on_change=rx.state.OnLoadInternalState.on_load_internal,
        )
    )


app = rx.App()
app.add_page(index, on_load=State.on_load)
```

```
REFLEX_HOT_RELOAD_EXCLUDE_PATHS=repro_module_not_found reflex run
```

Load the app in the browser, you should see the counter ticking up every 300ms

```
mv repro_module_not_found/repro_module_not_found.py repro_module_not_found/xx.py
```

This will induce the error on `main`

```
Traceback (most recent call last):
  File "/Users/masenf/code/reflex-dev/reflex/.venv/lib/python3.13/site-packages/socketio/async_server.py", line 612, in _handle_event_internal
    r = await server._trigger_event(data[0], namespace, sid, *data[1:])
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/masenf/code/reflex-dev/reflex/.venv/lib/python3.13/site-packages/socketio/async_server.py", line 662, in _trigger_event
    return await handler.trigger_event(event, *args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/masenf/code/reflex-dev/reflex/.venv/lib/python3.13/site-packages/socketio/async_namespace.py", line 38, in trigger_event
    ret = await handler(*args)
          ^^^^^^^^^^^^^^^^^^^^
  File "/Users/masenf/code/reflex-dev/reflex/reflex/app.py", line 2135, in on_event
    async for update in updates_gen:
        # Emit the update from processing the event.
        await self.emit_update(update=update, sid=sid)
  File "/Users/masenf/code/reflex-dev/reflex/reflex/app.py", line 1762, in process
    async for update in state._process(event):
    ...<4 lines>...
        yield update
  File "/Users/masenf/code/reflex-dev/reflex/reflex/state.py", line 1655, in _process
    async for update in self._process_event(
    ...<4 lines>...
        yield update
  File "/Users/masenf/code/reflex-dev/reflex/reflex/state.py", line 1879, in _process_event
    prerequisites.get_and_validate_app().app.backend_exception_handler(ex)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/masenf/code/reflex-dev/reflex/reflex/utils/prerequisites.py", line 424, in get_and_validate_app
    app_module = get_app(reload=reload)
  File "/Users/masenf/code/reflex-dev/reflex/reflex/utils/prerequisites.py", line 380, in get_app
    _check_app_name(config)
    ~~~~~~~~~~~~~~~^^^^^^^^
  File "/Users/masenf/code/reflex-dev/reflex/reflex/utils/prerequisites.py", line 360, in _check_app_name
    raise ModuleNotFoundError(msg)
ModuleNotFoundError: Module repro_module_not_found.repro_module_not_found not found. Ensure app_name='repro_module_not_found' in rxconfig.py matches your folder structure.
```
