### PR TITLE
`State.reset()` should not reset inherited backend vars

### DIFF
--- a/reflex/istate/shared.py
+++ b/reflex/istate/shared.py
@@ -98,7 +98,7 @@ async def _patch_state(
     try:
         if full_delta:
             linked_state.dirty_vars.update(linked_state.base_vars)
-            linked_state.dirty_vars.update(linked_state.backend_vars)
+            linked_state.dirty_vars.update(linked_state._backend_vars)
             linked_state.dirty_vars.update(linked_state.computed_vars)
             linked_state._mark_dirty()
         # Apply the updates into the existing state tree for rehydrate.

--- a/reflex/istate/shared.py
+++ b/reflex/istate/shared.py
@@ -118,6 +118,7 @@ class SharedStateBaseInternal(State):
 
     _exit_stack: contextlib.AsyncExitStack | None = None
     _held_locks: dict[str, dict[type[BaseState], BaseState]] | None = None
+    _held_locks_lock: asyncio.Lock = asyncio.Lock()
 
     def __getstate__(self):
         """Override redis serialization to remove temporary fields.
@@ -129,6 +130,7 @@ class SharedStateBaseInternal(State):
         s.pop("_previous_dirty_vars", None)
         s.pop("_exit_stack", None)
         s.pop("_held_locks", None)
+        s.pop("_held_locks_lock", None)
         return s
 
     @_override_base_method
@@ -154,6 +156,7 @@ class SharedStateBaseInternal(State):
         self.dirty_vars.discard("_previous_dirty_vars")
         self.dirty_vars.discard("_exit_stack")
         self.dirty_vars.discard("_held_locks")
+        self.dirty_vars.discard("_held_locks_lock")
         # Only mark dirty if there are still dirty vars, or any substate is dirty
         if self.dirty_vars or any(
             substate.dirty_vars for substate in self.substates.values()
@@ -305,27 +308,31 @@ class SharedStateBaseInternal(State):
             msg = "Cannot link shared state outside of _modify_linked_states context."
             raise ReflexRuntimeError(msg)
 
+        linked_root_state = None
+
         # Get the newly linked state and update pointers/delta for subsequent events.
         if token not in self._held_locks:
-            linked_root_state = await self._exit_stack.enter_async_context(
-                get_state_manager().modify_state(
-                    BaseStateToken(ident=token, cls=type(self))
-                )
-            )
-            # Set client_token on the linked root so that subsequent get_state
-            # calls when directly modifying a linked token will load the
-            # associated instance.
-            if linked_root_state.router.session.client_token != token:
-                import dataclasses as dc
+            async with self._held_locks_lock:
+                if token not in self._held_locks:
+                    linked_root_state = await self._exit_stack.enter_async_context(
+                        get_state_manager().modify_state(
+                            BaseStateToken(ident=token, cls=type(self))
+                        )
+                    )
+                    self._held_locks.setdefault(token, {})
+                    # Set client_token on the linked root so that subsequent get_state
+                    # calls when directly modifying a linked token will load the
+                    # associated instance.
+                    if linked_root_state.router.session.client_token != token:
+                        import dataclasses as dc
 
-                linked_root_state.router = dc.replace(
-                    linked_root_state.router,
-                    session=dc.replace(
-                        linked_root_state.router.session, client_token=token
-                    ),
-                )
-            self._held_locks.setdefault(token, {})
-        else:
+                        linked_root_state.router = dc.replace(
+                            linked_root_state.router,
+                            session=dc.replace(
+                                linked_root_state.router.session, client_token=token
+                            ),
+                        )
+        if linked_root_state is None:
             linked_root_state = await get_state_manager().get_state(
                 BaseStateToken(ident=token, cls=type(self))
             )

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1460,9 +1460,10 @@ class BaseState(EvenMoreBasicBaseState):
                 default = copy.deepcopy(field.default)
             setattr(self, prop_name, default)
 
-        # Reset the backend vars.
+        # Reset the backend vars that are not inherited from parent states.
         for prop_name, value in self.backend_vars.items():
-            setattr(self, prop_name, copy.deepcopy(value))
+            if prop_name not in self.inherited_backend_vars:
+                setattr(self, prop_name, copy.deepcopy(value))
 
         # Recursively reset the substates.
         for substate in self.substates.values():

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -432,8 +432,13 @@ class BaseState(EvenMoreBasicBaseState):
                     _reflex_internal_init=True,
                 )
 
-        # Create a fresh copy of the backend variables for this instance
-        self._backend_vars = copy.deepcopy(self.backend_vars)
+        # Create a fresh copy of only the non-inherited backend variables for this instance.
+        # Inherited backend vars are stored in the parent state, not in this instance.
+        self._backend_vars = {
+            k: copy.deepcopy(v)
+            for k, v in self.backend_vars.items()
+            if k not in self.inherited_backend_vars
+        }
 
     def __repr__(self) -> str:
         """Get the string representation of the state.
@@ -1792,6 +1797,7 @@ class BaseState(EvenMoreBasicBaseState):
         """Update the _was_touched flag based on dirty_vars."""
         if self.dirty_vars and not self._was_touched:
             for var in self.dirty_vars:
+                # Mark touched if a base var or owned backend var (not inherited) changed.
                 if var in self.base_vars or var in self._backend_vars:
                     self._was_touched = True
                     break

--- a/tests/integration/test_component_state.py
+++ b/tests/integration/test_component_state.py
@@ -38,9 +38,9 @@ def ComponentStateApp():
 
         @rx.event
         def assert_be_none(self):
-            assert set(self._backend_vars) == {
-                name
-                for name in self.backend_vars
+            assert self._backend_vars == {
+                name: value
+                for name, value in self.backend_vars.items()
                 if name not in self.inherited_backend_vars
             }
             assert self._be is None  # pyright: ignore [reportAttributeAccessIssue]

--- a/tests/integration/test_component_state.py
+++ b/tests/integration/test_component_state.py
@@ -38,7 +38,11 @@ def ComponentStateApp():
 
         @rx.event
         def assert_be_none(self):
-            assert self._backend_vars == self.backend_vars
+            assert set(self._backend_vars) == {
+                name
+                for name in self.backend_vars
+                if name not in self.inherited_backend_vars
+            }
             assert self._be is None  # pyright: ignore [reportAttributeAccessIssue]
 
         @rx.event

--- a/tests/integration/test_linked_state.py
+++ b/tests/integration/test_linked_state.py
@@ -57,6 +57,10 @@ def LinkedStateApp():
             self.event_seen_linked_to = self._linked_to
 
         @rx.event
+        def clear_event_link_status(self):
+            self.event_seen_linked_to = ""
+
+        @rx.event
         async def on_load_link_default(self):
             linked_state = await self._link_to(self.room or "default")  # pyright: ignore[reportAttributeAccessIssue]
             if self.room:  # pyright: ignore[reportAttributeAccessIssue]
@@ -172,6 +176,11 @@ def LinkedStateApp():
                 "Record Event Link Status",
                 on_click=SharedState.record_event_link_status,
                 id="record-link-status-button",
+            ),
+            rx.button(
+                "Clear Event Link Status",
+                on_click=SharedState.clear_event_link_status,
+                id="clear-link-status-button",
             ),
             rx.button(
                 "Reset Private State",
@@ -612,6 +621,10 @@ def test_unrelated_reset_does_not_break_shared_event_link_context(
     tab.find_element(By.ID, "record-link-status-button").click()
     assert linked_state.poll_for_content(event_seen, exp_not_equal="") == shared_token
 
+    # Clear the field first so we can distinguish a fresh record from the stale value,
+    # then trigger reset + record and wait for the DOM to reflect the new result.
+    tab.find_element(By.ID, "clear-link-status-button").click()
+    assert linked_state.poll_for_content(event_seen, exp_not_equal=shared_token) == ""
     tab.find_element(By.ID, "reset-private-state-button").click()
     tab.find_element(By.ID, "record-link-status-button").click()
     assert linked_state.poll_for_content(event_seen, exp_not_equal="") == shared_token

--- a/tests/integration/test_linked_state.py
+++ b/tests/integration/test_linked_state.py
@@ -129,6 +129,39 @@ def LinkedStateApp():
         def reset_self(self):
             self.reset()
 
+    class RaceState(rx.State):
+        """State with multiple async vars that race for the linked token lock."""
+
+        trigger: int = 0
+
+        @rx.var
+        async def race_val_0(self) -> str:
+            n = self.trigger
+            ss = await self.get_state(SharedState)
+            return f"{n}-{ss.counter}"
+
+        @rx.var
+        async def race_val_1(self) -> str:
+            n = self.trigger
+            ss = await self.get_state(SharedState)
+            return f"{n}-{ss.counter}"
+
+        @rx.var
+        async def race_val_2(self) -> str:
+            n = self.trigger
+            ss = await self.get_state(SharedState)
+            return f"{n}-{ss.counter}"
+
+        @rx.var
+        async def race_val_3(self) -> str:
+            n = self.trigger
+            ss = await self.get_state(SharedState)
+            return f"{n}-{ss.counter}"
+
+        @rx.event
+        def bump_trigger(self):
+            self.trigger += 1
+
     def index() -> rx.Component:
         return rx.vstack(
             rx.text(
@@ -199,6 +232,15 @@ def LinkedStateApp():
                 id="fetch-note-button",
             ),
             rx.text(PrivateState.fetched_note, id="fetched-note"),
+            rx.text(RaceState.race_val_0, id="race-val-0"),
+            rx.text(RaceState.race_val_1, id="race-val-1"),
+            rx.text(RaceState.race_val_2, id="race-val-2"),
+            rx.text(RaceState.race_val_3, id="race-val-3"),
+            rx.button(
+                "Bump Trigger",
+                on_click=RaceState.bump_trigger,
+                id="bump-trigger-button",
+            ),
         )
 
     from fastapi import FastAPI
@@ -628,3 +670,75 @@ def test_unrelated_reset_does_not_break_shared_event_link_context(
     tab.find_element(By.ID, "reset-private-state-button").click()
     tab.find_element(By.ID, "record-link-status-button").click()
     assert linked_state.poll_for_content(event_seen, exp_not_equal="") == shared_token
+
+
+def test_concurrent_async_vars_do_not_deadlock_linked_token(
+    linked_state: AppHarness,
+    tab_factory: Callable[[], WebDriver],
+):
+    """Ensure concurrent async vars accessing a linked SharedState do not deadlock.
+
+    When multiple async rx.var functions simultaneously call ``await
+    self.get_state(SharedState)`` and SharedState is not yet cached, each
+    resolves the linked state independently, meaning multiple concurrent calls
+    to ``state_manager.modify_state`` for the same linked token.  Without a lock
+    protecting this operation these races hit the Redis lock timeout
+    (~lock_expiration delay per blocked var).
+
+    Only meaningful with the Redis state manager; skipped otherwise.
+
+    Args:
+        linked_state: harness for LinkedStateApp.
+        tab_factory: factory to create WebDriver instances.
+    """
+    import time
+
+    from reflex.istate.manager.redis import StateManagerRedis
+
+    assert linked_state.app_instance is not None
+    sm = linked_state.app_instance.state_manager
+    if not isinstance(sm, StateManagerRedis):
+        pytest.skip("Only applicable with Redis state manager")
+
+    lock_expiration_s = sm.lock_expiration / 1000
+    # All 4 vars must update well within the lock expiration window.
+    # If any var hits a lock timeout it will delay by ~lock_expiration_s,
+    # which would exceed this threshold and fail the assertion.
+    max_acceptable_s = lock_expiration_s / 2
+
+    tab = tab_factory()
+    ss_storage = utils.SessionStorage(tab)
+    assert AppHarness._poll_for(lambda: ss_storage.get("token") is not None), (
+        "token not found"
+    )
+
+    shared_token = f"race-repro-{uuid.uuid4()}"
+    tab.find_element(By.ID, "token-input").send_keys(shared_token, Keys.ENTER)
+    linked_to = tab.find_element(By.ID, "linked-to")
+    assert linked_state.poll_for_content(linked_to, exp_not_equal="") == shared_token
+
+    race_elements = [tab.find_element(By.ID, f"race-val-{i}") for i in range(4)]
+
+    # Wait for all 4 vars to settle to their initial value after linking.
+    initial_texts = []
+    for el in race_elements:
+        assert AppHarness._poll_for(lambda e=el: e.text != ""), (
+            "race var never populated"
+        )
+        initial_texts.append(el.text)
+
+    # Trigger the race: bump_trigger causes all 4 async vars to recompute
+    # concurrently, each independently calling get_state(SharedState) which
+    # resolves via modify_state on the linked token.
+    tab.find_element(By.ID, "bump-trigger-button").click()
+
+    t0 = time.monotonic()
+    for el, initial in zip(race_elements, initial_texts, strict=True):
+        linked_state.poll_for_content(el, exp_not_equal=initial)
+    elapsed = time.monotonic() - t0
+
+    assert elapsed < max_acceptable_s, (
+        f"Async vars took {elapsed:.2f}s to update — expected < {max_acceptable_s:.2f}s "
+        f"(lock_expiration={lock_expiration_s:.2f}s). "
+        "Likely caused by concurrent async vars racing for the linked token lock."
+    )

--- a/tests/integration/test_linked_state.py
+++ b/tests/integration/test_linked_state.py
@@ -28,6 +28,7 @@ def LinkedStateApp():
         _who: str = "world"
         n_changes: int = 0
         counter: int = 0
+        event_seen_linked_to: str = ""
 
         @rx.event
         def set_counter(self, value: int) -> None:
@@ -50,6 +51,10 @@ def LinkedStateApp():
         @rx.event
         async def unlink(self):
             return await self._unlink()
+
+        @rx.event
+        def record_event_link_status(self):
+            self.event_seen_linked_to = self._linked_to
 
         @rx.event
         async def on_load_link_default(self):
@@ -116,6 +121,10 @@ def LinkedStateApp():
                 ss.counter += 1
                 yield
 
+        @rx.event
+        def reset_self(self):
+            self.reset()
+
     def index() -> rx.Component:
         return rx.vstack(
             rx.text(
@@ -133,6 +142,7 @@ def LinkedStateApp():
                 reset_on_submit=True,
             ),
             rx.text(PrivateState.linked_to, id="linked-to"),
+            rx.text(SharedState.event_seen_linked_to, id="event-seen-linked-to"),
             rx.button("Unlink", id="unlink-button", on_click=SharedState.unlink),
             rx.form(
                 rx.input(name="token", id="token-input"),
@@ -157,6 +167,16 @@ def LinkedStateApp():
                 "Bump Counter with Yield",
                 on_click=PrivateState.bump_counter_yield,
                 id="yield-button",
+            ),
+            rx.button(
+                "Record Event Link Status",
+                on_click=SharedState.record_event_link_status,
+                id="record-link-status-button",
+            ),
+            rx.button(
+                "Reset Private State",
+                on_click=PrivateState.reset_self,
+                id="reset-private-state-button",
             ),
             rx.button(
                 "Link to arbitrary token and Increment n_changes",
@@ -558,3 +578,40 @@ def test_get_state_returns_linked_state(
     tab.find_element(By.ID, "fetch-note-button").click()
     fetched = tab.find_element(By.ID, "fetched-note")
     assert linked_state.poll_for_content(fetched, exp_not_equal="") == initial_note
+
+
+def test_unrelated_reset_does_not_break_shared_event_link_context(
+    linked_state: AppHarness,
+    tab_factory: Callable[[], WebDriver],
+):
+    """Ensure private-state reset does not break SharedState event linkage context.
+
+    Repro sequence from reported issue:
+    1. Link SharedState to a shared token.
+    2. Confirm a SharedState event sees linked token in ``self._linked_to``.
+    3. Call ``self.reset()`` on an unrelated non-shared state.
+    4. Confirm subsequent SharedState events still see linked token.
+
+    Args:
+        linked_state: harness for LinkedStateApp.
+        tab_factory: factory to create WebDriver instances.
+    """
+    assert linked_state.app_instance is not None
+
+    tab = tab_factory()
+    ss = utils.SessionStorage(tab)
+    assert AppHarness._poll_for(lambda: ss.get("token") is not None), "token not found"
+
+    shared_token = f"reset-repro-{uuid.uuid4()}"
+    tab.find_element(By.ID, "token-input").send_keys(shared_token, Keys.ENTER)
+
+    linked_to = tab.find_element(By.ID, "linked-to")
+    assert linked_state.poll_for_content(linked_to, exp_not_equal="") == shared_token
+
+    event_seen = tab.find_element(By.ID, "event-seen-linked-to")
+    tab.find_element(By.ID, "record-link-status-button").click()
+    assert linked_state.poll_for_content(event_seen, exp_not_equal="") == shared_token
+
+    tab.find_element(By.ID, "reset-private-state-button").click()
+    tab.find_element(By.ID, "record-link-status-button").click()
+    assert linked_state.poll_for_content(event_seen, exp_not_equal="") == shared_token

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -857,6 +857,63 @@ def test_reset_does_not_reset_inherited_backend_vars(
     assert test_state._backend == 0  # Reset to default
 
 
+def test_backend_vars_does_not_include_inherited(
+    test_state: TestState, child_state: ChildState
+):
+    """Test that _backend_vars only contains non-inherited backend vars.
+
+    This ensures that each state instance only copies backend vars it owns,
+    not those inherited from parent states (which remain in the parent).
+
+    Args:
+        test_state: A state with backend vars.
+        child_state: A child state inheriting from test_state.
+    """
+    # ChildState inherits _backend from TestState
+    assert "_backend" in TestState.backend_vars
+    assert "_backend" in ChildState.backend_vars  # Present in the combined dict
+    assert "_backend" in ChildState.inherited_backend_vars  # But marked as inherited
+
+    # The child state instance's _backend_vars should NOT contain _backend
+    # (it's inherited, so it's stored only in the parent instance)
+    assert "_backend" not in child_state._backend_vars
+
+    # But the parent instance's _backend_vars should contain it
+    assert "_backend" in test_state._backend_vars
+
+
+def test_setting_inherited_backend_var_does_not_mark_child_touched(
+    test_state: TestState, child_state: ChildState
+):
+    """Test that setting a parent's backend var through a child doesn't mark child as touched.
+
+    When a backend var from a parent state is modified through a child state instance,
+    only the parent should be marked as touched, not the child.
+
+    Args:
+        test_state: A state with backend vars.
+        child_state: A child state inheriting from test_state.
+    """
+    # Initially neither should be touched
+    assert not test_state._was_touched
+    assert not child_state._was_touched
+
+    # Modify an inherited backend var through the child
+    # (This routes through __setattr__ to the parent)
+    child_state._backend = 99
+
+    # Call _get_was_touched to update the flags based on dirty_vars
+    parent_touched = test_state._get_was_touched()
+    child_touched = child_state._get_was_touched()
+
+    # The parent should be marked as touched (the var belongs to it)
+    assert parent_touched
+
+    # But the child should NOT be marked as touched
+    # (the var doesn't belong to the child, it belongs to the parent)
+    assert not child_touched
+
+
 @pytest.mark.asyncio
 async def test_process_event_simple(
     token: str,

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -825,6 +825,38 @@ def test_reset(test_state: TestState, child_state: ChildState):
     }
 
 
+def test_reset_does_not_reset_inherited_backend_vars(
+    test_state: TestState, child_state: ChildState
+):
+    """Test that reset() does not reset backend vars from parent states.
+
+    This is a regression test for the issue where calling reset() on a child state
+    would also reset backend vars that are inherited from the parent state, which
+    breaks SharedState linkage when an unrelated state calls reset().
+
+    Args:
+        test_state: A state with backend vars.
+        child_state: A child state inheriting from test_state.
+    """
+    # Set a backend var on the parent state to a non-default value
+    original_backend_value = 42
+    test_state._backend = original_backend_value
+
+    # Verify it's been changed
+    assert test_state._backend == original_backend_value
+
+    # Reset only the child state
+    child_state.reset()
+
+    # The parent state's backend vars should NOT be reset
+    # (they should retain their modified value)
+    assert test_state._backend == original_backend_value
+
+    # Now verify that resetting the parent state DOES reset its own backend vars
+    test_state.reset()
+    assert test_state._backend == 0  # Reset to default
+
+
 @pytest.mark.asyncio
 async def test_process_event_simple(
     token: str,


### PR DESCRIPTION
`self.backend_vars` contains backend vars from the current state instance and its parent states. When performing the reset, we should never touch vars that belong to the parent(s).

Ensure that a State instance's _backend_vars only copies backend vars that were defined in the given substate, and does not also copy inherited backend vars that are managed by the parent. Ensures that assigning an inherited backend var through a substate marks the owner as touched and not the substate it was assigned through.