### PR TITLE
feat: add rx.RestProp to internal icon memo helpers

### DIFF
--- a/packages/reflex-components-internal/src/reflex_components_internal/components/icons/others.py
+++ b/packages/reflex-components-internal/src/reflex_components_internal/components/icons/others.py
@@ -4,6 +4,7 @@ from reflex_components_core.el.elements.media import svg
 
 from reflex.components.component import Component
 from reflex.components.memo import memo
+from reflex.vars import RestProp
 from reflex.vars.base import EMPTY_VAR_STR, Var
 from reflex_components_internal.components.icons.hugeicon import hi
 from reflex_components_internal.utils.twmerge import cn
@@ -11,11 +12,13 @@ from reflex_components_internal.utils.twmerge import cn
 
 @memo
 def spinner_component(
+    rest: RestProp,
     class_name: Var[str] = EMPTY_VAR_STR,
 ) -> Component:
     """Create a spinner SVG icon.
 
     Args:
+        rest: Additional props forwarded to the root SVG element.
         class_name: The class name of the spinner.
 
     Returns:
@@ -34,6 +37,7 @@ def spinner_component(
             stroke="currentColor",
             stroke_width="1.5",
         ),
+        rest,
         xmlns="http://www.w3.org/2000/svg",
         custom_attrs={"viewBox": "0 0 16 16"},
         class_name=cn("animate-spin size-4 fill-none", class_name),
@@ -45,24 +49,36 @@ spinner = spinner_component
 
 @memo
 def select_arrow_icon(
+    rest: RestProp,
     class_name: Var[str] = EMPTY_VAR_STR,
 ) -> Component:
     """A select arrow SVG icon.
 
+    Args:
+        rest: Additional props forwarded to the root icon element.
+        class_name: The class name of the icon.
+
     Returns:
         The component.
     """
-    return hi("ChevronDoubleCloseIcon", class_name=cn("rotate-90", class_name))
+    return hi("ChevronDoubleCloseIcon", rest, class_name=cn("rotate-90", class_name))
 
 
 select_arrow = select_arrow_icon
 
 
 @memo
-def arrow_svg_component(class_name: Var[str] = EMPTY_VAR_STR) -> Component:
+def arrow_svg_component(
+    rest: RestProp,
+    class_name: Var[str] = EMPTY_VAR_STR,
+) -> Component:
     """Create a tooltip arrow SVG icon.
 
     The arrow SVG icon.
+
+    Args:
+        rest: Additional props forwarded to the root SVG element.
+        class_name: The class name of the icon.
 
     Returns:
             The component.
@@ -76,6 +92,7 @@ def arrow_svg_component(class_name: Var[str] = EMPTY_VAR_STR) -> Component:
             d="M10.3333 3.34539L5.47654 7.71648C4.55842 8.54279 3.36693 9 2.13172 9H0V8H2.13172C3.11989 8 4.07308 7.63423 4.80758 6.97318L9.66437 2.60207C10.0447 2.25979 10.622 2.2598 11.0023 2.60207L15.8591 6.97318C16.5936 7.63423 17.5468 8 18.5349 8H20V9H18.5349C17.2998 9 16.1083 8.54278 15.1901 7.71648L10.3333 3.34539Z",
             class_name="fill-none",
         ),
+        rest,
         width="20",
         height="10",
         xmlns="http://www.w3.org/2000/svg",


### PR DESCRIPTION
## What

`spinner`, `select_arrow`, and `arrow_svg` in `reflex_components_internal/components/icons/others.py` are `@memo` functions. Without an `rx.RestProp` parameter, the compiled memo function emits no `...rest` spread, so base `Component` props like `custom_attrs`, `id`, `style`, etc. passed at the call site are **silently dropped** instead of reaching the rendered element.

This adds a `rest: RestProp` parameter to each helper and forwards it onto the root element, so extra props flow through as a `...rest` spread.

## Notes

- `class_name` stays a declared param (rather than folded into `rest`) on purpose — it needs the internal `cn(...)` tailwind merge, which a raw rest-spread would bypass.
- Existing call sites (`spinner()`, `select_arrow(class_name=...)`, `arrow_svg()`) are unaffected; the `RestProp` param is optional at the call site and all callers pass `class_name` by keyword.

## Verification

Compiled memo templates now destructure `({className:..., ...rest})` and spread `...rest` onto the root `<svg>` / `HugeiconsIcon`:

```js
export const SpinnerComponent = memo(({className:classNameRxMemo, ...rest}) => {
  jsx("svg",{className:...,viewBox:"0 0 16 16",xmlns:...,...rest}, ...)
```

Calling `spinner(custom_attrs={"data-testid": "spin"}, id="myspinner")` now renders `data-testid`, `id`, and `ref` onto the element.

ruff + pyright clean.