### PR TITLE
[codex] Loosen enterprise docs alert copy

### DIFF
--- a/docs/enterprise/overview.md
+++ b/docs/enterprise/overview.md
@@ -20,7 +20,8 @@ Reflex Enterprise is a package containing paid features built on top of Reflex.
 The full [End-User License Agreement (EULA)](https://raw.githubusercontent.com/reflex-dev/reflex/main/docs/enterprise/LICENSE) for Reflex Enterprise is published in the Reflex repository.
 
 ```md alert info
-# Despite being an enterprise package, free users can use the components from this package. A badge "Built with Reflex" will be shown in the bottom right corner of the app.
+# Enterprise components are available to free users.
+Free apps can use these components with a "Built with Reflex" badge shown in the bottom right corner of the app.
 For more information on the badge, visit [Built with Reflex](/docs/enterprise/built-with-reflex/).
 ```
 


### PR DESCRIPTION
## Summary
- Shorten the Enterprise overview alert title so the collapsed state feels less crowded.
- Move the badge explanation into the alert body while preserving the Built with Reflex link.

## Why
The previous alert used the full badge explanation as the accordion title, which made the notice feel cramped in its collapsed state.

## Validation
- `uv run --project docs/app pytest tests/test_doc_links.py`
- `uv run --project docs/app pytest tests/test_routes.py`
- Verified locally at `http://localhost:3001/docs/enterprise/overview/` that the collapsed alert uses the shorter title and the expanded body contains the badge details/link.