### PR TITLE
set ComputedVar cache default to False

### DIFF
--- a/reflex/vars/base.py
+++ b/reflex/vars/base.py
@@ -2083,7 +2083,7 @@ class ComputedVar(Var[RETURN_TYPE]):
         self,
         fget: Callable[[BASE_STATE], RETURN_TYPE],
         initial_value: RETURN_TYPE | types.Unset = types.Unset(),
-        cache: bool = True,
+        cache: bool = False,
         deps: list[str | Var] | None = None,
         auto_deps: bool = True,
         interval: int | datetime.timedelta | None = None,
@@ -2703,7 +2703,7 @@ class _ComputedVarDecorator(Protocol):
 def computed_var(
     fget: None = None,
     initial_value: Any | types.Unset = types.Unset(),
-    cache: bool = True,
+    cache: bool = False,
     deps: list[str | Var] | None = None,
     auto_deps: bool = True,
     interval: datetime.timedelta | int | None = None,
@@ -2716,7 +2716,7 @@ def computed_var(
 def computed_var(
     fget: Callable[[BASE_STATE], Coroutine[Any, Any, RETURN_TYPE]],
     initial_value: RETURN_TYPE | types.Unset = types.Unset(),
-    cache: bool = True,
+    cache: bool = False,
     deps: list[str | Var] | None = None,
     auto_deps: bool = True,
     interval: datetime.timedelta | int | None = None,
@@ -2729,7 +2729,7 @@ def computed_var(
 def computed_var(
     fget: Callable[[BASE_STATE], RETURN_TYPE],
     initial_value: RETURN_TYPE | types.Unset = types.Unset(),
-    cache: bool = True,
+    cache: bool = False,
     deps: list[str | Var] | None = None,
     auto_deps: bool = True,
     interval: datetime.timedelta | int | None = None,
@@ -2741,7 +2741,7 @@ def computed_var(
 def computed_var(
     fget: Callable[[BASE_STATE], Any] | None = None,
     initial_value: Any | types.Unset = types.Unset(),
-    cache: bool = True,
+    cache: bool = False,
     deps: list[str | Var] | None = None,
     auto_deps: bool = True,
     interval: datetime.timedelta | int | None = None,


### PR DESCRIPTION
## Description

This PR changes the default value of the `cache` parameter in `ComputedVar` from `True` to `False` to align with the documented behavior at https://reflex.dev/docs/vars/computed-vars#cached-vars.

### Background

According to the documentation:
- `@rx.var` should recompute on every state change (cache=False behavior)
- `@rx.var(cache=True)` should only recompute when dependencies change (cached behavior)

However, the current implementation has `cache=True` as the default in the `computed_var()` function and `ComputedVar.__init__()`, which contradicts the documentation.

### Changes

Updated the default `cache` parameter to `False`.

### Related Issues

This change makes the code consistent with the documentation. As a result, [PR in reflex-web](https://github.com/reflex-dev/reflex-web/pull/1687) (which updates the documentation to state that the default is `True`) should be declined, as the code now correctly implements `cache=False` as the default behavior.

### Breaking Change

Existing computed vars that relied on the default caching behavior will no longer be cached automatically. Users who want caching enabled must now explicitly set `@rx.var(cache=True)`.

### Migration Guide

If you have existing code using computed vars that depends on caching:

```python
# Before (implicitly cached)
@rx.var
def my_computed_var(self) -> str:
    return expensive_computation()

# After (explicitly cache)
@rx.var(cache=True)
def my_computed_var(self) -> str:
    return expensive_computation()