### PR TITLE
Upcast str or int to annotated Enum type in event handlers

### DIFF
--- a/reflex/state.py
+++ b/reflex/state.py
@@ -16,6 +16,7 @@ import time
 import typing
 import warnings
 from collections.abc import AsyncIterator, Callable, Sequence
+from enum import Enum
 from hashlib import md5
 from types import FunctionType
 from typing import TYPE_CHECKING, Any, BinaryIO, ClassVar, TypeVar, cast, get_type_hints
@@ -1882,6 +1883,12 @@ class BaseState(EvenMoreBasicBaseState):
                 hinted_args is tuple or hinted_args is tuple
             ):
                 payload[arg] = tuple(value)
+            elif isinstance(hinted_args, type) and issubclass(hinted_args, Enum):
+                try:
+                    payload[arg] = hinted_args(value)
+                except ValueError:
+                    msg = f"Received an invalid enum value ({value}) for {arg} of type {hinted_args}"
+                    raise ValueError(msg) from None
             elif (
                 isinstance(value, str)
                 and (deserializer := _deserializers.get(hinted_args)) is not None


### PR DESCRIPTION
If the argument of an event handler is annotated as a python Enum type, attempt to upcast the passed value to the Enum type.