### PR TITLE
Unlink broken symlinks in the assets folder

### DIFF
--- a/reflex/assets.py
+++ b/reflex/assets.py
@@ -92,6 +92,11 @@ def asset(
         if not dst_file.exists() and (
             not dst_file.is_symlink() or dst_file.resolve() != src_file_shared.resolve()
         ):
-            dst_file.symlink_to(src_file_shared)
+            try:
+                dst_file.symlink_to(src_file_shared)
+            except FileExistsError:
+                # This happens when Simon builds the app on a bind mount in a docker container.
+                dst_file.unlink()
+                dst_file.symlink_to(src_file_shared)
 
     return f"/{external}/{subfolder}/{path}"


### PR DESCRIPTION
Certain build environments, such as docker bind mounts, can create symlinks that exist, but cannot be overwritten for whatever reason. So we unlink those for Simon 🎁