### PR TITLE
Fiex: ensure `cls.__dict__` compat w/ python3.14

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -508,7 +508,7 @@ class BaseState(EvenMoreBasicBaseState):
 
         new_backend_vars = {
             name: value
-            for name, value in cls.__dict__.items()
+            for name, value in list(cls.__dict__.items())
             if types.is_backend_base_variable(name, cls)
         }
         # Add annotated backend vars that may not have a default value.


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### New Feature Submission:

- [x] Does your submission pass the tests?
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.

Title:
Fix: wrap cls.__dict__.items() in list() for Python 3.14 compatibility

Description:
This change wraps cls.__dict__.items() in list() when building new_backend_vars in BaseState.__init_subclass__.
In Python 3.14 (currently in release candidate), dict_items views have updated semantics that cause iteration issues in this context. Wrapping in list() restores the expected iteration behavior and allows the application to build and run under Python 3.14 without impacting previous Python versions.

Reason for inclusion:
Maintains forward compatibility with upcoming Python releases while preserving behavior on all supported versions. See previous closed Pull Request 5659