### PR TITLE
Don't wrap return values of MutableProxy methods

### DIFF
--- a/reflex/istate/proxy.py
+++ b/reflex/istate/proxy.py
@@ -563,11 +563,8 @@ class MutableProxy(wrapt.ObjectProxy):
                 not isinstance(self.__wrapped__, Base)
                 or __name not in NEVER_WRAP_BASE_ATTRS
             ) and hasattr(value, "__func__"):
-                # Wrap methods which might do _anything_
-                return wrapt.FunctionWrapper(
-                    functools.partial(value.__func__, self),  # pyright: ignore [reportFunctionMemberAccess, reportAttributeAccessIssue]
-                    self._wrap_recursive_decorator,  # pyright: ignore[reportArgumentType]
-                )
+                # Rebind `self` to the proxy on methods to capture nested mutations.
+                return functools.partial(value.__func__, self)  # pyright: ignore [reportFunctionMemberAccess, reportAttributeAccessIssue]
 
         if is_mutable_type(type(value)) and __name not in (
             "__wrapped__",

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -2071,6 +2071,22 @@ class ModelDC:
         """
         return self.foo + self.foo
 
+    def copy(self, **kwargs) -> ModelDC:
+        """Create a copy of the dataclass with updated fields.
+
+        Returns:
+            A new instance of ModelDC with updated fields.
+        """
+        return dataclasses.replace(self, **kwargs)
+
+    def append_to_ls(self, item: dict):
+        """Append an item to the list attribute ls.
+
+        Args:
+            item: The item to append.
+        """
+        self.ls.append(item)
+
 
 @pytest.mark.asyncio
 async def test_state_proxy(
@@ -3918,6 +3934,15 @@ def test_mutable_models():
         foo="larp", ls=[{"hi": "reflex"}]
     )
     assert state.dirty_vars == set()
+    dc_copy = state.dc.copy()
+    assert dc_copy == state.dc
+    assert dc_copy is not state.dc
+    dc_copy.foo = "new_foo"
+    assert state.dirty_vars == set()
+    dc_copy.append_to_ls({"new": "item"})
+    assert state.dirty_vars == set()
+    state.dc.append_to_ls({"new": "item"})
+    assert state.dirty_vars == {"dc"}
 
 
 def test_dict_and_get_delta():


### PR DESCRIPTION
For arbitrary methods, we assume the return value is not associated directly with the dirty state of the class. If the method _does_ mutate some value on the `self`, then it will still be marked dirty by virtue of `self` being bound to the MutableProxy.
