### PR TITLE
Automatic websocket reconnect and reload handling

### DIFF
--- a/tests/integration/test_background_task.py
+++ b/tests/integration/test_background_task.py
@@ -109,13 +109,6 @@ def BackgroundTask():
                 yield
                 self.counter += 1
 
-        @rx.event
-        async def disconnect_reconnect(self):
-            self.counter += 1
-            yield rx.call_script("socket.disconnect()")
-            await asyncio.sleep(0.5)
-            self.counter += 1
-
         @rx.event(background=True)
         async def disconnect_reconnect_background(self):
             async with self:
@@ -203,11 +196,6 @@ def BackgroundTask():
                 "Yield in Async with Self",
                 on_click=State.yield_in_async_with_self,
                 id="yield-in-async-with-self",
-            ),
-            rx.button(
-                "Disconnect / Reconnect",
-                on_click=State.disconnect_reconnect_background,
-                id="disconnect-reconnect",
             ),
             rx.button(
                 "Disconnect / Reconnect Background",
@@ -429,7 +417,6 @@ def test_yield_in_async_with_self(
 @pytest.mark.parametrize(
     "button_id",
     [
-        "disconnect-reconnect",
         "disconnect-reconnect-background",
     ],
 )

--- a/tests/integration/test_background_task.py
+++ b/tests/integration/test_background_task.py
@@ -109,6 +109,22 @@ def BackgroundTask():
                 yield
                 self.counter += 1
 
+        @rx.event
+        async def disconnect_reconnect(self):
+            self.counter += 1
+            yield rx.call_script("socket.disconnect()")
+            await asyncio.sleep(0.5)
+            self.counter += 1
+
+        @rx.event(background=True)
+        async def disconnect_reconnect_background(self):
+            async with self:
+                self.counter += 1
+            yield rx.call_script("socket.disconnect()")
+            await asyncio.sleep(0.5)
+            async with self:
+                self.counter += 1
+
     class OtherState(rx.State):
         @rx.event(background=True)
         async def get_other_state(self):
@@ -133,6 +149,9 @@ def BackgroundTask():
         return rx.vstack(
             rx.input(
                 id="token", value=State.router.session.client_token, is_read_only=True
+            ),
+            rx.input(
+                id="sid", value=State.router.session.session_id, is_read_only=True
             ),
             rx.hstack(
                 rx.heading(State.counter, id="counter"),
@@ -184,6 +203,16 @@ def BackgroundTask():
                 "Yield in Async with Self",
                 on_click=State.yield_in_async_with_self,
                 id="yield-in-async-with-self",
+            ),
+            rx.button(
+                "Disconnect / Reconnect",
+                on_click=State.disconnect_reconnect_background,
+                id="disconnect-reconnect",
+            ),
+            rx.button(
+                "Disconnect / Reconnect Background",
+                on_click=State.disconnect_reconnect_background,
+                id="disconnect-reconnect-background",
             ),
             rx.button("Reset", on_click=State.reset_counter, id="reset"),
         )
@@ -395,3 +424,43 @@ def test_yield_in_async_with_self(
 
     yield_in_async_with_self_button.click()
     AppHarness.expect(lambda: counter.text == "2", timeout=5)
+
+
+@pytest.mark.parametrize(
+    "button_id",
+    [
+        "disconnect-reconnect",
+        "disconnect-reconnect-background",
+    ],
+)
+def test_disconnect_reconnect(
+    background_task: AppHarness,
+    driver: WebDriver,
+    token: str,
+    button_id: str,
+):
+    """Test that disconnecting and reconnecting works as expected.
+
+    Args:
+        background_task: harness for BackgroundTask app.
+        driver: WebDriver instance.
+        token: The token for the connected client.
+        button_id: The ID of the button to click.
+    """
+    counter = driver.find_element(By.ID, "counter")
+    button = driver.find_element(By.ID, button_id)
+    increment_button = driver.find_element(By.ID, "increment")
+    sid_input = driver.find_element(By.ID, "sid")
+    sid = background_task.poll_for_value(sid_input, timeout=5)
+    assert sid is not None
+
+    AppHarness.expect(lambda: counter.text == "0", timeout=5)
+    button.click()
+    AppHarness.expect(lambda: counter.text == "1", timeout=5)
+    increment_button.click()
+    # should get a new sid after the reconnect
+    assert (
+        background_task.poll_for_value(sid_input, timeout=5, exp_not_equal=sid) != sid
+    )
+    # Final update should come through on the new websocket connection
+    AppHarness.expect(lambda: counter.text == "3", timeout=5)

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -2005,6 +2005,7 @@ async def test_state_proxy(
     namespace = mock_app.event_namespace
     assert namespace is not None
     namespace.sid_to_token[router_data.session.session_id] = token
+    namespace.token_to_sid[token] = router_data.session.session_id
     if isinstance(mock_app.state_manager, (StateManagerMemory, StateManagerDisk)):
         mock_app.state_manager.states[parent_state.router.session.client_token] = (
             parent_state
@@ -2214,6 +2215,7 @@ async def test_background_task_no_block(mock_app: rx.App, token: str):
     namespace = mock_app.event_namespace
     assert namespace is not None
     namespace.sid_to_token[sid] = token
+    namespace.token_to_sid[token] = sid
     mock_app.state_manager.state = mock_app._state = BackgroundTaskState
     async for update in rx.app.process(
         mock_app,


### PR DESCRIPTION
* ensureSocketConnected is called when adding events or pumping the queue to trigger an automatic reconnection to the backend
* when "reload" event is encountered, trigger a re-hydrate and wait until ALL on_load have finished processing and `is_hydrated` is True before requeue the event that caused the "reload"