### PR TITLE
fix: pin moment-timezone to exact version 0.6.2

### DIFF
--- a/docs/app/reflex.lock/bun.lock
+++ b/docs/app/reflex.lock/bun.lock
@@ -35,7 +35,7 @@
         "lucide-react": "1.14.0",
         "mergician": "v2.0.2",
         "moment": "2.30.1",
-        "moment-timezone": "^0.6.2",
+        "moment-timezone": "0.6.2",
         "plotly.js": "3.5.1",
         "react": "19.2.6",
         "react-colorful": "5.7.0",

--- a/docs/app/reflex.lock/package.json
+++ b/docs/app/reflex.lock/package.json
@@ -36,7 +36,7 @@
     "lucide-react": "1.14.0",
     "mergician": "v2.0.2",
     "moment": "2.30.1",
-    "moment-timezone": "^0.6.2",
+    "moment-timezone": "0.6.2",
     "plotly.js": "3.5.1",
     "react": "19.2.6",
     "react-colorful": "5.7.0",

--- a/packages/reflex-components-moment/news/6649.bugfix.md
+++ b/packages/reflex-components-moment/news/6649.bugfix.md
@@ -1,0 +1,1 @@
+`rx.moment` now pins its `moment-timezone` dependency to the exact version `0.6.2` instead of a caret range, keeping frontend installs reproducible.

--- a/packages/reflex-components-moment/src/reflex_components_moment/moment.py
+++ b/packages/reflex-components-moment/src/reflex_components_moment/moment.py
@@ -131,6 +131,6 @@ class Moment(NoSSRComponent):
             # value at compile time so import all locales available.
             imports[""] = "moment/min/locales"
         if self.tz is not None:
-            imports["moment-timezone"] = ""
+            imports["moment-timezone@0.6.2"] = ""
 
         return imports


### PR DESCRIPTION
## Summary

Pin the `moment-timezone` dependency of `rx.moment` to the exact version `0.6.2` instead of an unpinned specifier, which previously resolved to a caret range (`^0.6.2`) in generated `package.json` files. This keeps frontend installs reproducible and consistent with the other pinned JS dependencies.

- `Moment.add_imports` now declares `moment-timezone@0.6.2` when `tz` is set
- Regenerated `docs/app/reflex.lock` accordingly