### PR TITLE
Add virtual environment setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,25 +39,50 @@ See our [architecture page](https://reflex.dev/blog/2024-03-21-reflex-architectu
 
 ## ⚙️ Installation
 
-Open a terminal and run (Requires Python 3.10+):
+**Important:** We strongly recommend using a virtual environment to ensure the `reflex` command is available in your PATH.
+
+## 🥳 Create your first app
+
+### 1. Create the project directory
+
+Replace `my_app_name` with your project name:
+
+```bash
+mkdir my_app_name
+cd my_app_name
+```
+
+### 2. Set up a virtual environment
+
+Create and activate virtual environment
+
+```bash
+# On Windows:
+python -m venv .venv
+.venv\Scripts\activate
+
+# On macOS/Linux:
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+### 3. Install Reflex
+
+Reflex is available as a pip package (Requires Python 3.10+):
 
 ```bash
 pip install reflex
 ```
 
-## 🥳 Create your first app
+### 4. Initialize the project
 
-Installing `reflex` also installs the `reflex` command line tool.
-
-Test that the install was successful by creating a new project. (Replace `my_app_name` with your project name):
+This command initializes a template app in your new directory:
 
 ```bash
-mkdir my_app_name
-cd my_app_name
 reflex init
 ```
 
-This command initializes a template app in your new directory.
+### 5. Run the app
 
 You can run this app in development mode:
 
@@ -68,6 +93,11 @@ reflex run
 You should see your app running at http://localhost:3000.
 
 Now you can modify the source code in `my_app_name/my_app_name.py`. Reflex has fast refreshes so you can see your changes instantly when you save your code.
+
+### Troubleshooting
+
+If you installed Reflex without a virtual environment and the `reflex` command is not found, you can run commands using: `python3 -m reflex init` and `python3 -m reflex run`
+
 
 ## 🫧 Example App
 


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.
- [x] This change requires a documentation update


### Description
Users installing Reflex without a virtual environment often encounter PATH issues where the `reflex` CLI command is not recognized. Restructured the Installation and "Create your first app" sections in the README to match the Reflex website Installation guide.

### Changes Made
- Updated Installation section to include virtual environment warning
- Restructured "Create your first app" section with numbered steps
- Added virtual environment setup instructions for Windows and macOS/Linux
- Added troubleshooting section for PATH issues
