### PR TITLE
fix: avoid ERR_REQUIRE_ESM during reflex export with rx.code_block

### DIFF
--- a/reflex/compiler/templates.py
+++ b/reflex/compiler/templates.py
@@ -581,6 +581,11 @@ export default defineConfig((config) => ({{
       }},
     }},
   }},
+  ssr: {{
+    noExternal: config.command === "build"
+      ? ["react-syntax-highlighter", "refractor"]
+      : [],
+  }},
   experimental: {{
     enableNativePlugin: false,
     hmr: {"true" if experimental_hmr else "false"},


### PR DESCRIPTION
Fixes #6054


### Solution
Updated the generated Vite configuration to prevent SSR build externalization of
`react-syntax-highlighter` and its ESM dependency `refractor`.

This ensures that during `reflex export`, Vite/Rolldown handles ESM/CJS interop
correctly instead of deferring module resolution to Node.js, which caused
`ERR_REQUIRE_ESM` failures on Node.js 21+.

The change is scoped to the build/export phase only and does not affect development mode.

---

### Changes Made

- Prevented SSR externalization of `react-syntax-highlighter` during export builds
- Added `refractor` to the non-externalized dependency list to avoid ESM/CJS conflicts

---


### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
