### PR TITLE
Split REFLEX_CORS_ALLOWED_ORIGINS by comma

### DIFF
--- a/reflex/config.py
+++ b/reflex/config.py
@@ -10,7 +10,7 @@ from collections.abc import Sequence
 from importlib.util import find_spec
 from pathlib import Path
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, ClassVar, Literal
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal
 
 from reflex import constants
 from reflex.constants.base import LogLevel
@@ -18,6 +18,7 @@ from reflex.environment import EnvironmentVariables as EnvironmentVariables
 from reflex.environment import EnvVar as EnvVar
 from reflex.environment import (
     ExistingPath,
+    SequenceOptions,
     _load_dotenv_from_files,
     _paths_from_env_files,
     interpret_env_var_value,
@@ -207,8 +208,10 @@ class BaseConfig:
     # Timeout to do a production build of a frontend page.
     static_page_generation_timeout: int = 60
 
-    # List of origins that are allowed to connect to the backend API.
-    cors_allowed_origins: Sequence[str] = dataclasses.field(default=("*",))
+    # Comma separated list of origins that are allowed to connect to the backend API.
+    cors_allowed_origins: Annotated[Sequence[str], SequenceOptions(delimiter=",")] = (
+        dataclasses.field(default=("*",))
+    )
 
     # Whether to use React strict mode.
     react_strict_mode: bool = True

--- a/tests/units/test_config.py
+++ b/tests/units/test_config.py
@@ -96,6 +96,41 @@ def test_update_from_env_path(
     assert config.bun_path == tmp_path
 
 
+def test_update_from_env_cors(
+    base_config_values: dict[str, Any],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    """Test that environment variables override config values.
+
+    Args:
+        base_config_values: Config values.
+        monkeypatch: The pytest monkeypatch object.
+        tmp_path: The pytest tmp_path fixture object.
+    """
+    config = rx.Config(**base_config_values)
+    assert config.cors_allowed_origins == ("*",)
+
+    monkeypatch.setenv("REFLEX_CORS_ALLOWED_ORIGINS", "")
+    config = rx.Config(**base_config_values)
+    assert config.cors_allowed_origins == ("*",)
+
+    monkeypatch.setenv("REFLEX_CORS_ALLOWED_ORIGINS", "https://foo.example.com")
+    config = rx.Config(**base_config_values)
+    assert config.cors_allowed_origins == [
+        "https://foo.example.com",
+    ]
+
+    monkeypatch.setenv(
+        "REFLEX_CORS_ALLOWED_ORIGINS", "http://example.com, http://another.com "
+    )
+    config = rx.Config(**base_config_values)
+    assert config.cors_allowed_origins == [
+        "http://example.com",
+        "http://another.com",
+    ]
+
+
 @pytest.mark.parametrize(
     ("kwargs", "expected"),
     [

--- a/tests/units/test_environment.py
+++ b/tests/units/test_environment.py
@@ -4,6 +4,7 @@ import enum
 import os
 import tempfile
 from pathlib import Path
+from typing import Annotated
 from unittest.mock import patch
 
 import pytest
@@ -15,6 +16,7 @@ from reflex.environment import (
     ExecutorType,
     ExistingPath,
     PerformanceMode,
+    SequenceOptions,
     _load_dotenv_from_files,
     _paths_from_env_files,
     _paths_from_environment,
@@ -174,6 +176,14 @@ class TestInterpretEnvVarValue:
         """Test list interpretation."""
         result = interpret_env_var_value("1:2:3", list[int], "TEST_FIELD")
         assert result == [1, 2, 3]
+
+    def test_interpret_annotated_sequence(self):
+        """Test annotated sequence interpretation."""
+        annotated_type = Annotated[
+            list[str], SequenceOptions(delimiter=",", strip=True)
+        ]
+        result = interpret_env_var_value("a, b, c ", annotated_type, "TEST_FIELD")
+        assert result == ["a", "b", "c"]
 
     def test_interpret_enum(self):
         """Test enum interpretation."""


### PR DESCRIPTION
Default delimiter is colon with no stripping of whitespace. However for CORS it's much more convenient to split on a comma.

Extend the env_var interpretation system to pull a new SequenceOptions object out of an Annotated type hint.

Fix #6066