### PR TITLE
ENG-7314: Only check for valid app name once per config instance

### DIFF
--- a/reflex/config.py
+++ b/reflex/config.py
@@ -284,6 +284,9 @@ class Config(BaseConfig):
     See the [configuration](https://reflex.dev/docs/getting-started/configuration/) docs for more info.
     """
 
+    # Track whether the app name has already been validated for this Config instance.
+    _app_name_is_valid: bool = dataclasses.field(default=False)
+
     def _post_init(self, **kwargs):
         """Post-initialization method to set up the config.
 

--- a/reflex/config.py
+++ b/reflex/config.py
@@ -285,7 +285,7 @@ class Config(BaseConfig):
     """
 
     # Track whether the app name has already been validated for this Config instance.
-    _app_name_is_valid: bool = dataclasses.field(default=False)
+    _app_name_is_valid: bool = dataclasses.field(default=False, repr=False)
 
     def _post_init(self, **kwargs):
         """Post-initialization method to set up the config.

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -165,6 +165,7 @@ def _check_app_name(config: Config):
             else:
                 msg += f"Ensure app_name='{config.app_name}' in rxconfig.py matches your folder structure."
             raise ModuleNotFoundError(msg)
+    config._app_name_is_valid = True
 
 
 def get_app(reload: bool = False) -> ModuleType:
@@ -184,7 +185,9 @@ def get_app(reload: bool = False) -> ModuleType:
     try:
         config = get_config()
 
-        _check_app_name(config)
+        # Avoid hitting disk when the app name has already been validated in this process.
+        if not config._app_name_is_valid:
+            _check_app_name(config)
 
         module = config.module
         sys.path.insert(0, str(Path.cwd()))


### PR DESCRIPTION
After the backend comes up, we check the app name once and validate that it's good. There is no need to check it again in the same process.

Fixes the spurious `app.app module not found` errors that occur when deleting and replacing the main app module while the backend is running, but before triggering a reload.

# Repro code

```python
import asyncio
from pathlib import Path

import reflex as rx


class State(rx.State):
    """The app state."""

    shuffling: bool = False
    interval: int = 0
    loaded: int = 0
    tasked: int = 0

    @rx.event
    def set_interval(self, interval: int):
        self.interval = interval

    @rx.event
    def on_load(self):
        self.loaded += 1

    @rx.event(background=True)
    async def bg_task(self):
        async with self:
            self.tasked += 1
        await asyncio.sleep(0.1)
        if self.tasked > 0:
            yield State.bg_task

    @rx.event(background=True)
    async def raise_over_400(self):
        while True:
            async with self:
                if self.tasked > 400:
                    self.tasked = 0
                    raise Exception("Task limit exceeded")
            await asyncio.sleep(0.1)

    @rx.event
    def backend_exception(self):
        raise RuntimeError("This is a backend exception")

    @rx.event
    def frontend_exception(self):
        return rx.call_script("foobarbaz")

    @rx.event(background=True)
    async def shuffle_app_module(self):
        """Rename the main app module for a couple seconds.

        This simulates replacing the code before manually triggering a hot reload.
        """
        async with self:
            if self.shuffling:
                return rx.toast("Shuffling in progress...")
            self.shuffling = True
        try:
            current_path = Path(__file__)
            new_path = current_path.with_name("renamed.py")
            current_path.rename(new_path)
            await asyncio.sleep(2)
            new_path.rename(current_path)
        finally:
            async with self:
                self.shuffling = False


def index() -> rx.Component:
    return rx.container(
        rx.vstack(
            rx.button(
                "Shuffle App Module",
                on_click=State.shuffle_app_module,
                disabled=State.shuffling,
            ),
            rx.hstack(
                rx.text(State.loaded),
                rx.button(
                    "Toggle periodic on_load",
                    on_click=State.set_interval(rx.cond(State.interval > 0, 0, 300)),
                ),
            ),
            rx.hstack(
                rx.text(State.tasked),
                rx.cond(
                    State.tasked > 0,
                    rx.button("Stop Background Task", on_click=State.set_tasked(0)),
                    rx.button("Start Background Task", on_click=State.bg_task),
                ),
            ),
            rx.hstack(
                rx.button("Backend Exception", on_click=State.backend_exception),
                rx.button("Frontend Exception", on_click=State.frontend_exception),
            ),
            rx.moment(
                interval=State.interval,
                on_change=rx.state.OnLoadInternalState.on_load_internal,
            ),
        ),
    )


app = rx.App()
app.add_page(index, on_load=State.on_load)
```

```
REFLEX_HOT_RELOAD_EXCLUDE_PATHS=repro_module_not_found reflex run
```

Click on "Shuffle App Module" to simulate removing the app module and putting it back 2 seconds later. While the app module is shuffled, clicking on Backend or Frontend exception should NOT raise the module not found error. For the other ones, start the background task or the periodic onload, then click "Shuffle App Module", this should NOT raise the module not found error.

Without this fix, the above 3 scenarios cause an exception on the backend. (on_load path was fixed previously)