### PR TITLE
test(integration): use Playwright wait_for_url in poll_for_navigation

### DIFF
--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -46,7 +46,7 @@ def poll_for_navigation(
     """
     prev_url = page.url
     yield
-    AppHarness.expect(lambda: prev_url != page.url, timeout=timeout)
+    page.wait_for_url(lambda url: url != prev_url, timeout=timeout * 1000)
 
 
 def n_expected_events(exp_event_order: Sequence[str | set[str]]) -> int:

--- a/tests/units/integration/test_utils.py
+++ b/tests/units/integration/test_utils.py
@@ -1,0 +1,50 @@
+"""Unit tests for integration test utilities."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from tests.integration import utils
+
+
+class _FakePage:
+    """Minimal page stub for testing poll_for_navigation."""
+
+    def __init__(self) -> None:
+        """Initialize fake page state."""
+        self.url = "http://localhost:3000/"
+        self.wait_calls: list[tuple[Callable[[str], bool], float]] = []
+
+    def wait_for_url(self, predicate: Callable[[str], bool], timeout: float) -> None:
+        """Record wait_for_url calls and validate the URL-change predicate.
+
+        Args:
+            predicate: URL-matcher callback passed by poll_for_navigation.
+            timeout: Timeout in milliseconds.
+        """
+        self.wait_calls.append((predicate, timeout))
+        assert not predicate("http://localhost:3000/")
+        assert predicate("http://localhost:3000/next")
+
+
+def test_poll_for_navigation_uses_playwright_wait_for_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """poll_for_navigation should delegate URL waiting to Playwright."""
+
+    def _unexpected_expect(*_args: object, **_kwargs: object) -> None:
+        msg = "poll_for_navigation should not call AppHarness.expect"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(utils.AppHarness, "expect", _unexpected_expect)
+
+    page = _FakePage()
+    with utils.poll_for_navigation(page, timeout=2.5):
+        # The helper snapshots the current URL before yielding.
+        pass
+
+    assert len(page.wait_calls) == 1
+    _, timeout_ms = page.wait_calls[0]
+    assert timeout_ms == pytest.approx(2500.0)


### PR DESCRIPTION
## Summary\nFollow-up to #6378 to remove custom URL polling from integration helpers.\n\npoll_for_navigation now uses Playwright's native page.wait_for_url(...) with a URL-change predicate instead of AppHarness.expect(...) polling.\n\n## Changes\n- Updated 	ests/integration/utils.py::poll_for_navigation to delegate to page.wait_for_url.\n- Added regression unit test in 	ests/units/integration/test_utils.py that fails if AppHarness.expect is called and verifies timeout conversion to milliseconds.\n\n## Validation\n- uv run pytest tests/units/integration/test_utils.py -q\n- uv run ruff check tests/integration/utils.py tests/units/integration/test_utils.py\n\nCloses #6384\n