### PR TITLE
Allow computed vars to yield events and update state reliably

### DIFF
--- a/tests/units/test_computed_var_side_effects.py
+++ b/tests/units/test_computed_var_side_effects.py
@@ -1,0 +1,76 @@
+from typing import AsyncIterator, Generator, List
+
+import pytest
+
+import reflex as rx
+from reflex.constants.state import FIELD_MARKER
+from reflex.state import BaseState, StateUpdate
+from reflex.vars.base import computed_var
+
+
+class SideEffectState(BaseState):
+    """State for testing computed var side effects."""
+    
+    count: int = 0
+    triggered: bool = False
+    side_effect_value: str = ""
+
+    @computed_var
+    def computed_with_side_effect(self) -> int:
+        if self.count > 0:
+            self.triggered = True
+            yield rx.window_alert("Triggered!")
+            return self.count * 2
+        return 0
+
+    @computed_var
+    def computed_modifying_other_var(self) -> str:
+        if self.count == 5:
+            self.side_effect_value = "Five"
+            return "Modified"
+        return "Not Modified"
+
+
+@pytest.mark.asyncio
+async def test_computed_var_yields_event():
+    """Test that a computed var can yield an event."""
+    state = SideEffectState()
+    state.count = 1
+    
+    # This should trigger the computed var
+    # In a real app, this happens via get_delta, but we can simulate the process
+    # The key is that accessing the var triggers the generator and collection
+    
+    # Manually trigger calculation as get_delta would
+    state._mark_dirty_computed_vars()
+    
+    # Accessing the property should run the getter
+    val = state.computed_with_side_effect
+    assert val == 2
+    assert state.triggered is True
+    
+    # Check if event was collected
+    assert hasattr(state, "_computed_var_events")
+    assert len(state._computed_var_events) > 0
+    # window_alert uses run_script which uses call_function which creates an EventHandler with _call_function
+    # so checking the handler name is tricky. We check if the event spec is returned.
+    event = state._computed_var_events[0]
+    assert event.handler.fn.__qualname__ == "_call_function"
+
+
+@pytest.mark.asyncio
+async def test_computed_var_modifies_state():
+    """Test that a computed var can modify other state variables."""
+    state = SideEffectState()
+    state.count = 5
+    
+    # This call to get_delta mimics the backend processing loop
+    delta = state.get_delta()
+    
+    full_name = state.get_full_name()
+    # Check that the computed var was calculated
+    assert delta[full_name]["computed_modifying_other_var" + FIELD_MARKER] == "Modified"
+    
+    # Check that the side effect on 'side_effect_value' was captured in the delta
+    # The fix involves iterating in get_delta to capture these changes
+    assert delta[full_name]["side_effect_value" + FIELD_MARKER] == "Five"


### PR DESCRIPTION


```markdown
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

### New Feature Submission:

- [x] Does your submission pass the tests?
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

---

### Description

This PR enables **Computed Vars** to reliably trigger side effects, such as yielding events or modifying other state variables, during their computation.

Previously, computed vars were expected to be pure functions. Attempting to `yield` events (like `rx.toast`) resulted in the property returning a generator object instead of the calculated value. Additionally, if a computed var modified another state variable, that change was often missed in the current state update cycle because `get_delta` did not re-evaluate dependencies after the initial computation.

**Key Changes:**
1.  **Support for Generator Computed Vars**: Updated `ComputedVar.__get__` (in `reflex/vars/base.py`) to detect generator return values. It now iterates through the generator, collects yielded events, and returns the final value (captured from `StopIteration`).
2.  **Event Collection**: Added `_computed_var_events` to `BaseState` to store these yielded events and updated `_as_state_update` to include them in the response sent to the frontend.
3.  **Iterative State Updates**: Modified `BaseState.get_delta` (in `reflex/state.py`) to iterate (up to a limit) when calculating the delta. This ensures that if a computed var modifies a base var (marking it dirty), the loop continues to capture the ripple effects of that change in the same update cycle.

### Example Usage

```python
class MyState(rx.State):
    count: int = 0
    status: str = "Normal"

    @rx.var
    def check_status(self) -> str:
        if self.count > 10:
            # This side effect (event) is now captured
            yield rx.toast("Count is too high!")
            
            # This side effect (state modification) is now reliably captured in the same update
            self.status = "High" 
            return "Alert"
        return "OK"
```

### Tests
Added `tests/units/test_computed_var_side_effects.py` which verifies:
- A computed var correctly yields an event (e.g., `rx.window_alert`).
- A computed var correctly modifies another state variable, and the change is present in the state delta.

Closes #5956
```