### PR TITLE
PropsBase converts EventHandler-annotated props to EventChain

### DIFF
--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -43,6 +43,7 @@ from reflex.event import (
     EventChain,
     EventHandler,
     EventSpec,
+    args_specs_from_fields,
     no_args_event_spec,
     parse_args_spec,
     pointer_event_spec,
@@ -909,18 +910,7 @@ class Component(BaseComponent, ABC):
         """
         # Look for component specific triggers,
         # e.g. variable declared as EventHandler types.
-        return DEFAULT_TRIGGERS | {
-            name: (
-                metadata[0]
-                if (
-                    (metadata := getattr(field.annotated_type, "__metadata__", None))
-                    is not None
-                )
-                else no_args_event_spec
-            )
-            for name, field in cls.get_fields().items()
-            if field.type_origin is EventHandler
-        }  # pyright: ignore [reportOperatorIssue]
+        return DEFAULT_TRIGGERS | args_specs_from_fields(cls.get_fields())  # pyright: ignore [reportOperatorIssue]
 
     def __repr__(self) -> str:
         """Represent the component in React.

--- a/reflex/event.py
+++ b/reflex/event.py
@@ -25,6 +25,7 @@ from typing import (
 from typing_extensions import Self, TypeAliasType, TypedDict, TypeVarTuple, Unpack
 
 from reflex import constants
+from reflex.components.field import BaseField
 from reflex.constants.compiler import CompileVars, Hooks, Imports
 from reflex.constants.state import FRONTEND_EVENT_STATE
 from reflex.utils import format
@@ -1654,6 +1655,31 @@ def parse_args_spec(arg_spec: ArgsSpec | Sequence[ArgsSpec]):
     ), annotations
 
 
+def args_specs_from_fields(
+    fields_dict: Mapping[str, BaseField],
+) -> dict[str, ArgsSpec | Sequence[ArgsSpec]]:
+    """Get the event triggers and arg specs from the given fields.
+
+    Args:
+        fields_dict: The fields, keyed by name
+
+    Returns:
+        The args spec for any field annotated as EventHandler.
+    """
+    return {
+        name: (
+            metadata[0]
+            if (
+                (metadata := getattr(field.annotated_type, "__metadata__", None))
+                is not None
+            )
+            else no_args_event_spec
+        )
+        for name, field in fields_dict.items()
+        if field.type_origin is EventHandler
+    }
+
+
 def check_fn_match_arg_spec(
     user_func: Callable,
     user_func_parameters: Mapping[str, inspect.Parameter],
@@ -2406,6 +2432,7 @@ class EventNamespace:
     check_fn_match_arg_spec = staticmethod(check_fn_match_arg_spec)
     resolve_annotation = staticmethod(resolve_annotation)
     parse_args_spec = staticmethod(parse_args_spec)
+    args_specs_from_fields = staticmethod(args_specs_from_fields)
     unwrap_var_annotation = staticmethod(unwrap_var_annotation)
     get_fn_signature = staticmethod(get_fn_signature)
 


### PR DESCRIPTION
Typing issue remains in that EventCallback/EventType cannot be assigned to a field annotated as EventHandler without pyi processing... not sure if we want to merge without support for this.