### PR TITLE
fix(hosting-cli): make ScaleParams.as_json() side-effect free

### DIFF
--- a/packages/reflex-hosting-cli/src/reflex_cli/utils/hosting.py
+++ b/packages/reflex-hosting-cli/src/reflex_cli/utils/hosting.py
@@ -216,16 +216,15 @@ class ScaleParams:
             dict: The object as a dictionary.
 
         """
-        if self.type is None:
-            self.type = ScaleType.REGION
+        effective_type = self.type or ScaleType.REGION
         return (
             {
-                "type": str(self.type.value),
+                "type": str(effective_type.value),
                 "size": self.vm_type,
             }
-            if self.type == ScaleType.SIZE
+            if effective_type == ScaleType.SIZE
             else {
-                "type": str(self.type.value),
+                "type": str(effective_type.value),
                 "regions": {
                     region["name"]: region["number_of_machines"]
                     for region in self.regions

--- a/tests/units/reflex_cli/utils/test_hosting.py
+++ b/tests/units/reflex_cli/utils/test_hosting.py
@@ -7,6 +7,8 @@ import click
 import pytest
 from pytest_mock import MockerFixture, MockFixture
 from reflex_cli.utils.hosting import (
+    ScaleParams,
+    ScaleType,
     authenticated_token,
     delete_token_from_config,
     get_authenticated_client,
@@ -164,3 +166,14 @@ def test_authenticate_with_env_token_in_non_interactive_mode(mocker: MockerFixtu
 
     assert result == mock_authenticated_client
     mock_get_auth_client.assert_called_once_with(None)
+
+
+def test_scale_params_as_json_is_pure_when_type_is_unspecified():
+    """ScaleParams.as_json should not mutate type when defaulting scale type."""
+    scale_params = ScaleParams(vm_type="shared-1x")
+
+    first = scale_params.as_json()
+    second = scale_params.as_json()
+
+    assert scale_params.type is None
+    assert first == second == {"type": ScaleType.REGION.value, "regions": {}}


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Description

`ScaleParams.as_json()` was mutating `self.type` when the type was unset:

- previous behavior: `if self.type is None: self.type = ScaleType.REGION`

This made serialization stateful and introduced side effects for callers reusing the same `ScaleParams` object.

This patch makes serialization pure by using a local `effective_type` variable:

- `effective_type = self.type or ScaleType.REGION`

No object fields are mutated during `as_json()`.

### Tests

Added regression test:

- `test_scale_params_as_json_is_pure_when_type_is_unspecified`

The test verifies:

- repeated `as_json()` calls are idempotent
- `scale_params.type` remains `None` after serialization

### Validation

- `uv run ruff check packages/reflex-hosting-cli/src/reflex_cli/utils/hosting.py tests/units/reflex_cli/utils/test_hosting.py`
- `uv run pytest tests/units/reflex_cli/utils/test_hosting.py -q`
- `uv run pytest tests/units/reflex_cli/v2/test_apps.py -k scale -q`

Follow-up to #6369