### PR TITLE
turn on inconsistentCjsInterop again

### DIFF
--- a/reflex/compiler/templates.py
+++ b/reflex/compiler/templates.py
@@ -585,6 +585,9 @@ export default defineConfig((config) => ({{
     enableNativePlugin: false,
     hmr: {"true" if experimental_hmr else "false"},
   }},
+  legacy: {{
+    inconsistentCjsInterop: true,
+  }},
   server: {{
     port: process.env.PORT,
     hmr: {"true" if hmr else "false"},


### PR DESCRIPTION
it caused failures in `react-simple-code-editor`