### PR TITLE
fix(data_table): resolve blank cells for non-camelCase column keys (#…

### DIFF
--- a/reflex/components/gridjs/datatable.py
+++ b/reflex/components/gridjs/datatable.py
@@ -127,5 +127,14 @@ class DataTable(Gridjs):
             self.columns = LiteralVar.create(data["columns"])
             self.data = LiteralVar.create(data["data"])
 
+        # If columns is a list of strings convert to list of dicts with id and name keys
+        if isinstance(self.columns, LiteralVar) and isinstance(
+            self.columns._var_value, list
+        ):
+            self.columns = LiteralVar.create([
+                {"id": col, "name": col} if isinstance(col, str) else col
+                for col in self.columns._var_value
+            ])
+
         # Render the table.
         return super()._render()


### PR DESCRIPTION
<!-- Title for the PR -->
fix(data_table): resolve blank cells for non-camelCase column keys (#6108)

---

### All Submissions:
- [x] Have you followed the guidelines stated in [[CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md)](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [[Pull Requests](https://github.com/reflex-dev/reflex/pulls)](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

---

### Description

When `rx.data_table` receives `data` as a runtime `Var` and `columns` as a static list of strings, any column key that isn't already fully lowercase renders with blank cells.

This happens because Grid.js infers each column's lookup `id` by camelCasing the column name string. So a key like `"Route"` gets inferred as `"route"`, which no longer matches the actual key in the data. Since `data` is a runtime `Var`, the keys aren't available at build time, so normalising columns alone can't fix it.

The fix converts each plain column string into the `{ id, name }` object format that Grid.js also supports. When `id` is set explicitly, Grid.js skips the camelCase inference entirely and uses it directly as the lookup key. This ensures the key always matches regardless of casing. Columns already in object format are left untouched, so this is fully backward-compatible.

Closes #6108