### PR TITLE
Use pytest-rerunfailures to avoid tmp_path stashkey issues

### DIFF
--- a/.github/workflows/integration_app_harness.yml
+++ b/.github/workflows/integration_app_harness.yml
@@ -56,4 +56,4 @@ jobs:
       - name: Run app harness tests
         env:
           REFLEX_REDIS_URL: ${{ matrix.state_manager == 'redis' && 'redis://localhost:6379' || '' }}
-        run: uv run pytest tests/integration --retries 3 -v --maxfail=5 --splits 2 --group ${{matrix.split_index}}
+        run: uv run pytest tests/integration --reruns 3 -v --maxfail=5 --splits 2 --group ${{matrix.split_index}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ dev = [
   "pytest-cov",
   "pytest-mock",
   "pytest-playwright",
-  "pytest-retry",
+  "pytest-rerunfailures",
   "pytest-split",
   "pytest",
   "python-dotenv",

--- a/uv.lock
+++ b/uv.lock
@@ -1648,15 +1648,16 @@ wheels = [
 ]
 
 [[package]]
-name = "pytest-retry"
-version = "1.7.0"
+name = "pytest-rerunfailures"
+version = "16.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "packaging" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/5b/607b017994cca28de3a1ad22a3eee8418e5d428dcd8ec25b26b18e995a73/pytest_retry-1.7.0.tar.gz", hash = "sha256:f8d52339f01e949df47c11ba9ee8d5b362f5824dff580d3870ec9ae0057df80f", size = 19977, upload-time = "2025-01-19T01:56:13.115Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/53/a543a76f922a5337d10df22441af8bf68f1b421cadf9aedf8a77943b81f6/pytest_rerunfailures-16.0.1.tar.gz", hash = "sha256:ed4b3a6e7badb0a720ddd93f9de1e124ba99a0cb13bc88561b3c168c16062559", size = 27612, upload-time = "2025-09-02T06:48:25.193Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/ff/3266c8a73b9b93c4b14160a7e2b31d1e1088e28ed29f4c2d93ae34093bfd/pytest_retry-1.7.0-py3-none-any.whl", hash = "sha256:a2dac85b79a4e2375943f1429479c65beb6c69553e7dae6b8332be47a60954f4", size = 13775, upload-time = "2025-01-19T01:56:11.199Z" },
+    { url = "https://files.pythonhosted.org/packages/38/73/67dc14cda1942914e70fbb117fceaf11e259362c517bdadd76b0dd752524/pytest_rerunfailures-16.0.1-py3-none-any.whl", hash = "sha256:0bccc0e3b0e3388275c25a100f7077081318196569a121217688ed05e58984b9", size = 13610, upload-time = "2025-09-02T06:48:23.615Z" },
 ]
 
 [[package]]
@@ -1883,7 +1884,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-playwright" },
-    { name = "pytest-retry" },
+    { name = "pytest-rerunfailures" },
     { name = "pytest-split" },
     { name = "python-dotenv" },
     { name = "ruff" },
@@ -1944,7 +1945,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "pytest-playwright" },
-    { name = "pytest-retry" },
+    { name = "pytest-rerunfailures" },
     { name = "pytest-split" },
     { name = "python-dotenv" },
     { name = "ruff" },


### PR DESCRIPTION
Sadly due to str0zzapreti/pytest-retry#46 having no resolution from upstream.

Had at least one rerun in this CI run https://github.com/reflex-dev/reflex/actions/runs/18383346259/job/52375408227
