### PR TITLE
feat: add rx.RestProp to internal skeleton memo helper

### DIFF
--- a/packages/reflex-components-internal/src/reflex_components_internal/components/base/skeleton.py
+++ b/packages/reflex-components-internal/src/reflex_components_internal/components/base/skeleton.py
@@ -4,6 +4,7 @@ from reflex_components_core.el.elements.typography import Div
 
 from reflex.components.component import Component
 from reflex.components.memo import EMPTY_VAR_COMPONENT, memo
+from reflex.vars import RestProp
 from reflex.vars.base import EMPTY_VAR_STR, Var
 from reflex_components_internal.utils.twmerge import cn
 
@@ -16,15 +17,21 @@ class ClassNames:
 
 @memo
 def skeleton_component(
+    rest: RestProp,
     children: Var[Component] = EMPTY_VAR_COMPONENT,
     class_name: Var[str] = EMPTY_VAR_STR,
 ) -> Component:
     """Skeleton component.
 
+    Args:
+        rest: Additional props forwarded to the root element.
+        children: The content wrapped by the skeleton.
+        class_name: The class name of the skeleton.
+
     Returns:
         The component.
     """
-    return Div.create(children, class_name=cn(ClassNames.ROOT, class_name))
+    return Div.create(children, rest, class_name=cn(ClassNames.ROOT, class_name))
 
 
 skeleton = skeleton_component


### PR DESCRIPTION
## What

`skeleton` in `reflex_components_internal/components/base/skeleton.py` is a `@memo` function. Without an `rx.RestProp` parameter, the compiled memo function emits no `...rest` spread, so base `Component` props like `custom_attrs`, `id`, `style`, etc. passed at the call site are **silently dropped** instead of reaching the rendered element.

This adds a `rest: RestProp` parameter and forwards it onto the root `Div`, so extra props flow through as a `...rest` spread. Follows the same pattern as #6608 (the icon helpers).

## Notes

- `children` and `class_name` keep their existing behavior; `class_name` retains its internal `cn(...)` tailwind merge.
- `rest` is placed first in the signature because Python forbids a non-default param after defaulted ones — positional children still bind correctly since the memo call layer captures them as `*children` independent of signature position.
- Existing call sites are unaffected.

## Verification

Compiled memo template now destructures `({children, className:..., ...rest})` and spreads `...rest` onto the root `<div>`:

```js
export const SkeletonComponent = memo(({children, className:classNameRxMemo, ...rest}) => {
  jsx("div",{className:(cn("animate-pulse bg-secondary-6", classNameRxMemo)),...rest},children)
```

`skeleton(rx.text("hi"), custom_attrs={"data-testid": "sk"}, id="myskel")` now renders `data-testid`, `id`, and `ref` onto the element.

ruff + pyright clean.