### PR TITLE
Adding new props to the data editor for exposing grid selections

### DIFF
--- a/pyi_hashes.json
+++ b/pyi_hashes.json
@@ -23,7 +23,7 @@
   "reflex/components/core/window_events.pyi": "af33ccec866b9540ee7fbec6dbfbd151",
   "reflex/components/datadisplay/__init__.pyi": "52755871369acbfd3a96b46b9a11d32e",
   "reflex/components/datadisplay/code.pyi": "b86769987ef4d1cbdddb461be88539fd",
-  "reflex/components/datadisplay/dataeditor.pyi": "35391d4ba147cf20ce4ac7a782066d61",
+  "reflex/components/datadisplay/dataeditor.pyi": "fb26f3e702fcb885539d1cf82a854be3",
   "reflex/components/datadisplay/shiki_code_block.pyi": "1d53e75b6be0d3385a342e7b3011babd",
   "reflex/components/el/__init__.pyi": "0adfd001a926a2a40aee94f6fa725ecc",
   "reflex/components/el/element.pyi": "c5974a92fbc310e42d0f6cfdd13472f4",

--- a/reflex/components/datadisplay/dataeditor.py
+++ b/reflex/components/datadisplay/dataeditor.py
@@ -384,7 +384,7 @@ class DataEditor(NoSSRComponent):
             JavaScript code to reconstruct GridSelection.
         """
         return [
-                    """
+            """
         function reconstructGridSelection(selection) {
             if (!selection || typeof selection !== 'object') {
                 return undefined;
@@ -420,7 +420,7 @@ class DataEditor(NoSSRComponent):
             };
         }
                     """
-                ]
+        ]
 
     def add_hooks(self) -> list[str]:
         """Get the hooks to render.
@@ -505,8 +505,12 @@ class DataEditor(NoSSRComponent):
             )
 
         # Apply the reconstruction function to grid_selection if it's a Var
-        if (grid_selection := props.get("grid_selection")) is not None and isinstance(grid_selection, Var):
-            props["grid_selection"] = FunctionStringVar.create("reconstructGridSelection").call(grid_selection)
+        if (grid_selection := props.get("grid_selection")) is not None and isinstance(
+            grid_selection, Var
+        ):
+            props["grid_selection"] = FunctionStringVar.create(
+                "reconstructGridSelection"
+            ).call(grid_selection)
 
         grid = super().create(*children, **props)
         return Div.create(


### PR DESCRIPTION
Add Grid Selection Props and Event Handler to DataEditor
This PR adds comprehensive grid selection capabilities to the DataEditor component, allowing developers to track and control cell, row, and column selections.

**New Props Added:**

**Selection Control:**
range_select: Controls range selection modes ("none", "cell", "rect", "multi-cell", "multi-rect")
column_select: Already existed, allows column selections ("none", "single", "multi")
row_select: Controls row selection modes ("none", "single", "multi")

**Selection Blending:**
range_selection_blending: Controls how range selections coexist ("exclusive", "mixed")
column_selection_blending: Controls how column selections coexist ("exclusive", "mixed")
row_selection_blending: Controls how row selections coexist ("exclusive", "mixed")
Selection Behavior:

span_range_behavior: Controls how cell spans are handled in selections ("default", "allowPartial")

**State Management:**
grid_selection: Controlled state prop for the current selection (columns, rows, and current cell/range)
on_grid_selection_change: Event handler that fires when selection changes, passing the current GridSelection object


### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### New Feature Submission:

- [x] Does your submission pass the tests?
- [x] Have you linted your code locally prior to submission?

