### PR TITLE
fix: collect imports from components in props in _get_all_imports()

### DIFF
--- a/packages/reflex-base/src/reflex_base/components/component.py
+++ b/packages/reflex-base/src/reflex_base/components/component.py
@@ -1750,7 +1750,12 @@ class Component(BaseComponent, ABC):
             The import dict with the required imports.
         """
         imports_ = imports.merge_parsed_imports(
-            self._get_imports(), *[child._get_all_imports() for child in self.children]
+            self._get_imports(),
+            *[child._get_all_imports() for child in self.children],
+            *[
+                component._get_all_imports()
+                for component in self._get_components_in_props()
+            ],
         )
         return imports.collapse_imports(imports_) if collapse else imports_
 

--- a/tests/units/components/test_component.py
+++ b/tests/units/components/test_component.py
@@ -522,6 +522,32 @@ def test_get_imports(component1, component2):
     }
 
 
+def test_get_all_imports_includes_components_in_props():
+    """Test that _get_all_imports collects imports from components in props."""
+
+    class InnerComponent(Component):
+        """A component that requires a specific import."""
+
+        def _get_imports(self) -> ParsedImportDict:
+            return {"some-library": [ImportVar(tag="SomeTag")]}
+
+    class OuterComponent(Component):
+        """A component with a component-typed prop."""
+
+        fallback: Component | None = None
+
+        def _get_imports(self) -> ParsedImportDict:
+            return {"outer-library": [ImportVar(tag="OuterTag")]}
+
+    inner = InnerComponent.create()
+    outer = OuterComponent.create(fallback=inner)
+    all_imports = outer._get_all_imports()
+    assert "some-library" in all_imports, (
+        "_get_all_imports() should collect imports from components in props"
+    )
+    assert "outer-library" in all_imports
+
+
 def test_get_custom_code(component1: Component, component2: Component):
     """Test getting the custom code of a component.
 


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

closes #6312

---

`_get_all_imports()` only walked `self.children` to collect transitive imports. Components embedded in props (e.g. a `fallback: Component` prop) were skipped, causing missing JS imports and `ReferenceError` at runtime.

The sibling methods `_get_all_custom_code()` (line 1608) and `_get_all_dynamic_imports()` (line 1649) already call `self._get_components_in_props()` for exactly this case. `_get_all_imports()` was the only tree-walking method that didn't.

**Before:** When a component like `rx.icon("crown")` is only used inside a component-typed prop (and not elsewhere on the page), its library import (`lucide-react`) is not emitted in the generated JSX. The app crashes at runtime with `ReferenceError: LucideCrown is not defined`.

**After:** Imports from components in props are collected alongside children imports, matching the behavior of the sibling methods.

**Tests:** Added a regression test that creates a component with a `Component`-typed prop and verifies imports from the inner component are included. The test fails without the fix and passes with it. All 125 existing component tests continue to pass.