### PR TITLE
feat: add `REFLEX_HOT_RELOAD_OVERRIDE_PATHS` to fully override reload paths

### DIFF
--- a/news/6639.feature.md
+++ b/news/6639.feature.md
@@ -1,0 +1,1 @@
+Added the `REFLEX_HOT_RELOAD_OVERRIDE_PATHS` environment variable, a colon-separated list of paths that, when set, fully replaces the paths watched for hot reload in dev mode — taking precedence over the config-derived defaults as well as `REFLEX_HOT_RELOAD_INCLUDE_PATHS` and `REFLEX_HOT_RELOAD_EXCLUDE_PATHS`.

--- a/packages/reflex-base/news/6639.feature.md
+++ b/packages/reflex-base/news/6639.feature.md
@@ -1,0 +1,1 @@
+Added the `REFLEX_HOT_RELOAD_OVERRIDE_PATHS` environment variable, a colon-separated list of paths that, when set, fully replaces the paths watched for hot reload in dev mode.

--- a/packages/reflex-base/src/reflex_base/environment.py
+++ b/packages/reflex-base/src/reflex_base/environment.py
@@ -642,6 +642,9 @@ class EnvironmentVariables:
     # Paths to exclude from the hot reload. Takes precedence over include paths. Separated by a colon.
     REFLEX_HOT_RELOAD_EXCLUDE_PATHS: EnvVar[list[Path]] = env_var([])
 
+    # Paths to override in the hot reload. Takes precedence over include and exclude paths. Separated by a colon.
+    REFLEX_HOT_RELOAD_OVERRIDE_PATHS: EnvVar[list[Path]] = env_var([])
+
     # Enables different behavior for when the backend would do a cold start if it was inactive.
     REFLEX_DOES_BACKEND_COLD_START: EnvVar[bool] = env_var(False)
 

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -500,6 +500,13 @@ def get_reload_paths() -> Sequence[Path]:
     Raises:
         RuntimeError: If the `__init__.py` file is found in the app root directory.
     """
+    override_dirs = tuple(
+        map(Path.absolute, environment.REFLEX_HOT_RELOAD_OVERRIDE_PATHS.get())
+    )
+
+    if override_dirs:
+        return override_dirs
+
     config = get_config()
     reload_paths = [Path.cwd()]
     app_module = config.module

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -505,6 +505,7 @@ def get_reload_paths() -> Sequence[Path]:
     )
 
     if override_dirs:
+        console.debug(f"Reload paths (override): {list(map(str, override_dirs))}")
         return override_dirs
 
     config = get_config()


### PR DESCRIPTION
## Summary

Adds a `REFLEX_HOT_RELOAD_OVERRIDE_PATHS` environment variable (colon-separated list of paths). When set, `get_reload_paths()` returns these paths directly, taking precedence over `REFLEX_HOT_RELOAD_INCLUDE_PATHS`, `REFLEX_HOT_RELOAD_EXCLUDE_PATHS`, and the config-derived defaults.

This gives embedders full control over what the dev-mode file watcher observes — e.g. pointing it at a dedicated control directory instead of relying on the app's project layout.

Linear: ENG-9752