### PR TITLE
feat: make rxconfig.py filename configurable via env vars

### DIFF
--- a/reflex/config.py
+++ b/reflex/config.py
@@ -377,7 +377,7 @@ class Config(BaseConfig):
                 if not any(isinstance(p, plugin) for p in self.plugins):
                     console.warn(
                         f"`{plugin_name}` plugin is enabled by default, but not explicitly added to the config. "
-                        "If you want to use it, please add it to the `plugins` list in your config inside of `rxconfig.py`. "
+                        f"If you want to use it, please add it to the `plugins` list in your config inside of `{constants.Config.FILE}`. "
                         f"To disable this plugin, set `disable_plugins` to `{[plugin_name, *self.disable_plugins]!r}`.",
                     )
                     self.plugins.append(plugin())
@@ -385,7 +385,7 @@ class Config(BaseConfig):
                 if any(isinstance(p, plugin) for p in self.plugins):
                     console.warn(
                         f"`{plugin_name}` is disabled in the config, but it is still present in the `plugins` list. "
-                        "Please remove it from the `plugins` list in your config inside of `rxconfig.py`.",
+                        f"Please remove it from the `plugins` list in your config inside of `{constants.Config.FILE}`.",
                     )
 
         for disabled_plugin in self.disable_plugins:
@@ -399,7 +399,7 @@ class Config(BaseConfig):
             ):
                 console.warn(
                     f"`{disabled_plugin}` is disabled in the config, but it is not a built-in plugin. "
-                    "Please remove it from the `disable_plugins` list in your config inside of `rxconfig.py`.",
+                    f"Please remove it from the `disable_plugins` list in your config inside of `{constants.Config.FILE}`.",
                 )
 
     @classmethod

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -421,7 +421,7 @@ def get_reload_paths() -> Sequence[Path]:
 
         while module_path.parent.name and _has_child_file(module_path, "__init__.py"):
             if (
-                _has_child_file(module_path, "rxconfig.py")
+                _has_child_file(module_path, str(constants.Config.FILE))
                 and module_path == Path.cwd()
             ):
                 init_file = module_path / "__init__.py"
@@ -436,7 +436,7 @@ def get_reload_paths() -> Sequence[Path]:
                 init_file.unlink()
                 break
 
-            # go up a level to find dir without `__init__.py` or with `rxconfig.py`
+            # go up a level to find dir without `__init__.py` or with config file
             module_path = module_path.parent
 
         reload_paths = [module_path]

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -421,7 +421,7 @@ def get_reload_paths() -> Sequence[Path]:
 
         while module_path.parent.name and _has_child_file(module_path, "__init__.py"):
             if (
-                _has_child_file(module_path, str(constants.Config.FILE))
+                _has_child_file(module_path, constants.Config.FILE.name)
                 and module_path == Path.cwd()
             ):
                 init_file = module_path / "__init__.py"

--- a/reflex/utils/prerequisites.py
+++ b/reflex/utils/prerequisites.py
@@ -149,7 +149,7 @@ def _check_app_name(config: Config):
     """
     if not config.app_name:
         msg = (
-            "Cannot get the app module because `app_name` is not set in rxconfig! "
+            f"Cannot get the app module because `app_name` is not set in {constants.Config.FILE}! "
             "If this error occurs in a reflex test case, ensure that `get_app` is mocked."
         )
         raise RuntimeError(msg)
@@ -161,9 +161,9 @@ def _check_app_name(config: Config):
         if module_path is None:
             msg = f"Module {config.module} not found. "
             if config.app_module_import is not None:
-                msg += f"Ensure app_module_import='{config.app_module_import}' in rxconfig.py matches your folder structure."
+                msg += f"Ensure app_module_import='{config.app_module_import}' in {constants.Config.FILE} matches your folder structure."
             else:
-                msg += f"Ensure app_name='{config.app_name}' in rxconfig.py matches your folder structure."
+                msg += f"Ensure app_name='{config.app_name}' in {constants.Config.FILE} matches your folder structure."
             raise ModuleNotFoundError(msg)
     config._app_name_is_valid = True
 
@@ -234,7 +234,7 @@ def get_and_validate_app(
     app_module = get_app(reload=reload)
     app = getattr(app_module, constants.CompileVars.APP)
     if not isinstance(app, App):
-        msg = "The app instance in the specified app_module_import in rxconfig must be an instance of rx.App."
+        msg = f"The app instance in the specified app_module_import in {constants.Config.FILE} must be an instance of rx.App."
         raise RuntimeError(msg)
 
     if check_if_schema_up_to_date:

--- a/reflex/utils/rename.py
+++ b/reflex/utils/rename.py
@@ -28,7 +28,7 @@ def rename_path_up_tree(full_path: str | Path, old_name: str, new_name: str) -> 
     while True:
         directory, base = current_path.parent, current_path.name
         # Stop renaming when we reach the root dir (which contains the config file)
-        if current_path.is_dir() and (current_path / constants.Config.FILE).exists():
+        if current_path.is_dir() and (current_path / constants.Config.FILE.name).exists():
             new_path = current_path
             break
 

--- a/reflex/utils/rename.py
+++ b/reflex/utils/rename.py
@@ -12,7 +12,7 @@ from reflex.utils.misc import get_module_path
 
 def rename_path_up_tree(full_path: str | Path, old_name: str, new_name: str) -> Path:
     """Rename all instances of `old_name` in the path (file and directories) to `new_name`.
-    The renaming stops when we reach the directory containing `rxconfig.py`.
+    The renaming stops when we reach the directory containing the config file.
 
     Args:
         full_path: The full path to start renaming from.
@@ -27,8 +27,8 @@ def rename_path_up_tree(full_path: str | Path, old_name: str, new_name: str) -> 
 
     while True:
         directory, base = current_path.parent, current_path.name
-        # Stop renaming when we reach the root dir (which contains rxconfig.py)
-        if current_path.is_dir() and (current_path / "rxconfig.py").exists():
+        # Stop renaming when we reach the root dir (which contains the config file)
+        if current_path.is_dir() and (current_path / constants.Config.FILE).exists():
             new_path = current_path
             break
 
@@ -62,7 +62,7 @@ def rename_app(new_app_name: str, loglevel: constants.LogLevel):
 
     if not constants.Config.FILE.exists():
         console.error(
-            "No rxconfig.py found. Make sure you are in the root directory of your app."
+            f"No {constants.Config.FILE} found. Make sure you are in the root directory of your app."
         )
         raise SystemExit(1)
 
@@ -88,7 +88,7 @@ def rename_app(new_app_name: str, loglevel: constants.LogLevel):
 
 
 def rename_imports_and_app_name(file_path: str | Path, old_name: str, new_name: str):
-    """Rename imports the file using string replacement as well as app_name in rxconfig.py.
+    """Rename imports the file using string replacement as well as app_name in the config file.
 
     Args:
         file_path: The file to process.


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### New Feature Submission:

- [x] Does your submission pass the tests?
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

---

## Summary

Make the `rxconfig.py` config filename configurable via two new environment variables:

- **`REFLEX_CONFIG_MODULE`** — Python module name to import (default: `rxconfig`)
- **`REFLEX_CONFIG_FILE`** — Config file path on disk (default: `{module_name}.py`)

This allows users to rename `rxconfig.py` to any filename they prefer, making the framework less opinionated about repo structure naming conventions.

### How it works

- A metaclass `_ConfigMeta` on `constants.Config` makes `MODULE` and `FILE` dynamic class-level properties that resolve from environment variables at access time
- All hardcoded `"rxconfig.py"` strings in error messages and file detection logic now use `constants.Config.FILE`
- Fully backward compatible — defaults to `rxconfig` / `rxconfig.py` when no env vars are set

### Files changed (5)

| File | Change |
|------|--------|
| `reflex/constants/config.py` | Added `_ConfigMeta` metaclass to make `Config.MODULE` and `Config.FILE` dynamic |
| `reflex/config.py` | Updated plugin warning messages to use dynamic `constants.Config.FILE` |
| `reflex/utils/exec.py` | Updated hot reload config file detection to use dynamic filename |
| `reflex/utils/prerequisites.py` | Updated error messages to use dynamic config filename |
| `reflex/utils/rename.py` | Updated file existence checks and error messages to use dynamic config filename |

### Usage

```bash
# Rename config file and run with custom module name
mv rxconfig.py myconfig.py
REFLEX_CONFIG_MODULE=myconfig reflex run

# Or with explicit file path
REFLEX_CONFIG_MODULE=app_config REFLEX_CONFIG_FILE=app_config.py reflex run
```

### Test results

- 3375 unit tests passed, 0 failed
- End-to-end tested: default behavior, custom module, custom file, error messages, hot reload detection

closes #6117