### PR TITLE
reflex-components-core depends on reflex-base >= 0.9.2

### DIFF
--- a/packages/reflex-components-core/pyproject.toml
+++ b/packages/reflex-components-core/pyproject.toml
@@ -8,7 +8,7 @@ authors = [{ name = "Khaleel Al-Adhami", email = "khaleel@reflex.dev" }]
 maintainers = [{ name = "Khaleel Al-Adhami", email = "khaleel@reflex.dev" }]
 requires-python = ">=3.10"
 dependencies = [
-    "reflex-base >= 0.9.0",
+    "reflex-base >= 0.9.2",
     "reflex-components-lucide >= 0.9.0",
     "reflex-components-sonner >= 0.9.0",
     "python_multipart",


### PR DESCRIPTION
Avoid `ModuleNotFoundError: No module named 'reflex_base.components.memoize_helpers'` with reflex-base-0.9.1

This will need to be backported to the released versions 0.9.2 and 0.9.3