### PR TITLE
docs: add "Contributing to the Docs" section to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,8 +124,8 @@ By default the dev server compiles every page, which can be slow. To only compil
 
 ```python
 WHITELISTED_PAGES = [
-    "/docs/getting-started/introduction",
-    "/docs/components/props",
+    "/getting-started/introduction",
+    "/components/props",
 ]
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,39 @@ We welcome AI-assisted contributions, but they must meet the same quality bar as
 - All added/changed lines MUST have unit or integration test coverage with _real_ assertions. No untested code, no bogus test code.
 - PRs with merge conflicts or failing tests will not be reviewed or merged. The maintainers do not spend time on PRs that are not in a ready state. If you need attention on a PR that is not ready, mention the maintainers in a comment.
 
+## 📝 Contributing to the Docs
+
+The Reflex documentation lives in this repo under [`docs/`](https://github.com/reflex-dev/reflex/tree/main/docs). All doc pages are plain Markdown files in [`docs/`](https://github.com/reflex-dev/reflex/tree/main/docs), and the docs site itself (a Reflex app that renders them) lives in [`docs/app/`](https://github.com/reflex-dev/reflex/tree/main/docs/app). If you're fixing a typo, clarifying an explanation, or adding a new page, you can do it all in this repo by editing the relevant `.md` file.
+
+**1. Run the docs site locally:**
+
+```bash
+cd docs/app
+uv sync
+uv run reflex run
+```
+
+Then open [http://localhost:3000/docs/](http://localhost:3000/docs/). The dev server picks up changes to the `.md` files in `docs/` so you can preview edits live.
+
+**2. Speed up dev builds with the page whitelist (optional):**
+
+By default the dev server compiles every page, which can be slow. To only compile the pages you're working on, edit `docs/app/reflex_docs/whitelist.py` and add paths to `WHITELISTED_PAGES`:
+
+```python
+WHITELISTED_PAGES = [
+    "/docs/getting-started/introduction",
+    "/docs/components/props",
+]
+```
+
+Paths must start with `/`, have no trailing slash, and are prefix-matched. An empty list builds everything. Restart the dev server after editing.
+
+**3. Style and review:**
+
+- Keep code examples runnable and minimal.
+- Match the tone and structure of surrounding pages.
+- Preview your changes locally before opening a PR.
+
 ## Editing Templates
 
 To edit the templates in Reflex you can do so in two way.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,12 +131,6 @@ WHITELISTED_PAGES = [
 
 Paths must start with `/`, have no trailing slash, and are prefix-matched. An empty list builds everything. Restart the dev server after editing.
 
-**3. Style and review:**
-
-- Keep code examples runnable and minimal.
-- Match the tone and structure of surrounding pages.
-- Preview your changes locally before opening a PR.
-
 ## Editing Templates
 
 To edit the templates in Reflex you can do so in two way.


### PR DESCRIPTION
## Summary
- Adds a new "Contributing to the Docs" section to `CONTRIBUTING.md` so new contributors know where the docs live and how to run them.
- Clarifies that all doc pages are plain Markdown files under [`docs/`](https://github.com/reflex-dev/reflex/tree/main/docs), and that the docs site itself is the Reflex app in [`docs/app/`](https://github.com/reflex-dev/reflex/tree/main/docs/app).
- Documents the `WHITELISTED_PAGES` trick in `docs/app/reflex_docs/whitelist.py` for faster dev builds.

## Test plan
- [x] Rendered the updated `CONTRIBUTING.md` locally to check formatting.
- [ ] Confirm links resolve on GitHub once the PR is open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)