### PR TITLE
do not set db_url to sqlite by default

### DIFF
--- a/packages/reflex-base/src/reflex_base/config.py
+++ b/packages/reflex-base/src/reflex_base/config.py
@@ -203,7 +203,7 @@ class BaseConfig:
 
     backend_host: str = "0.0.0.0"
 
-    db_url: str | None = "sqlite:///reflex.db"
+    db_url: str | None = None
 
     async_db_url: str | None = None
 

--- a/reflex/utils/templates.py
+++ b/reflex/utils/templates.py
@@ -11,6 +11,7 @@ from reflex_base import constants
 from reflex_base.config import get_config
 
 from reflex.utils import console, net, path_ops, redir
+from reflex.utils.rename import rename_imports_and_app_name
 
 
 @dataclasses.dataclass(frozen=True)
@@ -175,7 +176,9 @@ def create_config_init_app_from_remote_template(app_name: str, template_url: str
     # the source code repo name on github.
     template_name = new_config.app_name
 
-    create_config(app_name)
+    # Rewrite in place instead of regenerating from a stock template, so the
+    # template's own config (db_url, redis_url, plugins, etc.) is preserved.
+    rename_imports_and_app_name(constants.Config.FILE, template_name, app_name)
     initialize_app_directory(
         app_name,
         template_name=template_name,

--- a/tests/units/test_app.py
+++ b/tests/units/test_app.py
@@ -377,12 +377,17 @@ def test_add_duplicate_page_route_error(app: App, first_page, second_page, route
     or not find_spec("pydantic"),
     reason="starlette_admin not installed or sqlmodel not installed or pydantic not installed",
 )
-def test_initialize_with_admin_dashboard(test_model: Model):
+def test_initialize_with_admin_dashboard(
+    test_model: type[Model], mocker: MockerFixture
+):
     """Test setting the admin dashboard of an app.
 
     Args:
         test_model: The default model.
+        mocker: pytest mocker object.
     """
+    conf = rx.Config(app_name="testing", db_url="sqlite:///reflex.db")
+    mocker.patch("reflex_base.config._get_config", return_value=conf)
     app = App(admin_dash=AdminDash(models=[test_model]))
     assert app.admin_dash is not None
     assert len(app.admin_dash.models) > 0
@@ -425,16 +430,22 @@ def test_initialize_with_custom_admin_dashboard(
     or not find_spec("pydantic"),
     reason="starlette_admin not installed or sqlmodel not installed or pydantic not installed",
 )
-def test_initialize_admin_dashboard_with_view_overrides(test_model):
+def test_initialize_admin_dashboard_with_view_overrides(
+    test_model: type[Model], mocker: MockerFixture
+):
     """Test setting the admin dashboard of an app with view class overridden.
 
     Args:
         test_model: The default model.
+        mocker: pytest mocker object.
     """
     from starlette_admin.contrib.sqla.view import ModelView
 
     class TestModelView(ModelView):
         pass
+
+    conf = rx.Config(app_name="testing", db_url="sqlite:///reflex.db")
+    mocker.patch("reflex_base.config._get_config", return_value=conf)
 
     app = App(
         admin_dash=AdminDash(


### PR DESCRIPTION
since database modules are not installed by default, this provides a broken user experience as health metrics fail because db modules aren't isntalled