### PR TITLE
Fix #6165: Dynamically report backend_host in terminal logs

### DIFF
--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -159,8 +159,9 @@ def notify_frontend(url: str, backend_present: bool):
 
 def notify_backend():
     """Output a string notifying where the backend is running."""
+    config = get_config()
     console.print(
-        f"Backend running at: [bold green]http://0.0.0.0:{get_config().backend_port}[/bold green]"
+        f"Backend running at: [bold green]http://{config().backend_host}:{config().backend_port}[/bold green]"
     )
 
 

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -161,7 +161,7 @@ def notify_backend():
     """Output a string notifying where the backend is running."""
     config = get_config()
     console.print(
-        f"Backend running at: [bold green]http://{config().backend_host}:{config().backend_port}[/bold green]"
+        f"Backend running at: [bold green]http://{config.backend_host}:{config.backend_port}[/bold green]"
     )
 
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines stated in [[CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md)](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
* [x] Have you checked to ensure there aren't any other open [[Pull Requests](https://github.com/reflex-dev/reflex/pulls)](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

* [x] Bug fix (non-breaking change which fixes an issue)

### New Feature Submission:

* [x] Does your submission pass the tests?
* [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

## Pull Request Details

### **Descriptive Title**

`fix: accurately report configured backend_host in terminal logs`

### **Description of Changes**

Currently, the `notify_backend` function in `reflex/utils/exec.py` has the backend IP hardcoded as `0.0.0.0`. This leads to misleading terminal output when a user has explicitly configured a custom `backend_host` (e.g., `127.0.0.1` for local-only development) in their `rxconfig.py`.

This PR modifies the notification logic to dynamically pull the `backend_host` from the Reflex configuration, ensuring the logs match the actual network binding. This improves developer clarity and assists in verifying security configurations.

**Testing performed:**

* Verified on **EndeavourOS** by setting `backend_host="127.0.0.1"` in `rxconfig.py`.
* Confirmed terminal output correctly displays `http://127.0.0.1:8000` instead of the hardcoded `0.0.0.0`.
* Ensured local linting (`ruff`) passes.

### **Closing Issues**

Closes #6165