### PR TITLE
ENG-7948: Fix hanging frontend and other reconnection woes

### DIFF
--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -825,7 +825,7 @@ export const useEventLoop = (
   const [searchParams] = useSearchParams();
   const [connectErrors, setConnectErrors] = useState([]);
   const params = useRef(paramsR);
-  let mounted = false;
+  const mounted = useRef(false);
 
   useEffect(() => {
     const { "*": splat, ...remainingParams } = paramsR;
@@ -837,7 +837,7 @@ export const useEventLoop = (
   }, [paramsR]);
 
   const ensureSocketConnected = useCallback(async () => {
-    if (!mounted) {
+    if (!mounted.current) {
       // During hot reload, some components may still have a reference to
       // addEvents, so avoid reconnecting the socket of an unmounted event loop.
       return;
@@ -859,7 +859,15 @@ export const useEventLoop = (
         () => params.current,
       );
     }
-  }, [socket, dispatch, setConnectErrors, client_storage, navigate, params]);
+  }, [
+    socket,
+    dispatch,
+    setConnectErrors,
+    client_storage,
+    navigate,
+    params,
+    mounted,
+  ]);
 
   // Function to add new events to the event queue.
   const addEvents = useCallback((events, args, event_actions) => {
@@ -962,12 +970,12 @@ export const useEventLoop = (
   // Handle socket connect/disconnect.
   useEffect(() => {
     // Initialize the websocket connection.
-    mounted = true;
+    mounted.current = true;
     ensureSocketConnected();
 
     // Cleanup function.
     return () => {
-      mounted = false;
+      mounted.current = false;
       if (socket.current) {
         socket.current.disconnect();
         socket.current.off();


### PR DESCRIPTION
* Disable socketio automatic reconnection logic -- replace with manual reconnect logic
* Try to keep the socketio socket allocated, even when it gets disconnected for better resource management.

* Introduce new `socket.current.reconnect()` helper
  * Update query param token when reconnecting
  * Only allow one concurrent connection attempt

* ensureSocketConnected only reconnects if the event loop is mounted -- this avoids issues during hot reload where some Event-emitting components may still have a reference to the _old_ `addEvents` and `ensureSocketConnected` was reconnecting the old socket.

* Use `.off` and null the `socket` ref when cleaning up event loop to free memory and avoid unwanted reconnections when the socket will be recreated.

----------------

Also addresses the following ticket:
ENG-7762: [reconnect] client is given new_token when wifi disconnects and reconnects

This issue was the result of automatic reconnect logic and manual reconnect logic conflicting with each other and opening two sockets with the same token, which reflex reassigns the latter to a new token, and this is typically the socket that gets used in the app.