### PR TITLE
fix(config): normalize Config.plugins entries with clear errors (#6440)

### DIFF
--- a/packages/reflex-base/src/reflex_base/config.py
+++ b/packages/reflex-base/src/reflex_base/config.py
@@ -404,8 +404,8 @@ class Config(BaseConfig):
                     normalized.append(entry())
                 except TypeError as exc:
                     msg = (
-                        f"reflex.Config.plugins entry {entry.__name__!r} is a Plugin "
-                        f"class that requires constructor arguments; pass an instance "
+                        f"reflex.Config.plugins entry {entry.__name__!r} could not be "
+                        f"instantiated and may require arguments; pass an instance "
                         f"instead, e.g. plugins=[{entry.__name__}(...)]."
                     )
                     raise ConfigError(msg) from exc

--- a/packages/reflex-base/src/reflex_base/config.py
+++ b/packages/reflex-base/src/reflex_base/config.py
@@ -348,6 +348,9 @@ class Config(BaseConfig):
         for key, env_value in env_kwargs.items():
             setattr(self, key, env_value)
 
+        # Normalize plugins: auto-instantiate Plugin subclasses, reject bad values.
+        self._normalize_plugins()
+
         # Normalize disable_plugins: convert strings and Plugin subclasses to instances.
         self._normalize_disable_plugins()
 
@@ -381,6 +384,39 @@ class Config(BaseConfig):
         ):
             msg = f"{self._prefixes[0]}REDIS_URL is required when using the redis state manager."
             raise ConfigError(msg)
+
+    def _normalize_plugins(self):
+        """Normalize ``plugins`` entries to Plugin instances.
+
+        Auto-instantiates Plugin subclasses passed without parentheses (e.g.
+        ``plugins=[SitemapPlugin]``) so they behave the same as
+        ``plugins=[SitemapPlugin()]``. Any entry that is neither a Plugin
+        subclass nor a Plugin instance raises ``ConfigError`` with a message
+        that names the offending value, instead of failing later in the
+        compiler with a confusing ``TypeError`` about a missing ``self``.
+        """
+        normalized: list[Plugin] = []
+        for entry in self.plugins:
+            if isinstance(entry, Plugin):
+                normalized.append(entry)
+            elif isinstance(entry, type) and issubclass(entry, Plugin):
+                try:
+                    normalized.append(entry())
+                except TypeError as exc:
+                    msg = (
+                        f"reflex.Config.plugins entry {entry.__name__!r} is a Plugin "
+                        f"class that requires constructor arguments; pass an instance "
+                        f"instead, e.g. plugins=[{entry.__name__}(...)]."
+                    )
+                    raise ConfigError(msg) from exc
+            else:
+                msg = (
+                    f"reflex.Config.plugins must contain Plugin instances, but got "
+                    f"{entry!r} of type {type(entry).__name__}. "
+                    f"Pass an instance, e.g. plugins=[SitemapPlugin()]."
+                )
+                raise ConfigError(msg)
+        self.plugins = normalized
 
     def _normalize_disable_plugins(self):
         """Normalize disable_plugins list entries to Plugin subclasses.

--- a/tests/units/test_config.py
+++ b/tests/units/test_config.py
@@ -560,34 +560,34 @@ class TestDisablePlugins:
         assert any(isinstance(p, SitemapPlugin) for p in config.plugins)
 
 
-class TestPluginsNormalization:
-    """Tests for the plugins config option normalization (issue #6440)."""
+def test_plugins_instance_passthrough():
+    """A Plugin instance is kept as-is (issue #6440)."""
+    instance = SitemapPlugin()
+    config = rx.Config(app_name="test", plugins=[instance])
+    assert instance in config.plugins
 
-    def test_plugins_instance_passthrough(self):
-        """A Plugin instance is kept as-is."""
-        instance = SitemapPlugin()
-        config = rx.Config(app_name="test", plugins=[instance])
-        assert instance in config.plugins
 
-    def test_plugins_class_auto_instantiated(self):
-        """A Plugin subclass is auto-instantiated rather than raising deep in the compiler."""
-        config = rx.Config(app_name="test", plugins=[SitemapPlugin])  # pyright: ignore[reportArgumentType]
-        instances = [p for p in config.plugins if isinstance(p, SitemapPlugin)]
-        assert len(instances) == 1
-        # And it must be an instance, not the class itself.
-        assert not isinstance(instances[0], type)
+def test_plugins_class_auto_instantiated():
+    """A Plugin subclass is auto-instantiated rather than raising deep in the compiler (issue #6440)."""
+    config = rx.Config(app_name="test", plugins=[SitemapPlugin])  # pyright: ignore[reportArgumentType]
+    instances = [p for p in config.plugins if isinstance(p, SitemapPlugin)]
+    assert len(instances) == 1
+    # And it must be an instance, not the class itself.
+    assert not isinstance(instances[0], type)
 
-    def test_plugins_invalid_value_raises_config_error(self):
-        """A non-Plugin value raises ConfigError naming the entry, not a deep TypeError."""
-        with pytest.raises(ConfigError, match=r"reflex\.Config\.plugins"):
-            rx.Config(app_name="test", plugins=["not-a-plugin"])  # pyright: ignore[reportArgumentType]
 
-    def test_plugins_class_requiring_args_raises_config_error(self):
-        """A Plugin subclass that needs constructor args raises a clear ConfigError."""
+def test_plugins_invalid_value_raises_config_error():
+    """A non-Plugin value raises ConfigError naming the entry, not a deep TypeError (issue #6440)."""
+    with pytest.raises(ConfigError, match=r"reflex\.Config\.plugins"):
+        rx.Config(app_name="test", plugins=["not-a-plugin"])  # pyright: ignore[reportArgumentType]
 
-        class NeedsArgs(Plugin):
-            def __init__(self, required):
-                self.required = required
 
-        with pytest.raises(ConfigError, match="NeedsArgs"):
-            rx.Config(app_name="test", plugins=[NeedsArgs])  # pyright: ignore[reportArgumentType]
+def test_plugins_class_requiring_args_raises_config_error():
+    """A Plugin subclass that needs constructor args raises a clear ConfigError (issue #6440)."""
+
+    class NeedsArgs(Plugin):
+        def __init__(self, required):
+            self.required = required
+
+    with pytest.raises(ConfigError, match="NeedsArgs"):
+        rx.Config(app_name="test", plugins=[NeedsArgs])  # pyright: ignore[reportArgumentType]

--- a/tests/units/test_config.py
+++ b/tests/units/test_config.py
@@ -9,6 +9,7 @@ from pytest_mock import MockerFixture
 from reflex_base.constants import Endpoint, Env
 from reflex_base.plugins import Plugin
 from reflex_base.plugins.sitemap import SitemapPlugin
+from reflex_base.utils.exceptions import ConfigError
 
 import reflex as rx
 from reflex.environment import (
@@ -557,3 +558,36 @@ class TestDisablePlugins:
         """Test that builtin plugins are added when not disabled."""
         config = rx.Config(app_name="test")
         assert any(isinstance(p, SitemapPlugin) for p in config.plugins)
+
+
+class TestPluginsNormalization:
+    """Tests for the plugins config option normalization (issue #6440)."""
+
+    def test_plugins_instance_passthrough(self):
+        """A Plugin instance is kept as-is."""
+        instance = SitemapPlugin()
+        config = rx.Config(app_name="test", plugins=[instance])
+        assert instance in config.plugins
+
+    def test_plugins_class_auto_instantiated(self):
+        """A Plugin subclass is auto-instantiated rather than raising deep in the compiler."""
+        config = rx.Config(app_name="test", plugins=[SitemapPlugin])  # pyright: ignore[reportArgumentType]
+        instances = [p for p in config.plugins if isinstance(p, SitemapPlugin)]
+        assert len(instances) == 1
+        # And it must be an instance, not the class itself.
+        assert not isinstance(instances[0], type)
+
+    def test_plugins_invalid_value_raises_config_error(self):
+        """A non-Plugin value raises ConfigError naming the entry, not a deep TypeError."""
+        with pytest.raises(ConfigError, match=r"reflex\.Config\.plugins"):
+            rx.Config(app_name="test", plugins=["not-a-plugin"])  # pyright: ignore[reportArgumentType]
+
+    def test_plugins_class_requiring_args_raises_config_error(self):
+        """A Plugin subclass that needs constructor args raises a clear ConfigError."""
+
+        class NeedsArgs(Plugin):
+            def __init__(self, required):
+                self.required = required
+
+        with pytest.raises(ConfigError, match="NeedsArgs"):
+            rx.Config(app_name="test", plugins=[NeedsArgs])  # pyright: ignore[reportArgumentType]


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

---

closes #6440

### Description

Passing a `Plugin` class instead of an instance to `rx.Config(plugins=...)` previously failed deep in the compiler with:

```
TypeError: Plugin.get_stylesheet_paths() missing 1 required positional argument: 'self'
```

This PR adds `Config._normalize_plugins()` (mirroring the existing `_normalize_disable_plugins()`) that runs in `_post_init` and:

- Auto-instantiates bare `Plugin` subclasses so `plugins=[SitemapPlugin]` behaves like `plugins=[SitemapPlugin()]`. This matches the lenient handling already in place for `disable_plugins`.
- Raises `ConfigError` naming the offending value for non-`Plugin` entries (e.g. a stray string), instead of failing later with a confusing stylesheet-compilation traceback.
- Raises `ConfigError` naming the class when a `Plugin` subclass's `__init__` requires arguments, so the user knows to pass an instance.

The issue author proposed two options; I went with option 2 (auto-instantiate) since that is already the semantic of `disable_plugins` and avoids breaking ergonomic call sites that omit `()`.

### Repro before/after

```python
import reflex as rx
config = rx.Config(
    app_name="repro_sitemap",
    plugins=[rx.plugins.SitemapPlugin, rx.plugins.TailwindV4Plugin()],
)
```

Before: `TypeError: Plugin.get_stylesheet_paths() missing 1 required positional argument: 'self'` deep inside `compiler/_compile_root_stylesheet`.

After: Config builds successfully with both plugins instantiated.

```python
rx.Config(app_name="repro", plugins=["not-a-plugin"])
# ConfigError: reflex.Config.plugins must contain Plugin instances, but got
# 'not-a-plugin' of type str. Pass an instance, e.g. plugins=[SitemapPlugin()].
```

### Test plan

- `uv run pytest tests/units/test_config.py` (82 passed, 4 new cases under `TestPluginsNormalization`)
- `uv run ruff check packages/reflex-base/src/reflex_base/config.py tests/units/test_config.py`
- `uv run pyright packages/reflex-base/src/reflex_base/config.py tests/units/test_config.py` (0 errors)

New tests cover:

1. Plugin instance passthrough.
2. Plugin class auto-instantiation.
3. Non-Plugin value raises `ConfigError` mentioning `reflex.Config.plugins`.
4. Plugin subclass requiring constructor args raises `ConfigError` naming the class.
