### PR TITLE
ENG-8388: refetch cached state when missing substates

### DIFF
--- a/reflex/istate/manager/redis.py
+++ b/reflex/istate/manager/redis.py
@@ -557,7 +557,12 @@ class StateManagerRedis(StateManager):
                     ) is not None:
                         # Make sure we have the substate cached (or fetch it from redis).
                         try:
-                            _ = cached_state.get_substate(state_path.split("."))
+                            substate = cached_state.get_substate(state_path.split("."))
+                            if len(substate.substates) != len(
+                                type(substate).get_substates()
+                            ):
+                                # If the substate is missing substates, we need to refetch it.
+                                raise ValueError  # noqa: TRY301
                         except ValueError:
                             await self.get_state(token, for_state_instance=cached_state)
                         yield cached_state


### PR DESCRIPTION
Avoid issue where hydrate operates on a subset of the tree because the Root state was requested, but it didn't have all its substates cached, so it doesn't return the full dict.