### PR TITLE
fix: Textarea enter_key_submit uses add_custom_code instead of _get_all_custom_code

### DIFF
--- a/packages/reflex-components-core/src/reflex_components_core/el/elements/forms.py
+++ b/packages/reflex-components-core/src/reflex_components_core/el/elements/forms.py
@@ -770,14 +770,10 @@ class Textarea(RawTextBaseHTML):
         ]
 
     def add_custom_code(self) -> list[str]:
-        """Add custom Javascript code for auto_height and enter_key_submit.
-
-        Custom code is inserted at module level, after any imports. Each string
-        is deduplicated per-page, so the same const or function is only
-        included once even when multiple Textarea components are on the page.
+        """Inject the JS helpers used by ``auto_height`` and ``enter_key_submit``.
 
         Returns:
-            The additional custom code for this component.
+            The module-level JS snippets required by the enabled features.
         """
         code: list[str] = []
         if self.auto_height is not None:

--- a/packages/reflex-components-core/src/reflex_components_core/el/elements/forms.py
+++ b/packages/reflex-components-core/src/reflex_components_core/el/elements/forms.py
@@ -769,18 +769,22 @@ class Textarea(RawTextBaseHTML):
             "enter_key_submit",
         ]
 
-    def _get_all_custom_code(self) -> dict[str, None]:
-        """Include the custom code for auto_height and enter_key_submit functionality.
+    def add_custom_code(self) -> list[str]:
+        """Add custom Javascript code for auto_height and enter_key_submit.
+
+        Custom code is inserted at module level, after any imports. Each string
+        is deduplicated per-page, so the same const or function is only
+        included once even when multiple Textarea components are on the page.
 
         Returns:
-            The custom code for the component.
+            The additional custom code for this component.
         """
-        custom_code = super()._get_all_custom_code()
+        code: list[str] = []
         if self.auto_height is not None:
-            custom_code[AUTO_HEIGHT_JS] = None
+            code.append(AUTO_HEIGHT_JS)
         if self.enter_key_submit is not None:
-            custom_code[ENTER_KEY_SUBMIT_JS] = None
-        return custom_code
+            code.append(ENTER_KEY_SUBMIT_JS)
+        return code
 
 
 button = Button.create

--- a/pyi_hashes.json
+++ b/pyi_hashes.json
@@ -27,7 +27,7 @@
   "packages/reflex-components-core/src/reflex_components_core/el/element.pyi": "ff68d843c5987d3f0d773a6367eb9c63",
   "packages/reflex-components-core/src/reflex_components_core/el/elements/__init__.pyi": "e6c845f2f29eb079697a2e31b0c2f23a",
   "packages/reflex-components-core/src/reflex_components_core/el/elements/base.pyi": "a3ef8bcb5fe8e4bfb22a8f6d714611b8",
-  "packages/reflex-components-core/src/reflex_components_core/el/elements/forms.pyi": "ab968cdfc51968d6c0c4e8a884c4f246",
+  "packages/reflex-components-core/src/reflex_components_core/el/elements/forms.pyi": "21e51ccc7307c3c41f2556ffa7019f2c",
   "packages/reflex-components-core/src/reflex_components_core/el/elements/inline.pyi": "9c1432e70e6b9349f44df04a244a4303",
   "packages/reflex-components-core/src/reflex_components_core/el/elements/media.pyi": "f51120c31a1a8b79da9ecf58f19005b9",
   "packages/reflex-components-core/src/reflex_components_core/el/elements/metadata.pyi": "73d19f3d9e389447ad8bbb68e1b7d1c9",

--- a/tests/integration/tests_playwright/test_textarea_enter_key_submit.py
+++ b/tests/integration/tests_playwright/test_textarea_enter_key_submit.py
@@ -1,0 +1,114 @@
+"""Integration test for ``rx.el.textarea(enter_key_submit=True)``.
+
+Regression coverage for the frontend ``ReferenceError: enterKeySubmitOnKeyDown
+is not defined`` that fired when the helper JS was dropped during plugin-based
+compilation. Pressing Enter inside the textarea must submit the parent form
+without raising a runtime exception in the browser.
+"""
+
+from collections.abc import Generator
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from reflex.testing import AppHarness
+
+
+def EnterKeySubmitApp():
+    """Form containing a textarea that submits on Enter."""
+    import reflex as rx
+
+    class State(rx.State):
+        submitted_value: str = ""
+
+        @rx.event
+        def on_submit(self, form_data: dict):
+            self.submitted_value = form_data.get("t", "")
+
+    @rx.page("/")
+    def index():
+        return rx.box(
+            rx.input(
+                value=State.router.session.client_token,
+                read_only=True,
+                id="token",
+            ),
+            rx.el.form(
+                rx.el.textarea(
+                    enter_key_submit=True,
+                    name="t",
+                    id="ta",
+                ),
+                on_submit=State.on_submit,
+                custom_attrs={"action": "/invalid"},
+            ),
+            rx.text(State.submitted_value, id="submitted"),
+        )
+
+    app = rx.App()  # noqa: F841
+
+
+@pytest.fixture(scope="module")
+def enter_key_submit_app(tmp_path_factory) -> Generator[AppHarness, None, None]:
+    """Start EnterKeySubmitApp via AppHarness.
+
+    Args:
+        tmp_path_factory: pytest fixture for creating temporary directories.
+
+    Yields:
+        Running AppHarness instance.
+    """
+    with AppHarness.create(
+        root=tmp_path_factory.mktemp("enter_key_submit_app"),
+        app_source=EnterKeySubmitApp,
+    ) as harness:
+        assert harness.app_instance is not None, "app is not running"
+        yield harness
+
+
+def test_textarea_enter_key_submits_form(enter_key_submit_app: AppHarness, page: Page):
+    """Pressing Enter in the textarea submits the form and raises no JS errors.
+
+    Args:
+        enter_key_submit_app: AppHarness running the test app.
+        page: Playwright page.
+    """
+    assert enter_key_submit_app.frontend_url is not None
+
+    page_errors: list[str] = []
+    page.on("pageerror", lambda exc: page_errors.append(str(exc)))
+
+    page.goto(enter_key_submit_app.frontend_url)
+    expect(page.locator("#token")).not_to_have_value("")
+
+    textarea = page.locator("#ta")
+    textarea.click()
+    textarea.fill("hello")
+    textarea.press("Enter")
+
+    expect(page.locator("#submitted")).to_have_text("hello")
+    assert not page_errors, f"Frontend raised unexpected errors: {page_errors}"
+
+
+def test_textarea_shift_enter_inserts_newline(
+    enter_key_submit_app: AppHarness, page: Page
+):
+    """Shift+Enter must add a newline rather than submit the form.
+
+    Args:
+        enter_key_submit_app: AppHarness running the test app.
+        page: Playwright page.
+    """
+    assert enter_key_submit_app.frontend_url is not None
+
+    page.goto(enter_key_submit_app.frontend_url)
+    expect(page.locator("#token")).not_to_have_value("")
+
+    textarea = page.locator("#ta")
+    textarea.click()
+    textarea.type("line1")
+    textarea.press("Shift+Enter")
+    textarea.type("line2")
+    textarea.press("Enter")
+
+    expect(page.locator("#submitted")).to_have_text("line1\nline2")

--- a/tests/units/components/forms/test_form.py
+++ b/tests/units/components/forms/test_form.py
@@ -1,6 +1,13 @@
 from reflex_base.event import EventChain, prevent_default
 from reflex_base.vars.base import Var
+from reflex_components_core.el.elements.forms import (
+    AUTO_HEIGHT_JS,
+    ENTER_KEY_SUBMIT_JS,
+    Textarea,
+)
 from reflex_components_radix.primitives.form import Form
+
+from reflex.compiler.utils import _root_only_custom_code
 
 
 def test_render_on_submit():
@@ -20,3 +27,22 @@ def test_render_no_on_submit():
     assert isinstance(f.event_triggers["on_submit"], EventChain)
     assert len(f.event_triggers["on_submit"].events) == 1
     assert f.event_triggers["on_submit"].events[0] == prevent_default
+
+
+def test_textarea_enter_key_submit_emits_helper():
+    """`enter_key_submit=True` must inject the onKeyDown helper into the page."""
+    ta = Textarea.create(enter_key_submit=True)
+    assert ENTER_KEY_SUBMIT_JS in _root_only_custom_code(ta)
+
+
+def test_textarea_auto_height_emits_helper():
+    """`auto_height=True` must inject the onInput helper into the page."""
+    ta = Textarea.create(auto_height=True)
+    assert AUTO_HEIGHT_JS in _root_only_custom_code(ta)
+
+
+def test_textarea_without_features_emits_no_helpers():
+    """A bare textarea should not pull in either helper snippet."""
+    collected = _root_only_custom_code(Textarea.create())
+    assert ENTER_KEY_SUBMIT_JS not in collected
+    assert AUTO_HEIGHT_JS not in collected


### PR DESCRIPTION
## Description

Fixes #6482: Using `enter_key_submit=True` on `rx.el.textarea` throws a frontend `ReferenceError: enterKeySubmitOnKeyDown is not defined`.

## Root Cause

The Textarea component's `auto_height` and `enter_key_submit` features relied on overriding `_get_all_custom_code` to inject JavaScript helper functions (`autoHeightOnInput` and `enterKeySubmitOnKeyDown`). However, the compiler's builtin plugin collects custom code via `_get_custom_code()` (singular) and `add_custom_code()`, **not** `_get_all_custom_code()` (plural). This caused both JS functions to be missing from compiled pages.

## Fix

Replace the `_get_all_custom_code` override with an `add_custom_code` implementation. The parent class already merges `add_custom_code` results into `_get_all_custom_code`, so no behavior is lost for code paths that use the plural form. The compiler plugin also collects `add_custom_code` via `_iter_parent_classes_with_method`, ensuring the JS functions are properly injected into compiled pages.

## Testing

- All existing unit tests pass (`tests/units/components/test_component.py`: 122 passed, `tests/units/compiler/`: 158 passed)