### PR TITLE
use wget instead of curl

### DIFF
--- a/scripts/bun_install.sh
+++ b/scripts/bun_install.sh
@@ -142,8 +142,13 @@ if [[ ! -d $bin_dir ]]; then
         error "Failed to create install directory \"$bin_dir\""
 fi
 
-curl --fail --location --progress-bar --output "$exe.zip" "$bun_uri" ||
+if command -v curl >/dev/null 2>&1; then
+    curl --fail --location --progress-bar --output "$exe.zip" "$bun_uri" ||
     error "Failed to download bun from \"$bun_uri\""
+else
+    wget --quiet --show-progress --output-document="$exe.zip" "$bun_uri" ||
+    error "Failed to download bun from \"$bun_uri\""
+fi
 
 unzip -oqd "$bin_dir" "$exe.zip" ||
     error 'Failed to extract bun'


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them:
I am working in a restricted environment where high-level tools like cURL aren't installed by default, so I have to create large workarounds to collect all the necessary dependencies that aren't native to Python. It would be great if the project could use wget instead of curl, as wget is much deeper in the OS dependency tree than curl. In fact, wget is a dependency of the coreutils package, so we can assume that everyone has it installed.
