### PR TITLE
Allow custom toast message in production mode by adding optional connection_error_message arg in rx.config

### DIFF
--- a/reflex/components/core/banner.py
+++ b/reflex/components/core/banner.py
@@ -102,12 +102,10 @@ class ConnectionToaster(Fragment):
         toast_id = "websocket-error"
         target_url = WebsocketTargetURL.create()
         config = get_config()
-        is_dev_mode = environment.REFLEX_ENV_MODE.get().value == constants.Env.DEV
         props = ToastProps(
             description=LiteralVar.create(
-                f"Check if server is reachable at {target_url}"
-                if is_dev_mode or not config.connection_error_message
-                else config.connection_error_message
+                config.connection_error_message
+                or f"Check if server is reachable at {target_url}"
             ),
             close_button=True,
             duration=120000,
@@ -140,7 +138,7 @@ setTimeout(() => {{
         else:
             loading_message = Var.create(
                 f"Cannot connect to server: {connection_error}."
-                if is_dev_mode or not config.connection_error_message
+                if not config.connection_error_message
                 else ""
             )
             toast_var = Var(

--- a/reflex/config.py
+++ b/reflex/config.py
@@ -262,6 +262,7 @@ class BaseConfig:
 
     _prefixes: ClassVar[list[str]] = ["REFLEX_"]
 
+    # The message to display in the frontend when a connection error occurs.
     connection_error_message: str | None = None
 
 


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.

     Describe your changes:
Add connection_error_message variable to Config class and change the add_hooks method in ConnectionToaster class to show the custom message from the config only in production mode.
