### PR TITLE
Fix src file lookup when subfolder is provided in asset()

### DIFF
--- a/reflex/assets.py
+++ b/reflex/assets.py
@@ -73,7 +73,7 @@ def asset(
     assert module is not None
 
     external = constants.Dirs.EXTERNAL_APP_ASSETS
-    src_file_shared = Path(calling_file).parent / path
+    src_file_shared = Path(calling_file).parent / (Path(subfolder) / path if subfolder else path)
     if not src_file_shared.exists():
         msg = f"File not found: {src_file_shared}"
         raise FileNotFoundError(msg)


### PR DESCRIPTION
When using `rx.asset(path="logo.jpg", shared=True, subfolder="images")`, the current implementation looks for `.../logo.jpg` instead of `.../images/logo.jpg`. This PR updates the logic to include the `subfolder` in the source file path check.