### PR TITLE
ENG-9587: pyOr is not defined

### DIFF
--- a/packages/reflex-base/src/reflex_base/components/component.py
+++ b/packages/reflex-base/src/reflex_base/components/component.py
@@ -45,6 +45,7 @@ from reflex_base.utils import console, format, imports, types
 from reflex_base.utils.imports import ImportDict, ImportVar, ParsedImportDict
 from reflex_base.vars import VarData
 from reflex_base.vars.base import (
+    _PY_OR_IMPORT,
     CachedVarOperation,
     LiteralNoneVar,
     LiteralVar,
@@ -2581,6 +2582,18 @@ def empty_component() -> Component:
     return Bare.create("")
 
 
+def _format_patterns_into_condition(patterns: list, element: Var) -> Var:
+    if not patterns:
+        return Var.create(False)
+    conditions = [
+        Var(pattern).to_string() == element.to_string() for pattern in patterns
+    ]
+    return functools.reduce(
+        operator.or_,
+        conditions,
+    )
+
+
 def render_dict_to_var(tag: dict | Component | str) -> Var:
     """Convert a render dict to a Var.
 
@@ -2621,12 +2634,8 @@ def render_dict_to_var(tag: dict | Component | str) -> Var:
         conditionals = render_dict_to_var(tag["default"])
 
         for case in tag["match_cases"][::-1]:
-            conditions, return_value = case
-            condition = Var.create(False)
-            for pattern in conditions:
-                condition = condition | (
-                    Var(pattern).to_string() == element.to_string()
-                )
+            patterns, return_value = case
+            condition = _format_patterns_into_condition(patterns, element)
 
             conditionals = ternary_operation(
                 condition,
@@ -2695,6 +2704,17 @@ class LiteralComponentVar(CachedVarOperation, LiteralVar[Component], ComponentVa
             ),
             VarData(
                 imports=self._var_value._get_all_imports(),
+            ),
+            VarData(
+                # Rendering rx.match in the code above produces conditional expressions
+                # of the form (pattern1 == element || pattern2 == element || ...), which
+                # introduce the OR operator and get compiled to a pyOr function call. Since
+                # the component itself might not otherwise require pyOr, and since we ignore
+                # the imports of the rendered Var above, we add the pyOr import here to
+                # ensure it is available. An alternative would be to have `render_dict_to_var`
+                # return a Var carrying all the required VarData, so this call could just
+                # retrieve it from there.
+                imports=_PY_OR_IMPORT
             ),
         )
 

--- a/packages/reflex-base/src/reflex_base/components/component.py
+++ b/packages/reflex-base/src/reflex_base/components/component.py
@@ -2583,6 +2583,19 @@ def empty_component() -> Component:
 
 
 def _format_patterns_into_condition(patterns: list, element: Var) -> Var:
+    """Combine match-case patterns into a single boolean condition.
+
+    Each pattern is compared to `element` by stringified equality, and the
+    resulting comparisons are OR-ed together.
+
+    Args:
+        patterns: The patterns of a single match case to compare against `element`.
+        element: The Var to compare each pattern to.
+
+    Returns:
+        A Var that evaluates to True when `element` matches any pattern, or
+        `False` when `patterns` is empty.
+    """
     if not patterns:
         return Var.create(False)
     conditions = [

--- a/tests/units/compiler/test_dynamic_components_codegen.py
+++ b/tests/units/compiler/test_dynamic_components_codegen.py
@@ -28,7 +28,7 @@ def test_dynamic_component_codegen_wires_event_handlers() -> None:
     assert "const {Fragment,useContext,useEffect}" in code
     assert "const {EventLoopContext} = window['__reflex'][\"$/utils/context\"]" in code
     assert (
-        "const {ReflexEvent,applyEventActions} = window['__reflex'][\"$/utils/state\"]"
+        "const {ReflexEvent,applyEventActions,pyOr} = window['__reflex'][\"$/utils/state\"]"
         in code
     )
     assert "const [addEvents, connectErrors] = useContext(EventLoopContext);" in code
@@ -94,7 +94,7 @@ def test_dynamic_component_codegen_wires_state_var_counter_events() -> None:
     assert "const {Fragment,useContext,useEffect}" in code
     assert "const {EventLoopContext} = window['__reflex'][\"$/utils/context\"]" in code
     assert (
-        "const {ReflexEvent,applyEventActions} = window['__reflex'][\"$/utils/state\"]"
+        "const {ReflexEvent,applyEventActions,pyOr} = window['__reflex'][\"$/utils/state\"]"
         in code
     )
     assert "const [addEvents, connectErrors] = useContext(EventLoopContext);" in code


### PR DESCRIPTION
```python
import reflex as rx

import reflex_components_internal as ui


def match_thing():
    return rx.match(
        "Foo",
        ("foo", rx.text("foo is foo!")),
        ("bar", rx.text("foo is bar!")),
        rx.text("foo is something else!"),
    )


def index() -> rx.Component:
    return rx.vstack(
        ui.dialog.trigger(
            render_=match_thing(),
        ),
        match_thing(),
    )


app = rx.App()
app.add_page(index)
```
previously:
```jsx
import {
  Flex as RadixThemesFlex,
  Text as RadixThemesText,
} from "@radix-ui/themes";
import { Fragment, useEffect } from "react";
import { Dialog } from "@base-ui/react/dialog";
import { jsx } from "@emotion/react";

export default function Component() {
  return jsx(
    Fragment,
    {},
    jsx(
      RadixThemesFlex,
      { align: "start", className: "rx-Stack", direction: "column", gap: "3" },
      jsx(Dialog.Trigger, {
        "data-slot": "dialog-trigger",
        render: jsx(
          Fragment,
          {},
          pyOr(
            false,
            () =>
              JSON.stringify("foo")?.valueOf?.() ===
              JSON.stringify("Foo")?.valueOf?.(),
          )
            ? jsx(RadixThemesText, { as: "p" }, "foo is foo!")
            : pyOr(
                  false,
                  () =>
                    JSON.stringify("bar")?.valueOf?.() ===
                    JSON.stringify("Foo")?.valueOf?.(),
                )
              ? jsx(RadixThemesText, { as: "p" }, "foo is bar!")
              : jsx(RadixThemesText, { as: "p" }, "foo is something else!"),
        ),
      }),
      jsx(
        Fragment,
        {},
        (() => {
          switch (JSON.stringify("Foo")) {
            case JSON.stringify("foo"):
              return jsx(RadixThemesText, { as: "p" }, "foo is foo!");
              break;
            case JSON.stringify("bar"):
              return jsx(RadixThemesText, { as: "p" }, "foo is bar!");
              break;
            default:
              return jsx(
                RadixThemesText,
                { as: "p" },
                "foo is something else!",
              );
              break;
          }
        })(),
      ),
    ),
    jsx("title", {}, "ReproPyorImport | Index"),
    jsx("meta", { content: "favicon.ico", property: "og:image" }),
  );
}
```
now:
```jsx
import {
  Flex as RadixThemesFlex,
  Text as RadixThemesText,
} from "@radix-ui/themes";
import { Fragment, useEffect } from "react";
import { Dialog } from "@base-ui/react/dialog";
import { jsx } from "@emotion/react";
import { pyOr } from "$/utils/state";

export default function Component() {
  return jsx(
    Fragment,
    {},
    jsx(
      RadixThemesFlex,
      { align: "start", className: "rx-Stack", direction: "column", gap: "3" },
      jsx(Dialog.Trigger, {
        "data-slot": "dialog-trigger",
        render: jsx(
          Fragment,
          {},
          JSON.stringify("foo")?.valueOf?.() ===
            JSON.stringify("Foo")?.valueOf?.()
            ? jsx(RadixThemesText, { as: "p" }, "foo is foo!")
            : JSON.stringify("bar")?.valueOf?.() ===
                JSON.stringify("Foo")?.valueOf?.()
              ? jsx(RadixThemesText, { as: "p" }, "foo is bar!")
              : jsx(RadixThemesText, { as: "p" }, "foo is something else!"),
        ),
      }),
      jsx(
        Fragment,
        {},
        (() => {
          switch (JSON.stringify("Foo")) {
            case JSON.stringify("foo"):
              return jsx(RadixThemesText, { as: "p" }, "foo is foo!");
              break;
            case JSON.stringify("bar"):
              return jsx(RadixThemesText, { as: "p" }, "foo is bar!");
              break;
            default:
              return jsx(
                RadixThemesText,
                { as: "p" },
                "foo is something else!",
              );
              break;
          }
        })(),
      ),
    ),
    jsx("title", {}, "MatchTest | Index"),
    jsx("meta", { content: "favicon.ico", property: "og:image" }),
  );
}
```