### PR TITLE
Fix docs llms index links

### DIFF
--- a/docs/app/agent_files/_plugin.py
+++ b/docs/app/agent_files/_plugin.py
@@ -23,6 +23,14 @@ SKILLS_DOC_PATHS = {
     "ai/integrations/skills.md",
 }
 
+LLMS_TXT_INTRO = """\
+# Reflex Documentation
+
+> Reflex is a Python framework for building full-stack web apps. Use this index to find agent-readable Markdown docs, or see [llms-full.txt]({llms_full_txt_url}) for the complete docs in one file.
+
+## Docs
+"""
+
 LLMS_FULL_INTRO = """\
 # Reflex Documentation
 Source: {docs_home_url}
@@ -242,7 +250,12 @@ def generate_llms_txt(
             continue
         sections.setdefault(markdown_file.section, []).append(markdown_file)
 
-    lines = ["# Reflex", "", "## Docs", ""]
+    lines = [
+        LLMS_TXT_INTRO.format(
+            llms_full_txt_url=_llms_url_for_path(Path("llms-full.txt")),
+        ).strip(),
+        "",
+    ]
     for section in _ordered_sections(sections):
         entries = _ordered_entries(section, sections[section])
         lines.extend([f"### {section}", ""])

--- a/docs/app/reflex_docs/templates/docpage/docpage.py
+++ b/docs/app/reflex_docs/templates/docpage/docpage.py
@@ -350,6 +350,8 @@ def _copy_page_menu_item(
 
 
 DOCS_PROD_BASE = "https://reflex.dev/docs"
+LLMS_TXT_PATH = "/llms.txt"
+LLMS_FULL_TXT_PATH = "/llms-full.txt"
 
 
 def _build_prefill_url(base_url: str, path: str, action: str) -> str:
@@ -523,6 +525,12 @@ def _copy_page_button(doc_content: str, path: str = "") -> rx.Component:
                                 title="Copy page",
                                 description="Copy page as Markdown for LLMs",
                                 on_click=copy_action,
+                            ),
+                            _copy_page_menu_item(
+                                icon=ui.icon("DocumentValidationIcon", size=16),
+                                title="llms-full.txt",
+                                description="View all docs as Markdown for LLMs",
+                                href=LLMS_FULL_TXT_PATH,
                             ),
                             rx.el.div(class_name="h-px bg-secondary-4"),
                             _copy_page_menu_item(
@@ -759,6 +767,12 @@ def docpage(
             return rx.box(
                 docs_navbar(),
                 rx.el.main(
+                    rx.el.blockquote(
+                        rx.el.span("For the complete documentation index, see "),
+                        rx.el.a("llms.txt", href=LLMS_TXT_PATH),
+                        rx.el.span("."),
+                        class_name="sr-only",
+                    ),
                     rx.box(
                         sidebar,
                         class_name=(

--- a/docs/app/tests/test_agent_files.py
+++ b/docs/app/tests/test_agent_files.py
@@ -84,7 +84,14 @@ def test_generate_llms_txt_groups_docs_at_public_root(monkeypatch):
     ])
 
     assert path == Path("llms.txt")
-    assert content.startswith("# Reflex\n\n## Docs\n\n")
+    assert content.startswith(
+        "# Reflex Documentation\n\n"
+        "> Reflex is a Python framework for building full-stack web apps. "
+        "Use this index to find agent-readable Markdown docs, or see "
+        "[llms-full.txt](https://reflex.dev/docs/llms-full.txt) for the "
+        "complete docs in one file.\n\n"
+        "## Docs\n\n"
+    )
     assert "### Components\n\n" in content
     assert "- [Props](https://reflex.dev/docs/components/props.md)" in content
     assert (


### PR DESCRIPTION
## Summary

- Add the proposed llms.txt structure with an H1 and blockquote summary.
- Add a hidden docs-page blockquote directive that points agents to llms.txt.
- Restore the llms-full.txt option in the docs copy/LLM dropdown using the app-relative href so it resolves correctly under /docs.

## Validation

- uv run pytest tests/test_agent_files.py
- Ran the docs app locally and verified /docs/llms-full.txt loads as the full generated docs file after clearing the dev whitelist.