### PR TITLE
Allow opt-out of sitemap inclusion

### DIFF
--- a/reflex/plugins/sitemap.py
+++ b/reflex/plugins/sitemap.py
@@ -138,7 +138,11 @@ def generate_links_for_sitemap(
     links: list[SitemapLink] = []
 
     for page in unevaluated_pages:
-        sitemap_config: SitemapLinkConfiguration = page.context.get("sitemap", {})
+        sitemap_config: SitemapLinkConfiguration | None = page.context.get(
+            "sitemap", {}
+        )
+        if sitemap_config is None:
+            continue
 
         if is_route_dynamic(page.route) or page.route == "404":
             if not sitemap_config:

--- a/tests/units/plugins/test_sitemap.py
+++ b/tests/units/plugins/test_sitemap.py
@@ -241,6 +241,45 @@ def test_generate_links_for_sitemap_404_route(
 
 
 @patch("reflex.config.get_config")
+def test_generate_links_for_sitemap_opt_out(mock_get_config: MagicMock):
+    """Test generate_links_for_sitemap with sitemap set to None.
+
+    Args:
+        mock_get_config: Mock for the get_config function.
+    """
+    mock_get_config.return_value.deploy_url = None  # No deploy URL
+
+    def mock_component():
+        return rx.text("Unlisted")
+
+    pages = [
+        UnevaluatedPage(
+            component=mock_component,
+            route="unlisted",
+            title=None,
+            description=None,
+            image="favicon.ico",
+            on_load=None,
+            meta=[],
+            context={"sitemap": None},
+        ),
+        UnevaluatedPage(
+            component=mock_component,
+            route="listed",
+            title=None,
+            description=None,
+            image="favicon.ico",
+            on_load=None,
+            meta=[],
+            context={},
+        ),
+    ]
+    links = generate_links_for_sitemap(pages)
+    assert len(links) == 1
+    assert {"loc": "/listed"} in links
+
+
+@patch("reflex.config.get_config")
 def test_generate_links_for_sitemap_loc_override(mock_get_config: MagicMock):
     """Test generate_links_for_sitemap with loc override in sitemap config.
 


### PR DESCRIPTION
Pass `context={"sitemap": None}` to app.add_page to exclude the page from the generated sitemap.