### PR TITLE
Improve docs props table

### DIFF
--- a/docs/app/agent_files/_plugin.py
+++ b/docs/app/agent_files/_plugin.py
@@ -344,10 +344,7 @@ def _component_prop_type_display(type_: Any) -> str:
     args = get_args(type_)
     if origin is Literal:
         literal_values = [arg for arg in args if str(arg) != ""]
-        displayed_values = [_literal_display(arg) for arg in literal_values[:4]]
-        if len(literal_values) > 4:
-            displayed_values.append("...")
-        return f"Literal[{', '.join(displayed_values)}]"
+        return f"Literal[{', '.join(_literal_display(arg) for arg in literal_values)}]"
     if origin in (Union, UnionType):
         displays = []
         for arg in args:

--- a/docs/app/agent_files/_plugin.py
+++ b/docs/app/agent_files/_plugin.py
@@ -1,5 +1,4 @@
 import re
-import textwrap
 from collections import OrderedDict
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -50,12 +49,6 @@ MARKDOWN_DIRECTIVE = (
 )
 PUBLIC_LLMS_TXT_URL = "https://reflex.dev/docs/llms.txt"
 PUBLIC_EVENT_TRIGGERS_URL = "https://reflex.dev/docs/api-reference/event-triggers/"
-MARKDOWN_TABLE_COLUMN_WIDTHS = {
-    2: (32, 80),
-    3: (24, 36, 72),
-    4: (22, 38, 11, 64),
-}
-MARKDOWN_TABLE_DEFAULT_COLUMN_WIDTH = 36
 
 
 @dataclass(frozen=True)
@@ -486,54 +479,11 @@ def _markdown_table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> li
         return []
     escaped_headers = [_escape_table_cell(header) for header in headers]
     escaped_rows = [[_escape_table_cell(cell) for cell in row] for row in rows]
-    configured_widths = MARKDOWN_TABLE_COLUMN_WIDTHS.get(
-        len(escaped_headers),
-        (MARKDOWN_TABLE_DEFAULT_COLUMN_WIDTH,) * len(escaped_headers),
-    )
-    widths = [
-        max(
-            3,
-            len(escaped_headers[index]),
-            configured_widths[index],
-        )
-        for index in range(len(escaped_headers))
-    ]
-
-    def table_row(cells: Sequence[str]) -> str:
-        return (
-            "| "
-            + " | ".join(cell.ljust(widths[index]) for index, cell in enumerate(cells))
-            + " |"
-        )
-
-    def wrapped_cell(cell: str, width: int) -> list[str]:
-        normalized_cell = re.sub(r"\s+", " ", cell).strip()
-        if not normalized_cell:
-            return [""]
-        return textwrap.wrap(
-            normalized_cell,
-            width=width,
-            break_long_words=True,
-            break_on_hyphens=False,
-        ) or [""]
-
-    def wrapped_rows(row: Sequence[str]) -> list[str]:
-        cells = [
-            wrapped_cell(cell, width) for cell, width in zip(row, widths, strict=True)
-        ]
-        row_height = max(len(cell) for cell in cells)
-        return [
-            table_row([
-                cell_lines[line_index] if line_index < len(cell_lines) else ""
-                for cell_lines in cells
-            ])
-            for line_index in range(row_height)
-        ]
 
     return [
-        table_row(escaped_headers),
-        "| " + " | ".join("-" * width for width in widths) + " |",
-        *[line for row in escaped_rows for line in wrapped_rows(row)],
+        "| " + " | ".join(escaped_headers) + " |",
+        "| " + " | ".join("---" for _ in escaped_headers) + " |",
+        *["| " + " | ".join(row) + " |" for row in escaped_rows],
     ]
 
 

--- a/docs/app/agent_files/_plugin.py
+++ b/docs/app/agent_files/_plugin.py
@@ -1,8 +1,11 @@
 import re
+import textwrap
 from collections import OrderedDict
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from types import SimpleNamespace, UnionType
+from typing import Any, Literal, Union, get_args, get_origin
 
 from reflex.constants import Dirs
 from reflex_base.plugins import CommonContext, Plugin
@@ -45,6 +48,14 @@ MARKDOWN_DIRECTIVE = (
     "[llms.txt]({llms_txt_url}). Markdown versions are available by appending "
     "`.md` or sending `Accept: text/markdown`."
 )
+PUBLIC_LLMS_TXT_URL = "https://reflex.dev/docs/llms.txt"
+PUBLIC_EVENT_TRIGGERS_URL = "https://reflex.dev/docs/api-reference/event-triggers/"
+MARKDOWN_TABLE_COLUMN_WIDTHS = {
+    2: (32, 80),
+    3: (24, 36, 72),
+    4: (22, 38, 11, 64),
+}
+MARKDOWN_TABLE_DEFAULT_COLUMN_WIDTH = 36
 
 
 @dataclass(frozen=True)
@@ -283,9 +294,7 @@ def _markdown_directive() -> str:
     Returns:
         The markdown blockquote directive.
     """
-    return MARKDOWN_DIRECTIVE.format(
-        llms_txt_url=_llms_url_for_path(Path("llms.txt"))
-    ).strip()
+    return MARKDOWN_DIRECTIVE.format(llms_txt_url=PUBLIC_LLMS_TXT_URL).strip()
 
 
 def generate_markdown_file_content(entry: MarkdownFileEntry) -> str:
@@ -298,7 +307,160 @@ def generate_markdown_file_content(entry: MarkdownFileEntry) -> str:
         The generated markdown content.
     """
     source = entry.source_path.read_text(encoding="utf-8").lstrip()
-    return f"{_markdown_directive()}\n\n{source}"
+    component_reference = _component_api_reference_markdown(entry.source_path)
+    body = source.rstrip()
+    if component_reference:
+        body = f"{body}\n\n{component_reference}"
+    return f"{_markdown_directive()}\n\n{body.rstrip()}\n"
+
+
+def _literal_display(value: Any) -> str:
+    """Return a readable display value for a Literal option."""
+    return f'"{value}"' if isinstance(value, str) else repr(value)
+
+
+def _type_name(type_: Any) -> str:
+    """Return a readable name for a type."""
+    if type_ is None:
+        return "None"
+    name = getattr(type_, "__name__", None)
+    if name:
+        return name
+    return str(type_).replace("typing.", "")
+
+
+def _component_prop_type_display(type_: Any) -> str:
+    """Return a markdown-friendly display type for a component prop."""
+    import reflex as rx
+
+    origin = get_origin(type_)
+    try:
+        if issubclass(origin, rx.Var):
+            type_ = get_args(type_)[0]
+            origin = get_origin(type_)
+    except TypeError:
+        pass
+
+    args = get_args(type_)
+    if origin is Literal:
+        literal_values = [arg for arg in args if str(arg) != ""]
+        displayed_values = [_literal_display(arg) for arg in literal_values[:4]]
+        if len(literal_values) > 4:
+            displayed_values.append("...")
+        return f"Literal[{', '.join(displayed_values)}]"
+    if origin in (Union, UnionType):
+        displays = []
+        for arg in args:
+            display = _component_prop_type_display(arg)
+            if display and display not in displays:
+                displays.append(display)
+        return ", ".join(displays)
+    if origin is not None and args:
+        return f"{_type_name(origin)}[{', '.join(_component_prop_type_display(arg) for arg in args)}]"
+    return _type_name(type_)
+
+
+def _component_prop_description_display(description: str | None) -> str:
+    """Return a markdown-friendly display description for a component prop."""
+    return (description or "").replace(" | ", ", ")
+
+
+def _component_from_frontmatter_ref(component_ref: str):
+    """Resolve a component reference from a docs frontmatter component entry."""
+    import reflex as rx
+    from reflex_components_core.core.cond import Cond
+    from reflex_pyplot import pyplot as pyplot
+
+    component = (
+        Cond
+        if component_ref == "rx.cond"
+        else eval(component_ref, {"rx": rx, "pyplot": pyplot})
+    )
+    if isinstance(component, type):
+        return component
+    if hasattr(component, "__self__"):
+        return component.__self__
+    if isinstance(component, SimpleNamespace) and hasattr(component, "__call__"):  # noqa: B004
+        return component.__call__.__self__
+    msg = f"Invalid component: {component}"
+    raise ValueError(msg)
+
+
+def _component_refs_from_source(source_path: Path) -> tuple[tuple[type, str], ...]:
+    """Return component classes and display refs from a markdown source file."""
+    from reflex_docgen.markdown import parse_document
+
+    source = source_path.read_text(encoding="utf-8")
+    doc = parse_document(source)
+    if doc.frontmatter is None:
+        return ()
+    component_refs = getattr(doc.frontmatter, "components", ()) or ()
+    return tuple(
+        (_component_from_frontmatter_ref(component_ref), component_ref)
+        for component_ref in component_refs
+    )
+
+
+def _component_api_reference_markdown(source_path: Path) -> str:
+    """Generate the component API reference section for a markdown docs page."""
+    from reflex_docgen import generate_documentation
+
+    components = _component_refs_from_source(source_path)
+    if not components:
+        return ""
+
+    lines = ["## API Reference", ""]
+    component_display_name_map = {
+        "rx.el.Del": "rx.el.del",
+    }
+    for component, component_ref in components:
+        doc = generate_documentation(component)
+        display_name = component_display_name_map.get(component_ref, component_ref)
+        lines.extend([f"### {display_name}", ""])
+        if doc.description:
+            lines.extend([doc.description.strip(), ""])
+
+        props_table = _markdown_table(
+            ["Prop", "Type", "Default", "Description"],
+            [
+                (
+                    f"`{prop.name}`",
+                    _component_prop_type_display(prop.type),
+                    f"`{prop.default_value}`"
+                    if prop.default_value is not None
+                    else "-",
+                    _component_prop_description_display(prop.description),
+                )
+                for prop in doc.props
+                if not prop.name.startswith("on_")
+            ],
+        )
+        if props_table:
+            lines.extend(["#### Props", "", *props_table, ""])
+
+        custom_event_handlers = [
+            handler for handler in doc.event_handlers if not handler.is_inherited
+        ]
+        event_table = _markdown_table(
+            ["Event Trigger", "Description"],
+            [
+                (
+                    f"`{handler.name}`",
+                    handler.description or "",
+                )
+                for handler in custom_event_handlers
+            ],
+        )
+        lines.extend([
+            "#### Event Triggers",
+            "",
+            f"Base event triggers: {PUBLIC_EVENT_TRIGGERS_URL}",
+            "",
+        ])
+        if event_table:
+            lines.extend(["Component-specific event triggers:", "", *event_table, ""])
+
+    return "\n".join(lines).rstrip()
 
 
 def _escape_table_cell(value: str) -> str:
@@ -325,13 +487,56 @@ def _markdown_table(headers: Sequence[str], rows: Sequence[Sequence[str]]) -> li
     """
     if not rows:
         return []
+    escaped_headers = [_escape_table_cell(header) for header in headers]
+    escaped_rows = [[_escape_table_cell(cell) for cell in row] for row in rows]
+    configured_widths = MARKDOWN_TABLE_COLUMN_WIDTHS.get(
+        len(escaped_headers),
+        (MARKDOWN_TABLE_DEFAULT_COLUMN_WIDTH,) * len(escaped_headers),
+    )
+    widths = [
+        max(
+            3,
+            len(escaped_headers[index]),
+            configured_widths[index],
+        )
+        for index in range(len(escaped_headers))
+    ]
+
+    def table_row(cells: Sequence[str]) -> str:
+        return (
+            "| "
+            + " | ".join(cell.ljust(widths[index]) for index, cell in enumerate(cells))
+            + " |"
+        )
+
+    def wrapped_cell(cell: str, width: int) -> list[str]:
+        normalized_cell = re.sub(r"\s+", " ", cell).strip()
+        if not normalized_cell:
+            return [""]
+        return textwrap.wrap(
+            normalized_cell,
+            width=width,
+            break_long_words=True,
+            break_on_hyphens=False,
+        ) or [""]
+
+    def wrapped_rows(row: Sequence[str]) -> list[str]:
+        cells = [
+            wrapped_cell(cell, width) for cell, width in zip(row, widths, strict=True)
+        ]
+        row_height = max(len(cell) for cell in cells)
+        return [
+            table_row([
+                cell_lines[line_index] if line_index < len(cell_lines) else ""
+                for cell_lines in cells
+            ])
+            for line_index in range(row_height)
+        ]
+
     return [
-        "| " + " | ".join(headers) + " |",
-        "| " + " | ".join("---" for _ in headers) + " |",
-        *[
-            "| " + " | ".join(_escape_table_cell(cell) for cell in row) + " |"
-            for row in rows
-        ],
+        table_row(escaped_headers),
+        "| " + " | ".join("-" * width for width in widths) + " |",
+        *[line for row in escaped_rows for line in wrapped_rows(row)],
     ]
 
 
@@ -633,7 +838,9 @@ def generate_llms_full_txt(
         "",
     ]
     for entry in markdown_files:
-        source = _strip_first_heading(entry.source_path.read_text(encoding="utf-8"))
+        source = _strip_first_heading(
+            _strip_markdown_directive(generate_markdown_file_content(entry))
+        )
         lines.extend([
             f"# {entry.title}",
             f"Source: {_llms_url_for_path(entry.url_path)}",

--- a/docs/app/reflex_docs/pages/docs/component.py
+++ b/docs/app/reflex_docs/pages/docs/component.py
@@ -87,12 +87,23 @@ EXCLUDED_COMPONENTS = [
 
 
 _PILL_BTN_CLASS = (
-    "text-sm font-medium cursor-pointer rounded-md px-2.5 py-1 text-secondary-11 "
-    "border border-secondary-5 bg-secondary-1 hover:bg-secondary-3 transition-colors"
+    "inline-flex h-7 cursor-pointer items-center justify-center rounded-md "
+    "border border-slate-5 bg-slate-1 px-2.5 text-sm font-medium text-slate-11 "
+    "transition-colors hover:border-slate-6 hover:bg-slate-2 hover:text-slate-12 "
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-7"
 )
 _PILL_BTN_ACTIVE_CLASS = (
-    "text-sm font-medium cursor-pointer rounded-md px-2.5 py-1 text-secondary-12 "
-    "border border-secondary-8 bg-secondary-4"
+    "inline-flex h-7 cursor-pointer items-center justify-center rounded-md "
+    "border border-slate-8 bg-slate-3 px-2.5 text-sm font-medium text-slate-12 "
+    "shadow-[inset_0_0_0_1px_var(--c-slate-6)] transition-colors "
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-7"
+)
+_PROPS_TABLE_CELL_CLASS = "min-w-0 px-4 py-3 align-top"
+_PROPS_TABLE_HEADER_CLASS = "px-4 py-3 text-left text-xs font-semibold text-slate-10"
+_PROPS_TABLE_COMPACT_CELL_CLASS = (
+    "cell-content max-h-[4.25rem] overflow-hidden "
+    "[mask-image:linear-gradient(to_bottom,black_82%,transparent)] "
+    "[-webkit-mask-image:linear-gradient(to_bottom,black_82%,transparent)]"
 )
 
 
@@ -106,14 +117,14 @@ def _pill_button(label: str, active, on_click) -> rx.Component:
 
 
 def _pill_row(values, var, setter) -> rx.Component:
-    return rx.box(
+    return rx.el.div(
         *[_pill_button(v, var == v, setter(v)) for v in values],
         class_name="flex flex-wrap gap-1.5",
     )
 
 
 def _bool_pills(var, setter) -> rx.Component:
-    return rx.box(
+    return rx.el.div(
         _pill_button("false", ~var, setter(False)),
         _pill_button("true", var, setter(True)),
         class_name="flex flex-wrap gap-1.5",
@@ -191,12 +202,17 @@ def render_select(prop: PropDocumentation, component: type[Component], prop_dict
 
     if prop.name == "color_scheme":
         return ui.popover(
-            trigger=rx.button(
-                rx.text(var, class_name="text-sm font-medium"),
+            trigger=rx.el.button(
+                rx.el.span(var, class_name="text-sm font-medium"),
                 ui.icon("ArrowDown01Icon"),
-                color_scheme=var,
-                variant="surface",
-                class_name="w-32 justify-between cursor-pointer",
+                type="button",
+                class_name=(
+                    "inline-flex h-8 w-32 cursor-pointer items-center justify-between "
+                    "rounded-md border border-slate-5 bg-slate-1 px-2.5 text-slate-11 "
+                    "transition-colors hover:border-slate-6 hover:bg-slate-2 "
+                    "hover:text-slate-12 focus-visible:outline-none "
+                    "focus-visible:ring-2 focus-visible:ring-slate-7"
+                ),
             ),
             content=rx.box(
                 *[
@@ -239,26 +255,6 @@ def hovercard(trigger: rx.Component, content: rx.Component) -> rx.Component:
     )
 
 
-def color_scheme_hovercard(literal_values: list[str]) -> rx.Component:
-    return hovercard(
-        rx.icon(tag="palette", size=15, class_name="!text-slate-9 shrink-0"),
-        rx.grid(
-            *[
-                rx.tooltip(
-                    rx.box(
-                        bg=f"var(--{color}-9)", class_name="rounded-md size-8 shrink-0"
-                    ),
-                    content=color,
-                    delay_duration=0,
-                )
-                for color in literal_values
-            ],
-            columns="6",
-            spacing="3",
-        ),
-    )
-
-
 def safe_issubclass(cls, class_or_tuple):
     try:
         return issubclass(cls, class_or_tuple)
@@ -269,7 +265,7 @@ def safe_issubclass(cls, class_or_tuple):
 def prop_docs(
     prop: PropDocumentation,
     component: type[Component],
-) -> tuple[list[rx.Component], bool]:
+) -> tuple[list[rx.Component], bool, str | None, rx.Var | None]:
     """Generate the docs for a prop."""
     # Get the type of the prop.
     type_ = prop.type
@@ -345,106 +341,128 @@ def prop_docs(
         literal_values and len(literal_values) > 8 and prop.name not in common_types
     )
 
+    expanded_name = None
+    expanded = None
+    if is_long_row:
+        expanded_name = get_id(f"{component.__qualname__}_{prop.name}_expanded")
+        PropDocsState.add_var(expanded_name, bool, False)
+        expanded = getattr(PropDocsState, expanded_name)
+        PropDocsState._create_setter(expanded_name, expanded)
+
     cell_content_class = (
-        (
-            "cell-content max-h-[6.5em] overflow-hidden "
-            "[mask-image:linear-gradient(to_bottom,black_85%,transparent)] "
-            "[-webkit-mask-image:linear-gradient(to_bottom,black_85%,transparent)]"
-        )
-        if is_long_row
+        rx.cond(expanded, "cell-content", _PROPS_TABLE_COMPACT_CELL_CLASS)
+        if expanded is not None
         else "cell-content"
     )
 
     # Return the docs for the prop.
-    return [
-        rx.table.cell(
-            rx.box(
-                rx.code(prop.name, class_name="code-style text-nowrap leading-normal"),
-                class_name=cell_content_class,
-            ),
-            class_name="justify-start pl-4 align-top py-3",
-        ),
-        rx.table.cell(
-            rx.box(
+    return (
+        [
+            rx.el.td(
                 rx.box(
-                    rx.box(
-                        *(
-                            [
-                                rx.code(
-                                    f'"{v}"',
-                                    color_scheme=color,
-                                    variant="soft",
-                                    class_name="code-style leading-normal text-nowrap",
-                                )
-                                for v in literal_values
-                            ]
-                            if literal_values and prop.name not in common_types
-                            else [
-                                rx.code(
-                                    type_name,
-                                    color_scheme=color,
-                                    variant="soft",
-                                    class_name="code-style leading-normal whitespace-normal break-words",
-                                )
-                            ]
+                    rx.el.div(
+                        rx.code(
+                            prop.name,
+                            class_name="code-style text-nowrap leading-normal",
                         ),
-                        class_name="flex flex-wrap gap-1",
+                        rx.icon(
+                            "chevron-down",
+                            size=14,
+                            class_name=rx.cond(
+                                expanded,
+                                "row-expand-icon mt-0.5 shrink-0 rotate-180 text-slate-9 opacity-100 transition-[opacity,transform]",
+                                "row-expand-icon mt-0.5 shrink-0 text-slate-9 opacity-0 transition-[opacity,transform] group-hover:opacity-100",
+                            ),
+                        )
+                        if expanded is not None
+                        else rx.fragment(),
+                        class_name="flex items-start gap-1.5",
                     ),
                     class_name=cell_content_class,
                 ),
-                rx.cond(
-                    (origin == Union)
-                    & (
-                        "Breakpoints" in all_types
-                    ),  # Display that the type is Union with Breakpoints
-                    hovercard(
-                        rx.icon(
-                            tag="info",
-                            size=15,
-                            class_name="!text-slate-9 shrink-0",
+                class_name=ui.cn(_PROPS_TABLE_CELL_CLASS, "w-[20%]"),
+            ),
+            rx.el.td(
+                rx.box(
+                    rx.box(
+                        rx.box(
+                            *(
+                                [
+                                    rx.code(
+                                        f'"{v}"',
+                                        color_scheme=color,
+                                        variant="soft",
+                                        class_name="code-style leading-normal text-nowrap",
+                                    )
+                                    for v in literal_values
+                                ]
+                                if literal_values and prop.name not in common_types
+                                else [
+                                    rx.code(
+                                        type_name,
+                                        color_scheme=color,
+                                        variant="soft",
+                                        class_name="code-style leading-normal whitespace-normal break-words",
+                                    )
+                                ]
+                            ),
+                            class_name="flex flex-wrap gap-1",
                         ),
-                        rx.text(
-                            f"Union[{', '.join(all_types)}]",
-                            class_name="font-small text-slate-11",
+                        class_name=cell_content_class,
+                    ),
+                    rx.cond(
+                        (origin == Union)
+                        & (
+                            "Breakpoints" in all_types
+                        ),  # Display that the type is Union with Breakpoints
+                        hovercard(
+                            rx.icon(
+                                tag="info",
+                                size=15,
+                                class_name="!text-slate-9 shrink-0",
+                            ),
+                            rx.text(
+                                f"Union[{', '.join(all_types)}]",
+                                class_name="font-small text-slate-11",
+                            ),
                         ),
                     ),
+                    class_name="flex flex-row items-start gap-2",
                 ),
-                rx.cond(
-                    (prop.name == "color_scheme") | (prop.name == "accent_color"),
-                    color_scheme_hovercard(literal_values),
-                ),
-                class_name="flex flex-row items-start gap-2",
+                class_name=ui.cn(_PROPS_TABLE_CELL_CLASS, "w-[34%]"),
             ),
-            class_name="justify-start pl-4 align-top py-3",
-        ),
-        rx.table.cell(
-            rx.box(
-                rx.code(
-                    default_value,
-                    style=get_code_style(
-                        "red"
-                        if default_value == "False"
-                        else "green"
-                        if default_value == "True"
-                        else "gray"
+            rx.el.td(
+                rx.box(
+                    rx.code(
+                        default_value,
+                        style=get_code_style(
+                            "red"
+                            if default_value == "False"
+                            else "green"
+                            if default_value == "True"
+                            else "gray"
+                        ),
+                        class_name="code-style leading-normal text-nowrap",
                     ),
-                    class_name="code-style leading-normal text-nowrap",
+                    class_name=cell_content_class,
                 ),
-                class_name=cell_content_class,
+                class_name=ui.cn(_PROPS_TABLE_CELL_CLASS, "w-[12%]"),
             ),
-            class_name="justify-start pl-4 align-top py-3",
-        ),
-        rx.table.cell(
-            rx.box(
-                rx.text(
-                    description,
-                    class_name="font-small text-slate-11 whitespace-normal leading-snug break-words",
+            rx.el.td(
+                rx.box(
+                    rx.text(
+                        description,
+                        class_name="font-small text-slate-11 whitespace-normal leading-snug break-words",
+                    ),
+                    class_name=cell_content_class,
                 ),
-                class_name=cell_content_class,
+                class_name=ui.cn(_PROPS_TABLE_CELL_CLASS, "w-[34%]"),
             ),
-            class_name="justify-start pl-4 align-top py-3 w-full",
-        ),
-    ], is_long_row
+        ],
+        is_long_row,
+        expanded_name,
+        expanded,
+    )
 
 
 def generate_props(
@@ -460,10 +478,6 @@ def generate_props(
             rx.text("No component specific props", class_name="text-slate-9 font-base"),
             class_name="flex flex-col overflow-x-auto justify-start py-2 w-full",
         )
-
-    table_header_class_name = (
-        "text-xs text-secondary-11 w-auto justify-start pl-4 font-semibold capitalize"
-    )
 
     prop_dict = {}
 
@@ -514,69 +528,27 @@ def generate_props(
             if not isinstance(control, Fragment):
                 interactive_controls.append((prop, control))
 
-    def _toggle_row() -> rx.Component:
-        return rx.el.tr(
-            rx.el.td(
-                rx.el.details(
-                    rx.el.summary(
-                        rx.el.span(
-                            "Show more",
-                            rx.icon(
-                                "chevron-down",
-                                size=12,
-                                class_name="inline-block align-[-2px] ml-1",
-                            ),
-                            class_name="group-open/details:hidden",
-                        ),
-                        rx.el.span(
-                            "Show less",
-                            rx.icon(
-                                "chevron-up",
-                                size=12,
-                                class_name="inline-block align-[-2px] ml-1",
-                            ),
-                            class_name="hidden group-open/details:inline",
-                        ),
-                        class_name=(
-                            "block list-none cursor-pointer text-center text-xs "
-                            "font-medium text-slate-11 hover:text-slate-12 py-2 "
-                            "[&::-webkit-details-marker]:hidden [&::marker]:hidden"
-                        ),
-                    ),
-                    class_name="group/details",
-                ),
-                col_span=4,
-                class_name=(
-                    "!p-0 !border-t-0 [box-shadow:0_-1px_0_0_var(--gray-a4)_inset]"
-                ),
-            ),
-            class_name="api-toggle-row bg-slate-2",
-        )
-
-    data_row_class = (
-        "[&:has(+_tr.api-toggle-row_details[open])_.cell-content]:!max-h-none "
-        "[&:has(+_tr.api-toggle-row_details[open])_.cell-content]:!overflow-visible "
-        "[&:has(+_tr.api-toggle-row_details[open])_.cell-content]:![mask-image:none] "
-        "[&:has(+_tr.api-toggle-row_details[open])_.cell-content]:![-webkit-mask-image:none] "
-        "[&>td]:!shadow-none"
-    )
-
     rows: list[rx.Component] = []
     for prop in prop_list:
         if prop.name.startswith("on_"):  # ignore event trigger props
             continue
-        cells, is_long_row = prop_docs(prop, component)
+        cells, is_long_row, expanded_name, expanded = prop_docs(prop, component)
+        row_props = {
+            "class_name": ui.cn(
+                "border-b border-slate-4 last:border-b-0 transition-colors hover:bg-slate-2",
+                "group cursor-pointer" if is_long_row else "",
+            )
+        }
+        if is_long_row and expanded_name is not None and expanded is not None:
+            row_props["on_click"] = PropDocsState.setvar(expanded_name, ~expanded)
         rows.append(
-            rx.table.row(
+            rx.el.tr(
                 *cells,
-                align="center",
-                class_name=data_row_class if is_long_row else "",
+                **row_props,
             )
         )
-        if is_long_row:
-            rows.append(_toggle_row())
 
-    body = rx.table.body(*rows, class_name="bg-slate-2")
+    body = rx.el.tbody(*rows, class_name="bg-slate-1")
 
     comp: rx.Component
     try:
@@ -745,8 +717,8 @@ def generate_props(
                 code_children.append(_render_dynamic_prop("    ", p, var))
             code_children.append(rx.el.div(")", class_name=line_class))
 
-        interactive_component = rx.box(
-            rx.box(
+        interactive_component = rx.el.div(
+            rx.el.div(
                 comp,
                 class_name=(
                     "flex flex-col items-center justify-center p-6 flex-1 "
@@ -754,7 +726,7 @@ def generate_props(
                     "border-slate-4 min-w-0"
                 ),
             ),
-            rx.box(
+            rx.el.div(
                 *code_children,
                 class_name="flex-1 p-4 bg-slate-1 min-w-0 overflow-x-auto",
             ),
@@ -768,19 +740,26 @@ def generate_props(
 
     controls_panel: rx.Component = rx.fragment()
     if not isinstance(comp, Fragment) and interactive_controls:
-        controls_panel = rx.box(
+        controls_panel = rx.el.div(
             *[
-                rx.box(
+                rx.el.div(
                     rx.code(
                         prop.name,
                         class_name="code-style text-nowrap leading-normal text-slate-11",
                     ),
                     control,
-                    class_name="grid grid-cols-[8rem_1fr] gap-4 items-start",
+                    class_name=(
+                        "grid grid-cols-[8rem_minmax(0,1fr)] items-start gap-4 "
+                        "border-b border-slate-4 px-4 py-3 transition-colors "
+                        "last:border-b-0 hover:bg-slate-2"
+                    ),
                 )
                 for prop, control in interactive_controls
             ],
-            class_name="flex flex-col gap-3 border border-secondary-4 rounded-md p-4 bg-secondary-1 mb-4 w-full",
+            class_name=(
+                "mb-4 w-full min-w-0 overflow-hidden rounded-xl border "
+                "border-slate-4 bg-slate-1 shadow-small"
+            ),
         )
 
     return rx.vstack(
@@ -792,41 +771,32 @@ def generate_props(
             class_name="font-large text-slate-12 mt-4 mb-2 text-left self-start",
         ),
         rx.box(
-            rx.table.root(
-                rx.el.style(
-                    """
-                    .rt-TableRoot:where(.rt-variant-surface) :where(.rt-TableRootTable) :where(.rt-TableHeader) {
-                    --table-row-background-color: "transparent"
-                    }
-                    """
-                ),
-                rx.table.header(
-                    rx.table.row(
-                        rx.table.column_header_cell(
-                            "prop",
-                            class_name=ui.cn(table_header_class_name, "w-[9rem]"),
+            rx.el.table(
+                rx.el.thead(
+                    rx.el.tr(
+                        rx.el.th(
+                            "Prop",
+                            class_name=ui.cn(_PROPS_TABLE_HEADER_CLASS, "w-[20%]"),
                         ),
-                        rx.table.column_header_cell(
-                            "type",
-                            class_name=ui.cn(table_header_class_name, "w-[34rem]"),
+                        rx.el.th(
+                            "Type",
+                            class_name=ui.cn(_PROPS_TABLE_HEADER_CLASS, "w-[34%]"),
                         ),
-                        rx.table.column_header_cell(
-                            "default",
-                            class_name=ui.cn(table_header_class_name, "w-[4rem]"),
+                        rx.el.th(
+                            "Default",
+                            class_name=ui.cn(_PROPS_TABLE_HEADER_CLASS, "w-[12%]"),
                         ),
-                        rx.table.column_header_cell(
-                            "description",
-                            class_name=ui.cn(table_header_class_name, "w-[18rem]"),
+                        rx.el.th(
+                            "Description",
+                            class_name=ui.cn(_PROPS_TABLE_HEADER_CLASS, "w-[34%]"),
                         ),
                     ),
-                    class_name="bg-secondary-2",
+                    class_name="border-b border-slate-4 bg-slate-2",
                 ),
                 body,
-                variant="surface",
-                size="1",
-                class_name="px-0 border border-slate-4 w-full",
+                class_name="w-full table-fixed border-collapse text-left",
             ),
-            class_name="mb-4 w-full overflow-hidden",
+            class_name="mb-4 w-full min-w-0 overflow-hidden rounded-xl border border-slate-4 bg-slate-1 shadow-small",
         ),
     )
 

--- a/docs/app/reflex_docs/whitelist.py
+++ b/docs/app/reflex_docs/whitelist.py
@@ -10,7 +10,10 @@ Examples:
 - Incorrect: WHITELISTED_PAGES = ["/getting-started/introduction/"]
 """
 
-WHITELISTED_PAGES = []
+WHITELISTED_PAGES = [
+    "/getting-started/introduction",
+    "/library/data-display/badge",
+]
 
 
 def _check_whitelisted_path(path: str):

--- a/docs/app/reflex_docs/whitelist.py
+++ b/docs/app/reflex_docs/whitelist.py
@@ -10,10 +10,7 @@ Examples:
 - Incorrect: WHITELISTED_PAGES = ["/getting-started/introduction/"]
 """
 
-WHITELISTED_PAGES = [
-    "/getting-started/introduction",
-    "/library/data-display/badge",
-]
+WHITELISTED_PAGES = []
 
 
 def _check_whitelisted_path(path: str):

--- a/docs/app/tests/test_agent_files.py
+++ b/docs/app/tests/test_agent_files.py
@@ -128,7 +128,7 @@ def test_generate_markdown_file_content_adds_agent_directive(monkeypatch, tmp_pa
     monkeypatch.setattr(
         "reflex_base.config.get_config",
         lambda: SimpleNamespace(
-            deploy_url="https://reflex.dev",
+            deploy_url="http://localhost:3000",
             frontend_path="/docs",
         ),
     )
@@ -153,6 +153,59 @@ def test_generate_markdown_file_content_adds_agent_directive(monkeypatch, tmp_pa
         "available by appending `.md` or sending `Accept: text/markdown`.\n\n"
         "# Overview"
     )
+
+
+def test_generate_markdown_file_content_appends_component_props_table(
+    monkeypatch, tmp_path
+):
+    """Component docs markdown includes generated API reference props tables."""
+    monkeypatch.setattr(
+        "reflex_base.config.get_config",
+        lambda: SimpleNamespace(
+            deploy_url="https://reflex.dev",
+            frontend_path="/docs",
+        ),
+    )
+    source = tmp_path / "badge.md"
+    source.write_text(
+        "---\n"
+        "components:\n"
+        "  - rx.badge\n"
+        "---\n\n"
+        "# Badge\n\n"
+        "Badges are used to highlight status.\n",
+        encoding="utf-8",
+    )
+
+    content = generate_markdown_file_content(
+        MarkdownFileEntry(
+            url_path=Path("library/data-display/badge.md"),
+            source_path=source,
+            title="Badge",
+            section="Library",
+        )
+    )
+
+    assert "## API Reference\n\n### rx.badge" in content
+    assert "#### Props" in content
+    assert "#### Event Triggers" in content
+    assert (
+        "Base event triggers: https://reflex.dev/docs/api-reference/event-triggers/"
+        in content
+    )
+    props_table = content.split("#### Props\n\n", maxsplit=1)[1].split(
+        "\n\n", maxsplit=1
+    )[0]
+    props_rows = props_table.splitlines()
+    assert props_rows[0].startswith("| Prop")
+    assert "Type" in props_rows[0]
+    assert "Default" in props_rows[0]
+    assert "Description" in props_rows[0]
+    assert len({len(row) for row in props_rows}) == 1
+    assert max(len(row) for row in props_rows) <= 150
+    assert "\\|" not in props_table
+    assert any(row.startswith("| `variant`") for row in props_rows)
+    assert any(row.split("|")[1].strip() == "" for row in props_rows[2:])
 
 
 def test_generate_dynamic_api_reference_files(monkeypatch):

--- a/docs/app/tests/test_agent_files.py
+++ b/docs/app/tests/test_agent_files.py
@@ -166,27 +166,27 @@ def test_generate_markdown_file_content_appends_component_props_table(
             frontend_path="/docs",
         ),
     )
-    source = tmp_path / "badge.md"
+    source = tmp_path / "button.md"
     source.write_text(
         "---\n"
         "components:\n"
-        "  - rx.badge\n"
+        "  - rx.button\n"
         "---\n\n"
-        "# Badge\n\n"
-        "Badges are used to highlight status.\n",
+        "# Button\n\n"
+        "Buttons trigger actions.\n",
         encoding="utf-8",
     )
 
     content = generate_markdown_file_content(
         MarkdownFileEntry(
-            url_path=Path("library/data-display/badge.md"),
+            url_path=Path("library/forms/button.md"),
             source_path=source,
-            title="Badge",
+            title="Button",
             section="Library",
         )
     )
 
-    assert "## API Reference\n\n### rx.badge" in content
+    assert "## API Reference\n\n### rx.button" in content
     assert "#### Props" in content
     assert "#### Event Triggers" in content
     assert (
@@ -203,8 +203,11 @@ def test_generate_markdown_file_content_appends_component_props_table(
     assert "Description" in props_rows[0]
     assert len({len(row) for row in props_rows}) == 1
     assert max(len(row) for row in props_rows) <= 150
+    assert "Literal[...]" not in props_table
     assert "\\|" not in props_table
     assert any(row.startswith("| `variant`") for row in props_rows)
+    assert '"classic", "solid", "soft",' in props_table
+    assert '"surface", "outline", "ghost"' in props_table
     assert any(row.split("|")[1].strip() == "" for row in props_rows[2:])
 
 

--- a/docs/app/tests/test_agent_files.py
+++ b/docs/app/tests/test_agent_files.py
@@ -201,14 +201,16 @@ def test_generate_markdown_file_content_appends_component_props_table(
     assert "Type" in props_rows[0]
     assert "Default" in props_rows[0]
     assert "Description" in props_rows[0]
-    assert len({len(row) for row in props_rows}) == 1
-    assert max(len(row) for row in props_rows) <= 150
+    assert props_rows[1] == "| --- | --- | --- | --- |"
     assert "Literal[...]" not in props_table
     assert "\\|" not in props_table
-    assert any(row.startswith("| `variant`") for row in props_rows)
-    assert '"classic", "solid", "soft",' in props_table
-    assert '"surface", "outline", "ghost"' in props_table
-    assert any(row.split("|")[1].strip() == "" for row in props_rows[2:])
+    variant_rows = [row for row in props_rows if row.startswith("| `variant`")]
+    assert len(variant_rows) == 1
+    assert (
+        'Literal["classic", "solid", "soft", "surface", "outline", "ghost"]'
+        in variant_rows[0]
+    )
+    assert not any(row.split("|")[1].strip() == "" for row in props_rows[2:])
 
 
 def test_generate_dynamic_api_reference_files(monkeypatch):


### PR DESCRIPTION
## Summary
- Restyle the component docs Props table with Tailwind-native table markup and lighter table chrome.
- Keep long prop rows compact by default and expand them by clicking the row, with a hover chevron affordance.
- Match the interactive controls section to the table styling and add the badge docs page to the local whitelist.

## Validation
- `uv run --python 3.13 ruff format docs/app/reflex_docs/pages/docs/component.py`
- `uv run --python 3.13 ruff check docs/app/reflex_docs/pages/docs/component.py`
- `curl -sS -L --max-time 15 -o /tmp/badge-page.html -w '%{http_code} %{content_type} %{time_total}\\n' http://localhost:3000/docs/library/data-display/badge`\n- Verified the expandable row behavior in the in-app browser with Browser Use DOM checks.