### PR TITLE
Provide descriptive names for asyncio.Task

### DIFF
--- a/reflex/app_mixins/lifespan.py
+++ b/reflex/app_mixins/lifespan.py
@@ -7,6 +7,7 @@ import contextlib
 import dataclasses
 import functools
 import inspect
+import time
 from collections.abc import Callable, Coroutine
 
 from starlette.applications import Starlette
@@ -36,6 +37,7 @@ class LifespanMixin(AppMixin):
                     if isinstance(task, asyncio.Task):
                         running_tasks.append(task)
                     else:
+                        task_name = task.__name__
                         signature = inspect.signature(task)
                         if "app" in signature.parameters:
                             task = functools.partial(task, app=app)
@@ -44,7 +46,10 @@ class LifespanMixin(AppMixin):
                             await stack.enter_async_context(_t)
                             console.debug(run_msg.format(type="asynccontextmanager"))
                         elif isinstance(_t, Coroutine):
-                            task_ = asyncio.create_task(_t)
+                            task_ = asyncio.create_task(
+                                _t,
+                                name=f"reflex_lifespan_task|{task_name}|{time.time()}",
+                            )
                             task_.add_done_callback(lambda t: t.result())
                             running_tasks.append(task_)
                             console.debug(run_msg.format(type="coroutine"))
@@ -70,9 +75,10 @@ class LifespanMixin(AppMixin):
             msg = f"Task {task.__name__} of type generator must be decorated with contextlib.asynccontextmanager."
             raise InvalidLifespanTaskTypeError(msg)
 
+        task_name = task.__name__  # pyright: ignore [reportAttributeAccessIssue]
         if task_kwargs:
             original_task = task
             task = functools.partial(task, **task_kwargs)  # pyright: ignore [reportArgumentType]
             functools.update_wrapper(task, original_task)  # pyright: ignore [reportArgumentType]
         self.lifespan_tasks.add(task)
-        console.debug(f"Registered lifespan task: {task.__name__}")  # pyright: ignore [reportAttributeAccessIssue]
+        console.debug(f"Registered lifespan task: {task_name}")

--- a/reflex/istate/manager.py
+++ b/reflex/istate/manager.py
@@ -667,7 +667,8 @@ class StateManagerRedis(StateManager):
                     _substate_key(client_token, substate),
                     substate,
                     lock_id,
-                )
+                ),
+                name=f"reflex_set_state|{client_token}|{substate.get_full_name()}",
             )
             for substate in state.substates.values()
         ]

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -11,6 +11,7 @@ import functools
 import inspect
 import pickle
 import sys
+import time
 import typing
 import warnings
 from collections.abc import AsyncIterator, Callable, Sequence
@@ -284,7 +285,10 @@ async def _resolve_delta(delta: Delta) -> Delta:
     for state_name, state_delta in delta.items():
         for var_name, value in state_delta.items():
             if asyncio.iscoroutine(value):
-                tasks[state_name, var_name] = asyncio.create_task(value)
+                tasks[state_name, var_name] = asyncio.create_task(
+                    value,
+                    name=f"reflex_resolve_delta|{state_name}|{var_name}|{time.time()}",
+                )
     for (state_name, var_name), task in tasks.items():
         delta[state_name][var_name] = await task
     return delta

--- a/reflex/utils/telemetry.py
+++ b/reflex/utils/telemetry.py
@@ -353,7 +353,10 @@ def send(event: str, telemetry_enabled: bool | None = None, **kwargs):
 
     try:
         # Within an event loop context, send the event asynchronously.
-        task = asyncio.create_task(async_send(event, telemetry_enabled, **kwargs))
+        task = asyncio.create_task(
+            async_send(event, telemetry_enabled, **kwargs),
+            name=f"reflex_send_telemetry_event|{event}",
+        )
         background_tasks.add(task)
         task.add_done_callback(background_tasks.discard)
     except RuntimeError:


### PR DESCRIPTION
Reflex internally spawns async tasks for background event processing, emitting websocket data, lifespan, telementry, and resolving async computed vars. Now these tasks all have descriptive names that include the event being processed, the token, and a timestamp of when the task started. This extra information in the task name allows users to better identify where potentially problems in the app are hiding.