### PR TITLE
feat: list valid triggers in error message for invalid event triggers

### DIFF
--- a/reflex/components/component.py
+++ b/reflex/components/component.py
@@ -758,7 +758,7 @@ class Component(BaseComponent, ABC):
                 and key not in component_specific_triggers
                 and key not in props
             ):
-                valid_triggers = sorted(self.get_event_triggers().keys())
+                valid_triggers = sorted(component_specific_triggers.keys())
                 msg = (
                     f"The {(comp_name := type(self).__name__)} does not take in an `{key}` event trigger. "
                     f"Valid triggers for {comp_name}: {valid_triggers}. "


### PR DESCRIPTION
# feat: Improve error message for invalid triggers by listing valid options

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran tests with your changes locally?

### Description

This PR improves the developer experience when an invalid event trigger is used on a component. Previously, the error message only stated that the trigger was invalid. Now, it lists all valid triggers for that specific component, making it much easier for developers to identify the correct trigger name (e.g., seeing `on_mouse_enter` instead of trying `on_hover`).

### Proof of Fix

I verified this change using a reproduction script that attempts to pass an invalid trigger (`on_invalid_trigger`) to a `rx.box` component.

**Before:**
```
ValueError: The Box does not take in an `on_invalid_trigger` event trigger. If Box is a third party component make sure to add `on_invalid_trigger` to the component's event triggers. visit https://reflex.dev/docs/wrapping-react/guide/#event-triggers for more info.
```

**After (with this PR):**
```
ValueError: The Box does not take in an `on_invalid_trigger` event trigger. Valid triggers for Box: ['on_blur', 'on_click', 'on_context_menu', 'on_double_click', 'on_focus', 'on_mount', 'on_mouse_down', 'on_mouse_enter', 'on_mouse_leave', 'on_mouse_move', 'on_mouse_out', 'on_mouse_over', 'on_mouse_up', 'on_scroll', 'on_scroll_end', 'on_unmount']. If Box is a third party component make sure to add `on_invalid_trigger` to the component's event triggers. visit https://reflex.dev/docs/wrapping-react/guide/#event-triggers for more info.
```

closes #4883
