### PR TITLE
Improve templates fetching logic and filtering

### DIFF
--- a/reflex/utils/templates.py
+++ b/reflex/utils/templates.py
@@ -283,7 +283,7 @@ def fetch_app_templates(version: str) -> dict[str, Template]:
             continue
         filtered_templates[template["name"]] = Template(
             **{k: v for k, v in template.items() if k in known_fields},
-            code_url=code_url
+            code_url=code_url,
         )
     return filtered_templates
 


### PR DESCRIPTION
This PR optimizes template fetching by retrieving templates directly for a specific tag instead of fetching all releases and filtering afterward.
Additionally, it streamlines the iteration over assets using a prebuilt asset map for faster lookups.