### PR TITLE
AgentFilesPlugin writes md files to frontend_path subdir

### DIFF
--- a/docs/app/agent_files/_plugin.py
+++ b/docs/app/agent_files/_plugin.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace, UnionType
 from typing import Any, Literal, Union, get_args, get_origin
 
 from reflex.constants import Dirs
+from reflex_base.config import get_config
 from reflex_base.plugins import CommonContext, Plugin
 from typing_extensions import Unpack
 
@@ -882,6 +883,8 @@ class AgentFilesPlugin(Plugin):
     def get_static_assets(
         self, **context: Unpack[CommonContext]
     ) -> Sequence[tuple[Path, str | bytes]]:
-        return [
-            (Dirs.PUBLIC / path, content) for path, content in generate_agent_files()
-        ]
+        root = Path(Dirs.PUBLIC)
+        if frontend_path := get_config().frontend_path:
+            # Make sure the pre-rendered HTML does not get overwritten by md files.
+            root = root / frontend_path.lstrip("/")
+        return [(root / path, content) for path, content in generate_agent_files()]

--- a/docs/app/agent_files/_plugin.py
+++ b/docs/app/agent_files/_plugin.py
@@ -113,8 +113,6 @@ def _extract_markdown_title(source: str) -> str | None:
 
 def _llms_url_for_path(url_path: Path) -> str:
     """Return the public URL for a generated markdown asset."""
-    from reflex_base.config import get_config
-
     config = get_config()
     deploy_url = config.deploy_url.removesuffix("/") if config.deploy_url else ""
     frontend_path = (config.frontend_path or "").strip("/")
@@ -128,8 +126,6 @@ def _llms_url_for_path(url_path: Path) -> str:
 
 def _docs_home_url() -> str:
     """Return the public URL for the docs home."""
-    from reflex_base.config import get_config
-
     config = get_config()
     deploy_url = config.deploy_url.removesuffix("/") if config.deploy_url else ""
     frontend_path = (config.frontend_path or "").strip("/")


### PR DESCRIPTION
This change is required because the build step that moves top-level dirs into the frontend_path subdir of the output directory uses `overwrite=True` by default. So any same-named directories in the output root silently overwrite the existing pre-rendered HTML files in the basename dir.

When the plugin just writes the markdown files into the basename dir itself, then there is no mv step that blows them away.