### PR TITLE
ENG-7732: plumb through `Upload.on_drop_rejected`

### DIFF
--- a/pyi_hashes.json
+++ b/pyi_hashes.json
@@ -19,7 +19,7 @@
   "reflex/components/core/helmet.pyi": "43f8497c8fafe51e29dca1dd535d143a",
   "reflex/components/core/html.pyi": "ea5919db8c8172913185977df900f36b",
   "reflex/components/core/sticky.pyi": "a9b4492e423f1dd4ccbf270c8ea90157",
-  "reflex/components/core/upload.pyi": "360fb929edf960aca289a37d0433fc38",
+  "reflex/components/core/upload.pyi": "77e828bbc55dd6593efdba1504e0cb5e",
   "reflex/components/core/window_events.pyi": "76bf03a273a1fbbb3b333e10d5d08c30",
   "reflex/components/datadisplay/__init__.pyi": "52755871369acbfd3a96b46b9a11d32e",
   "reflex/components/datadisplay/code.pyi": "b86769987ef4d1cbdddb461be88539fd",


### PR DESCRIPTION
Allow user to supply an event handler for dropped files that do not meet the defined criteria.

By default it will display an error toast with the file names and rejection reasons.

<img width="1102" height="746" alt="image" src="https://github.com/user-attachments/assets/2a05bc28-f379-4f7d-9472-d65f421a092e" />
