### PR TITLE
fix: propagate `frontend_path` to `base` in `vite.config.js`

### DIFF
--- a/reflex/.templates/jinja/web/vite.config.js.jinja2
+++ b/reflex/.templates/jinja/web/vite.config.js.jinja2
@@ -25,6 +25,7 @@ function alwaysUseReactDomServerNode() {
 }
 
 export default defineConfig((config) => ({
+  base: "{{base}}",
   plugins: [
     alwaysUseReactDomServerNode(),
     reactRouter(),

--- a/reflex/compiler/templates.py
+++ b/reflex/compiler/templates.py
@@ -149,6 +149,9 @@ STYLE = get_template("web/styles/styles.css.jinja2")
 # Code that generate the package json file
 PACKAGE_JSON = get_template("web/package.json.jinja2")
 
+# Code that generate the vite.config.js file
+VITE_CONFIG = get_template("web/vite.config.js.jinja2")
+
 # Template containing some macros used in the web pages.
 MACROS = get_template("web/pages/macros.js.jinja2")
 

--- a/reflex/constants/base.py
+++ b/reflex/constants/base.py
@@ -160,6 +160,9 @@ class ReactRouter(Javascript):
     # The react router config file
     CONFIG_FILE = "react-router.config.js"
 
+    # The associated Vite config file
+    VITE_CONFIG_FILE = "vite.config.js"
+
     # Regex to check for message displayed when frontend comes up
     DEV_FRONTEND_LISTENING_REGEX = r"Local:[\s]+"
 

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -972,6 +972,9 @@ def initialize_web_directory():
     console.debug("Initializing the react-router.config.js file.")
     update_react_router_config()
 
+    console.debug("Initializing the vite.config.js file.")
+    initialize_vite_config()
+
     console.debug("Initializing the reflex.json file.")
     # Initialize the reflex json file.
     init_reflex_json(project_hash=project_hash)
@@ -994,6 +997,20 @@ def initialize_package_json():
     """Render and write in .web the package.json file."""
     output_path = get_web_dir() / constants.PackageJson.PATH
     output_path.write_text(_compile_package_json())
+
+
+def _compile_vite_config(config: Config):
+    # base must have exactly one trailing slash
+    base = "/"
+    if frontend_path := config.frontend_path.strip("/"):
+        base += frontend_path + "/"
+    return templates.VITE_CONFIG.render(base=base)
+
+
+def initialize_vite_config():
+    """Render and write in .web the vite.config.js file using Reflex config."""
+    vite_config_file_path = get_web_dir() / constants.ReactRouter.VITE_CONFIG_FILE
+    vite_config_file_path.write_text(_compile_vite_config(get_config()))
 
 
 def initialize_bun_config():

--- a/tests/units/test_prerequisites.py
+++ b/tests/units/test_prerequisites.py
@@ -10,6 +10,7 @@ from reflex.reflex import cli
 from reflex.testing import chdir
 from reflex.utils.prerequisites import (
     CpuInfo,
+    _compile_vite_config,
     _update_react_router_config,
     cached_procedure,
     get_cpu_info,
@@ -57,6 +58,37 @@ runner = CliRunner()
 def test_update_react_router_config(config, export, expected_output):
     output = _update_react_router_config(config, prerender_routes=export)
     assert output == expected_output
+
+
+@pytest.mark.parametrize(
+    ("config", "expected_output"),
+    [
+        (
+            Config(
+                app_name="test",
+                frontend_path="",
+            ),
+            'base: "/",',
+        ),
+        (
+            Config(
+                app_name="test",
+                frontend_path="/test",
+            ),
+            'base: "/test/",',
+        ),
+        (
+            Config(
+                app_name="test",
+                frontend_path="/test/",
+            ),
+            'base: "/test/",',
+        ),
+    ],
+)
+def test_initialise_vite_config(config, expected_output):
+    output = _compile_vite_config(config)
+    assert expected_output in output
 
 
 def test_cached_procedure():


### PR DESCRIPTION
Currently all javascript assets built using vite are served from the '/assets' path, ignoring whatever has been set for `frontend_path`.  This is problematic when trying to serve two distinct reflex apps from the same web server but using distinct frontend paths. This patch set the `base` config entry for vite based on the reflex configuration so the compiled javascript will be served from a subfolder of the frontend_path.

Not sure if this is the best place to tweak the configuration.  I've tried to follow what has been done elsewhere. :sweat_smile:  