### PR TITLE
Refactor docs sidebar to frontend state

### DIFF
--- a/docs/app/assets/tailwind-theme.css
+++ b/docs/app/assets/tailwind-theme.css
@@ -2131,6 +2131,16 @@
         background-color: transparent;
     }
 
+    .hidden-scrollbar::-webkit-scrollbar-track,
+    .hidden-scrollbar::-webkit-scrollbar-corner,
+    .hidden-scrollbar::-webkit-scrollbar-button {
+        background-color: transparent;
+    }
+
+    .hidden-scrollbar {
+        scrollbar-color: transparent transparent;
+    }
+
     /* Hide scrollbar for Chrome, Safari and Opera */
     .no-scrollbar::-webkit-scrollbar {
         display: none;

--- a/docs/app/reflex_docs/templates/docpage/sidebar/sidebar.py
+++ b/docs/app/reflex_docs/templates/docpage/sidebar/sidebar.py
@@ -6,8 +6,6 @@ import reflex as rx
 import reflex_components_internal as ui
 from reflex_site_shared.styles.colors import c_color
 
-from reflex_docs.templates.docpage.state import NavbarState
-
 from .sidebar_items.ai import (
     ai_builder_integrations,
     ai_builder_overview_items,
@@ -24,7 +22,33 @@ from .sidebar_items.enterprise import (
 from .sidebar_items.learn import backend, cli_ref, frontend, hosting, learn
 from .sidebar_items.recipes import recipes
 from .sidebar_items.reference import api_reference
-from .state import SideBarBase, SideBarItem, SidebarState
+from .state import SideBarBase, SideBarItem
+
+SIDEBAR_ICON_MAP = {
+    "Getting Started": "rocket",
+    "Tutorials": "graduation-cap",
+    "Advanced Onboarding": "newspaper",
+    "Components": "layers",
+    "Pages": "sticky-note",
+    "Styling": "palette",
+    "Assets": "folder-open-dot",
+    "Wrapping React": "atom",
+    "Vars": "variable",
+    "Events": "arrow-left-right",
+    "State Structure": "boxes",
+    "API Routes": "route",
+    "Client Storage": "package-open",
+    "Database": "database",
+    "Authentication": "lock-keyhole",
+    "Utility Methods": "cog",
+    "Deploy Quick Start": "earth",
+    "CLI Reference": "square-terminal",
+    "App": "blocks",
+    "Project": "server",
+    "Self Hosting": "server",
+    "Custom Components": "blocks",
+    "Usage": "chart-column",
+}
 
 Scrollable_SideBar = """
 function scrollToActiveSidebarLink() {
@@ -32,9 +56,15 @@ function scrollToActiveSidebarLink() {
   if (!sidebarContainer) return;
 
   const currentPath = window.location.pathname.replace(/\\/+$|\\/$/g, "") + "/";
+  const baseComponentPath = currentPath.replace(/\\/low\\/$/, "/");
+  const baseComponentPathWithoutDocs = baseComponentPath.replace(/^\\/docs\\//, "/");
 
   const activeLink = sidebarContainer.querySelector(`a[href="${currentPath}"]`) ||
-                    sidebarContainer.querySelector(`a[href="${currentPath.slice(0, -1)}"]`);
+                    sidebarContainer.querySelector(`a[href="${currentPath.slice(0, -1)}"]`) ||
+                    sidebarContainer.querySelector(`a[href="${baseComponentPath}"]`) ||
+                    sidebarContainer.querySelector(`a[href="${baseComponentPath.slice(0, -1)}"]`) ||
+                    sidebarContainer.querySelector(`a[href="${baseComponentPathWithoutDocs}"]`) ||
+                    sidebarContainer.querySelector(`a[href="${baseComponentPathWithoutDocs.slice(0, -1)}"]`);
 
   if (activeLink) {
     // Get the scrollable parent within the sidebar
@@ -68,10 +98,9 @@ document.addEventListener('click', (e) => {
 
 
 def sidebar_link(*children, **props):
-    """Create a sidebar link that closes the sidebar when clicked."""
+    """Create a sidebar link."""
     return rx.link(
         *children,
-        on_click=props.pop("on_click", NavbarState.set_sidebar_open(False)),
         underline="none",
         **props,
     )
@@ -81,108 +110,69 @@ def sidebar_leaf(
     item_index: str,
     item: SideBarItem,
     url: str,
+    guide_margin_class: str = "ml-[3rem]",
 ) -> rx.Component:
     """Get the leaf node of the sidebar."""
     item.link = item.link.replace("_", "-").rstrip("/") + "/"
-    return (
-        rx.accordion.item(
-            rx.accordion.header(
-                sidebar_link(
-                    rx.flex(
-                        rx.text(
-                            item.names,
-                            color=rx.cond(
-                                item.link == url,
-                                c_color("violet", 9),
-                                c_color("slate", 9),
-                            ),
-                            _hover={
-                                "color": c_color("slate", 11),
-                            },
-                            margin="0.5em 0.5em 0.2em 0.5em",
-                            width="100%",
-                            class_name="transition-color",
-                        ),
-                    ),
-                    href=item.link,
-                ),
-            ),
-            value=item_index,
-            border="none",
-            width="100%",
-            class_name="!overflow-visible",
-        )
-        if item.outer
-        else rx.accordion.item(
-            rx.accordion.header(
-                rx.cond(
-                    item.link == url,
-                    sidebar_link(
-                        rx.el.div(
-                            class_name="absolute left-0 top-1/2 -translate-y-1/2 w-full h-8 rounded-lg bg-m-slate-2 dark:bg-slate-3 z-[-1]",
-                        ),
-                        rx.flex(
-                            rx.text(
-                                item.names,
-                                class_name="text-sm text-primary-10 font-[525] transition-color pl-4",
-                            ),
-                            class_name="border-l-[1.5px] border-primary-10 relative ml-[2.5rem] max-w-[14rem] h-8 flex items-center",
-                        ),
-                        href=item.link,
-                        class_name="w-full relative",
-                    ),
-                    sidebar_link(
-                        rx.flex(
-                            rx.text(
-                                item.names,
-                                class_name="text-sm text-secondary-11 hover:text-secondary-12 transition-color w-full font-[525]",
-                            ),
-                            class_name="border-l-[1.5px] border-m-slate-4 dark:border-m-slate-9 hover:border-m-slate-8 dark:hover:border-m-slate-5 pl-4 h-8 flex items-center",
-                        ),
-                        href=item.link,
-                        class_name="w-full ml-[2.5rem]",
+    is_active = item.link == url
+    if item.outer:
+        return rx.el.li(
+            sidebar_link(
+                rx.flex(
+                    rx.text(
+                        item.names,
+                        color=c_color("violet", 9)
+                        if is_active
+                        else c_color("slate", 9),
+                        _hover={
+                            "color": c_color("slate", 11),
+                        },
+                        margin="0.5em 0.5em 0.2em 0.5em",
+                        width="100%",
+                        class_name="m-0 transition-color",
                     ),
                 ),
+                href=item.link,
+                class_name="block w-full",
             ),
-            border="none",
-            value=item_index,
-            width="100%",
-            class_name="!overflow-visible",
+            class_name="m-0 p-0 !overflow-visible w-full list-none",
         )
+
+    active_background = (
+        [
+            rx.el.div(
+                class_name="absolute left-0 top-1/2 -translate-y-1/2 w-full h-8 rounded-lg bg-m-slate-2 dark:bg-slate-3 z-[-1]",
+            )
+        ]
+        if is_active
+        else []
     )
-
-
-def sidebar_icon(name):
-    icon_map = {
-        "Getting Started": "rocket",
-        "Tutorials": "graduation-cap",
-        "Advanced Onboarding": "newspaper",
-        "Components": "layers",
-        "Pages": "sticky-note",
-        "Styling": "palette",
-        "Assets": "folder-open-dot",
-        "Wrapping React": "atom",
-        "Vars": "variable",
-        "Events": "arrow-left-right",
-        "State Structure": "boxes",
-        "API Routes": "route",
-        "Client Storage": "package-open",
-        "Database": "database",
-        "Authentication": "lock-keyhole",
-        "Utility Methods": "cog",
-        "Deploy Quick Start": "earth",
-        "CLI Reference": "square-terminal",
-        "App": "blocks",
-        "Project": "server",
-        "Self Hosting": "server",
-        "Custom Components": "blocks",
-        "Usage": "chart-column",
-    }
-
-    return (
-        rx.icon(tag=icon_map.get(name), size=16, class_name="mr-4")
-        if name in icon_map
-        else rx.fragment()
+    return rx.el.li(
+        sidebar_link(
+            *active_background,
+            rx.flex(
+                rx.text(
+                    item.names,
+                    class_name=(
+                        "m-0 text-sm text-primary-10 font-[525] transition-color pl-4"
+                        if is_active
+                        else "m-0 text-sm text-secondary-11 hover:text-secondary-12 transition-color w-full font-[525]"
+                    ),
+                ),
+                class_name=(
+                    f"border-l-[1.5px] border-primary-10 relative {guide_margin_class} max-w-[14rem] h-8 flex items-center"
+                    if is_active
+                    else "border-l-[1.5px] border-m-slate-4 dark:border-m-slate-9 hover:border-m-slate-8 dark:hover:border-m-slate-5 pl-4 h-8 flex items-center"
+                ),
+            ),
+            href=item.link,
+            class_name=(
+                "block w-full relative"
+                if is_active
+                else f"block w-full {guide_margin_class}"
+            ),
+        ),
+        class_name="m-0 p-0 !overflow-visible w-full relative list-none",
     )
 
 
@@ -191,54 +181,72 @@ def sidebar_item_comp(
     item: SideBarItem,
     index: list[int],
     url: str,
+    guide_margin_class: str = "ml-[3rem]",
 ):
-    index = rx.Var.create(index)
-    return (
-        sidebar_leaf(item_index=item_index, item=item, url=url)
-        if not item.children
-        else rx.accordion.item(
-            rx.accordion.header(
-                rx.accordion.trigger(
-                    sidebar_icon(item.names),
-                    rx.text(
-                        item.names,
-                        class_name="text-sm font-[525]",
-                    ),
-                    rx.box(class_name="flex-grow"),
-                    ui.icon(
-                        "ArrowDown01Icon",
-                        class_name="size-4 group-data-[state=open]:rotate-180 transition-transform",
-                    ),
-                    class_name="!px-0 flex items-center !bg-transparent !hover:bg-transparent !py-1 !pr-0 w-full !text-m-slate-7 hover:!text-m-slate-11 dark:hover:!text-m-slate-5 dark:!text-m-slate-6 transition-color group xl:max-w-[14rem]",
-                ),
-                class_name="justify-start !ml-[2.5rem]",
-            ),
-            rx.accordion.content(
-                rx.accordion.root(
-                    rx.accordion.item(
-                        class_name="absolute left-[2.5rem] size-full !shadow-[1.5px_0_0_0_var(--m-slate-4)_inset] dark:!shadow-[1.5px_0_0_0_var(--m-slate-9)_inset] z-[-1] pointer-events-none !rounded-none",
-                    ),
-                    *[
-                        sidebar_item_comp(
-                            item_index="index" + str(child_index),
-                            item=child,
-                            index=index[1:],
-                            url=url,
-                        )
-                        for child_index, child in enumerate(item.children)
-                    ],
-                    type="multiple",
-                    collapsible=True,
-                    default_value=index[:1].foreach(lambda x: "index" + x.to_string()),
-                    class_name="!my-1 flex flex-col items-start gap-1 list-none !bg-transparent !rounded-none !shadow-none relative",
-                ),
-                class_name="!p-0 w-full !bg-transparent before:!h-0 after:!h-0",
-            ),
-            value=item_index,
-            class_name="border-none w-full !bg-transparent",
+    if not item.children:
+        return sidebar_leaf(
+            item_index=item_index,
+            item=item,
+            url=url,
+            guide_margin_class=guide_margin_class,
         )
+
+    is_open = bool(index) and item_index == f"index{index[0]}"
+    nested_index = index[1:] if is_open else []
+    child_guide_left_class = (
+        "left-[3rem]" if has_sidebar_icon(item.names) else "left-[2.5rem]"
+    )
+    child_guide_margin_class = (
+        "ml-[3rem]" if has_sidebar_icon(item.names) else "ml-[2.5rem]"
+    )
+    return rx.el.li(
+        rx.el.details(
+            rx.el.summary(
+                sidebar_icon(item.names),
+                rx.text(
+                    item.names,
+                    class_name="m-0 text-sm font-[525]",
+                ),
+                rx.box(class_name="flex-grow"),
+                ui.icon(
+                    "ArrowDown01Icon",
+                    class_name="size-4 group-open/details:rotate-180 transition-transform",
+                ),
+                class_name="!px-0 m-0 flex items-center justify-start !ml-[2.5rem] !bg-transparent !hover:bg-transparent !py-1 !pr-0 w-[calc(100%-2.5rem)] !text-m-slate-7 hover:!text-m-slate-11 dark:hover:!text-m-slate-5 dark:!text-m-slate-6 transition-color group xl:max-w-[14rem] cursor-pointer list-none [&::-webkit-details-marker]:hidden [&::marker]:hidden",
+            ),
+            rx.el.ul(
+                rx.el.li(
+                    class_name=f"m-0 p-0 absolute {child_guide_left_class} size-full !shadow-[1.5px_0_0_0_var(--m-slate-4)_inset] dark:!shadow-[1.5px_0_0_0_var(--m-slate-9)_inset] z-[-1] pointer-events-none !rounded-none list-none",
+                ),
+                *[
+                    sidebar_item_comp(
+                        item_index="index" + str(child_index),
+                        item=child,
+                        index=nested_index,
+                        url=url,
+                        guide_margin_class=child_guide_margin_class,
+                    )
+                    for child_index, child in enumerate(item.children)
+                ],
+                class_name="!my-1 p-0 flex flex-col items-start gap-1 list-none !bg-transparent !rounded-none !shadow-none relative",
+            ),
+            open=is_open,
+            class_name="group/details m-0 p-0 w-full !bg-transparent border-none",
+        ),
+        class_name="m-0 p-0 border-none w-full !bg-transparent list-none",
     )
 
+
+def has_sidebar_icon(name):
+    return name in SIDEBAR_ICON_MAP
+
+
+def sidebar_icon(name):
+    return (
+        rx.icon(tag=SIDEBAR_ICON_MAP.get(name), size=16, class_name="mr-4")
+        if has_sidebar_icon(name)
+        else rx.fragment()
+    )
 
 def calculate_index(sidebar_items, url: str) -> list[int]:
     sidebar_items = (
@@ -316,48 +324,39 @@ def filter_out_non_sidebar_items(items: list[SideBarBase]) -> list[SideBarItem]:
     return [item for item in items if isinstance(item, SideBarItem)]
 
 
-def sidebar_category(name: str, url: str, icon: str, index: int):
+def sidebar_category(name: str, url: str, icon: str, active: bool):
+    active_background = (
+        [
+            rx.el.div(
+                class_name="absolute left-0 top-1/2 -translate-y-1/2 w-full h-8 rounded-lg bg-m-slate-2 dark:bg-slate-3 z-[-1]",
+            )
+        ]
+        if active
+        else []
+    )
     return rx.el.li(
-        rx.el.div(
+        rx.link(
+            *active_background,
             rx.box(
-                rx.box(
-                    rx.icon(
-                        tag=icon,
-                        size=16,
-                    ),
-                    rx.el.h3(
-                        name,
-                        class_name=ui.cn(
-                            "w-full font-[525]",
-                        ),
-                    ),
-                    class_name=ui.cn(
-                        "flex flex-row justify-start items-center gap-2.5 w-full text-sm text-secondary-11 hover:text-secondary-12 h-8",
-                        rx.cond(
-                            SidebarState.sidebar_index == index,
-                            "text-slate-12",
-                            "",
-                        ),
-                    ),
+                rx.icon(
+                    tag=icon,
+                    size=16,
                 ),
-                class_name="cursor-pointer flex flex-row items-center gap-2.5",
-            ),
-            rx.cond(
-                SidebarState.sidebar_index == index,
-                rx.el.div(
-                    class_name="absolute left-0 top-0 w-full h-full bg-m-slate-2 dark:bg-slate-3 rounded-lg z-[-1]",
+                rx.el.h3(
+                    name,
+                    class_name="m-0 w-full font-[525]",
+                ),
+                class_name=ui.cn(
+                    "cursor-pointer flex flex-row justify-start items-center gap-2.5 ml-[3rem] text-sm text-secondary-11 hover:text-secondary-12 h-8",
+                    "text-slate-12" if active else "",
                 ),
             ),
-            rx.el.a(
-                to=url,
-                on_click=rx.prevent_default,
-                class_name="inset-0 absolute z-[-1]",
-                aria_label=f"Navigate to {name}",
-            ),
-            class_name="w-full",
-            on_click=[SidebarState.set_sidebar_index(index), rx.redirect(url)],
+            href=url,
+            underline="none",
+            class_name="block w-full relative no-underline",
+            custom_attrs={"aria-label": f"Navigate to {name}"},
         ),
-        class_name="w-full pl-[2.5rem] relative",
+        class_name="m-0 p-0 w-full relative list-none",
     )
 
 
@@ -365,47 +364,56 @@ def create_sidebar_section(
     section_title: str,
     section_url: str,
     items: list[SideBarItem],
-    index: rx.Var[list[str]] | list[str],
-    url: rx.Var[str] | str,
+    index: list[int],
+    url: str,
     connected_line: bool = False,
 ) -> rx.Component:
-    # Check if the section has any nested sections (Like the Other Libraries Section)
-    nested = any(len(child.children) > 0 for item in items for child in item.children)
-    # Make sure the index is a list
-    index = index.to(list)
     return rx.el.li(
         rx.link(
             rx.el.h2(
                 section_title,
-                class_name="font-mono text-m-slate-12 dark:text-m-slate-3 hover:text-primary-10 dark:hover:text-primary-9 uppercase text-[0.8125rem] leading-6 font-medium",
+                class_name="m-0 font-mono text-m-slate-12 dark:text-m-slate-3 hover:text-primary-10 dark:hover:text-primary-9 uppercase text-[0.8125rem] leading-6 font-medium",
             ),
             underline="none",
             href=section_url,
             class_name="h-8 mb-2 flex items-center justify-start ml-[2.5rem]",
         ),
-        rx.accordion.root(
+        rx.el.ul(
             *[
                 sidebar_item_comp(
                     item_index="index" + str(item_index),
                     item=item,
-                    index=index[1:] if nested else [],
+                    index=index,
                     url=url,
                 )
                 for item_index, item in enumerate(items)
             ],
-            type="multiple",
-            collapsible=True,
-            default_value=index[:1].foreach(lambda x: "index" + x.to_string()),
             class_name=ui.cn(
-                "ml-0 pl-0 w-full !bg-transparent !shadow-none rounded-[0px] flex flex-col",
+                "m-0 ml-0 p-0 pl-0 w-full !bg-transparent !shadow-none rounded-[0px] flex flex-col list-none",
                 "gap-0" if connected_line else "gap-1",
             ),
         ),
-        class_name="flex flex-col items-start ml-0 w-full",
+        class_name="m-0 p-0 flex flex-col items-start ml-0 w-full list-none",
     )
 
 
-@rx.memo
+def normalize_url(url: str | None) -> str:
+    """Normalize a docs route for static sidebar selection."""
+    if not url:
+        return "/"
+    path = str(url).split("#", 1)[0].split("?", 1)[0]
+    if not path.startswith("/"):
+        path = f"/{path}"
+    path = path.rstrip("/")
+    if path == "/docs":
+        path = "/"
+    elif path.startswith("/docs/"):
+        path = path.removeprefix("/docs")
+    if path.startswith("/library/") and path.endswith("/low"):
+        path = path.removesuffix("/low")
+    return path.rstrip("/") + "/"
+
+
 def sidebar_comp(
     url: str,
     learn_index: list[int],
@@ -426,7 +434,6 @@ def sidebar_comp(
     cli_ref_index: list[int],
     ai_builder_overview_index: list[int],
     ai_builder_integrations_index: list[int],
-    tutorials_index: list[int],
     width: str = "100%",
 ):
     from reflex_docs.pages.docs import ai_builder as ai_builder_pages
@@ -437,296 +444,246 @@ def sidebar_comp(
     from reflex_docs.pages.docs.library import library
     from reflex_docs.pages.docs.recipes_overview import overview
 
-    _path = rx.State.router.page.path
-    _is_docs_hosting = _path.startswith("/docs/hosting/") | _path.startswith(
-        "/hosting/"
+    path = normalize_url(url)
+    is_docs_hosting = path.startswith("/hosting/")
+    is_docs_ai_builder = path.startswith("/ai/")
+    is_ai_mcp_or_skills = path.startswith(
+        (
+            "/ai/integrations/ai-onboarding/",
+            "/ai/integrations/skills/",
+            "/ai/integrations/mcp",
+        )
     )
-    _is_docs_ai_builder = _path.startswith("/docs/ai/") | _path.startswith("/ai/")
+
+    ai_category = 1 if is_ai_mcp_or_skills else 0
+    docs_category = 0
+    if "library" in path or "/mcp-" in path:
+        docs_category = 1
+    elif "api-reference" in path:
+        docs_category = 2
+    elif "enterprise" in path:
+        docs_category = 3
+
+    if is_docs_hosting:
+        categories = rx.el.ul(
+            sidebar_category(
+                "Cloud",
+                hosting_page.deploy_quick_start.path,
+                "cloud",
+                True,
+            ),
+            class_name="flex flex-col items-start gap-2 w-full list-none",
+        )
+        content = rx.el.ul(
+            create_sidebar_section(
+                "Cloud",
+                hosting_page.deploy_quick_start.path,
+                hosting,
+                hosting_index,
+                url,
+            ),
+            class_name="m-0 p-0 flex flex-col items-start gap-8  w-full list-none list-style-none",
+        )
+    elif is_docs_ai_builder:
+        categories = rx.el.ul(
+            sidebar_category(
+                "AI Builder",
+                ai_builder_pages.overview.best_practices.path,
+                "bot",
+                ai_category == 0,
+            ),
+            sidebar_category(
+                "MCP/Skills",
+                ai_builder_pages.integrations.ai_onboarding.path,
+                "plug",
+                ai_category == 1,
+            ),
+            class_name="flex flex-col items-start gap-2 w-full list-none",
+        )
+        content = (
+            rx.el.ul(
+                create_sidebar_section(
+                    "Overview",
+                    ai_builder_pages.integrations.ai_onboarding.path,
+                    ai_onboarding_items,
+                    ai_onboarding_index,
+                    url,
+                ),
+                create_sidebar_section(
+                    "MCP",
+                    ai_builder_pages.integrations.mcp_overview.path,
+                    mcp_items,
+                    mcp_index,
+                    url,
+                    connected_line=True,
+                ),
+                create_sidebar_section(
+                    "Skills",
+                    ai_builder_pages.integrations.skills.path,
+                    skills_items,
+                    skills_index,
+                    url,
+                    connected_line=True,
+                ),
+                class_name="m-0 p-0 flex flex-col items-start gap-8  w-full list-none list-style-none",
+            )
+            if ai_category == 1
+            else rx.el.ul(
+                create_sidebar_section(
+                    "Overview",
+                    ai_builder_pages.overview.best_practices.path,
+                    ai_builder_overview_items,
+                    ai_builder_overview_index,
+                    url,
+                ),
+                create_sidebar_section(
+                    "Integrations",
+                    ai_builder_pages.integrations.overview.path,
+                    ai_builder_integrations,
+                    ai_builder_integrations_index,
+                    url,
+                ),
+                class_name="m-0 p-0 flex flex-col items-start gap-8  w-full list-none list-style-none",
+            )
+        )
+    else:
+        categories = rx.el.ul(
+            sidebar_category(
+                "Learn",
+                getting_started.introduction.path,
+                "graduation-cap",
+                docs_category == 0,
+            ),
+            sidebar_category(
+                "Components",
+                library.path,
+                "layout-panel-left",
+                docs_category == 1,
+            ),
+            sidebar_category(
+                "API Reference",
+                pages[0].path,
+                "book-text",
+                docs_category == 2,
+            ),
+            sidebar_category(
+                "Enterprise",
+                enterprise.overview.path,
+                "building-2",
+                docs_category == 3,
+            ),
+            class_name="flex flex-col items-start gap-2 w-full list-none",
+        )
+        if docs_category == 1:
+            content = rx.el.ul(
+                create_sidebar_section(
+                    "Core",
+                    library.path,
+                    component_lib,
+                    component_lib_index,
+                    url,
+                ),
+                create_sidebar_section(
+                    "Graphing",
+                    library.path,
+                    graphing_libs,
+                    graphing_libs_index,
+                    url,
+                ),
+                create_sidebar_section(
+                    "Other",
+                    "/library/html/",
+                    html_lib,
+                    html_lib_index,
+                    url,
+                ),
+                rx.link(  # pyright: ignore [reportCallIssue]
+                    rx.box(  # pyright: ignore [reportCallIssue]
+                        rx.box(  # pyright: ignore [reportCallIssue]
+                            rx.icon("atom", size=16),  # pyright: ignore [reportCallIssue]
+                            rx.el.h5(
+                                "Custom Components",
+                                class_name="font-smbold text-[0.875rem] text-slate-12 leading-5 tracking-[-0.01313rem] transition-color",
+                            ),
+                            class_name="flex flex-row items-center gap-3 text-slate-12",
+                        ),
+                        rx.text(  # pyright: ignore [reportCallIssue]
+                            "See what components people have made with Reflex!",
+                            class_name="font-small text-slate-9",
+                        ),
+                        class_name="flex flex-col gap-2 border-slate-5 bg-slate-1 hover:bg-slate-3 shadow-large px-3.5 py-2 border rounded-xl transition-bg",
+                    ),
+                    underline="none",
+                    href=custom_components.path,
+                    class_name="w-fit lg:ml-[2.5rem]",
+                ),
+                class_name="m-0 p-0 flex flex-col items-start gap-8  w-full list-none list-style-none",
+            )
+        elif docs_category == 2:
+            content = rx.el.ul(
+                create_sidebar_section(
+                    "Reference",
+                    pages[0].path,
+                    api_reference,
+                    api_reference_index,
+                    url,
+                ),
+                class_name="m-0 p-0 flex flex-col items-start gap-8  w-full list-none list-style-none",
+            )
+        elif docs_category == 3:
+            content = rx.el.ul(
+                create_sidebar_section(
+                    "Enterprise Usage",
+                    enterprise.overview.path,
+                    enterprise_usage_items,
+                    enterprise_usage_index,
+                    url,
+                ),
+                create_sidebar_section(
+                    "Components",
+                    enterprise.components.path,
+                    enterprise_component_items,
+                    enterprise_component_index,
+                    url,
+                ),
+                class_name="m-0 p-0 flex flex-col items-start gap-8  w-full list-none list-style-none",
+            )
+        else:
+            content = rx.el.ul(
+                create_sidebar_section(
+                    "Onboarding",
+                    getting_started.introduction.path,
+                    learn,
+                    learn_index,
+                    url,
+                ),
+                create_sidebar_section(
+                    "User Interface",
+                    ui.overview.path,
+                    filter_out_non_sidebar_items(frontend),
+                    frontend_index,
+                    url,
+                ),
+                create_sidebar_section(
+                    "State",
+                    state.overview.path,
+                    filter_out_non_sidebar_items(backend),
+                    backend_index,
+                    url,
+                ),
+                create_sidebar_section(
+                    "Recipes",
+                    overview.path,
+                    recipes,
+                    recipes_index,
+                    url,
+                ),
+                class_name="m-0 p-0 flex flex-col items-start gap-8  w-full list-none list-style-none",
+            )
 
     return rx.box(  # pyright: ignore [reportCallIssue]
-        # Handle sidebar categories for docs/cloud first
-        rx.cond(  # pyright: ignore [reportCallIssue]
-            _is_docs_hosting,
-            rx.el.ul(
-                sidebar_category(
-                    "Cloud", hosting_page.deploy_quick_start.path, "cloud", 0
-                ),
-                # sidebar_category(
-                #     "CLI Reference", cloud_pages[0].path, "book-marked", 1
-                # ),
-                class_name="flex flex-col items-start gap-2 w-full list-none",
-            ),
-            rx.cond(  # pyright: ignore [reportCallIssue]
-                _is_docs_ai_builder,
-                rx.el.ul(
-                    sidebar_category(
-                        "AI Builder",
-                        ai_builder_pages.overview.best_practices.path,
-                        "bot",
-                        0,
-                    ),
-                    sidebar_category(
-                        "MCP/Skills",
-                        ai_builder_pages.integrations.ai_onboarding.path,
-                        "plug",
-                        1,
-                    ),
-                    # sidebar_category(
-                    #     "Integrations",
-                    #     ai_builder_pages.integrations.overview.path,
-                    #     "codesandbox",
-                    #     2,
-                    # ),
-                    class_name="flex flex-col items-start gap-2 w-full list-none",
-                ),
-                rx.el.ul(
-                    sidebar_category(
-                        "Learn",
-                        getting_started.introduction.path,
-                        "graduation-cap",
-                        0,
-                    ),
-                    sidebar_category(
-                        "Components",
-                        library.path,
-                        "layout-panel-left",
-                        1,
-                    ),
-                    sidebar_category(
-                        "API Reference",
-                        pages[0].path,
-                        "book-text",
-                        2,
-                    ),
-                    sidebar_category(
-                        "Enterprise",
-                        enterprise.overview.path,
-                        "building-2",
-                        3,
-                    ),
-                    class_name="flex flex-col items-start gap-2 w-full list-none",
-                ),
-            ),
-        ),
-        # Handle the sidebar content based on docs/cloud or docs
-        rx.cond(  # pyright: ignore [reportCallIssue]
-            _is_docs_hosting,
-            rx.match(  # pyright: ignore [reportCallIssue]
-                SidebarState.sidebar_index,
-                (
-                    0,
-                    rx.el.ul(
-                        create_sidebar_section(
-                            "Cloud",
-                            hosting_page.deploy_quick_start.path,
-                            hosting,
-                            hosting_index,
-                            url,
-                        ),
-                        class_name="flex flex-col items-start gap-8  w-full list-none list-style-none",
-                    ),
-                ),
-                # (
-                #     1,
-                #     rx.el.ul(
-                #         create_sidebar_section(
-                #             "CLI Reference",
-                #             cloud_pages[0].path,
-                #             cli_ref,
-                #             cli_ref_index,
-                #             url,
-                #         ),
-                #         class_name="flex flex-col items-start gap-8  w-full list-none list-style-none",
-                #     ),
-                # ),
-            ),
-            rx.cond(  # pyright: ignore [reportCallIssue]
-                _is_docs_ai_builder,
-                rx.match(  # pyright: ignore [reportCallIssue]
-                    SidebarState.sidebar_index,
-                    (
-                        0,
-                        rx.el.ul(
-                            create_sidebar_section(
-                                "Overview",
-                                ai_builder_pages.overview.best_practices.path,
-                                ai_builder_overview_items,
-                                ai_builder_overview_index,
-                                url,
-                            ),
-                            create_sidebar_section(
-                                "Integrations",
-                                ai_builder_pages.integrations.overview.path,
-                                ai_builder_integrations,
-                                ai_builder_integrations_index,
-                                url,
-                            ),
-                            class_name="flex flex-col items-start gap-8  w-full list-none list-style-none",
-                        ),
-                    ),
-                    (
-                        1,
-                        rx.el.ul(
-                            create_sidebar_section(
-                                "Overview",
-                                ai_builder_pages.integrations.ai_onboarding.path,
-                                ai_onboarding_items,
-                                ai_onboarding_index,
-                                url,
-                            ),
-                            create_sidebar_section(
-                                "MCP",
-                                ai_builder_pages.integrations.mcp_overview.path,
-                                mcp_items,
-                                mcp_index,
-                                url,
-                                connected_line=True,
-                            ),
-                            create_sidebar_section(
-                                "Skills",
-                                ai_builder_pages.integrations.skills.path,
-                                skills_items,
-                                skills_index,
-                                url,
-                                connected_line=True,
-                            ),
-                            class_name="flex flex-col items-start gap-8  w-full list-none list-style-none",
-                        ),
-                    ),
-                    # (
-                    #     2,
-                    #     rx.el.ul(
-                    #         create_sidebar_section(
-                    #             "Integration",
-                    #             ai_builder_pages.integrations.overview.path,
-                    #             ai_builder_integrations,
-                    #             ai_builder_integrations_index,
-                    #             url,
-                    #         ),
-                    #         class_name="flex flex-col items-start gap-6  w-full list-none list-style-none",
-                    #     ),
-                    # ),
-                ),
-                rx.match(  # pyright: ignore [reportCallIssue]
-                    SidebarState.sidebar_index,
-                    (
-                        0,
-                        rx.el.ul(
-                            create_sidebar_section(
-                                "Onboarding",
-                                getting_started.introduction.path,
-                                learn,
-                                learn_index,
-                                url,
-                            ),
-                            create_sidebar_section(
-                                "User Interface",
-                                ui.overview.path,
-                                filter_out_non_sidebar_items(frontend),
-                                frontend_index,
-                                url,
-                            ),
-                            create_sidebar_section(
-                                "State",
-                                state.overview.path,
-                                filter_out_non_sidebar_items(backend),
-                                backend_index,
-                                url,
-                            ),
-                            create_sidebar_section(
-                                "Recipes",
-                                overview.path,
-                                recipes,
-                                recipes_index,
-                                url,
-                            ),
-                            class_name="flex flex-col items-start gap-8  w-full list-none list-style-none",
-                        ),
-                    ),
-                    (
-                        1,
-                        rx.el.ul(
-                            create_sidebar_section(
-                                "Core",
-                                library.path,
-                                component_lib,
-                                component_lib_index,
-                                url,
-                            ),
-                            create_sidebar_section(
-                                "Graphing",
-                                library.path,
-                                graphing_libs,
-                                graphing_libs_index,
-                                url,
-                            ),
-                            create_sidebar_section(
-                                "Other",
-                                "/library/html/",
-                                html_lib,
-                                html_lib_index,
-                                url,
-                            ),
-                            rx.link(  # pyright: ignore [reportCallIssue]
-                                rx.box(  # pyright: ignore [reportCallIssue]
-                                    rx.box(  # pyright: ignore [reportCallIssue]
-                                        rx.icon("atom", size=16),  # pyright: ignore [reportCallIssue]
-                                        rx.el.h5(
-                                            "Custom Components",
-                                            class_name="font-smbold text-[0.875rem] text-slate-12 leading-5 tracking-[-0.01313rem] transition-color",
-                                        ),
-                                        class_name="flex flex-row items-center gap-3 text-slate-12",
-                                    ),
-                                    rx.text(  # pyright: ignore [reportCallIssue]
-                                        "See what components people have made with Reflex!",
-                                        class_name="font-small text-slate-9",
-                                    ),
-                                    class_name="flex flex-col gap-2 border-slate-5 bg-slate-1 hover:bg-slate-3 shadow-large px-3.5 py-2 border rounded-xl transition-bg",
-                                ),
-                                underline="none",
-                                href=custom_components.path,
-                                class_name="w-fit lg:ml-[2.5rem]",
-                            ),
-                            class_name="flex flex-col items-start gap-8  w-full list-none list-style-none",
-                        ),
-                    ),
-                    (
-                        2,
-                        rx.el.ul(
-                            create_sidebar_section(
-                                "Reference",
-                                pages[0].path,
-                                api_reference,
-                                api_reference_index,
-                                url,
-                            ),
-                            class_name="flex flex-col items-start gap-8  w-full list-none list-style-none",
-                        ),
-                    ),
-                    (
-                        3,
-                        rx.el.ul(
-                            create_sidebar_section(
-                                "Enterprise Usage",
-                                enterprise.overview.path,
-                                enterprise_usage_items,
-                                enterprise_usage_index,
-                                url,
-                            ),
-                            create_sidebar_section(
-                                "Components",
-                                enterprise.components.path,
-                                enterprise_component_items,
-                                enterprise_component_index,
-                                url,
-                            ),
-                            class_name="flex flex-col items-start gap-8  w-full list-none list-style-none",
-                        ),
-                    ),
-                ),
-            ),
-        ),
-        # Handle general docs sections
+        categories,
+        content,
         style={
             "&::-webkit-scrollbar-thumb": {
                 "background_color": "transparent",
@@ -741,28 +698,33 @@ def sidebar_comp(
 
 def sidebar(url=None, width: str = "100%") -> rx.Component:
     """Render the sidebar."""
-    learn_index = calculate_index(learn, url)
-    component_lib_index = calculate_index(component_lib, url)
-    frontend_index = calculate_index(frontend, url)
-    backend_index = calculate_index(backend, url)
-    hosting_index = calculate_index(hosting, url)
-    html_lib_index = calculate_index(html_lib, url)
-    graphing_libs_index = calculate_index(graphing_libs, url)
-    api_reference_index = calculate_index(api_reference, url)
-    recipes_index = calculate_index(recipes, url)
-    enterprise_usage_index = calculate_index(enterprise_usage_items, url)
-    enterprise_component_index = calculate_index(enterprise_component_items, url)
+    normalized_url = normalize_url(url)
+    learn_index = calculate_index(learn, normalized_url)
+    component_lib_index = calculate_index(component_lib, normalized_url)
+    frontend_index = calculate_index(frontend, normalized_url)
+    backend_index = calculate_index(backend, normalized_url)
+    hosting_index = calculate_index(hosting, normalized_url)
+    html_lib_index = calculate_index(html_lib, normalized_url)
+    graphing_libs_index = calculate_index(graphing_libs, normalized_url)
+    api_reference_index = calculate_index(api_reference, normalized_url)
+    recipes_index = calculate_index(recipes, normalized_url)
+    enterprise_usage_index = calculate_index(enterprise_usage_items, normalized_url)
+    enterprise_component_index = calculate_index(enterprise_component_items, normalized_url)
 
-    cli_ref_index = calculate_index(cli_ref, url)
-    ai_builder_overview_index = calculate_index(ai_builder_overview_items, url)
-    ai_builder_integrations_index = calculate_index(ai_builder_integrations, url)
-    ai_onboarding_index = calculate_index(ai_onboarding_items, url)
-    mcp_index = calculate_index(mcp_items, url)
-    skills_index = calculate_index(skills_items, url)
+    cli_ref_index = calculate_index(cli_ref, normalized_url)
+    ai_builder_overview_index = calculate_index(
+        ai_builder_overview_items, normalized_url
+    )
+    ai_builder_integrations_index = calculate_index(
+        ai_builder_integrations, normalized_url
+    )
+    ai_onboarding_index = calculate_index(ai_onboarding_items, normalized_url)
+    mcp_index = calculate_index(mcp_items, normalized_url)
+    skills_index = calculate_index(skills_items, normalized_url)
 
     return rx.box(
         sidebar_comp(
-            url=url,
+            url=normalized_url,
             learn_index=learn_index,
             component_lib_index=component_lib_index,
             frontend_index=frontend_index,
@@ -786,6 +748,3 @@ def sidebar(url=None, width: str = "100%") -> rx.Component:
         id=rx.Var.create("sidebar-container"),
         class_name="flex justify-end w-full h-full",
     )
-
-
-sb = sidebar(width="100%")

--- a/docs/app/reflex_docs/templates/docpage/sidebar/sidebar.py
+++ b/docs/app/reflex_docs/templates/docpage/sidebar/sidebar.py
@@ -248,6 +248,7 @@ def sidebar_icon(name):
         else rx.fragment()
     )
 
+
 def calculate_index(sidebar_items, url: str) -> list[int]:
     sidebar_items = (
         sidebar_items if isinstance(sidebar_items, list) else [sidebar_items]
@@ -447,13 +448,11 @@ def sidebar_comp(
     path = normalize_url(url)
     is_docs_hosting = path.startswith("/hosting/")
     is_docs_ai_builder = path.startswith("/ai/")
-    is_ai_mcp_or_skills = path.startswith(
-        (
-            "/ai/integrations/ai-onboarding/",
-            "/ai/integrations/skills/",
-            "/ai/integrations/mcp",
-        )
-    )
+    is_ai_mcp_or_skills = path.startswith((
+        "/ai/integrations/ai-onboarding/",
+        "/ai/integrations/skills/",
+        "/ai/integrations/mcp",
+    ))
 
     ai_category = 1 if is_ai_mcp_or_skills else 0
     docs_category = 0
@@ -709,7 +708,9 @@ def sidebar(url=None, width: str = "100%") -> rx.Component:
     api_reference_index = calculate_index(api_reference, normalized_url)
     recipes_index = calculate_index(recipes, normalized_url)
     enterprise_usage_index = calculate_index(enterprise_usage_items, normalized_url)
-    enterprise_component_index = calculate_index(enterprise_component_items, normalized_url)
+    enterprise_component_index = calculate_index(
+        enterprise_component_items, normalized_url
+    )
 
     cli_ref_index = calculate_index(cli_ref, normalized_url)
     ai_builder_overview_index = calculate_index(

--- a/docs/app/reflex_docs/templates/docpage/sidebar/sidebar.py
+++ b/docs/app/reflex_docs/templates/docpage/sidebar/sidebar.py
@@ -691,7 +691,7 @@ def sidebar_comp(
                 "background_color": "transparent",
             },
         },
-        class_name="flex flex-col pb-24 gap-8 items-start h-full pt-8 pr-4 scroll-p-4 overflow-y-scroll hidden-scrollbar w-full 3xl:pl-0 pl-6",
+        class_name="flex flex-col pb-24 gap-8 items-start h-full pt-8 pr-4 scroll-p-4 overflow-y-scroll overflow-x-hidden hidden-scrollbar w-full 3xl:pl-0 pl-6",
     )
 
 

--- a/docs/app/reflex_docs/templates/docpage/sidebar/state.py
+++ b/docs/app/reflex_docs/templates/docpage/sidebar/state.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-import reflex as rx
-
-
 @dataclass(kw_only=True)
 class SideBarBase:
     """Base class for the Side bar."""
@@ -36,45 +33,3 @@ class SideBarSection(SideBarBase):
     """A section in the sidebar."""
 
     ...
-
-
-class SidebarState(rx.State):
-    _sidebar_index: int = -1
-
-    @rx.event(temporal=True)
-    def set_sidebar_index(self, num) -> int:
-        self._sidebar_index = num
-
-    @rx.var(initial_value=-1)
-    def sidebar_index(self) -> int:
-        route = self.router.url.path
-        if route.startswith((
-            "/docs/ai/integrations/ai-onboarding",
-            "/ai/integrations/ai-onboarding",
-        )):
-            return 1
-        if route.startswith((
-            "/docs/ai/integrations/skills",
-            "/ai/integrations/skills",
-        )):
-            return 1
-        if route.startswith(("/docs/ai/integrations/mcp", "/ai/integrations/mcp")):
-            return 1
-        if route.startswith(("/docs/ai/", "/ai/")):
-            return 0
-        if self._sidebar_index < 0:
-            if "library" in route:
-                return 1
-            elif "hosting" in route:
-                return 0
-            elif "api-reference" in route:
-                return 2
-            elif "enterprise" in route:
-                return 3
-            elif "/mcp-" in route:
-                return 1
-            else:
-                return 0
-        if "hosting" in route:
-            return 0
-        return self._sidebar_index

--- a/docs/app/reflex_docs/templates/docpage/sidebar/state.py
+++ b/docs/app/reflex_docs/templates/docpage/sidebar/state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+
 @dataclass(kw_only=True)
 class SideBarBase:
     """Base class for the Side bar."""


### PR DESCRIPTION
## Summary
- remove backend `SidebarState` usage from the docs sidebar
- replace the Radix accordion sidebar with native HTML `details` / `summary` structure
- derive active sidebar sections from the current route on render, including low-level component docs routes

## Why
The docs sidebar was coupled to backend state for category selection and accordion state. This makes the sidebar depend on backend state even though the active/open state can be derived from the frontend route.

## Validation
- `python3.13 -m compileall -q docs/app/reflex_docs/templates/docpage/sidebar`
- `git diff --check -- docs/app/reflex_docs/templates/docpage/sidebar/sidebar.py docs/app/reflex_docs/templates/docpage/sidebar/state.py`
- browser-use check on `/docs/library/forms/input/low/` confirmed the Forms sidebar group stays open and Input remains active on the Low Level page
