### PR TITLE
fix(hosting-cli): exit deploy when --envfile requires missing python-dotenv

### DIFF
--- a/packages/reflex-hosting-cli/src/reflex_cli/v2/cli.py
+++ b/packages/reflex-hosting-cli/src/reflex_cli/v2/cli.py
@@ -386,6 +386,7 @@ def deploy(
             console.error(
                 """The `python-dotenv` package is required to load environment variables from a file. Run `pip install "python-dotenv>=1.0.1"`."""
             )
+            raise click.exceptions.Exit(1) from None
 
     # Compile the app in production mode: backend first then frontend.
     temporary_dir = tempfile.TemporaryDirectory()

--- a/tests/units/reflex_cli/v2/test_cli.py
+++ b/tests/units/reflex_cli/v2/test_cli.py
@@ -500,6 +500,77 @@ def test_deploy_non_interactive_export_failure(
     watch_deployment.assert_not_called()
 
 
+def test_deploy_envfile_missing_python_dotenv_exits(
+    mocker: MockerFixture,
+    mock_export_fn: Callable[[str, str, str, bool, bool, bool, bool], None],
+):
+    """Deploy should exit when --envfile is used without python-dotenv."""
+    import builtins
+
+    mocker.patch(
+        "reflex_cli.utils.hosting.get_authenticated_client",
+        return_value=hosting.AuthenticatedClient(
+            token="fake-token", validated_data={"foo": "bar"}
+        ),
+    )
+    mocker.patch(
+        "reflex_cli.utils.hosting.validate_deployment_args",
+        return_value="success",
+    )
+    mocker.patch(
+        "reflex_cli.utils.hosting.get_selected_project",
+        return_value="fake-project",
+    )
+    mocker.patch(
+        "reflex_cli.utils.hosting.search_app",
+        return_value={
+            "name": "fake-app",
+            "id": "fake-id",
+            "project_id": "fake-project",
+        },
+    )
+    mocker.patch(
+        "reflex_cli.utils.hosting.get_hostname",
+        return_value={"hostname": "fake-hostname", "server": "fake-server"},
+    )
+    mocker.patch(
+        "reflex_cli.utils.hosting.get_project",
+    )
+    create_deployment = mocker.patch(
+        "reflex_cli.utils.hosting.create_deployment",
+        return_value={"deployment_id": "fake-deployment-id"},
+    )
+    watch_deployment = mocker.patch(
+        "reflex_cli.utils.hosting.watch_deployment_status",
+        return_value={"status": "ready"},
+    )
+    console_error = mocker.patch("reflex_cli.utils.console.error")
+
+    real_import = builtins.__import__
+
+    def _mock_import(name: str, *args, **kwargs):
+        if name == "dotenv":
+            raise ImportError
+        return real_import(name, *args, **kwargs)
+
+    mocker.patch("builtins.__import__", side_effect=_mock_import)
+
+    with pytest.raises(click.exceptions.Exit):
+        cli.deploy(
+            app_name="fake-app",
+            export_fn=mock_export_fn,
+            interactive=False,
+            envfile=".env",
+        )
+
+    console_error.assert_any_call(
+        """The `python-dotenv` package is required to load environment variables from a file. Run `pip install "python-dotenv>=1.0.1"`."""
+    )
+    mock_export_fn.assert_not_called()
+    create_deployment.assert_not_called()
+    watch_deployment.assert_not_called()
+
+
 def test_deploy_non_interactive_with_invalid_project(mocker: MockFixture):
     mocker.patch(
         "reflex_cli.utils.hosting.get_authenticated_client",

--- a/tests/units/reflex_cli/v2/test_cli.py
+++ b/tests/units/reflex_cli/v2/test_cli.py
@@ -502,7 +502,7 @@ def test_deploy_non_interactive_export_failure(
 
 def test_deploy_envfile_missing_python_dotenv_exits(
     mocker: MockerFixture,
-    mock_export_fn: Callable[[str, str, str, bool, bool, bool, bool], None],
+    mock_export_fn: MagicMock,
 ):
     """Deploy should exit when --envfile is used without python-dotenv."""
     import builtins


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Description

Fixes a deploy error path in `reflex-hosting-cli` when `--envfile` is provided but `python-dotenv` is not installed.

Before this change, `deploy()` logged an error in the `ImportError` branch but continued execution, which could lead to a deployment proceeding without envfile secrets.

After this change, `deploy()` exits immediately with `click.exceptions.Exit(1)` in that branch (matching existing behavior in `v2/secrets.py`).

### Tests

Added regression test:

- `test_deploy_envfile_missing_python_dotenv_exits`

The test verifies:

- `deploy()` exits when dotenv import fails
- export is not started
- deployment is not created

### Validation

- `uv run ruff check packages/reflex-hosting-cli/src/reflex_cli/v2/cli.py tests/units/reflex_cli/v2/test_cli.py`
- `uv run pytest tests/units/reflex_cli/v2/test_cli.py -q`

Follow-up to #6369