### PR TITLE
fix(docs): align sidebar_comp signature with sidebar caller

### DIFF
--- a/docs/app/reflex_docs/templates/docpage/sidebar/sidebar.py
+++ b/docs/app/reflex_docs/templates/docpage/sidebar/sidebar.py
@@ -423,7 +423,6 @@ def sidebar_comp(
     cli_ref_index: list[int],
     ai_builder_overview_index: list[int],
     ai_builder_integrations_index: list[int],
-    tutorials_index: list[int],
     width: str = "100%",
 ):
     from reflex_docs.pages.docs import ai_builder as ai_builder_pages

--- a/docs/app/tests/test_sidebar.py
+++ b/docs/app/tests/test_sidebar.py
@@ -1,0 +1,15 @@
+"""Tests for docs sidebar wiring."""
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+
+def test_sidebar_renders_without_tutorials_index_arg():
+    """Sidebar should render without requiring a tutorials index argument."""
+    from reflex_docs.templates.docpage.sidebar.sidebar import sidebar
+
+    component = sidebar(url="/docs/getting-started/introduction/")
+
+    assert component is not None


### PR DESCRIPTION
### All Submissions:\n\n- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?\n- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?\n\n### Type of change\n\n- [x] Bug fix (non-breaking change which fixes an issue)\n\n### Changes To Core Features:\n\n- [x] Have you added an explanation of what your changes do and why you'd like us to include them?\n- [x] Have you written new tests for your core changes, as applicable?\n- [x] Have you successfully ran tests with your changes locally?\n\n### Description\n\nFollow-up to #6359 to fix a sidebar API mismatch in docs.\n\nBefore this change, sidebar_comp(...) required a 	utorials_index parameter, but the only call site in sidebar(...) never passed it. That parameter was also unused in the implementation.\n\nThis PR removes the stale required argument so the function signature and caller stay aligned.\n\n### Tests\n\nAdded regression test:\n- docs/app/tests/test_sidebar.py::test_sidebar_renders_without_tutorials_index_arg\n\nValidation run:\n- uv run ruff check docs/app/reflex_docs/templates/docpage/sidebar/sidebar.py docs/app/tests/test_sidebar.py\n- uv run pytest docs/app/tests/test_sidebar.py -q\n- uv run pytest tests/test_routes.py -q (from docs/app)\n