### PR TITLE
fix(app): pass Reflex app instance to lifespan task app parameter

### DIFF
--- a/docs/utility_methods/lifespan_tasks.md
+++ b/docs/utility_methods/lifespan_tasks.md
@@ -40,8 +40,11 @@ async def long_running_task(foo, bar):
 To register a lifespan task, use `app.register_lifespan_task(coro_func, **kwargs)`.
 Any keyword arguments specified during registration will be passed to the task.
 
-If the task accepts the special argument, `app`, it will be passed the `Starlette`
-application instance.
+If the task accepts the special argument, `app`, it will be passed the Reflex app
+instance (`rx.App`/`LifespanMixin`).
+
+If the task accepts the special argument, `starlette_app`, it will be passed the
+underlying `Starlette` application instance.
 
 ```python
 app = rx.App()

--- a/reflex/app_mixins/lifespan.py
+++ b/reflex/app_mixins/lifespan.py
@@ -102,9 +102,7 @@ class LifespanMixin(AppMixin):
                         if "app" in signature.parameters:
                             task = functools.partial(task, app=self)
                         if "starlette_app" in signature.parameters:
-                            task = functools.partial(
-                                task, starlette_app=starlette_app
-                            )
+                            task = functools.partial(task, starlette_app=starlette_app)
                         t_ = task()
                         if isinstance(t_, contextlib._AsyncGeneratorContextManager):
                             await stack.enter_async_context(t_)

--- a/reflex/app_mixins/lifespan.py
+++ b/reflex/app_mixins/lifespan.py
@@ -87,7 +87,7 @@ class LifespanMixin(AppMixin):
         return tuple(self._lifespan_tasks)
 
     @contextlib.asynccontextmanager
-    async def _run_lifespan_tasks(self, app: Starlette):
+    async def _run_lifespan_tasks(self, starlette_app: Starlette):
         self._lifespan_tasks_started = True
         running_tasks = []
         try:
@@ -100,7 +100,11 @@ class LifespanMixin(AppMixin):
                     else:
                         signature = inspect.signature(task)
                         if "app" in signature.parameters:
-                            task = functools.partial(task, app=app)
+                            task = functools.partial(task, app=self)
+                        if "starlette_app" in signature.parameters:
+                            task = functools.partial(
+                                task, starlette_app=starlette_app
+                            )
                         t_ = task()
                         if isinstance(t_, contextlib._AsyncGeneratorContextManager):
                             await stack.enter_async_context(t_)

--- a/tests/units/app_mixins/test_lifespan.py
+++ b/tests/units/app_mixins/test_lifespan.py
@@ -7,6 +7,7 @@ import contextlib
 
 import pytest
 from reflex_base.utils.exceptions import InvalidLifespanTaskTypeError
+from starlette.applications import Starlette
 
 from reflex.app_mixins.lifespan import LifespanMixin
 
@@ -38,6 +39,7 @@ def test_register_lifespan_task_with_kwargs_can_be_used_as_decorator():
     assert registered_task() == 10
 
 
+@pytest.mark.asyncio
 async def test_register_lifespan_task_rejects_kwargs_for_asyncio_task():
     """Registering kwargs against an asyncio.Task raises a clear error."""
     mixin = LifespanMixin()
@@ -53,3 +55,73 @@ async def test_register_lifespan_task_rejects_kwargs_for_asyncio_task():
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await task
+
+
+@pytest.mark.asyncio
+async def test_lifespan_task_app_param_receives_reflex_app_instance():
+    """Lifespan tasks should receive the Reflex app instance, not Starlette."""
+
+    class DummyApp(LifespanMixin):
+        """Minimal test app based on the lifespan mixin."""
+
+    app = DummyApp()
+    received: dict[str, object] = {}
+
+    def lifespan_task(app):
+        """Record the app argument injected by the lifespan runner."""
+        received["app"] = app
+
+    app.register_lifespan_task(lifespan_task)
+
+    async with app._run_lifespan_tasks(Starlette()):
+        await asyncio.sleep(0)
+
+    assert received["app"] is app
+
+
+@pytest.mark.asyncio
+async def test_lifespan_task_starlette_app_param_receives_starlette_instance():
+    """Lifespan tasks should receive the Starlette app when requested."""
+
+    class DummyApp(LifespanMixin):
+        """Minimal test app based on the lifespan mixin."""
+
+    app = DummyApp()
+    received: dict[str, object] = {}
+    starlette_app = Starlette()
+
+    def lifespan_task(starlette_app):
+        """Record the Starlette app argument injected by the lifespan runner."""
+        received["starlette_app"] = starlette_app
+
+    app.register_lifespan_task(lifespan_task)
+
+    async with app._run_lifespan_tasks(starlette_app):
+        await asyncio.sleep(0)
+
+    assert received["starlette_app"] is starlette_app
+
+
+@pytest.mark.asyncio
+async def test_lifespan_task_both_app_and_starlette_app_params_are_injected():
+    """Lifespan tasks should receive both app and starlette_app when declared."""
+
+    class DummyApp(LifespanMixin):
+        """Minimal test app based on the lifespan mixin."""
+
+    app = DummyApp()
+    received: dict[str, object] = {}
+    starlette_app = Starlette()
+
+    def lifespan_task(app, starlette_app):
+        """Record both injected app objects from the lifespan runner."""
+        received["app"] = app
+        received["starlette_app"] = starlette_app
+
+    app.register_lifespan_task(lifespan_task)
+
+    async with app._run_lifespan_tasks(starlette_app):
+        await asyncio.sleep(0)
+
+    assert received["app"] is app
+    assert received["starlette_app"] is starlette_app

--- a/tests/units/app_mixins/test_lifespan.py
+++ b/tests/units/app_mixins/test_lifespan.py
@@ -91,7 +91,11 @@ async def test_lifespan_task_starlette_app_param_receives_starlette_instance():
     starlette_app = Starlette()
 
     def lifespan_task(starlette_app):
-        """Record the Starlette app argument injected by the lifespan runner."""
+        """Record the Starlette app argument injected by the lifespan runner.
+
+        Args:
+            starlette_app: Starlette app object injected by the lifespan runner.
+        """
         received["starlette_app"] = starlette_app
 
     app.register_lifespan_task(lifespan_task)
@@ -114,7 +118,12 @@ async def test_lifespan_task_both_app_and_starlette_app_params_are_injected():
     starlette_app = Starlette()
 
     def lifespan_task(app, starlette_app):
-        """Record both injected app objects from the lifespan runner."""
+        """Record both injected app objects from the lifespan runner.
+
+        Args:
+            app: Reflex app object injected by the lifespan runner.
+            starlette_app: Starlette app object injected by the lifespan runner.
+        """
         received["app"] = app
         received["starlette_app"] = starlette_app
 

--- a/tests/units/app_mixins/test_lifespan.py
+++ b/tests/units/app_mixins/test_lifespan.py
@@ -60,33 +60,25 @@ async def test_register_lifespan_task_rejects_kwargs_for_asyncio_task():
 @pytest.mark.asyncio
 async def test_lifespan_task_app_param_receives_reflex_app_instance():
     """Lifespan tasks should receive the Reflex app instance, not Starlette."""
-
-    class DummyApp(LifespanMixin):
-        """Minimal test app based on the lifespan mixin."""
-
-    app = DummyApp()
+    mixin = LifespanMixin()
     received: dict[str, object] = {}
 
     def lifespan_task(app):
         """Record the app argument injected by the lifespan runner."""
         received["app"] = app
 
-    app.register_lifespan_task(lifespan_task)
+    mixin.register_lifespan_task(lifespan_task)
 
-    async with app._run_lifespan_tasks(Starlette()):
+    async with mixin._run_lifespan_tasks(Starlette()):
         await asyncio.sleep(0)
 
-    assert received["app"] is app
+    assert received["app"] is mixin
 
 
 @pytest.mark.asyncio
 async def test_lifespan_task_starlette_app_param_receives_starlette_instance():
     """Lifespan tasks should receive the Starlette app when requested."""
-
-    class DummyApp(LifespanMixin):
-        """Minimal test app based on the lifespan mixin."""
-
-    app = DummyApp()
+    mixin = LifespanMixin()
     received: dict[str, object] = {}
     starlette_app = Starlette()
 
@@ -98,9 +90,9 @@ async def test_lifespan_task_starlette_app_param_receives_starlette_instance():
         """
         received["starlette_app"] = starlette_app
 
-    app.register_lifespan_task(lifespan_task)
+    mixin.register_lifespan_task(lifespan_task)
 
-    async with app._run_lifespan_tasks(starlette_app):
+    async with mixin._run_lifespan_tasks(starlette_app):
         await asyncio.sleep(0)
 
     assert received["starlette_app"] is starlette_app
@@ -109,11 +101,7 @@ async def test_lifespan_task_starlette_app_param_receives_starlette_instance():
 @pytest.mark.asyncio
 async def test_lifespan_task_both_app_and_starlette_app_params_are_injected():
     """Lifespan tasks should receive both app and starlette_app when declared."""
-
-    class DummyApp(LifespanMixin):
-        """Minimal test app based on the lifespan mixin."""
-
-    app = DummyApp()
+    mixin = LifespanMixin()
     received: dict[str, object] = {}
     starlette_app = Starlette()
 
@@ -127,10 +115,10 @@ async def test_lifespan_task_both_app_and_starlette_app_params_are_injected():
         received["app"] = app
         received["starlette_app"] = starlette_app
 
-    app.register_lifespan_task(lifespan_task)
+    mixin.register_lifespan_task(lifespan_task)
 
-    async with app._run_lifespan_tasks(starlette_app):
+    async with mixin._run_lifespan_tasks(starlette_app):
         await asyncio.sleep(0)
 
-    assert received["app"] is app
+    assert received["app"] is mixin
     assert received["starlette_app"] is starlette_app


### PR DESCRIPTION
### All Submissions:

  - [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://
  github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
  - [x] Have you checked to ensure there aren't any other open [Pull
  Requests](https://github.com/reflex-dev/reflex/pulls) for the desired
  changed?

  ### Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)

  ### New Feature Submission:

  - [x] Does your submission pass the tests?
  - [x] Have you linted your code locally prior to submission?

  ### Changes To Core Features:

  - [x] Have you added an explanation of what your changes do and why you'd
  like us to include them?
  - [x] Have you written new tests for your core changes, as applicable?
  - [x] Have you successfully ran tests with your changes locally?

  ### Description

  This fixes lifespan task app injection so tasks that declare an `app`
  parameter receive the Reflex app instance (`rx.App`) instead of the
  Starlette wrapper.

  Before:
  - In `_run_lifespan_tasks`, tasks with an `app` parameter were called with
  the Starlette lifespan app object.
  - This made `app` inconsistent with expected Reflex app behavior.

  After:
  - `app` parameter now receives `self` (the Reflex app instance).
  - Added optional `starlette_app` parameter support for tasks that
  explicitly want the Starlette instance.

  ### Tests

  Added regression test:
  - `tests/units/app_mixins/test_lifespan.py`
    - `test_lifespan_task_app_param_receives_reflex_app_instance`

  Validation run:
  - `uv run pytest tests/units/app_mixins/test_lifespan.py -q`
  - `uv run ruff check reflex/app_mixins/lifespan.py tests/units/app_mixins/
  test_lifespan.py`

  Closes #6331