### PR TITLE
ENG-8049: pass correct parameters to queueEvents

### DIFF
--- a/reflex/.templates/web/utils/state.js
+++ b/reflex/.templates/web/utils/state.js
@@ -176,7 +176,7 @@ export const queueEventIfSocketExists = async (
   if (!socket) {
     return;
   }
-  await queueEvents(events, socket, navigate, params);
+  await queueEvents(events, socket, false, navigate, params);
 };
 
 /**
@@ -256,13 +256,13 @@ export const applyEvent = async (event, socket, navigate, params) => {
 
   if (event.name == "_clear_session_storage") {
     sessionStorage.clear();
-    queueEvents(initialEvents(), socket, navigate, params);
+    queueEventIfSocketExists(initialEvents(), socket, navigate, params);
     return false;
   }
 
   if (event.name == "_remove_session_storage") {
     sessionStorage.removeItem(event.payload.key);
-    queueEvents(initialEvents(), socket, navigate, params);
+    queueEventIfSocketExists(initialEvents(), socket, navigate, params);
     return false;
   }
 

--- a/reflex/utils/format.py
+++ b/reflex/utils/format.py
@@ -586,8 +586,8 @@ def format_queue_events(
     # Return the final code snippet, expecting queueEvents, processEvent, and socket to be in scope.
     # Typically this snippet will _only_ run from within an rx.call_script eval context.
     return Var(
-        f"{arg_def} => {{queueEvents([{','.join(payloads)}], {constants.CompileVars.SOCKET}); "
-        f"processEvent({constants.CompileVars.SOCKET})}}",
+        f"{arg_def} => {{queueEvents([{','.join(payloads)}], {constants.CompileVars.SOCKET}, false, navigate, params);"
+        f"processEvent({constants.CompileVars.SOCKET}, navigate, params);}}",
     ).to(FunctionVar, EventChain)
 
 


### PR DESCRIPTION
There was also another place in the call_script callback path where the incorrect parameters have been passed since at least 0.8 🙀