### PR TITLE
fix(make_pyi): also diff staged changes when scanning for pyi updates

### DIFF
--- a/scripts/make_pyi.py
+++ b/scripts/make_pyi.py
@@ -83,6 +83,7 @@ def _get_changed_files() -> list[Path] | None:
     # worktree with the index, so without this they'd be invisible to the
     # diffs above and the corresponding .pyi files would not be regenerated.
     changed_files.extend(_git_changed_files(["--cached"]))
+    changed_files = list(dict.fromkeys(changed_files))
     if _relative_to_pwd(GENERATOR_FILE) not in changed_files:
         return changed_files
     logger.info("make_pyi.py has changed, checking diff now")

--- a/scripts/make_pyi.py
+++ b/scripts/make_pyi.py
@@ -79,6 +79,10 @@ def _get_changed_files() -> list[Path] | None:
     changed_files = _git_changed_files([f"{last_run_commit_sha}..HEAD"])
     # get all unstaged changes
     changed_files.extend(_git_changed_files())
+    # also pick up staged-but-uncommitted changes — pre-commit aligns the
+    # worktree with the index, so without this they'd be invisible to the
+    # diffs above and the corresponding .pyi files would not be regenerated.
+    changed_files.extend(_git_changed_files(["--cached"]))
     if _relative_to_pwd(GENERATOR_FILE) not in changed_files:
         return changed_files
     logger.info("make_pyi.py has changed, checking diff now")


### PR DESCRIPTION
pre-commit aligns the worktree with the index, so staged-but-uncommitted edits don't appear in the unstaged diff and their .pyi files were never regenerated.

Why?

For me VS Code commit does not work because it does not detect the uv venv beause i dont activate it. 

To commit code i have to stage the files and then run the git commit command, which causes the pre-commit hook to miss files. 

Then i come back and regenerate the hashes from scratch and push again. 
