### PR TITLE
fix(component): compare field values in BaseComponent.__eq__

### DIFF
--- a/packages/reflex-base/src/reflex_base/components/component.py
+++ b/packages/reflex-base/src/reflex_base/components/component.py
@@ -137,6 +137,35 @@ def field(
     )
 
 
+def _field_values_equal(a: Any, b: Any) -> bool:
+    """Compare two component field values, handling Vars and nested containers.
+
+    Var equality returns a BooleanVar (not a Python bool), and bool-ifying a Var
+    raises VarTypeError. So Vars are compared structurally via ``Var.equals``,
+    and lists/dicts are walked element-wise so a contained Var doesn't trip up
+    the default container ``__eq__``.
+
+    Args:
+        a: First value.
+        b: Second value.
+
+    Returns:
+        Whether the values are structurally equal.
+    """
+    if a is b:
+        return True
+    a_is_var = isinstance(a, Var)
+    if a_is_var or isinstance(b, Var):
+        return a_is_var and isinstance(b, Var) and a.equals(b)
+    if isinstance(a, list) and isinstance(b, list):
+        return len(a) == len(b) and all(
+            _field_values_equal(x, y) for x, y in zip(a, b, strict=False)
+        )
+    if isinstance(a, dict) and isinstance(b, dict):
+        return a.keys() == b.keys() and all(_field_values_equal(a[k], b[k]) for k in a)
+    return a == b
+
+
 @dataclass_transform(kw_only_default=True, field_specifiers=(field,))
 class BaseComponentMeta(FieldBasedMeta, ABCMeta):
     """Meta class for BaseComponent."""
@@ -347,7 +376,8 @@ class BaseComponent(metaclass=BaseComponentMeta):
             Whether the component is equal to the value.
         """
         return type(self) is type(value) and all(
-            getattr(self, key) == getattr(value, key) for key in self.get_fields()
+            _field_values_equal(getattr(self, key), getattr(value, key))
+            for key in self.get_fields()
         )
 
     @classmethod

--- a/packages/reflex-base/src/reflex_base/components/component.py
+++ b/packages/reflex-base/src/reflex_base/components/component.py
@@ -346,7 +346,7 @@ class BaseComponent(metaclass=BaseComponentMeta):
         Returns:
             Whether the component is equal to the value.
         """
-        return type(self) is type(value) and bool(
+        return type(self) is type(value) and all(
             getattr(self, key) == getattr(value, key) for key in self.get_fields()
         )
 

--- a/tests/units/components/test_component.py
+++ b/tests/units/components/test_component.py
@@ -2334,3 +2334,36 @@ def test_component_equality_compares_fields():
 
     assert EqProbe.create() != OtherProbe.create()
     assert EqProbe.create() != "not a component"
+
+
+def test_component_equality_handles_var_fields():
+    """``BaseComponent.__eq__`` must not raise when a field holds a Var.
+
+    ``Var.__eq__`` returns a ``BooleanVar``; bool-ifying that raises
+    ``VarTypeError``. Equality has to compare Vars structurally (via
+    ``Var.equals``) and walk containers element-wise so list/dict fields that
+    hold Vars don't trip up the default container ``__eq__``.
+    """
+
+    class VarState(BaseState):
+        text: str = "hi"
+
+    class VarProbe(Component):
+        tag = "VarProbe"
+        label: str = ""
+        items: list = []
+        meta: dict = {}
+
+    same_a = VarProbe.create(label=VarState.text)
+    same_b = VarProbe.create(label=VarState.text)
+    different = VarProbe.create(label="literal")
+    assert same_a == same_b
+    assert same_a != different
+
+    list_a = VarProbe.create(items=[VarState.text])
+    list_b = VarProbe.create(items=[VarState.text])
+    assert list_a == list_b
+
+    dict_a = VarProbe.create(meta={"k": VarState.text})
+    dict_b = VarProbe.create(meta={"k": VarState.text})
+    assert dict_a == dict_b

--- a/tests/units/components/test_component.py
+++ b/tests/units/components/test_component.py
@@ -2301,3 +2301,36 @@ def test_ref():
     assert id_component._render().props["ref"].equals(Var("ref_custom_id"))
 
     assert "ref" not in rx.box()._render().props
+
+
+def test_component_equality_compares_fields():
+    """``BaseComponent.__eq__`` must compare field values, not just class identity.
+
+    HTML ``Element`` subclasses (``rx.box`` etc.) override ``__eq__`` to compare by
+    tag only, so this test uses a plain ``Component`` subclass to exercise the
+    base implementation.
+    """
+
+    class EqProbe(Component):
+        tag = "EqProbe"
+        label: str = ""
+
+    class OtherProbe(Component):
+        tag = "OtherProbe"
+        label: str = ""
+
+    a = EqProbe.create(label="x")
+    b = EqProbe.create(label="x")
+    c = EqProbe.create(label="y")
+
+    assert a == b
+    assert a != c
+
+    parent_same = EqProbe.create(EqProbe.create(label="leaf"), label="root")
+    parent_other = EqProbe.create(EqProbe.create(label="leaf"), label="root")
+    parent_diff = EqProbe.create(EqProbe.create(label="other"), label="root")
+    assert parent_same == parent_other
+    assert parent_same != parent_diff
+
+    assert EqProbe.create() != OtherProbe.create()
+    assert EqProbe.create() != "not a component"


### PR DESCRIPTION
bool() on a generator is always True, so any two same-class components compared equal. Use all() to actually evaluate the per-field comparisons.

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### New Feature Submission:

- [x] Does your submission pass the tests?
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

