### PR TITLE
Fix rx.code_block rendering empty when content is a state Var

### DIFF
--- a/packages/reflex-base/src/reflex_base/compiler/templates.py
+++ b/packages/reflex-base/src/reflex_base/compiler/templates.py
@@ -67,12 +67,22 @@ class _RenderUtils:
     @staticmethod
     def render_tag(component: Mapping[str, Any]) -> str:
         name = component.get("name") or "Fragment"
-        props = f"{{{','.join(component['props'])}}}"
+        props_list = component["props"]
+        props = f"{{{','.join(props_list)}}}"
         rendered_children = [
             _RenderUtils.render(child)
             for child in component.get("children", [])
             if child
         ]
+
+        # When `props` already declares `children:` (e.g. `rx.code_block` routes
+        # its content there via `CodeBlock._render`), do NOT also emit positional
+        # children. React's `createElement(type, props, x)` overrides
+        # `props.children` with the positional arg even when it is `undefined`
+        # (which is what the auto-memo wrapper passes when invoked with no
+        # children), silently nulling the legitimate value in props. See #6480.
+        if any(p.startswith("children:") for p in props_list):
+            return f"jsx({name},{props})"
 
         return f"jsx({name},{props},{','.join(rendered_children)})"
 

--- a/tests/units/compiler/test_compiler.py
+++ b/tests/units/compiler/test_compiler.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 from pytest_mock import MockerFixture
 from reflex_base import constants
+from reflex_base.compiler.templates import _RenderUtils
 from reflex_base.components.dynamic import bundle_library, reset_bundled_libraries
 from reflex_base.constants.compiler import PageNames
 from reflex_base.utils.imports import ImportVar, ParsedImportDict
@@ -514,3 +515,42 @@ def test_create_document_root_with_meta_viewport():
     assert str(root.children[0].children[2].name) == '"viewport"'  # pyright: ignore [reportAttributeAccessIssue]
     assert str(root.children[0].children[2].content) == '"foo"'  # pyright: ignore [reportAttributeAccessIssue]
     assert str(root.children[0].children[3].char_set) == '"utf-8"'  # pyright: ignore [reportAttributeAccessIssue]
+
+
+def test_render_tag_skips_positional_children_when_props_have_children():
+    """Regression for #6480.
+
+    Components that route their content through ``props.children`` (notably
+    ``rx.code_block`` via ``CodeBlock._render``) must not also receive the
+    rendered subtree as a positional argument — React's ``createElement``
+    overrides ``props.children`` with the positional arg even when that arg
+    is ``undefined`` (which the auto-memo wrapper passes whenever it is
+    invoked without children, as is always the case for ``rx.code_block``).
+    """
+    tag = {
+        "name": "SyntaxHighlighter",
+        "props": [
+            "children:state.template_file_content_rx_state_",
+            "language:'yaml'",
+        ],
+        "children": ["children"],  # auto-memo's `Bare(children)` placeholder
+    }
+    assert _RenderUtils.render_tag(tag) == (
+        "jsx(SyntaxHighlighter,"
+        "{children:state.template_file_content_rx_state_,language:'yaml'})"
+    )
+
+
+def test_render_tag_preserves_positional_children_for_normal_components():
+    """Components without a ``children:`` prop should still receive their
+    rendered subtree positionally — this is the common path and must not
+    regress when the #6480 guard is added.
+    """
+    tag = {
+        "name": "Box",
+        "props": ["style:({})"],
+        "children": [
+            {"name": "p", "props": [], "children": ["hello"]},
+        ],
+    }
+    assert _RenderUtils.render_tag(tag) == "jsx(Box,{style:({})},jsx(p,{},hello))"


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Summary

Fixes #6480.

`rx.code_block(state_var, language=..., show_line_numbers=True)` renders an empty `<pre><code class="language-yaml">` element. The state Var is populated at runtime — `rx.set_clipboard(state_var)` copies the full content, and `rx.cond(state_var != "", ...)` evaluates `True` — but `SyntaxHighlighter` receives nothing.

### Root cause

`CodeBlock._render()` moves the user's first positional argument into `props["children"]`. For a stateful subtree, the compiler wraps the call in an auto-memo:

```jsx
export const Codeblock_prismasynclight_<hash> = memo(({children}) => {
    const reflex___state__... = useContext(...)
    return jsx(SyntaxHighlighter, {children: state_var, ...}, children);
});
```

The third positional `children` is the wrapper's destructured prop, which is `undefined` when the wrapper is invoked with no children (always, for `rx.code_block`). `@emotion/react`'s classic `jsx` delegates to `React.createElement.apply(void 0, args)`, and `React.createElement(type, props, undefined)` has `arguments.length === 3`, so React sets `props.children = undefined`, overriding the legitimate value from the props object.

### Fix

In `_RenderUtils.render_tag` (`packages/reflex-base/src/reflex_base/compiler/templates.py`), when `props` already declares a `children:` key, omit the positional children in the emitted `jsx()` call. Components that don't bind `props.children` keep their existing behaviour.

### Tests

Two new tests in `tests/units/compiler/test_compiler.py`:

- `test_render_tag_skips_positional_children_when_props_have_children` — direct regression for #6480.
- `test_render_tag_preserves_positional_children_for_normal_components` — guards the common path so a future refactor can't re-introduce the bug by over-correcting.

`uv run pytest tests/units/compiler/` — 160 passed.

### Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tests pass: `uv run pytest tests/units/compiler/test_compiler.py -k render_tag`
- [x] Reproduced the bug end-to-end before the fix, and confirmed the fix renders syntax-highlighted content for `rx.code_block(state_var, ...)` across three independent call sites in a downstream application (Reflex 0.9.2 + the equivalent patch applied via post-install script).
