### PR TITLE
[claude-code] Add SessionStart hook to provision web environment

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -34,9 +34,14 @@ cd "$CLAUDE_PROJECT_DIR"
 req="$(sed -n 's/^[[:space:]]*required-version[[:space:]]*=[[:space:]]*"[^0-9]*\([0-9][0-9.]*\).*/\1/p' pyproject.toml | head -n1)"
 python3 -m pip install --user --quiet --root-user-action=ignore "uv${req:+>=$req}"
 
-# pip --user installs land in ~/.local/bin; make sure they win over the baked uv.
+# pip --user installs land in ~/.local/bin; make sure they win over the baked uv,
+# both for the rest of this script and -- via CLAUDE_ENV_FILE -- for the session's
+# later commands, which otherwise wouldn't see this PATH change once we exit.
 export PATH="$HOME/.local/bin:$PATH"
 hash -r 2>/dev/null || true
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$CLAUDE_ENV_FILE"
+fi
 
 # 2. Ensure a stable interpreter matching .python-version is installed, so sync
 #    doesn't fall back to the pre-baked prerelease.
@@ -46,7 +51,11 @@ uv python install
 #    still get a best-effort sync).
 git fetch --tags --quiet || true
 
-# 4. Install all workspace dependencies (uses .python-version).
-uv sync
+# 4. Install all workspace dependencies (uses .python-version). Don't let a
+#    transient sync failure (e.g. a flaky network) abort startup -- the container
+#    should still come up so the session can retry sync manually.
+if ! uv sync; then
+  echo "WARNING: 'uv sync' failed; the environment may be incomplete. Re-run 'uv sync' once any transient issue clears." >&2
+fi
 
 echo "Environment ready: uv $(uv --version), Python $(uv run python --version 2>/dev/null), reflex $(uv run python -c 'import importlib.metadata as m; print(m.version("reflex"))' 2>/dev/null || echo '?')"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# SessionStart hook for Claude Code on the web.
+#
+# The web container image is baked with tools that predate this repo's current
+# requirements, so a fresh `uv sync` + test run fails out of the box. This hook
+# reconciles the environment with the repo on every web session start:
+#
+#   1. uv: the image ships an older uv than tool.uv.required-version in
+#      pyproject.toml. The astral.sh installer and `uv self update` are
+#      blocked / GitHub-rate-limited here, so we upgrade from PyPI instead.
+#   2. Python: the image pre-installs a 3.14 prerelease whose typing._eval_type
+#      signature is incompatible with the pinned pydantic (breaks every import).
+#      We install the stable interpreter and pass it to uv explicitly so it
+#      doesn't fall back to the prerelease.
+#   3. git tags: web clones are shallow with no tags, so Reflex's VCS-derived
+#      version resolves to 0.0.0 and trips downstream version gates (e.g.
+#      reflex-hosting-cli rejects it). Fetching tags lets the version compute.
+set -euo pipefail
+
+# Only the web container needs this fixup; local dev environments are managed
+# by the developer.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+PY_VERSION="3.14.5"
+
+# 1. Upgrade uv if it's below the repo's required-version.
+need_uv="$(python3 - <<'PY'
+import re, shutil, subprocess
+from pathlib import Path
+
+req = "0"
+m = re.search(r'required-version\s*=\s*"[><=~ ]*([0-9][0-9.]*)"', Path("pyproject.toml").read_text())
+if m:
+    req = m.group(1)
+
+cur = "0"
+if shutil.which("uv"):
+    out = subprocess.run(["uv", "--version"], capture_output=True, text=True).stdout
+    mm = re.search(r"(\d+\.\d+\.\d+)", out)
+    if mm:
+        cur = mm.group(1)
+
+def tup(v):
+    return tuple(int(x) for x in v.split("."))
+
+print("yes" if tup(cur) < tup(req) else "no")
+PY
+)"
+
+if [ "$need_uv" = "yes" ]; then
+  echo "Upgrading uv to satisfy required-version..."
+  python3 -m pip install --user --upgrade --quiet uv
+fi
+
+# pip --user installs land in ~/.local/bin; make sure they win over the baked uv.
+export PATH="$HOME/.local/bin:$PATH"
+hash -r 2>/dev/null || true
+
+# 2. Ensure the stable interpreter is available.
+uv python install "$PY_VERSION"
+
+# 3. Fetch tags so the dynamic version resolves (ignore failures; offline runs
+#    still get a best-effort sync).
+git fetch --tags --quiet || true
+
+# 4. Install all workspace dependencies against the stable interpreter.
+uv sync --python "$PY_VERSION"
+
+echo "Environment ready: uv $(uv --version), Python $PY_VERSION, reflex $(uv run python -c 'import importlib.metadata as m; print(m.version("reflex"))' 2>/dev/null || echo '?')"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -8,11 +8,13 @@
 #   1. uv: the image ships an older uv than tool.uv.required-version in
 #      pyproject.toml. The astral.sh installer and `uv self update` are
 #      blocked / GitHub-rate-limited here, so we upgrade from PyPI instead.
-#   2. Python: the image pre-installs a 3.14 prerelease whose typing._eval_type
-#      signature is incompatible with the pinned pydantic (breaks every import).
-#      `uv sync` would reuse that prerelease since it's the only installed match
-#      for .python-version. `uv python install` excludes prereleases, so it
-#      fetches the stable patch; once present, sync prefers it over the rc.
+#   2. Python: the baked uv (see #1) predates Python 3.14.0 final, so its
+#      bundled release manifest only knows 3.14 prereleases -- a bare `uv sync`
+#      with it resolves .python-version=3.14 to a release candidate whose
+#      typing._eval_type signature is incompatible with the pinned pydantic
+#      (breaks every import). Upgrading uv first fixes the manifest; we then run
+#      `uv python install` (which excludes prereleases) as a guard so sync can't
+#      reuse a prerelease that an earlier stale-uv sync may have already fetched.
 #   3. git tags: web clones are shallow with no tags, so Reflex's VCS-derived
 #      version resolves to 0.0.0 and trips downstream version gates (e.g.
 #      reflex-hosting-cli rejects it). Fetching tags lets the version compute.

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -2,22 +2,22 @@
 # SessionStart hook for Claude Code on the web.
 #
 # The web container image is baked with tools that predate this repo's current
-# requirements, so a fresh `uv sync` + test run fails out of the box. This hook
-# reconciles the environment with the repo on every web session start:
+# requirements, so a later `uv sync` + test run fails out of the box. This hook
+# reconciles the environment with the repo on every web session start (it does
+# not sync dependencies -- that cost is paid on the first 'uv run'/'uv sync'):
 #
-#   1. uv: the repo pins tool.uv.required-version in pyproject.toml. The web
-#      image usually already has a compatible uv installed (e.g. in
-#      /usr/local/bin), but an older standalone build can sit ahead of it on
-#      PATH. We pick whichever installed uv meets the requirement and put it
-#      first; only if none qualifies do we install one from PyPI (the astral.sh
-#      installer and `uv self update` are blocked / GitHub-rate-limited here).
-#   2. Python: the baked uv (see #1) predates Python 3.14.0 final, so its
-#      bundled release manifest only knows 3.14 prereleases -- a bare `uv sync`
-#      with it resolves .python-version=3.14 to a release candidate whose
+#   1. uv: the repo pins tool.uv.required-version in pyproject.toml. If the uv on
+#      PATH is older, pip-install a satisfying one for --user (into ~/.local/bin,
+#      assumed already on PATH); the astral.sh installer and `uv self update` are
+#      blocked / GitHub-rate-limited here.
+#   2. Python: an older uv (see #1) predates Python 3.14.0 final, so its bundled
+#      release manifest only knows 3.14 prereleases -- a bare `uv sync` with it
+#      resolves .python-version=3.14 to a release candidate whose
 #      typing._eval_type signature is incompatible with the pinned pydantic
 #      (breaks every import). Upgrading uv first fixes the manifest; we then run
-#      `uv python install` (which excludes prereleases) as a guard so sync can't
-#      reuse a prerelease that an earlier stale-uv sync may have already fetched.
+#      `uv python install` (which excludes prereleases) as a guard so a later
+#      sync can't reuse a prerelease that an earlier stale-uv run may have
+#      already fetched.
 #   3. git tags: web clones are shallow with no tags, so Reflex's VCS-derived
 #      version resolves to 0.0.0 and trips downstream version gates (e.g.
 #      reflex-hosting-cli rejects it). Fetching tags lets the version compute.
@@ -53,14 +53,10 @@ fi
 uv python install
 
 # 3. Fetch tags so the dynamic version resolves (ignore failures; offline runs
-#    still get a best-effort sync).
+#    still compute a best-effort version).
 git fetch --tags --quiet || true
 
-# 4. Install all workspace dependencies (uses .python-version). Don't let a
-#    transient sync failure (e.g. a flaky network) abort startup -- the container
-#    should still come up so the session can retry sync manually.
-if ! uv sync; then
-  echo "WARNING: 'uv sync' failed; the environment may be incomplete. Re-run 'uv sync' once any transient issue clears." >&2
-fi
-
-echo "Environment ready: uv $(uv --version), Python $(uv run python --version 2>/dev/null), reflex $(uv run python -c 'import importlib.metadata as m; print(m.version("reflex"))' 2>/dev/null || echo '?')"
+# Dependencies are intentionally not synced here -- the first 'uv run'/'uv sync'
+# (e.g. running tests or an app) installs them, so sessions that don't touch the
+# code don't pay that cost.
+echo "Environment ready: uv $(uv --version). Dependencies install on first 'uv sync' / 'uv run'."

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -28,34 +28,11 @@ fi
 
 cd "$CLAUDE_PROJECT_DIR"
 
-# 1. Upgrade uv if it's below the repo's required-version.
-need_uv="$(python3 - <<'PY'
-import re, shutil, subprocess
-from pathlib import Path
-
-req = "0"
-m = re.search(r'required-version\s*=\s*"[><=~ ]*([0-9][0-9.]*)"', Path("pyproject.toml").read_text())
-if m:
-    req = m.group(1)
-
-cur = "0"
-if shutil.which("uv"):
-    out = subprocess.run(["uv", "--version"], capture_output=True, text=True).stdout
-    mm = re.search(r"(\d+\.\d+\.\d+)", out)
-    if mm:
-        cur = mm.group(1)
-
-def tup(v):
-    return tuple(int(x) for x in v.split("."))
-
-print("yes" if tup(cur) < tup(req) else "no")
-PY
-)"
-
-if [ "$need_uv" = "yes" ]; then
-  echo "Upgrading uv to satisfy required-version..."
-  python3 -m pip install --user --upgrade --quiet uv
-fi
+# 1. Ensure uv meets the repo's required-version. pip is a near-instant no-op
+#    when the constraint is already satisfied, and installs from PyPI otherwise
+#    (the astral.sh installer and `uv self update` are blocked here).
+req="$(sed -n 's/^[[:space:]]*required-version[[:space:]]*=[[:space:]]*"[^0-9]*\([0-9][0-9.]*\).*/\1/p' pyproject.toml | head -n1)"
+python3 -m pip install --user --quiet --root-user-action=ignore "uv${req:+>=$req}"
 
 # pip --user installs land in ~/.local/bin; make sure they win over the baked uv.
 export PATH="$HOME/.local/bin:$PATH"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -5,9 +5,12 @@
 # requirements, so a fresh `uv sync` + test run fails out of the box. This hook
 # reconciles the environment with the repo on every web session start:
 #
-#   1. uv: the image ships an older uv than tool.uv.required-version in
-#      pyproject.toml. The astral.sh installer and `uv self update` are
-#      blocked / GitHub-rate-limited here, so we upgrade from PyPI instead.
+#   1. uv: the repo pins tool.uv.required-version in pyproject.toml. The web
+#      image usually already has a compatible uv installed (e.g. in
+#      /usr/local/bin), but an older standalone build can sit ahead of it on
+#      PATH. We pick whichever installed uv meets the requirement and put it
+#      first; only if none qualifies do we install one from PyPI (the astral.sh
+#      installer and `uv self update` are blocked / GitHub-rate-limited here).
 #   2. Python: the baked uv (see #1) predates Python 3.14.0 final, so its
 #      bundled release manifest only knows 3.14 prereleases -- a bare `uv sync`
 #      with it resolves .python-version=3.14 to a release candidate whose
@@ -28,19 +31,40 @@ fi
 
 cd "$CLAUDE_PROJECT_DIR"
 
-# 1. Ensure uv meets the repo's required-version. pip is a near-instant no-op
-#    when the constraint is already satisfied, and installs from PyPI otherwise
-#    (the astral.sh installer and `uv self update` are blocked here).
+# 1. Make a uv satisfying the repo's required-version the first thing on PATH.
+#    Prefer an already-installed compatible uv (the web image usually has one);
+#    only install from PyPI if none qualifies. We search PATH first, then a few
+#    well-known locations in case the on-PATH uv is an older standalone build.
 req="$(sed -n 's/^[[:space:]]*required-version[[:space:]]*=[[:space:]]*"[^0-9]*\([0-9][0-9.]*\).*/\1/p' pyproject.toml | head -n1)"
-python3 -m pip install --user --quiet --root-user-action=ignore "uv${req:+>=$req}"
 
-# pip --user installs land in ~/.local/bin; make sure they win over the baked uv,
-# both for the rest of this script and -- via CLAUDE_ENV_FILE -- for the session's
-# later commands, which otherwise wouldn't see this PATH change once we exit.
-export PATH="$HOME/.local/bin:$PATH"
+uv_satisfies() {  # $1=uv binary; true if its version >= $req (or no req parsed)
+  local v
+  v="$("$1" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"
+  [ -n "$v" ] || return 1
+  [ -z "$req" ] && return 0
+  [ "$(printf '%s\n%s\n' "$req" "$v" | sort -V | head -n1)" = "$req" ]
+}
+
+uv_dir=""
+for cand in $(command -v -a uv 2>/dev/null) /usr/local/bin/uv /usr/bin/uv "$HOME/.local/bin/uv"; do
+  if [ -x "$cand" ] && uv_satisfies "$cand"; then
+    uv_dir="$(cd "$(dirname "$cand")" && pwd)"
+    break
+  fi
+done
+
+if [ -z "$uv_dir" ]; then
+  python3 -m pip install --user --quiet --root-user-action=ignore "uv${req:+>=$req}"
+  uv_dir="$HOME/.local/bin"
+fi
+
+# Put the chosen uv first on PATH for the rest of this script and -- via
+# CLAUDE_ENV_FILE -- for the session's later commands, which otherwise wouldn't
+# see this change once we exit.
+export PATH="$uv_dir:$PATH"
 hash -r 2>/dev/null || true
 if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
-  echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$CLAUDE_ENV_FILE"
+  printf 'export PATH="%s:$PATH"\n' "$uv_dir" >> "$CLAUDE_ENV_FILE"
 fi
 
 # 2. Ensure a stable interpreter matching .python-version is installed, so sync

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -10,8 +10,9 @@
 #      blocked / GitHub-rate-limited here, so we upgrade from PyPI instead.
 #   2. Python: the image pre-installs a 3.14 prerelease whose typing._eval_type
 #      signature is incompatible with the pinned pydantic (breaks every import).
-#      We install the stable interpreter and pass it to uv explicitly so it
-#      doesn't fall back to the prerelease.
+#      `uv sync` would reuse that prerelease since it's the only installed match
+#      for .python-version. `uv python install` excludes prereleases, so it
+#      fetches the stable patch; once present, sync prefers it over the rc.
 #   3. git tags: web clones are shallow with no tags, so Reflex's VCS-derived
 #      version resolves to 0.0.0 and trips downstream version gates (e.g.
 #      reflex-hosting-cli rejects it). Fetching tags lets the version compute.
@@ -24,8 +25,6 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
 fi
 
 cd "$CLAUDE_PROJECT_DIR"
-
-PY_VERSION="3.14.5"
 
 # 1. Upgrade uv if it's below the repo's required-version.
 need_uv="$(python3 - <<'PY'
@@ -60,14 +59,15 @@ fi
 export PATH="$HOME/.local/bin:$PATH"
 hash -r 2>/dev/null || true
 
-# 2. Ensure the stable interpreter is available.
-uv python install "$PY_VERSION"
+# 2. Ensure a stable interpreter matching .python-version is installed, so sync
+#    doesn't fall back to the pre-baked prerelease.
+uv python install
 
 # 3. Fetch tags so the dynamic version resolves (ignore failures; offline runs
 #    still get a best-effort sync).
 git fetch --tags --quiet || true
 
-# 4. Install all workspace dependencies against the stable interpreter.
-uv sync --python "$PY_VERSION"
+# 4. Install all workspace dependencies (uses .python-version).
+uv sync
 
-echo "Environment ready: uv $(uv --version), Python $PY_VERSION, reflex $(uv run python -c 'import importlib.metadata as m; print(m.version("reflex"))' 2>/dev/null || echo '?')"
+echo "Environment ready: uv $(uv --version), Python $(uv run python --version 2>/dev/null), reflex $(uv run python -c 'import importlib.metadata as m; print(m.version("reflex"))' 2>/dev/null || echo '?')"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -31,10 +31,10 @@ fi
 
 cd "$CLAUDE_PROJECT_DIR"
 
-# 1. Make a uv satisfying the repo's required-version the first thing on PATH.
-#    Prefer an already-installed compatible uv (the web image usually has one);
-#    only install from PyPI if none qualifies. We search PATH first, then a few
-#    well-known locations in case the on-PATH uv is an older standalone build.
+# 1. Put a uv satisfying the repo's required-version in ~/.local/bin and front-load
+#    that dir, leaving the system PATH order untouched. Symlink a compatible uv if
+#    one exists elsewhere; only pip-install when none is found.
+local_bin="$HOME/.local/bin"
 req="$(sed -n 's/^[[:space:]]*required-version[[:space:]]*=[[:space:]]*"[^0-9]*\([0-9][0-9.]*\).*/\1/p' pyproject.toml | head -n1)"
 
 uv_satisfies() {  # $1=uv binary; true if its version >= $req (or no req parsed)
@@ -45,27 +45,21 @@ uv_satisfies() {  # $1=uv binary; true if its version >= $req (or no req parsed)
   [ "$(printf '%s\n%s\n' "$req" "$v" | sort -V | head -n1)" = "$req" ]
 }
 
-uv_dir=""
-for cand in $(command -v -a uv 2>/dev/null) /usr/local/bin/uv /usr/bin/uv "$HOME/.local/bin/uv"; do
-  if [ -x "$cand" ] && uv_satisfies "$cand"; then
-    uv_dir="$(cd "$(dirname "$cand")" && pwd)"
-    break
-  fi
-done
-
-if [ -z "$uv_dir" ]; then
-  python3 -m pip install --user --quiet --root-user-action=ignore "uv${req:+>=$req}"
-  uv_dir="$HOME/.local/bin"
-fi
-
-# Put the chosen uv first on PATH for the rest of this script and -- via
-# CLAUDE_ENV_FILE -- for the session's later commands, which otherwise wouldn't
-# see this change once we exit.
-export PATH="$uv_dir:$PATH"
-hash -r 2>/dev/null || true
+# Front-load ~/.local/bin here and -- via CLAUDE_ENV_FILE -- for later commands.
+export PATH="$local_bin:$PATH"
 if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
-  printf 'export PATH="%s:$PATH"\n' "$uv_dir" >> "$CLAUDE_ENV_FILE"
+  echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$CLAUDE_ENV_FILE"
 fi
+
+if ! uv_satisfies "$local_bin/uv"; then
+  mkdir -p "$local_bin"
+  for cand in $(type -aP uv 2>/dev/null) /usr/local/bin/uv /usr/bin/uv; do
+    uv_satisfies "$cand" && ln -sf "$cand" "$local_bin/uv" && break
+  done
+  uv_satisfies "$local_bin/uv" ||
+    python3 -m pip install --user --quiet --root-user-action=ignore "uv${req:+>=$req}"
+fi
+hash -r 2>/dev/null || true
 
 # 2. Ensure a stable interpreter matching .python-version is installed, so sync
 #    doesn't fall back to the pre-baked prerelease.

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -31,10 +31,8 @@ fi
 
 cd "$CLAUDE_PROJECT_DIR"
 
-# 1. Put a uv satisfying the repo's required-version in ~/.local/bin and front-load
-#    that dir, leaving the system PATH order untouched. Symlink a compatible uv if
-#    one exists elsewhere; only pip-install when none is found.
-local_bin="$HOME/.local/bin"
+# 1. Ensure the uv on PATH satisfies the repo's required-version; if not, pip
+#    installs a satisfying one into ~/.local/bin (assumed already on PATH).
 req="$(sed -n 's/^[[:space:]]*required-version[[:space:]]*=[[:space:]]*"[^0-9]*\([0-9][0-9.]*\).*/\1/p' pyproject.toml | head -n1)"
 
 uv_satisfies() {  # $1=uv binary; true if its version >= $req (or no req parsed)
@@ -45,21 +43,10 @@ uv_satisfies() {  # $1=uv binary; true if its version >= $req (or no req parsed)
   [ "$(printf '%s\n%s\n' "$req" "$v" | sort -V | head -n1)" = "$req" ]
 }
 
-# Front-load ~/.local/bin here and -- via CLAUDE_ENV_FILE -- for later commands.
-export PATH="$local_bin:$PATH"
-if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
-  echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$CLAUDE_ENV_FILE"
+if ! uv_satisfies uv; then
+  python3 -m pip install --user --quiet --root-user-action=ignore "uv${req:+>=$req}"
+  hash -r 2>/dev/null || true
 fi
-
-if ! uv_satisfies "$local_bin/uv"; then
-  mkdir -p "$local_bin"
-  for cand in $(type -aP uv 2>/dev/null) /usr/local/bin/uv /usr/bin/uv; do
-    uv_satisfies "$cand" && ln -sf "$cand" "$local_bin/uv" && break
-  done
-  uv_satisfies "$local_bin/uv" ||
-    python3 -m pip install --user --quiet --root-user-action=ignore "uv${req:+>=$req}"
-fi
-hash -r 2>/dev/null || true
 
 # 2. Ensure a stable interpreter matching .python-version is installed, so sync
 #    doesn't fall back to the pre-baked prerelease.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ node_modules
 package-lock.json
 *.pyi
 .pre-commit-config.yaml
-.claude
+.claude/.worktrees

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ package-lock.json
 *.pyi
 .pre-commit-config.yaml
 .claude/.worktrees
+.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ package-lock.json
 .pre-commit-config.yaml
 .claude/.worktrees
 .claude/settings.local.json
+CLAUDE.local.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 **/.DS_Store
 **/*.pyc
+**/__pycache__/
+.pytest_cache/
+.ruff_cache/
+**/.ruff_cache/
+.mypy_cache/
 assets/external/*
 dist/*
 examples/


### PR DESCRIPTION
For running properly in Claude Code web containers, which are baked with tooling that predates this repo's current requirements.

### `.claude/hooks/session-start.sh` (registered via `.claude/settings.json`)

Runs only in web containers (`CLAUDE_CODE_REMOTE=true`) and reconciles the environment with the repo on every session start. It does **not** sync dependencies — that cost is paid lazily on the first `uv run` / `uv sync` (e.g. running tests or an app), so sessions that don't touch the code start fast.

- **uv**: if the `uv` on `PATH` is older than `tool.uv.required-version`, pip-install a satisfying one for `--user` (lands in `~/.local/bin`, assumed already on `PATH`). The astral.sh installer and `uv self update` are blocked / GitHub-rate-limited here, so PyPI is the only reliable source.
- **Python**: an older uv's bundled release manifest only knows 3.14 prereleases, so a later `uv sync` would resolve `.python-version=3.14` to a release candidate whose `typing._eval_type` signature is incompatible with the pinned pydantic (breaks every import). Upgrading uv fixes the manifest; `uv python install` (which excludes prereleases) then guards against reusing a prerelease a stale-uv run may have fetched.
- **git tags**: web clones are shallow with no tags, so Reflex's VCS-derived version resolves to `0.0.0` and trips downstream version gates (e.g. reflex-hosting-cli's compatibility check). Fetching tags lets the version compute.

### `.gitignore`

Narrow the previous blanket `.claude` ignore to just `.claude/.worktrees` and `.claude/settings.local.json` so the shared hook and `settings.json` are tracked, ignore user-local `CLAUDE.local.md`, and ignore tool scratch dirs (`__pycache__`, `.pytest_cache`, `.ruff_cache`, `.mypy_cache`).

> https://claude.ai/code/session_014Bp9oVCfiq8DSnTK8VfozK