### PR TITLE
improve upload state handlers ergonomics

### DIFF
--- a/pyi_hashes.json
+++ b/pyi_hashes.json
@@ -19,7 +19,7 @@
   "reflex/components/core/helmet.pyi": "43f8497c8fafe51e29dca1dd535d143a",
   "reflex/components/core/html.pyi": "ea5919db8c8172913185977df900f36b",
   "reflex/components/core/sticky.pyi": "a9b4492e423f1dd4ccbf270c8ea90157",
-  "reflex/components/core/upload.pyi": "77e828bbc55dd6593efdba1504e0cb5e",
+  "reflex/components/core/upload.pyi": "6dc28804a6dddf903e31162e87c1b023",
   "reflex/components/core/window_events.pyi": "76bf03a273a1fbbb3b333e10d5d08c30",
   "reflex/components/datadisplay/__init__.pyi": "52755871369acbfd3a96b46b9a11d32e",
   "reflex/components/datadisplay/code.pyi": "b86769987ef4d1cbdddb461be88539fd",

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -69,7 +69,6 @@ from reflex.components.core.banner import (
 )
 from reflex.components.core.breakpoints import set_breakpoints
 from reflex.components.core.sticky import sticky
-from reflex.components.core.upload import Upload, get_upload_dir
 from reflex.components.radix import themes
 from reflex.components.sonner.toast import toast
 from reflex.config import get_config
@@ -670,6 +669,8 @@ class App(MiddlewareMixin, LifespanMixin):
 
     def _add_optional_endpoints(self):
         """Add optional api endpoints (_upload)."""
+        from reflex.components.core.upload import Upload, get_upload_dir
+
         if not self._api:
             return
         upload_is_used_marker = (


### PR DESCRIPTION
the following:
```python
rx.upload(
    id="upload",
    on_drop =State.on_upload,
)
```
would be converted to
```python
rx.upload(
    id="upload",
    on_drop =State.on_upload(rx.upload_files("upload")),
)
```