### PR TITLE
Remove redundant lost-and-found warning log

### DIFF
--- a/reflex/app.py
+++ b/reflex/app.py
@@ -1593,10 +1593,7 @@ class EventNamespace(AsyncNamespace):
         ):
             if isinstance(self._token_manager, RedisTokenManager):
                 # The socket belongs to another instance of the app, send it to the lost and found.
-                if not await self._token_manager.emit_lost_and_found(token, update):
-                    console.warn(
-                        f"Failed to send delta to lost and found for client {token!r}"
-                    )
+                await self._token_manager.emit_lost_and_found(token, update)
             else:
                 # If the socket record is None, we are not connected to a client. Prevent sending
                 # updates to all clients.

--- a/reflex/utils/token_manager.py
+++ b/reflex/utils/token_manager.py
@@ -428,7 +428,6 @@ class RedisTokenManager(LocalTokenManager):
                 self.token_to_socket[token] = socket_record
                 self.sid_to_token[socket_record.sid] = token
                 return socket_record.instance_id
-            console.warn(f"Redis token owner not found for token {token}")
         except Exception as e:
             console.error(f"Redis error getting token owner: {e}")
         return None


### PR DESCRIPTION
The warning "Failed to send delta to lost and found for client" was duplicative — emit_lost_and_found already logs the underlying cause (either "Redis token owner not found" or "Redis error publishing lost and found delta") for both failure modes. The extra warning wasn't actionable and confused users.
