### PR TITLE
allow state mutation with contextmanager from normal (non-background) events

### DIFF
--- a/reflex/environment.py
+++ b/reflex/environment.py
@@ -727,11 +727,6 @@ class EnvironmentVariables:
     # How long to wait between automatic reload on frontend error to avoid reload loops.
     REFLEX_AUTO_RELOAD_COOLDOWN_TIME_MS: EnvVar[int] = env_var(10_000)
 
-    # Whether to allow entering a state mutation with `async with self` in normal (non background) event handlers
-    REFLEX_STATE_ALLOW_CONTEXTMANAGER_WITHOUT_BACKGROUND_TASK: EnvVar[bool] = env_var(
-        False
-    )
-
 
 environment = EnvironmentVariables()
 

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -2189,19 +2189,12 @@ class BaseState(EvenMoreBasicBaseState):
     async def __aenter__(self) -> BaseState:
         """Enter the async context manager protocol.
 
-        This should not be used for the State class, but exists for
-        type-compatibility with StateProxy.
+        This is a no-op for the State class and mainly used in background-tasks/StateProxy.
 
         Returns:
             The unmodified state (self)
-
-        Raises:
-            TypeError: always, because async contextmanager protocol is only supported for background task.
         """
-        if environment.REFLEX_STATE_ALLOW_CONTEXTMANAGER_WITHOUT_BACKGROUND_TASK.get():
-            return self
-        msg = "Only background task should use `async with self` to modify state."
-        raise TypeError(msg)
+        return self
 
     async def __aexit__(self, *exc_info: Any) -> None:
         """Exit the async context manager protocol.


### PR DESCRIPTION
this makes it much easier to write reusable code which can be used in background and "normal" events and avoids a lot of dirty workarounds to make it possible

we can also choose to make this the default instead of adding just another config option