### PR TITLE
fix: enforce server-side upload size and file count limits

### DIFF
--- a/reflex/config.py
+++ b/reflex/config.py
@@ -260,6 +260,13 @@ class BaseConfig:
     # The transport method for client-server communication.
     transport: Literal["websocket", "polling"] = "websocket"
 
+    # Maximum file upload size in bytes. Files larger than this will be rejected with HTTP 413.
+    # Defaults to 10 MB. Set to 0 to disable the limit.
+    upload_max_size: int = 10 * 1024 * 1024  # 10 MB
+
+    # Maximum number of files per upload request. Set to 0 to disable the limit.
+    upload_max_files: int = 10
+
     # Whether to skip plugin checks.
     _skip_plugins_checks: bool = dataclasses.field(default=False, repr=False)
 
@@ -367,6 +374,13 @@ class Config(BaseConfig):
             and not self.redis_url
         ):
             msg = f"{self._prefixes[0]}REDIS_URL is required when using the redis state manager."
+            raise ConfigError(msg)
+
+        if self.upload_max_size < 0:
+            msg = "upload_max_size must be >= 0."
+            raise ConfigError(msg)
+        if self.upload_max_files < 0:
+            msg = "upload_max_files must be >= 0."
             raise ConfigError(msg)
 
     def _add_builtin_plugins(self):

--- a/tests/units/test_upload_size_limit.py
+++ b/tests/units/test_upload_size_limit.py
@@ -1,0 +1,299 @@
+"""Tests for upload file size limit enforcement in the upload handler."""
+
+import io
+import unittest.mock
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import reflex as rx
+from starlette.datastructures import UploadFile as StarletteUploadFile
+from starlette.responses import JSONResponse
+
+from reflex.app import upload
+
+# Use a small limit for tests to avoid allocating large buffers.
+_TEST_MAX_SIZE = 500  # 500 bytes
+_TEST_MAX_FILES = 2
+
+
+def _make_upload_file(filename: str, content: bytes, *, report_size: bool = True):
+    """Create a StarletteUploadFile with given content."""
+    file = StarletteUploadFile(filename=filename, file=io.BytesIO(content))
+    file.size = len(content) if report_size else None
+    return file
+
+
+_SENTINEL = object()
+
+
+def _make_request_mock(files, content_length=_SENTINEL):
+    """Create a mock Starlette Request with the given files.
+
+    Args:
+        files: List of upload files.
+        content_length: If provided, set as the raw content-length header value.
+            Pass an int for valid values, or a raw string (e.g. "", "  ", "abc")
+            to test malformed header handling. Omit to leave the header unset.
+    """
+    request_mock = unittest.mock.Mock()
+    headers = {
+        "reflex-client-token": "test-token",
+        "reflex-event-handler": "fake_state.handle_upload",
+    }
+    if content_length is not _SENTINEL:
+        headers["content-length"] = str(content_length) if isinstance(content_length, int) else content_length
+    request_mock.headers = headers
+
+    async def form():  # noqa: RUF029
+        files_mock = unittest.mock.Mock()
+        files_mock.getlist = lambda key: files
+        return files_mock
+
+    request_mock.form = form
+    return request_mock
+
+
+def _mock_config(upload_max_size=_TEST_MAX_SIZE, upload_max_files=_TEST_MAX_FILES):
+    """Create a mock config with given upload limits."""
+    config = unittest.mock.Mock()
+    config.upload_max_size = upload_max_size
+    config.upload_max_files = upload_max_files
+    return config
+
+
+class _FakeState:
+    """A minimal fake state that has a handle_upload method with correct annotations."""
+
+    def handle_upload(self, files: list[rx.UploadFile]):
+        pass
+
+    def get_substate(self, path):
+        return self
+
+
+def _make_app_mock():
+    """Create a mock app whose state manager returns a _FakeState."""
+    app_mock = unittest.mock.Mock()
+    app_mock.state_manager.get_state = AsyncMock(return_value=_FakeState())
+    return app_mock
+
+
+# --- Config default tests ---
+
+
+def test_default_upload_max_size():
+    """Default upload_max_size should be 10 MB."""
+    from reflex.config import get_config
+
+    config = get_config()
+    assert config.upload_max_size == 10 * 1024 * 1024
+
+
+def test_default_upload_max_files():
+    """Default upload_max_files should be 10."""
+    from reflex.config import get_config
+
+    config = get_config()
+    assert config.upload_max_files == 10
+
+
+def test_negative_upload_max_size_rejected():
+    """Negative upload_max_size should raise ConfigError."""
+    from reflex.config import Config
+    from reflex.utils.exceptions import ConfigError
+
+    with pytest.raises(ConfigError, match="upload_max_size must be >= 0"):
+        Config(app_name="test", upload_max_size=-1, _skip_plugins_checks=True)
+
+
+def test_negative_upload_max_files_rejected():
+    """Negative upload_max_files should raise ConfigError."""
+    from reflex.config import Config
+    from reflex.utils.exceptions import ConfigError
+
+    with pytest.raises(ConfigError, match="upload_max_files must be >= 0"):
+        Config(app_name="test", upload_max_files=-1, _skip_plugins_checks=True)
+
+
+# --- Content-Length pre-check tests ---
+
+
+@pytest.mark.asyncio
+async def test_content_length_over_limit_rejected():
+    """Request with Content-Length exceeding total limit is rejected before form parsing."""
+    app_mock = unittest.mock.Mock()
+    max_request_size = _TEST_MAX_SIZE * _TEST_MAX_FILES
+
+    with patch("reflex.app.get_config", return_value=_mock_config()):
+        upload_fn = upload(app_mock)
+        request = _make_request_mock([], content_length=max_request_size + 1)
+        response = await upload_fn(request)
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_content_length_under_limit_passes_precheck():
+    """Request with Content-Length under the total limit passes the pre-check."""
+    small_file = _make_upload_file("ok.txt", b"x" * 100)
+    app_mock = _make_app_mock()
+
+    with patch("reflex.app.get_config", return_value=_mock_config()):
+        upload_fn = upload(app_mock)
+        request = _make_request_mock([small_file], content_length=100)
+        response = await upload_fn(request)
+
+    # Content-Length is under the limit, file is small — should reach
+    # the streaming response (event processing), not a 413.
+    assert not isinstance(response, JSONResponse) or response.status_code != 413
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_value",
+    ["not-a-number", "", "   ", "12.5", "1e3"],
+    ids=["text", "empty", "whitespace", "float", "scientific"],
+)
+async def test_malformed_content_length_returns_400(bad_value):
+    """Non-integer Content-Length header returns 400 Bad Request."""
+    app_mock = unittest.mock.Mock()
+
+    with patch("reflex.app.get_config", return_value=_mock_config()):
+        upload_fn = upload(app_mock)
+        request = _make_request_mock([], content_length=bad_value)
+        response = await upload_fn(request)
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 400
+
+
+# --- Per-file size enforcement tests ---
+
+
+@pytest.mark.asyncio
+async def test_file_over_limit_rejected_413():
+    """Oversized file is rejected with HTTP 413 by the upload handler."""
+    oversized = _make_upload_file("big.bin", b"x" * (_TEST_MAX_SIZE + 1))
+    app_mock = _make_app_mock()
+
+    with patch("reflex.app.get_config", return_value=_mock_config()):
+        upload_fn = upload(app_mock)
+        request = _make_request_mock([oversized])
+        response = await upload_fn(request)
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_file_over_limit_rejected_by_chunked_read():
+    """File with size=None but content over limit is rejected during chunked read."""
+    oversized_no_size = _make_upload_file(
+        "big.bin", b"x" * (_TEST_MAX_SIZE + 1), report_size=False
+    )
+    app_mock = _make_app_mock()
+
+    with patch("reflex.app.get_config", return_value=_mock_config()):
+        upload_fn = upload(app_mock)
+        request = _make_request_mock([oversized_no_size])
+        response = await upload_fn(request)
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_file_under_limit_not_rejected():
+    """File under the limit passes the size enforcement and reaches event processing."""
+    small = _make_upload_file("ok.txt", b"x" * 100)
+    app_mock = _make_app_mock()
+
+    with patch("reflex.app.get_config", return_value=_mock_config()):
+        upload_fn = upload(app_mock)
+        request = _make_request_mock([small])
+        response = await upload_fn(request)
+
+    # Handler should proceed past size checks to event processing.
+    # It returns a StreamingResponse on success, never a 413 JSONResponse.
+    assert not isinstance(response, JSONResponse) or response.status_code != 413
+
+
+# --- Max files tests ---
+
+
+@pytest.mark.asyncio
+async def test_too_many_files_rejected_with_400():
+    """Uploading more files than upload_max_files is rejected with 400."""
+    files = [
+        _make_upload_file(f"file{i}.txt", b"x" * 10)
+        for i in range(_TEST_MAX_FILES + 1)
+    ]
+    app_mock = unittest.mock.Mock()
+
+    with patch("reflex.app.get_config", return_value=_mock_config()):
+        upload_fn = upload(app_mock)
+        request = _make_request_mock(files)
+        response = await upload_fn(request)
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_files_within_limit_not_rejected_for_count():
+    """Uploading files within upload_max_files passes the count check."""
+    files = [
+        _make_upload_file(f"file{i}.txt", b"x" * 10) for i in range(_TEST_MAX_FILES)
+    ]
+    app_mock = _make_app_mock()
+
+    with patch("reflex.app.get_config", return_value=_mock_config()):
+        upload_fn = upload(app_mock)
+        request = _make_request_mock(files)
+        response = await upload_fn(request)
+
+    # Should not be rejected for file count — reaches event processing.
+    assert not isinstance(response, JSONResponse) or response.status_code not in (400, 413)
+
+
+# --- Limit disabled tests ---
+
+
+@pytest.mark.asyncio
+async def test_size_limit_disabled_allows_large_file():
+    """When upload_max_size=0, large files are not rejected for size."""
+    large = _make_upload_file("big.bin", b"x" * 1000)
+    app_mock = _make_app_mock()
+
+    with patch(
+        "reflex.app.get_config",
+        return_value=_mock_config(upload_max_size=0, upload_max_files=0),
+    ):
+        upload_fn = upload(app_mock)
+        request = _make_request_mock([large])
+        response = await upload_fn(request)
+
+    # With limits disabled, should never get a 413.
+    assert not isinstance(response, JSONResponse) or response.status_code != 413
+
+
+# --- Filename sanitization test ---
+
+
+@pytest.mark.asyncio
+async def test_error_message_does_not_contain_filename():
+    """413 error message should not echo back the attacker-controlled filename."""
+    evil_name = "<script>alert('xss')</script>.bin"
+    oversized = _make_upload_file(evil_name, b"x" * (_TEST_MAX_SIZE + 1))
+    app_mock = _make_app_mock()
+
+    with patch("reflex.app.get_config", return_value=_mock_config()):
+        upload_fn = upload(app_mock)
+        request = _make_request_mock([oversized])
+        response = await upload_fn(request)
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 413
+    body = response.body.decode()
+    assert evil_name not in body


### PR DESCRIPTION
## Problem

The upload handler in `reflex/app.py` reads entire uploaded files into memory
(`io.BytesIO`) with no size limit. The frontend `Upload` component has
`max_size`/`max_files` props, but these are client-side only and trivially
bypassed via direct HTTP requests. An attacker can send arbitrarily large or
numerous files to exhaust server memory and crash the process.

Closes #6115

## Solution

Add server-side enforcement with three layers of defense, controlled by two new
config fields:

| Config field | Env var | Default | Description |
|---|---|---|---|
| `upload_max_size` | `REFLEX_UPLOAD_MAX_SIZE` | `10485760` (10 MB) | Per-file size limit in bytes. `0` disables. |
| `upload_max_files` | `REFLEX_UPLOAD_MAX_FILES` | `10` | Max files per request. `0` disables. |

**Layer 1 — Content-Length pre-check.** Before Starlette parses the multipart
body, the request's `Content-Length` header is compared against
`upload_max_size × upload_max_files`. Oversized requests are rejected
immediately with HTTP 413. Malformed `Content-Length` values return HTTP 400.

**Layer 2 — Per-file `file.size` header check.** After form parsing, each
file's reported size is checked against `upload_max_size`. Files that declare a
size over the limit are rejected without reading any bytes.

**Layer 3 — Chunked read with byte counting.** File content is streamed in 1 MB
chunks during the copy loop. If accumulated bytes exceed `upload_max_size`, the
read is aborted. This catches files that omitted or spoofed their size header.

## Files changed

- **`reflex/config.py`** — Add `upload_max_size` and `upload_max_files` to
  `BaseConfig`. Add validation in `Config._post_init` (after `update_from_env`
  applies overrides, so invalid env values like `REFLEX_UPLOAD_MAX_SIZE=-1` are
  caught).
- **`reflex/app.py`** — Add all three enforcement layers plus file count check
  to `upload_file()`. A `_cleanup()` helper ensures all file handles and
  already-copied `BytesIO` buffers are closed on every rejection path. Error
  messages do not include the attacker-controlled filename.
- **`tests/units/test_upload_size_limit.py`** *(new)* — 14 tests covering
  config defaults, negative value rejection, Content-Length handling
  (over/under/malformed), per-file rejection (via size header and chunked read),
  file count enforcement, disabled-limit behavior, and filename sanitization.
  All tests invoke the actual `upload()` handler with mocked requests.

## Migration note

Existing apps that accept uploads larger than 10 MB or more than 10 files per
request will need to adjust their config:

```python
# rxconfig.py
config = rx.Config(
    app_name="myapp",
    upload_max_size=50 * 1024 * 1024,  # 50 MB
    upload_max_files=25,
)
```

Or via environment variables:

```bash
REFLEX_UPLOAD_MAX_SIZE=0 reflex run  # disable size limit entirely
```

## Design decisions

- **HTTP 413** (Payload Too Large) for size violations, **HTTP 400** (Bad
  Request) for file count violations — correct HTTP semantics for each case.
- **`0` disables the limit** rather than a separate boolean — follows the
  convention used by nginx (`client_max_body_size 0`), Apache, and others.
- **Filename omitted from error messages** — `file.filename` is
  attacker-controlled input; echoing it in the response risks reflected XSS if
  the JSON is ever rendered as HTML downstream.
- **`_cleanup()` takes explicit parameters** rather than closing over the
  `file_list` variable — avoids a fragile closure dependency and also closes
  `BytesIO` buffers from already-copied files when a later file triggers
  rejection.

## Test plan

- [x] New tests: `pytest tests/units/test_upload_size_limit.py` — 14 passed
- [x] Existing upload handler tests: `pytest tests/units/test_app.py -k upload` — 9 passed
- [x] Existing upload component tests: `pytest tests/units/components/core/test_upload.py` — 6 passed
- [x] Config tests: `pytest tests/units/test_config.py` — 31 passed