### PR TITLE
fix(docs): dropdown bg in dark mode, MCP sidebar sync, Safari copy

### DIFF
--- a/docs/app/assets/custom-colors.css
+++ b/docs/app/assets/custom-colors.css
@@ -108,7 +108,7 @@
   --slate-10: #737c8a;
   --slate-11: #adb4bf;
   --slate-12: #eceef1;
-  /* #151618 */
+  --c-slate-1: #151618;
   --c-slate-2: #1a1b1d;
   /* #1A1B1D */
   --c-slate-3: #222326;

--- a/docs/app/reflex_docs/templates/docpage/docpage.py
+++ b/docs/app/reflex_docs/templates/docpage/docpage.py
@@ -453,20 +453,21 @@ def _copy_page_button(doc_content: str, path: str = "") -> rx.Component:
     });
   };
   animate();
+  if (navigator.clipboard && typeof ClipboardItem !== 'undefined' && navigator.clipboard.write) {
+    const blobPromise = fetch(mdUrl).then((r) => {
+      if (!r.ok) throw new Error(r.status);
+      return r.text().then((t) => new Blob([t], { type: 'text/plain' }));
+    });
+    navigator.clipboard
+      .write([new ClipboardItem({ 'text/plain': blobPromise })])
+      .catch((err) => console.error('Copy page failed:', err));
+    return;
+  }
   fetch(mdUrl)
     .then((r) => (r.ok ? r.text() : Promise.reject(r.status)))
     .then((text) => {
       if (navigator.clipboard && navigator.clipboard.writeText) {
-        return navigator.clipboard.writeText(text).catch(() => {
-          const ta = document.createElement('textarea');
-          ta.value = text;
-          ta.style.position = 'fixed';
-          ta.style.opacity = '0';
-          document.body.appendChild(ta);
-          ta.select();
-          try { document.execCommand('copy'); } catch (e) {}
-          document.body.removeChild(ta);
-        });
+        return navigator.clipboard.writeText(text);
       }
       const ta = document.createElement('textarea');
       ta.value = text;
@@ -522,12 +523,6 @@ def _copy_page_button(doc_content: str, path: str = "") -> rx.Component:
                                 title="Copy page",
                                 description="Copy page as Markdown for LLMs",
                                 on_click=copy_action,
-                            ),
-                            _copy_page_menu_item(
-                                icon=ui.icon("File01Icon", size=16),
-                                title="llms-full.txt",
-                                description="View all docs as Markdown for LLMs",
-                                href="/docs/llms-full.txt",
                             ),
                             rx.el.div(class_name="h-px bg-slate-4 my-1 mx-2"),
                             _copy_page_menu_item(

--- a/docs/app/reflex_docs/templates/docpage/sidebar/state.py
+++ b/docs/app/reflex_docs/templates/docpage/sidebar/state.py
@@ -57,6 +57,8 @@ class SidebarState(rx.State):
                 return 2
             elif "enterprise" in route:
                 return 3
+            elif "/mcp-" in route:
+                return 1
             else:
                 return 0
         if "hosting" in route:


### PR DESCRIPTION
## Summary

Three small docs-site bugs found while reviewing `/docs/ai-builder/integrations/mcp-overview/`, plus a dropdown cleanup.

- **Transparent dropdown in dark mode.** `--c-slate-1` was missing from the dark-theme block in `custom-colors.css` (only an orphan comment marked the slot). Tailwind's `bg-slate-1` resolves through `--color-slate-1` → `var(--c-slate-1)`, which fell back to `transparent` in dark mode. Affects every `bg-slate-1` surface; most visible on the copy-page popover.
- **Sidebar didn't sync on direct MCP navigation.** Loading `/docs/ai-builder/integrations/mcp-*` directly fell through to `sidebar_index = 0` (AI Builder), so the MCP category wasn't selected. Clicking MCP first worked because the click handler set `_sidebar_index = 1`. Added an `/mcp-` branch to `SidebarState.sidebar_index`.
- **Copy-page button broken on Safari.** The previous code did `fetch(mdUrl).then(text => navigator.clipboard.writeText(text))`. By the time `writeText` ran, Safari's user-gesture window had closed and the call was rejected. Chrome was lenient and allowed it. Switched to `navigator.clipboard.write([new ClipboardItem({ 'text/plain': blobPromise })])` — calling `write` synchronously with a Promise-backed `ClipboardItem` preserves the gesture binding in both browsers.
- **Removed `llms-full.txt`** from the copy-page dropdown.

## Test plan

- [ ] In dark mode, open the copy-page dropdown — background is solid (`#151618`).
- [ ] Hard-refresh on `/docs/ai-builder/integrations/mcp-overview/` — sidebar shows MCP category selected and the MCP Integration accordion expanded.
- [ ] In Safari, click the copy-page button — page markdown lands in clipboard.
- [ ] In Chrome, click the copy-page button — same.
- [ ] Confirm the `llms-full.txt` row no longer appears in the dropdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)