### PR TITLE
fix(state.js): drop deprecated unload listener, use pagehide (#6195)

### DIFF
--- a/packages/reflex-base/src/reflex_base/.templates/web/utils/state.js
+++ b/packages/reflex-base/src/reflex_base/.templates/web/utils/state.js
@@ -608,16 +608,21 @@ export const connect = async (
 
   const disconnectTrigger = (event) => {
     if (socket.current?.connected) {
-      console.log("Disconnect websocket on unload");
+      console.log("Disconnect websocket on page navigation");
       socket.current.disconnect();
     }
   };
 
   const pagehideHandler = (event) => {
-    if (event.persisted && socket.current?.connected) {
-      console.log("Disconnect backend before bfcache on navigation");
-      socket.current.disconnect();
+    if (!socket.current?.connected) {
+      return;
     }
+    if (event.persisted) {
+      console.log("Disconnect backend before bfcache on navigation");
+    } else {
+      console.log("Disconnect websocket on pagehide");
+    }
+    socket.current.disconnect();
   };
 
   // Once the socket is open, hydrate the page.
@@ -626,7 +631,6 @@ export const connect = async (
     setConnectErrors([]);
     window.addEventListener("pagehide", pagehideHandler);
     window.addEventListener("beforeunload", disconnectTrigger);
-    window.addEventListener("unload", disconnectTrigger);
     if (socket.current.rehydrate) {
       socket.current.rehydrate = false;
       queueEvents(initialEvents(), socket, true, navigate, params);
@@ -656,7 +660,6 @@ export const connect = async (
     socket.current.wait_connect = false;
     const try_reconnect =
       reason !== "io server disconnect" && reason !== "io client disconnect";
-    window.removeEventListener("unload", disconnectTrigger);
     window.removeEventListener("beforeunload", disconnectTrigger);
     window.removeEventListener("pagehide", pagehideHandler);
     if (try_reconnect) {

--- a/tests/units/compiler/test_state_js_template.py
+++ b/tests/units/compiler/test_state_js_template.py
@@ -1,0 +1,44 @@
+"""Regression tests for the state.js frontend template."""
+
+from pathlib import Path
+
+STATE_JS_TEMPLATE = (
+    Path(__file__).parents[3]
+    / "packages/reflex-base/src/reflex_base/.templates/web/utils/state.js"
+)
+
+
+def test_state_js_does_not_register_deprecated_unload_listener() -> None:
+    """The template must not register the deprecated `unload` event listener.
+
+    Regression for https://github.com/reflex-dev/reflex/issues/6195: Chrome
+    emits a deprecation warning when pages register `unload` handlers. The
+    `pagehide` listener already covers the cases `unload` was being used for
+    (tab close, navigation, bfcache), so the deprecated listener must not be
+    re-introduced.
+    """
+    content = STATE_JS_TEMPLATE.read_text()
+
+    assert 'addEventListener("unload"' not in content, (
+        "state.js registers a deprecated `unload` listener; use `pagehide` instead."
+    )
+    assert 'removeEventListener("unload"' not in content, (
+        "state.js still removes a `unload` listener that should no longer be registered."
+    )
+
+
+def test_state_js_still_handles_page_lifecycle_disconnect() -> None:
+    """The template must still disconnect on page lifecycle events.
+
+    Replacing the deprecated `unload` listener with `pagehide` is the
+    recommended Web Page Lifecycle pattern; verify the replacement listeners
+    remain wired so the socket is closed when the user navigates away.
+    """
+    content = STATE_JS_TEMPLATE.read_text()
+
+    assert 'addEventListener("pagehide"' in content, (
+        "state.js should register a `pagehide` listener to disconnect the socket."
+    )
+    assert 'addEventListener("beforeunload"' in content, (
+        "state.js should keep its `beforeunload` listener as a disconnect fallback."
+    )


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

closes #6195

### Summary

Chrome 134+ surfaces a deprecation warning because `state.js` registers a `unload` event listener. Per the Web Page Lifecycle API, `pagehide` is the canonical replacement.

- Remove the deprecated `unload` add/remove listeners on the socket `connect`/`disconnect` paths.
- Update `pagehideHandler` to disconnect on every page-hide event, not only the bfcache (`event.persisted`) case, since `pagehide` is the recommended replacement for `unload` and fires reliably on tab close, navigation, and bfcache.
- Keep `beforeunload` as the synchronous disconnect path; in practice it fires first on standard navigations and triggers Socket.IO's local `disconnect` event, which tears down the `pagehide` listener before `pagehide` runs. `pagehide` therefore acts as a fallback for cases where `beforeunload` is skipped (programmatic navigation, some mobile browsers, bfcache).

No behavior change is intended on the happy path: the socket still disconnects when the user leaves the page; the deprecation warning is gone.