### PR TITLE
Allow granian log level to be set

### DIFF
--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -670,7 +670,6 @@ def run_granian_backend_prod(host: str, port: int, loglevel: LogLevel):
         sys.executable,
         "-m",
         "granian",
-        *("--log-level", "critical"),
         *("--host", host),
         *("--port", str(port)),
         *("--interface", str(Interfaces.ASGI)),
@@ -683,6 +682,8 @@ def run_granian_backend_prod(host: str, port: int, loglevel: LogLevel):
 
     if "GRANIAN_WORKERS" not in os.environ:
         extra_env["GRANIAN_WORKERS"] = str(_get_backend_workers())
+    if "GRANIAN_LOG_LEVEL" not in os.environ:
+        extra_env["GRANIAN_LOG_LEVEL"] = "critical"
 
     processes.new_process(
         command,


### PR DESCRIPTION
User can set `GRANIAN_LOG_LEVEL` environment variable to override the default "critical" value.