### PR TITLE
[codex] Fix memoized component hook prop rendering

### DIFF
--- a/reflex/compiler/utils.py
+++ b/reflex/compiler/utils.py
@@ -460,8 +460,8 @@ def compile_experimental_component_memo(
         rendered = render.render()
     else:
         render = _apply_component_style_for_compile(copy.deepcopy(definition.component))
-        rendered = render.render()
         hooks = render._get_all_hooks()
+        rendered = render.render()
         custom_code = render._get_all_custom_code()
         dynamic_imports = render._get_all_dynamic_imports()
         all_imports = render._get_all_imports()

--- a/tests/units/compiler/test_memoize_plugin.py
+++ b/tests/units/compiler/test_memoize_plugin.py
@@ -87,6 +87,25 @@ class ChildrenViaProp(Component):
         return super()._render().remove_props("code").add_props(children=self.code)
 
 
+class HookGeneratedProp(Component):
+    """Component whose hook collection fills a prop needed by render output."""
+
+    tag = "HookGeneratedProp"
+    library = "hook-generated-prop-lib"
+
+    label: Var[str] = component_field(default=LiteralVar.create(""))
+    callback: Var[Any] = component_field(default=LiteralVar.create(None))
+
+    def add_hooks(self) -> list[str]:
+        """Add a hook and wire its identifier into a component prop.
+
+        Returns:
+            The hook lines this component contributes.
+        """
+        self.callback = Var(_js_expr="generatedCallback")
+        return ["function generatedCallback(){ return true; }"]
+
+
 class SpecialFormMemoState(BaseState):
     items: Field[list[str]] = field(default_factory=lambda: ["a"])
     flag: Field[bool] = field(default=True)
@@ -190,6 +209,17 @@ def test_memoize_wrapper_uses_experimental_memo_component_and_call_site() -> Non
     assert f'import {{{wrapper_tag}}} from "$/utils/components/{wrapper_tag}"' in output
     assert f"jsx({wrapper_tag}," in (page_ctx.output_code or "")
     assert f"const {wrapper_tag} = memo" not in output
+
+
+def test_auto_memo_component_renders_after_add_hooks_mutates_props() -> None:
+    """Auto-memo modules render after ``add_hooks`` has filled derived props."""
+    ctx, _page_ctx = _compile_single_page(
+        lambda: HookGeneratedProp.create(label=STATE_VAR)
+    )
+    memo_code = _compile_memo_module_text(ctx)
+
+    assert "function generatedCallback(){ return true; }" in memo_code
+    assert "callback:generatedCallback" in memo_code
 
 
 def test_memoize_wrapper_deduped_across_repeated_subtrees() -> None:


### PR DESCRIPTION
## Summary
- Compile auto-memo component hooks before rendering so hook-mutated props are present in memo modules.
- Add regression coverage for auto-memo components whose add_hooks fills a render prop.

## Root Cause
The auto-memo full-component path rendered before calling _get_all_hooks(). DataEditor.add_hooks() generates the getData_* hook and mutates the component with the getCellContent prop, so the memoized docs module included the hook function but rendered without getCellContent. Glide then tried to call the missing callback and the docs page failed with TypeError: x is not a function.

## Validation
- uv run ruff check reflex/compiler/utils.py tests/units/compiler/test_memoize_plugin.py
- uv run pytest tests/units/compiler/test_memoize_plugin.py -q
- uv run pytest tests/units/components/datadisplay/test_dataeditor.py -q
- Ran the docs locally at http://localhost:3030/docs/library/tables-and-data-grids/data-editor/ and verified the page renders, including the first data grid, without the Application Error / TypeError. The only console noise seen locally was unrelated Base UI nativeButton messaging from the docs shell.