### PR TITLE
refactor: drop json5 dep, handle non-finite floats in socket parse fallback

### DIFF
--- a/packages/reflex-base/src/reflex_base/.templates/web/utils/state.js
+++ b/packages/reflex-base/src/reflex_base/.templates/web/utils/state.js
@@ -1,6 +1,5 @@
 // State management for Reflex web apps.
 import io from "socket.io-client";
-import JSON5 from "json5";
 import env from "$/env.json";
 import reflexEnvironment from "$/reflex.json";
 import Cookies from "universal-cookie";
@@ -436,6 +435,22 @@ const resolveSocket = (socket) => {
   return socket?.current ?? socket;
 };
 
+// Python's json.dumps emits bare Infinity/-Infinity/NaN tokens (invalid JSON).
+// Rewrite them outside string literals so JSON.parse accepts the payload.
+// 1e999 / -1e999 overflow to ±Infinity; NaN has no JSON literal so it becomes null.
+// The alternation matches whole string literals first (passed through unchanged),
+// guaranteeing bare-token matches only land in numeric positions.
+const NON_FINITE_FLOAT_RE = /"(?:[^"\\]|\\.)*"|-?Infinity|NaN/g;
+const NON_FINITE_REPLACEMENTS = {
+  Infinity: "1e999",
+  "-Infinity": "-1e999",
+  NaN: "null",
+};
+const rewriteBareNonFiniteFloats = (str) =>
+  str.replace(NON_FINITE_FLOAT_RE, (match) =>
+    match[0] === '"' ? match : NON_FINITE_REPLACEMENTS[match],
+  );
+
 /**
  * Queue events to be processed and trigger processing of queue.
  * @param events Array of events to queue.
@@ -541,9 +556,13 @@ export const connect = async (
   socket.current.io.encoder.replacer = (k, v) => (v === undefined ? null : v);
   socket.current.io.decoder.tryParse = (str) => {
     try {
-      return JSON5.parse(str);
+      return JSON.parse(str);
     } catch (e) {
-      return false;
+      try {
+        return JSON.parse(rewriteBareNonFiniteFloats(str));
+      } catch (e2) {
+        return false;
+      }
     }
   };
   // Set up a reconnect helper function

--- a/packages/reflex-base/src/reflex_base/.templates/web/utils/state.js
+++ b/packages/reflex-base/src/reflex_base/.templates/web/utils/state.js
@@ -437,19 +437,22 @@ const resolveSocket = (socket) => {
 
 // Python's json.dumps emits bare Infinity/-Infinity/NaN tokens (invalid JSON).
 // Rewrite them outside string literals so JSON.parse accepts the payload.
-// 1e999 / -1e999 overflow to ±Infinity; NaN has no JSON literal so it becomes null.
+// 1e999 / -1e999 overflow to ±Infinity; NaN has no JSON literal, so it is
+// swapped for a sentinel string and revived back to NaN after parsing.
 // The alternation matches whole string literals first (passed through unchanged),
 // guaranteeing bare-token matches only land in numeric positions.
-const NON_FINITE_FLOAT_RE = /"(?:[^"\\]|\\.)*"|-?Infinity|NaN/g;
+const NAN_SENTINEL = "__reflex_nan__";
+const NON_FINITE_FLOAT_RE = /"(?:[^"\\]|\\.)*"|-?\bInfinity\b|\bNaN\b/g;
 const NON_FINITE_REPLACEMENTS = {
   Infinity: "1e999",
   "-Infinity": "-1e999",
-  NaN: "null",
+  NaN: `"${NAN_SENTINEL}"`,
 };
 const rewriteBareNonFiniteFloats = (str) =>
   str.replace(NON_FINITE_FLOAT_RE, (match) =>
     match[0] === '"' ? match : NON_FINITE_REPLACEMENTS[match],
   );
+const reviveNonFiniteFloats = (_k, v) => (v === NAN_SENTINEL ? NaN : v);
 
 /**
  * Queue events to be processed and trigger processing of queue.
@@ -559,7 +562,10 @@ export const connect = async (
       return JSON.parse(str);
     } catch (e) {
       try {
-        return JSON.parse(rewriteBareNonFiniteFloats(str));
+        return JSON.parse(
+          rewriteBareNonFiniteFloats(str),
+          reviveNonFiniteFloats,
+        );
       } catch (e2) {
         return false;
       }

--- a/packages/reflex-base/src/reflex_base/constants/installer.py
+++ b/packages/reflex-base/src/reflex_base/constants/installer.py
@@ -122,7 +122,6 @@ class PackageJson(SimpleNamespace):
             A dictionary of dependencies with their versions.
         """
         return {
-            "json5": "2.2.3",
             "react-router": cls._react_router_version,
             "react-router-dom": cls._react_router_version,
             "@react-router/node": cls._react_router_version,

--- a/tests/integration/test_computed_vars.py
+++ b/tests/integration/test_computed_vars.py
@@ -232,7 +232,7 @@ async def test_computed_vars(
 
     special_floats = driver.find_element(By.ID, "special_floats")
     assert special_floats
-    assert special_floats.text == "42.9, NaN, Infinity, -Infinity"
+    assert special_floats.text == "42.9, , Infinity, -Infinity"
 
     increment = driver.find_element(By.ID, "increment")
     assert increment.is_enabled()

--- a/tests/integration/test_computed_vars.py
+++ b/tests/integration/test_computed_vars.py
@@ -232,7 +232,7 @@ async def test_computed_vars(
 
     special_floats = driver.find_element(By.ID, "special_floats")
     assert special_floats
-    assert special_floats.text == "42.9, , Infinity, -Infinity"
+    assert special_floats.text == "42.9, NaN, Infinity, -Infinity"
 
     increment = driver.find_element(By.ID, "increment")
     assert increment.is_enabled()


### PR DESCRIPTION
…

Happy path uses native JSON.parse; the catch rewrites Python"s bare Infinity/-Infinity/NaN tokens outside string literals before retrying, so only payloads that actually contain specials pay the extra cost. NaN has no JSON literal and becomes null (matches JSON.stringify).

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.


- [x] New feature (non-breaking change which adds functionality)


### New Feature Submission:

- [x] Does your submission pass the tests?
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you successfully ran tests with your changes locally?

claoses #5820 

Will also help with the lighthouse score, I think. 