### PR TITLE
Make oplock_hold_time_ms configurable

### DIFF
--- a/reflex/environment.py
+++ b/reflex/environment.py
@@ -733,6 +733,9 @@ class EnvironmentVariables:
     # Whether to opportunistically hold the redis lock to allow fast in-memory access while uncontended.
     REFLEX_OPLOCK_ENABLED: EnvVar[bool] = env_var(False)
 
+    # How long to opportunistically hold the redis lock in milliseconds (must be less than the token expiration).
+    REFLEX_OPLOCK_HOLD_TIME_MS: EnvVar[int] = env_var(0)
+
 
 environment = EnvironmentVariables()
 


### PR DESCRIPTION
Make the oplock hold time configurable and drop the default down to 50% of the configured lock timeout to avoid lock expiration between the lease breaker sleep ending and the coroutine actually getting scheduled for execution.