### PR TITLE
bump reflex-components-radix -> reflex-components-core >= 0.9.5

### DIFF
--- a/packages/reflex-components-radix/pyproject.toml
+++ b/packages/reflex-components-radix/pyproject.toml
@@ -9,7 +9,7 @@ maintainers = [{ name = "Khaleel Al-Adhami", email = "khaleel@reflex.dev" }]
 requires-python = ">=3.10"
 dependencies = [
     "reflex-base >= 0.9.5",
-    "reflex-components-core >= 0.9.0",
+    "reflex-components-core >= 0.9.5",
     "reflex-components-lucide >= 0.9.0",
 ]
 


### PR DESCRIPTION
also, for consistency to avoid potentially unvalidated TypedDict form values
