### PR TITLE
fix(recharts): bundle es-toolkit/compat as ESM (#6561)

### DIFF
--- a/packages/reflex-base/news/6561.bugfix.md
+++ b/packages/reflex-base/news/6561.bugfix.md
@@ -1,0 +1,1 @@
+Fixed recharts charts crashing at runtime with a `TypeError` and an infinite route-reload loop. recharts default-imports CommonJS `es-toolkit/compat/*` shims, whose interop helper could be bundled into a chunk that loaded after a lazy route chunk; the generated `vite.config.js` now redirects those imports to the pure-ESM `es-toolkit/compat` barrel.

--- a/packages/reflex-base/src/reflex_base/compiler/templates.py
+++ b/packages/reflex-base/src/reflex_base/compiler/templates.py
@@ -576,9 +576,10 @@ function fullReload() {{
 }}
 
 function esToolkitCompatEsm() {{
-  // recharts default-imports CJS shims like `es-toolkit/compat/get`; Rolldown can
-  // emit their interop helper into a chunk that loads after a lazy route chunk,
-  // crashing any page with a chart (#6561). Redirect to the pure-ESM compat barrel.
+  // recharts default-imports CJS shims like `es-toolkit/compat/get`; the CJS interop
+  // helper can land in a chunk that runs before it is initialized, crashing any page
+  // with a chart (#6561). Redirect to the pure-ESM compat barrel. Registered for both
+  // the prod build (plugins) and the dev prebundle (optimizeDeps.rolldownOptions).
   const VIRTUAL = "\0es-toolkit-compat:";
   return {{
     name: "vite-plugin-es-toolkit-compat-esm",
@@ -621,6 +622,11 @@ export default defineConfig((config) => ({{
           ],
         }},
       }},
+    }},
+  }},
+  optimizeDeps: {{
+    rolldownOptions: {{
+      plugins: [esToolkitCompatEsm()],
     }},
   }},
   experimental: {{

--- a/packages/reflex-base/src/reflex_base/compiler/templates.py
+++ b/packages/reflex-base/src/reflex_base/compiler/templates.py
@@ -575,10 +575,31 @@ function fullReload() {{
   }};
 }}
 
+function esToolkitCompatEsm() {{
+  // recharts default-imports CJS shims like `es-toolkit/compat/get`; Rolldown can
+  // emit their interop helper into a chunk that loads after a lazy route chunk,
+  // crashing any page with a chart (#6561). Redirect to the pure-ESM compat barrel.
+  const VIRTUAL = "\0es-toolkit-compat:";
+  return {{
+    name: "vite-plugin-es-toolkit-compat-esm",
+    enforce: "pre",
+    resolveId(source) {{
+      const match = /^es-toolkit\/compat\/([A-Za-z0-9_]+)$/.exec(source);
+      return match ? VIRTUAL + match[1] : null;
+    }},
+    load(id) {{
+      if (!id.startsWith(VIRTUAL)) return null;
+      const name = id.slice(VIRTUAL.length);
+      return "export {{ " + name + " as default }} from \"es-toolkit/compat\";";
+    }},
+  }};
+}}
+
 export default defineConfig((config) => ({{
   base: "{base}",
   plugins: [
     alwaysUseReactDomServerNode(),
+    esToolkitCompatEsm(),
     reactRouter(),
     safariCacheBustPlugin(),
   ].concat({"[fullReload()]" if force_full_reload else "[]"}),

--- a/tests/integration/tests_playwright/test_recharts.py
+++ b/tests/integration/tests_playwright/test_recharts.py
@@ -1,0 +1,85 @@
+"""Integration test that recharts charts render at runtime.
+
+Regression coverage for https://github.com/reflex-dev/reflex/issues/6561: any page
+rendering a ``rx.recharts`` chart crashed with ``TypeError`` and an infinite React
+Router route-reload loop. recharts default-imports CommonJS ``es-toolkit/compat/*``
+shims from its core utils; the bundler emitted the CJS interop helper into a chunk
+that loaded after the lazy route chunk. The bug only surfaced at runtime in a real
+(esp. production / Rolldown) build, which this test exercises via ``app_harness_env``.
+"""
+
+from collections.abc import Generator
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from reflex.testing import AppHarness
+
+
+def RechartsApp():
+    """App with an area chart on the index route (the issue's reproduction)."""
+    import reflex as rx
+
+    @rx.page("/")
+    def index():
+        return rx.box(
+            rx.heading("recharts"),
+            rx.recharts.area_chart(
+                rx.recharts.area(data_key="value"),
+                rx.recharts.x_axis(data_key="name"),
+                data=[
+                    {"name": "A", "value": 1},
+                    {"name": "B", "value": 3},
+                    {"name": "C", "value": 2},
+                ],
+                width=500,
+                height=300,
+            ),
+            id="page",
+        )
+
+    app = rx.App()  # noqa: F841
+
+
+@pytest.fixture(scope="module")
+def recharts_app(
+    app_harness_env: type[AppHarness],
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Generator[AppHarness, None, None]:
+    """Start RechartsApp in both dev and prod mode.
+
+    Args:
+        app_harness_env: AppHarness (dev) or AppHarnessProd (prod), from conftest.
+        tmp_path_factory: pytest fixture for creating temporary directories.
+
+    Yields:
+        Running AppHarness instance.
+    """
+    name = f"recharts_{app_harness_env.__name__.lower()}"
+    with app_harness_env.create(
+        root=tmp_path_factory.mktemp(name),
+        app_name=name,
+        app_source=RechartsApp,
+    ) as harness:
+        assert harness.app_instance is not None, "app is not running"
+        yield harness
+
+
+def test_recharts_renders_without_error(recharts_app: AppHarness, page: Page):
+    """The chart's SVG renders and the page raises no JS error or reload loop.
+
+    Args:
+        recharts_app: AppHarness running the recharts test app.
+        page: Playwright page.
+    """
+    assert recharts_app.frontend_url is not None
+
+    page_errors: list[str] = []
+    page.on("pageerror", lambda exc: page_errors.append(str(exc)))
+
+    page.goto(recharts_app.frontend_url)
+
+    # Under #6561 the route module fails to load and React Router reloads forever,
+    # so the chart never appears and this assertion times out.
+    expect(page.locator(".recharts-surface")).to_be_visible()
+    assert not page_errors, f"Frontend raised unexpected errors: {page_errors}"


### PR DESCRIPTION
## Summary

Fixes #6561. Pages that render a `rx.recharts` chart could crash at runtime with a `TypeError` and an infinite route-reload loop.

recharts default-imports the CommonJS `es-toolkit/compat/*` shims (`get`, `range`, `sortBy`, `throttle`, …). These are reached through recharts' shared chart utilities, so even a single chart pulls a CJS module into the bundle. Vite then emits the CJS interop helper into a chunk that isn't guaranteed to be initialized before a lazily-loaded route chunk runs, which surfaces as `TypeError: … is not a function` and a reload loop.

This adds a small Vite plugin to the generated `vite.config.js` that redirects `es-toolkit/compat/<name>` default-imports to the pure-ESM `es-toolkit/compat` barrel (it re-exports the same functions). The module graph stays ESM-only, so no CJS interop helper is emitted, and the plugin is a no-op for apps that don't import `es-toolkit/compat`.

Thanks @hctilf for the thorough report and reproduction.

## Verification

Building a minimal `import get from 'es-toolkit/compat/get'` with Vite 8:

- **before:** the output includes the `__commonJS` interop helper and throws `require_isUnsafeProperty is not a function` at runtime
- **after:** the output is pure ESM with no interop helper, and `get()` still works

Also adds `tests/integration/tests_playwright/test_recharts.py`, which renders an area chart and asserts the SVG appears with no page errors. It runs in both dev and prod via the existing `app_harness_env` fixture.

## Test plan

- [ ] recharts integration test passes in CI (dev + prod)
- [ ] existing integration tests unaffected


---
_Generated by [Claude Code](https://claude.ai/code/session_01B53hepRQu8LCtZxaxAFPSm)_