### PR TITLE
Add CODEOWNERS rules for docs and README

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
-@reflex-dev/reflex-team
+* @reflex-dev/reflex-team
+
+/docs/ @Alek99

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 * @reflex-dev/reflex-team
 
 /docs/ @Alek99
+/README.md @Alek99

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 * @reflex-dev/reflex-team
 
-/docs/ @Alek99
-/README.md @Alek99
+/docs/ @Alek99 @reflex-dev/reflex-team
+/README.md @Alek99 @reflex-dev/reflex-team


### PR DESCRIPTION
## Summary
- Keep `@reflex-dev/reflex-team` as the default owner
- Route PRs touching `/docs/` to @Alek99
- Route PRs touching `README.md` to @Alek99

## Test plan
- [ ] Open a test PR editing a file under `docs/` and confirm @Alek99 is auto-requested
- [ ] Open a test PR editing `README.md` and confirm @Alek99 is auto-requested

🤖 Generated with [Claude Code](https://claude.com/claude-code)