### PR TITLE
reflex-site-shared: canonical override + Try-for-free primary CTA

### DIFF
--- a/packages/reflex-site-shared/src/reflex_site_shared/meta/meta.py
+++ b/packages/reflex-site-shared/src/reflex_site_shared/meta/meta.py
@@ -126,7 +126,11 @@ def to_cdn_image_url(image: str | None) -> str:
 
 
 def create_meta_tags(
-    title: str, description: str, image: str | None, url: str | None = None
+    title: str,
+    description: str,
+    image: str | None,
+    url: str | None = None,
+    canonical: str | None = None,
 ) -> list[dict[str, str] | rx.Component]:
     """Create meta tags for a page.
 
@@ -135,11 +139,18 @@ def create_meta_tags(
         description: The page description.
         image: The image path for social media previews (None to omit).
         url: The page URL (optional, defaults to REFLEX_DOMAIN_URL).
+        canonical: Override for the canonical link. Use when one page should
+            consolidate SEO signals to a different URL (for example, a blog
+            post that canonicalizes to a dedicated comparison lander). When
+            set, ``og:url`` and ``twitter:url`` also follow the canonical so
+            social crawlers index the same target as search engines. Leave
+            None to canonicalize to ``url``.
 
     Returns:
         A list of meta tag dictionaries.
     """
     page_url = url or REFLEX_DOMAIN_URL
+    canonical_url = canonical if canonical is not None else page_url
     image_url = to_cdn_image_url(image) if image else None
 
     return [
@@ -147,9 +158,9 @@ def create_meta_tags(
             title=title,
             description=description,
             image=image_url,
-            url=page_url,
+            url=canonical_url,
         ),
-        rx.el.link(rel="canonical", href=page_url),
+        rx.el.link(rel="canonical", href=canonical_url),
     ]
 
 

--- a/packages/reflex-site-shared/src/reflex_site_shared/views/cta_card.py
+++ b/packages/reflex-site-shared/src/reflex_site_shared/views/cta_card.py
@@ -26,20 +26,20 @@ def cta_card():
                 class_name="text-m-slate-7 dark:text-m-slate-6 text-sm font-medium",
             ),
             rx.el.div(
-                demo_form_dialog(
-                    trigger=marketing_button(
-                        "Book a Demo",
-                        variant="primary",
-                    ),
-                ),
                 rx.el.elements.a(
                     marketing_button(
                         "Try for free",
                         ui.icon("ArrowRight01Icon"),
-                        variant="ghost",
+                        variant="primary",
                     ),
                     href=REFLEX_BUILD_URL,
                     target="_blank",
+                ),
+                demo_form_dialog(
+                    trigger=marketing_button(
+                        "Book a Demo",
+                        variant="ghost",
+                    ),
                 ),
                 class_name="flex flex-row gap-4 items-center",
             ),


### PR DESCRIPTION
## Summary

Two small changes to `reflex-site-shared` for the Streamlit migration PR series:

1. **`meta.create_meta_tags` grows an optional `canonical` kwarg.** When set, the rendered `<link rel="canonical">`, `og:url`, and `twitter:url` all point at that URL instead of the page's own `url`, so search engines and social crawlers index the same target. Default behavior is unchanged when the kwarg is omitted. The blog companion PR uses this to canonicalize `/blog/reflex-streamlit` to `/migration/streamlit`.

2. **`cta_card` (bottom CTA on every marketing page) swaps Try-for-free into the primary slot** and demotes Book a Demo to the ghost-variant secondary. Affects every marketing-templated page across `reflex-dev/marketing`, `reflex-dev/docs`, and `reflex-dev/blog` once their `reflex-site-shared` lockfiles are bumped. No layout change beyond variant and ordering.

## Why

The Streamlit lander targets paid-search traffic on "streamlit alternative" intent. That audience self-serves, so the primary CTA across the site should be "Try for free" with Book a Demo as a clearly secondary path.

## Pairs with

- **[reflex-dev/marketing PR](https://github.com/reflex-dev/marketing/pull/31)** — adds the `/migration/streamlit` lander.
- **[reflex-dev/blog PR](https://github.com/reflex-dev/blog/pull/29)** — refreshes `/blog/reflex-streamlit` with a frontmatter canonical override pointing at the new lander.

## Test plan

- [ ] `create_meta_tags(..., canonical=None)` produces the same output as before.
- [ ] `create_meta_tags(..., canonical="https://reflex.dev/foo")` renders `<link rel="canonical" href="https://reflex.dev/foo">` AND sets `og:url`/`twitter:url` to the same URL.
- [ ] `cta_card` shows "Try for free" (primary, left, with ArrowRight icon) + "Book a Demo" (ghost, right) on every marketing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
