### PR TITLE
Cache expensive introspection calls in pyi_generator for faster stub generation

### DIFF
--- a/reflex/utils/pyi_generator.py
+++ b/reflex/utils/pyi_generator.py
@@ -252,14 +252,14 @@ def _get_source(obj: Any) -> str:
 
 
 @cache
-def _get_class_prop_comments(clz: type[Component]) -> dict[str, tuple[str, ...]]:
+def _get_class_prop_comments(clz: type[Component]) -> Mapping[str, tuple[str, ...]]:
     """Parse and cache prop comments for a component class.
 
     Args:
         clz: The class to extract prop comments from.
 
     Returns:
-        A mapping of prop name to comment lines.
+        An immutable mapping of prop name to comment lines.
     """
     props_comments: dict[str, tuple[str, ...]] = {}
     comments = []
@@ -295,7 +295,7 @@ def _get_class_prop_comments(clz: type[Component]) -> dict[str, tuple[str, ...]]
             )
         comments.clear()
 
-    return props_comments
+    return MappingProxyType(props_comments)
 
 
 @cache
@@ -621,7 +621,7 @@ def _get_parent_imports(func: Callable) -> Mapping[str, tuple[str, ...]]:
         An immutable mapping of module names to imported symbol names.
     """
     imports_: dict[str, set[str]] = {"reflex.vars": {"Var"}}
-    module_dir = set(importlib.import_module(func.__module__).__dir__())
+    module_dir = set(dir(importlib.import_module(func.__module__)))
     for type_hint in inspect.get_annotations(func).values():
         try:
             match = re.match(r"\w+\[([\w\d]+)\]", type_hint)
@@ -826,7 +826,7 @@ def _generate_staticmethod_call_functiondef(
     clz: type[Component] | type[SimpleNamespace],
     type_hint_globals: dict[str, Any],
 ) -> ast.FunctionDef | None:
-    fullspec = getfullargspec(clz.__call__)
+    fullspec = _get_full_argspec(clz.__call__)
 
     call_args = ast.arguments(
         args=[
@@ -1209,6 +1209,18 @@ class InitStubGenerator(StubGenerator):
         return [node]
 
 
+def _path_to_module_name(path: Path) -> str:
+    """Convert a file path to a dotted module name.
+
+    Args:
+        path: The file path to convert.
+
+    Returns:
+        The dotted module name.
+    """
+    return _relative_to_pwd(path).with_suffix("").as_posix().replace("/", ".")
+
+
 def _write_pyi_file(module_path: Path, source: str) -> str:
     relpath = str(_relative_to_pwd(module_path)).replace("\\", "/")
     pyi_content = (
@@ -1298,13 +1310,7 @@ def _scan_file(module_path: Path) -> tuple[str, str] | None:
     Returns:
         Tuple of (pyi_path, content_hash) or None if no stub needed.
     """
-    module_import = (
-        _relative_to_pwd(module_path)
-        .with_suffix("")
-        .as_posix()
-        .replace("/", ".")
-        .replace("\\", ".")
-    )
+    module_import = _path_to_module_name(module_path)
     module = importlib.import_module(module_import)
     logger.debug(f"Read {module_path}")
     class_names = {
@@ -1364,16 +1370,12 @@ class PyiGenerator:
 
         # Pre-import all modules sequentially to populate sys.modules
         # so forked workers inherit the cache and skip redundant imports.
+        importable_files: list[Path] = []
         for file in files:
-            module_import = (
-                _relative_to_pwd(file)
-                .with_suffix("")
-                .as_posix()
-                .replace("/", ".")
-                .replace("\\", ".")
-            )
+            module_import = _path_to_module_name(file)
             try:
                 importlib.import_module(module_import)
+                importable_files.append(file)
             except Exception:
                 logger.exception(f"Failed to import {module_import}")
 
@@ -1381,7 +1383,7 @@ class PyiGenerator:
         ctx = multiprocessing.get_context("fork")
         with ProcessPoolExecutor(max_workers=max_workers, mp_context=ctx) as executor:
             self.written_files.extend(
-                r for r in executor.map(_scan_file, files) if r is not None
+                r for r in executor.map(_scan_file, importable_files) if r is not None
             )
 
     def scan_all(


### PR DESCRIPTION


Extract repeated inspect.getsource, getfullargspec, inspect.signature, and module import calls into @cache-decorated helper functions. Replace inline exec() calls with explicit dict updates for resolving type hints. Convert all_props from list to set for O(1) membership checks. 
` /usr/bin/time -p uv run python3 -m reflex.utils.pyi_generator`
Before:
8 files reformatted, 112 files left unchanged
real 4.12
user 5.37
sys 0.33
After:
8 files reformatted, 112 files left unchanged
real 1.93
user 3.00
sys 0.32

After multiprocess forking:
117 files reformatted, 3 files left unchanged
real 1.57
user 3.86
sys 0.67

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### New Feature Submission:

- [x] Does your submission pass the tests?
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran tests with your changes locally?


closes #6183