### PR TITLE
Fixing `code_tag_props` in `rx.code_block`

### DIFF
--- a/pyi_hashes.json
+++ b/pyi_hashes.json
@@ -22,7 +22,7 @@
   "reflex/components/core/upload.pyi": "c11465a3a88e3a374251dd1a16582938",
   "reflex/components/core/window_events.pyi": "76bf03a273a1fbbb3b333e10d5d08c30",
   "reflex/components/datadisplay/__init__.pyi": "52755871369acbfd3a96b46b9a11d32e",
-  "reflex/components/datadisplay/code.pyi": "ec35c215a219c616ff38c30047d9b601",
+  "reflex/components/datadisplay/code.pyi": "b86769987ef4d1cbdddb461be88539fd",
   "reflex/components/datadisplay/dataeditor.pyi": "82c652f0679148d8431a0cf645686a50",
   "reflex/components/datadisplay/shiki_code_block.pyi": "1d53e75b6be0d3385a342e7b3011babd",
   "reflex/components/el/__init__.pyi": "0adfd001a926a2a40aee94f6fa725ecc",

--- a/reflex/components/datadisplay/code.py
+++ b/reflex/components/datadisplay/code.py
@@ -382,7 +382,7 @@ for theme_name in dir(Theme):
 class CodeBlock(Component, MarkdownComponentMap):
     """A code block."""
 
-    library = "react-syntax-highlighter@15.6.1"
+    library = "react-syntax-highlighter@15.6.6"
 
     tag = "PrismAsyncLight"
 
@@ -412,7 +412,7 @@ class CodeBlock(Component, MarkdownComponentMap):
     )
 
     # Props passed down to the code tag.
-    code_tag_props: Var[dict[str, str]]
+    code_tag_props: Var[dict[str, str | dict[str, str]]]
 
     # Whether a copy button should appear.
     can_copy: bool | None = field(


### PR DESCRIPTION
The downgrade to `react-syntax-highlighter@15.6.1` (#4368)  does not actually fix the issue with `wrap_long_lines` (see [this issue](https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/597)). There isn't an issue with the default HighlightJS, but there is one with Prism. Based on [this comment](https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/597#issuecomment-3104158542) one could overwrite the code tag style to use `pre-wrap` instad of `pre`, but the `code_tag_props` only accepts a `dict[str, str]` which prevents a successful style override of `code_tag_props={"style": {"white-space": "pre-wrap"}}`. 

This PR changes the type hinting of `code_tag_props: rx.Var[dict[str, str]]` to `code_tag_props: rx.Var[dict[str, str | dict[str, str]]]` so the component renderer doesn't throw a fit. The `wrap_long_lines` keyword argument will still not work with Prism, but this will allow users to override the `<code>` styling.

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### **After** these steps, you're ready to open a pull request.

    a. Give a descriptive title to your PR.

    b. Describe your changes.

    c. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
