### PR TITLE
fix(app): support register_lifespan_task as a decorator

### DIFF
--- a/reflex/app_mixins/lifespan.py
+++ b/reflex/app_mixins/lifespan.py
@@ -9,7 +9,7 @@ import functools
 import inspect
 import time
 from collections.abc import Callable, Coroutine
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar, overload
 
 from reflex_base.utils import console
 from reflex_base.utils.exceptions import InvalidLifespanTaskTypeError
@@ -19,6 +19,8 @@ from .mixin import AppMixin
 
 if TYPE_CHECKING:
     from typing_extensions import deprecated
+
+_LifespanTaskT = TypeVar("_LifespanTaskT", bound="Callable | asyncio.Task")
 
 
 def _get_task_name(task: asyncio.Task | Callable) -> str:
@@ -137,24 +139,35 @@ class LifespanMixin(AppMixin):
         else:
             await state_manager.close()
 
+    @overload
+    def register_lifespan_task(
+        self, task: _LifespanTaskT, **task_kwargs
+    ) -> _LifespanTaskT: ...
+
+    @overload
+    def register_lifespan_task(
+        self, task: None = None, **task_kwargs
+    ) -> Callable[[_LifespanTaskT], _LifespanTaskT]: ...
+
     def register_lifespan_task(
         self,
         task: Callable | asyncio.Task | None = None,
         **task_kwargs,
-    ) -> (
-        Callable
-        | asyncio.Task
-        | Callable[[Callable | asyncio.Task], Callable | asyncio.Task]
     ):
         """Register a task to run during the lifespan of the app.
 
+        Supports three call shapes:
+            - `app.register_lifespan_task(fn, **kwargs)` — direct call.
+            - `@app.register_lifespan_task` — bare decorator.
+            - `@app.register_lifespan_task(**kwargs)` — parameterized decorator.
+
         Args:
-            task: The task to register.
+            task: The task to register, or None to return a decorator.
             **task_kwargs: The kwargs of the task.
 
         Returns:
-            The original task when called directly, or a decorator when called
-            with kwargs only.
+            The original task when called with a task, or a decorator when
+            called without one.
 
         Raises:
             InvalidLifespanTaskTypeError: If the task is a generator function.
@@ -176,12 +189,11 @@ class LifespanMixin(AppMixin):
         task_name = _get_task_name(task)
         registered_task = task
         if task_kwargs:
-            registered_task = functools.partial(
-                task, **task_kwargs
-            )  # pyright: ignore [reportArgumentType]
-            functools.update_wrapper(
-                registered_task, task
-            )  # pyright: ignore [reportArgumentType]
+            if isinstance(task, asyncio.Task):
+                msg = f"Task {task_name!r} of type asyncio.Task cannot be registered with kwargs."
+                raise InvalidLifespanTaskTypeError(msg)
+            registered_task = functools.partial(task, **task_kwargs)
+            functools.update_wrapper(registered_task, task)
         self._lifespan_tasks[registered_task] = None
         console.debug(f"Registered lifespan task: {task_name}")
         return task

--- a/reflex/app_mixins/lifespan.py
+++ b/reflex/app_mixins/lifespan.py
@@ -137,17 +137,32 @@ class LifespanMixin(AppMixin):
         else:
             await state_manager.close()
 
-    def register_lifespan_task(self, task: Callable | asyncio.Task, **task_kwargs):
+    def register_lifespan_task(
+        self,
+        task: Callable | asyncio.Task | None = None,
+        **task_kwargs,
+    ) -> (
+        Callable
+        | asyncio.Task
+        | Callable[[Callable | asyncio.Task], Callable | asyncio.Task]
+    ):
         """Register a task to run during the lifespan of the app.
 
         Args:
             task: The task to register.
             **task_kwargs: The kwargs of the task.
 
+        Returns:
+            The original task when called directly, or a decorator when called
+            with kwargs only.
+
         Raises:
             InvalidLifespanTaskTypeError: If the task is a generator function.
             RuntimeError: If lifespan tasks are already running.
         """
+        if task is None:
+            return functools.partial(self.register_lifespan_task, **task_kwargs)
+
         if self._lifespan_tasks_started:
             msg = (
                 f"Cannot register lifespan task {_get_task_name(task)!r} after "
@@ -159,9 +174,14 @@ class LifespanMixin(AppMixin):
             raise InvalidLifespanTaskTypeError(msg)
 
         task_name = _get_task_name(task)
+        registered_task = task
         if task_kwargs:
-            original_task = task
-            task = functools.partial(task, **task_kwargs)  # pyright: ignore [reportArgumentType]
-            functools.update_wrapper(task, original_task)  # pyright: ignore [reportArgumentType]
-        self._lifespan_tasks[task] = None
+            registered_task = functools.partial(
+                task, **task_kwargs
+            )  # pyright: ignore [reportArgumentType]
+            functools.update_wrapper(
+                registered_task, task
+            )  # pyright: ignore [reportArgumentType]
+        self._lifespan_tasks[registered_task] = None
         console.debug(f"Registered lifespan task: {task_name}")
+        return task

--- a/tests/units/app_mixins/test_lifespan.py
+++ b/tests/units/app_mixins/test_lifespan.py
@@ -2,22 +2,21 @@
 
 from __future__ import annotations
 
-import functools
+import asyncio
+import contextlib
+
+import pytest
+from reflex_base.utils.exceptions import InvalidLifespanTaskTypeError
 
 from reflex.app_mixins.lifespan import LifespanMixin
 
 
 def test_register_lifespan_task_can_be_used_as_decorator():
-    """Decorating a task registers it and preserves the task callable."""
+    """Bare decorator registers the task and preserves the name binding."""
     mixin = LifespanMixin()
 
     @mixin.register_lifespan_task
     def polling_task() -> str:
-        """Return a sentinel value for direct-call verification.
-
-        Returns:
-            A sentinel string.
-        """
         return "ok"
 
     assert polling_task() == "ok"
@@ -25,26 +24,32 @@ def test_register_lifespan_task_can_be_used_as_decorator():
 
 
 def test_register_lifespan_task_with_kwargs_can_be_used_as_decorator():
-    """Decorator-with-kwargs preserves function binding and registers partial."""
+    """Decorator-with-kwargs registers a partial that applies the kwargs."""
     mixin = LifespanMixin()
 
     @mixin.register_lifespan_task(timeout=10)
     def check_for_updates(timeout: int) -> int:
-        """Echo timeout to verify direct function access is preserved.
-
-        Args:
-            timeout: Timeout value in seconds.
-
-        Returns:
-            The timeout value passed to the function.
-        """
         return timeout
 
     assert check_for_updates(timeout=4) == 4
 
-    registered_tasks = mixin.get_lifespan_tasks()
-    assert len(registered_tasks) == 1
-    registered_task = registered_tasks[0]
-    assert isinstance(registered_task, functools.partial)
-    assert registered_task.func is check_for_updates
-    assert registered_task.keywords == {"timeout": 10}
+    (registered_task,) = mixin.get_lifespan_tasks()
+    assert not isinstance(registered_task, asyncio.Task)
+    assert registered_task() == 10
+
+
+async def test_register_lifespan_task_rejects_kwargs_for_asyncio_task():
+    """Registering kwargs against an asyncio.Task raises a clear error."""
+    mixin = LifespanMixin()
+    task = asyncio.create_task(asyncio.sleep(0), name="scheduled-lifespan-task")
+
+    try:
+        with pytest.raises(
+            InvalidLifespanTaskTypeError,
+            match=r"of type asyncio\.Task cannot be registered with kwargs",
+        ):
+            mixin.register_lifespan_task(task, timeout=10)
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task

--- a/tests/units/app_mixins/test_lifespan.py
+++ b/tests/units/app_mixins/test_lifespan.py
@@ -1,0 +1,50 @@
+"""Unit tests for lifespan app mixin behavior."""
+
+from __future__ import annotations
+
+import functools
+
+from reflex.app_mixins.lifespan import LifespanMixin
+
+
+def test_register_lifespan_task_can_be_used_as_decorator():
+    """Decorating a task registers it and preserves the task callable."""
+    mixin = LifespanMixin()
+
+    @mixin.register_lifespan_task
+    def polling_task() -> str:
+        """Return a sentinel value for direct-call verification.
+
+        Returns:
+            A sentinel string.
+        """
+        return "ok"
+
+    assert polling_task() == "ok"
+    assert polling_task in mixin.get_lifespan_tasks()
+
+
+def test_register_lifespan_task_with_kwargs_can_be_used_as_decorator():
+    """Decorator-with-kwargs preserves function binding and registers partial."""
+    mixin = LifespanMixin()
+
+    @mixin.register_lifespan_task(timeout=10)
+    def check_for_updates(timeout: int) -> int:
+        """Echo timeout to verify direct function access is preserved.
+
+        Args:
+            timeout: Timeout value in seconds.
+
+        Returns:
+            The timeout value passed to the function.
+        """
+        return timeout
+
+    assert check_for_updates(timeout=4) == 4
+
+    registered_tasks = mixin.get_lifespan_tasks()
+    assert len(registered_tasks) == 1
+    registered_task = registered_tasks[0]
+    assert isinstance(registered_task, functools.partial)
+    assert registered_task.func is check_for_updates
+    assert registered_task.keywords == {"timeout": 10}


### PR DESCRIPTION
### All Submissions:

  - [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://
  github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
  - [x] Have you checked to ensure there aren't any other open [Pull
  Requests](https://github.com/reflex-dev/reflex/pulls) for the desired
  changed?

  ### Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

  ### New Feature Submission:

  - [x] Does your submission pass the tests?
  - [x] Have you linted your code locally prior to submission?

  ### Changes To Core Features:

  - [x] Have you added an explanation of what your changes do and why you'd
  like us to include them?
  - [x] Have you written new tests for your core changes, as applicable?
  - [x] Have you successfully ran tests with your changes locally?

  ### Description

  This fixes `App.register_lifespan_task` so it can be used as a decorator.

  Before this change:
  - `@app.register_lifespan_task` bound the function name to `None` because
  the method did not return the task.
  - `@app.register_lifespan_task(timeout=10)` raised because the method
  required `task` as a positional arg.

  What changed:
  - `register_lifespan_task` now accepts `task: Callable | asyncio.Task |
  None = None`.
  - If called with no task and kwargs only, it returns a decorator via
  `functools.partial(...)`.
  - When registration succeeds, it now returns the original task callable.
  - Internal registration behavior is unchanged: kwargs still produce a
  wrapped `functools.partial` that is stored in `_lifespan_tasks`.

  ### Tests

  Added:
  - `tests/units/app_mixins/test_lifespan.py`
    - `test_register_lifespan_task_can_be_used_as_decorator`
    - `test_register_lifespan_task_with_kwargs_can_be_used_as_decorator`

  Validation run:
  - `uv run pytest tests/units/app_mixins/test_lifespan.py -q`
  - `uv run ruff check reflex/app_mixins/lifespan.py tests/units/app_mixins/
  test_lifespan.py`

  Closes #6330