### PR TITLE
fix(upload): correct on_drop_rejected args spec

### DIFF
--- a/packages/reflex-components-core/src/reflex_components_core/core/upload.py
+++ b/packages/reflex-components-core/src/reflex_components_core/core/upload.py
@@ -177,6 +177,7 @@ _on_drop_args_spec = (
     _on_drop_spec,
     passthrough_event_spec(UploadChunkIterator),
 )
+_on_drop_rejected_spec = passthrough_event_spec(list[dict[str, Any]])
 _UPLOAD_FILES_CLIENT_HANDLER = "uploadFiles"
 
 
@@ -220,7 +221,7 @@ class GhostUpload(Fragment):
     # Fired when files are dropped.
     on_drop: EventHandler[_on_drop_args_spec]
 
-    on_drop_rejected: EventHandler[_on_drop_spec] = field(
+    on_drop_rejected: EventHandler[_on_drop_rejected_spec] = field(
         doc="Fired when dropped files do not meet the specified criteria."
     )
 
@@ -264,7 +265,7 @@ class Upload(MemoizationLeaf):
     # Fired when files are dropped.
     on_drop: EventHandler[_on_drop_args_spec]
 
-    on_drop_rejected: EventHandler[_on_drop_spec] = field(
+    on_drop_rejected: EventHandler[_on_drop_rejected_spec] = field(
         doc="Fired when dropped files do not meet the specified criteria."
     )
 

--- a/pyi_hashes.json
+++ b/pyi_hashes.json
@@ -20,7 +20,7 @@
   "packages/reflex-components-core/src/reflex_components_core/core/helmet.pyi": "7fd81a99bde5b0ff94bb52523597fd5c",
   "packages/reflex-components-core/src/reflex_components_core/core/html.pyi": "753d6ae315369530dad450ed643f5be6",
   "packages/reflex-components-core/src/reflex_components_core/core/sticky.pyi": "ba60a7d9cba75b27a1133bd63a9fbd59",
-  "packages/reflex-components-core/src/reflex_components_core/core/upload.pyi": "17775edb94cc804686ae4cd873584810",
+  "packages/reflex-components-core/src/reflex_components_core/core/upload.pyi": "48bccd1cf1cedaf24503e7dbd2c0b02b",
   "packages/reflex-components-core/src/reflex_components_core/core/window_events.pyi": "cab827931770be082cd1598a9908abbc",
   "packages/reflex-components-core/src/reflex_components_core/datadisplay/__init__.pyi": "c96fed4da42a13576d64f84e3c7cb25c",
   "packages/reflex-components-core/src/reflex_components_core/el/__init__.pyi": "f09129ddefb57ab4c7769c86dc9a3153",

--- a/tests/units/components/core/test_upload.py
+++ b/tests/units/components/core/test_upload.py
@@ -4,6 +4,7 @@ import pytest
 from reflex_base.event import EventChain, EventHandler, EventSpec, parse_args_spec
 from reflex_base.vars.base import LiteralVar, Var
 from reflex_components_core.core.upload import (
+    GhostUpload,
     StyledUpload,
     Upload,
     UploadNamespace,
@@ -76,8 +77,9 @@ def test__on_drop_spec():
     assert isinstance(_on_drop_spec(LiteralVar.create([])), tuple)
 
 
-def test_on_drop_rejected_uses_file_rejection_payload_spec():
-    rejected_spec = Upload.get_event_triggers()["on_drop_rejected"]
+@pytest.mark.parametrize("component", [Upload, GhostUpload])
+def test_on_drop_rejected_uses_file_rejection_payload_spec(component):
+    rejected_spec = component.get_event_triggers()["on_drop_rejected"]
     placeholders, _ = parse_args_spec(rejected_spec)
 
     assert placeholders[0]._var_type == list[dict[str, Any]]

--- a/tests/units/components/core/test_upload.py
+++ b/tests/units/components/core/test_upload.py
@@ -1,7 +1,7 @@
 from typing import Any, cast
 
 import pytest
-from reflex_base.event import EventChain, EventHandler, EventSpec
+from reflex_base.event import EventChain, EventHandler, EventSpec, parse_args_spec
 from reflex_base.vars.base import LiteralVar, Var
 from reflex_components_core.core.upload import (
     StyledUpload,
@@ -74,6 +74,13 @@ def test_get_upload_url():
 
 def test__on_drop_spec():
     assert isinstance(_on_drop_spec(LiteralVar.create([])), tuple)
+
+
+def test_on_drop_rejected_uses_file_rejection_payload_spec():
+    rejected_spec = Upload.get_event_triggers()["on_drop_rejected"]
+    placeholders, _ = parse_args_spec(rejected_spec)
+
+    assert placeholders[0]._var_type == list[dict[str, Any]]
 
 
 def test_upload_files_chunk_requires_background():


### PR DESCRIPTION
  ### All Submissions:

  - [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://
  github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
  - [x] Have you checked to ensure there aren't any other open [Pull
  Requests](https://github.com/reflex-dev/reflex/pulls) for the desired
  changed?

  ### Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

  ### New Feature Submission:

  - [x] Does your submission pass the tests?
  - [x] Have you linted your code locally prior to submission?

  ### Changes To Core Features:

  - [x] Have you added an explanation of what your changes do and why you'd
  like us to include them?
  - [x] Have you written new tests for your core changes, as applicable?
  - [x] Have you successfully ran tests with your changes locally?

  ### Description

  This fixes the `Upload.on_drop_rejected` trigger args spec.

  Before this change, `on_drop_rejected` used the same spec as `on_drop`
  (`list[rx.UploadFile]`), which is incorrect for rejected files.
  Now `on_drop_rejected` uses its own spec (`list[dict[str, Any]]`) and is
  wired on both `GhostUpload` and `Upload`.

  Changes included:
  - Added `_on_drop_rejected_spec = passthrough_event_spec(list[dict[str,
  Any]])`.
  - Updated `on_drop_rejected` type annotations in `GhostUpload` and
  `Upload`.
  - Added regression test:
    - `test_on_drop_rejected_uses_file_rejection_payload_spec`
  - Updated `pyi_hashes.json` for `packages/reflex-components-core/src/
  reflex_components_core/core/upload.pyi`.

  ### Validation

  - `uv run pytest tests/units/components/core/test_upload.py -q`
  - `uv run ruff check packages/reflex-components-core/src/
  reflex_components_core/core/upload.py tests/units/components/core/
  test_upload.py`

  Closes #6205