### PR TITLE
README.md: link to static video asset for PyPI, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Build an image generation app in Python with Reflex: define the UI, manage state
 
 <div align="center">
 <video src="https://github.com/user-attachments/assets/aaff28ad-8b3c-43bf-967e-439ee34c8a87" width="900" controls muted poster="https://raw.githubusercontent.com/reflex-dev/reflex/main/docs/images/reflex-image-generation-app.png">
-  <a href="https://github.com/user-attachments/assets/aaff28ad-8b3c-43bf-967e-439ee34c8a87">
+  <a href="https://web.reflex-assets.dev/video/reflex-dalle-video-2x.mp4">
     <img src="https://raw.githubusercontent.com/reflex-dev/reflex/main/docs/images/reflex-image-generation-app.png" alt="Preview of an image generation app built with Reflex" width="900">
   </a>
 </video>


### PR DESCRIPTION
Updated video link in README for image generation app.

1. embedded video must be hosted as a github attachment to be rendered inline on github
2. `<video>` does not render on PyPI so it falls back to the link+img
3. embedded video link is not accessible directly, so also host the video on R2 bucket so link works