### PR TITLE
use `uv run --no-sync` in pre-commit commands

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,13 +4,13 @@ repos:
   hooks:
   - id: ruff-format
     name: ruff-format
-    entry: ruff format
+    entry: uv run --no-sync ruff format
     language: system
     types_or: [python, markdown]
     require_serial: true
   - id: ruff-check
     name: ruff-check
-    entry: ruff check
+    entry: uv run --no-sync ruff check
     language: system
     args: [--fix, --exit-non-zero-on-fix]
     types_or: [python, pyi]
@@ -19,7 +19,7 @@ repos:
   hooks:
   - id: codespell
     name: codespell
-    entry: codespell
+    entry: uv run --no-sync codespell
     language: system
     types: [text]
     require_serial: true
@@ -28,7 +28,7 @@ repos:
   - id: update-pyi-files
     name: update-pyi-files
     description: Update pyi files as needed
-    entry: python3 scripts/make_pyi.py
+    entry: uv run --no-sync python scripts/make_pyi.py
     language: system
     always_run: true
     require_serial: true
@@ -36,7 +36,7 @@ repos:
   hooks:
   - id: pyright
     name: pyright
-    entry: pyright
+    entry: uv run --no-sync pyright
     language: system
     types: [python]
     require_serial: true


### PR DESCRIPTION
allow pre-commit to work whether you have activated the virtualenv or not