### PR TITLE
fix(exec): correct frontend URL when frontend_path lacks a leading slash (#6360)

### DIFF
--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -159,6 +159,29 @@ def notify_frontend(url: str, backend_present: bool):
     )
 
 
+def _apply_frontend_path(base_url: str, frontend_path: str) -> str:
+    """Apply ``frontend_path`` to a base URL emitted by the frontend dev server.
+
+    ``urljoin`` treats a relative path differently from an absolute one, so
+    a ``frontend_path`` configured without a leading slash (e.g. ``"app"``)
+    used to produce duplicated path segments like
+    ``http://localhost:3001/app/app/`` (issue #6360). Normalizing the
+    configured path to ``/path/`` form before joining makes the behavior
+    consistent regardless of how the user wrote it.
+
+    Args:
+        base_url: The base URL printed by the frontend dev server.
+        frontend_path: The configured ``Config.frontend_path``.
+
+    Returns:
+        The URL with the frontend path correctly applied.
+    """
+    if not frontend_path:
+        return base_url
+    normalized = "/" + frontend_path.strip("/") + "/"
+    return urljoin(base_url, normalized)
+
+
 def notify_backend(host: str | None = None):
     """Output a string notifying where the backend is running.
 
@@ -226,9 +249,9 @@ def run_process_and_launch_url(
                 match = re.search(constants.ReactRouter.FRONTEND_LISTENING_REGEX, line)
                 if match:
                     if first_run:
-                        url = match.group(1)
-                        if get_config().frontend_path != "":
-                            url = urljoin(url, get_config().frontend_path)
+                        url = _apply_frontend_path(
+                            match.group(1), get_config().frontend_path
+                        )
 
                         notify_frontend(url, backend_present)
                         if backend_present:

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -178,7 +178,10 @@ def _apply_frontend_path(base_url: str, frontend_path: str) -> str:
     """
     if not frontend_path:
         return base_url
-    normalized = "/" + frontend_path.strip("/") + "/"
+    stripped = frontend_path.strip("/")
+    if not stripped:
+        return base_url
+    normalized = "/" + stripped + "/"
     return urljoin(base_url, normalized)
 
 

--- a/tests/units/utils/test_exec.py
+++ b/tests/units/utils/test_exec.py
@@ -1,0 +1,43 @@
+"""Tests for reflex.utils.exec."""
+
+from __future__ import annotations
+
+import pytest
+
+from reflex.utils.exec import _apply_frontend_path
+
+
+@pytest.mark.parametrize(
+    ("listening_url", "frontend_path", "expected"),
+    [
+        # Empty frontend_path is a no-op.
+        ("http://localhost:3001/", "", "http://localhost:3001/"),
+        # Vite has not yet baked the path into the URL (e.g. prod listening line).
+        ("http://localhost:3001/", "/app", "http://localhost:3001/app/"),
+        ("http://localhost:3001/", "app", "http://localhost:3001/app/"),
+        ("http://localhost:3001/", "app/", "http://localhost:3001/app/"),
+        ("http://localhost:3001/", "/app/", "http://localhost:3001/app/"),
+        # Vite already prints the URL with the base appended (dev server).
+        # Either form of frontend_path must NOT cause the path to be duplicated.
+        ("http://localhost:3001/noslash/", "noslash", "http://localhost:3001/noslash/"),
+        (
+            "http://localhost:3001/noslash/",
+            "/noslash",
+            "http://localhost:3001/noslash/",
+        ),
+        # Multi-segment frontend_path.
+        (
+            "http://localhost:3001/",
+            "app/v1",
+            "http://localhost:3001/app/v1/",
+        ),
+        (
+            "http://localhost:3001/app/v1/",
+            "app/v1",
+            "http://localhost:3001/app/v1/",
+        ),
+    ],
+)
+def test_apply_frontend_path(listening_url: str, frontend_path: str, expected: str):
+    """Issue #6360: frontend_path without a leading slash must not duplicate path segments."""
+    assert _apply_frontend_path(listening_url, frontend_path) == expected

--- a/tests/units/utils/test_exec.py
+++ b/tests/units/utils/test_exec.py
@@ -12,6 +12,10 @@ from reflex.utils.exec import _apply_frontend_path
     [
         # Empty frontend_path is a no-op.
         ("http://localhost:3001/", "", "http://localhost:3001/"),
+        # Root path "/" must also be a no-op (would otherwise produce "//", a
+        # protocol-relative reference that strips the host).
+        ("http://localhost:3001/", "/", "http://localhost:3001/"),
+        ("http://localhost:3001/", "//", "http://localhost:3001/"),
         # Vite has not yet baked the path into the URL (e.g. prod listening line).
         ("http://localhost:3001/", "/app", "http://localhost:3001/app/"),
         ("http://localhost:3001/", "app", "http://localhost:3001/app/"),


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

---

closes #6360

### Description

Setting `REFLEX_FRONTEND_PATH=noslash` (no leading slash) caused startup to print a URL with a duplicated segment:

```
App running at: http://localhost:3001/noslash/noslash/
```

#### Root cause

`urllib.parse.urljoin` treats a relative path differently from an absolute one. Vite already prints its listening URL with the configured base appended (e.g. `http://localhost:3001/noslash/`), so:

- `urljoin("http://localhost:3001/noslash/", "/noslash")` returns `http://localhost:3001/noslash` (absolute path replaces).
- `urljoin("http://localhost:3001/noslash/", "noslash")` returns `http://localhost:3001/noslash/noslash` (relative path appends).

#### Fix

Extract `_apply_frontend_path(base_url, frontend_path)` in `reflex/utils/exec.py` that normalizes the configured path to `/path/` form before joining. The result is now independent of how the user wrote `frontend_path`:

| `frontend_path` | Result |
|---|---|
| `"/app"` | `http://localhost:3001/app/` |
| `"app"` | `http://localhost:3001/app/` |
| `"/app/"` | `http://localhost:3001/app/` |
| `"app/v1"` | `http://localhost:3001/app/v1/` |

The helper is pure, so it is unit-tested directly without mocking the dev-server subprocess.

### Test plan

- `uv run pytest tests/units/utils/test_exec.py` (9 parametrized cases pass)
- `uv run ruff check reflex/utils/exec.py tests/units/utils/test_exec.py`
- `uv run pyright reflex/utils/exec.py tests/units/utils/test_exec.py` (0 errors)
- Manual: `REFLEX_FRONTEND_PATH=noslash reflex run` now prints `http://localhost:3001/noslash/` (one segment).

The new test file covers: empty path, leading-slash, no-leading-slash, trailing-slash, both-slashes, multi-segment path, and the bug scenario where vite has already baked the path into its listening URL.
