### PR TITLE
ENG-9830 fix: avoid config re-entry when a State is defined in rxconfig.py

### DIFF
--- a/news/6662.bugfix.md
+++ b/news/6662.bugfix.md
@@ -1,0 +1,1 @@
+Avoid re-entering config loading when a `State` subclass is defined in `rxconfig.py`.

--- a/packages/reflex-base/news/6662.bugfix.md
+++ b/packages/reflex-base/news/6662.bugfix.md
@@ -1,0 +1,1 @@
+Avoid re-entering config loading when a `State` subclass is defined in `rxconfig.py`.

--- a/packages/reflex-base/src/reflex_base/config.py
+++ b/packages/reflex-base/src/reflex_base/config.py
@@ -392,6 +392,11 @@ class Config(BaseConfig):
         self._non_default_attributes = set(kwargs.keys())
         self._replace_defaults(**kwargs)
 
+        # Publish for State-class creation so it never re-enters get_config()
+        # (which AttributeErrors if a State is defined while rxconfig.py is mid-import).
+        global _state_auto_setters
+        _state_auto_setters = self.state_auto_setters
+
         if (
             self.state_manager_mode == constants.StateManagerMode.REDIS
             and not self.redis_url
@@ -738,6 +743,28 @@ def _get_config() -> Config:
 
 # Protect sys.path from concurrent modification
 _config_lock = threading.RLock()
+
+# Cached state_auto_setters so State-class creation never re-enters get_config().
+_state_auto_setters: bool | None = None
+
+
+def get_state_auto_setters() -> bool:
+    """Return whether state auto-setters are enabled, without importing rxconfig.
+
+    Reads the value cached when the Config was built. Before any Config exists
+    (e.g. a State defined inside rxconfig.py during its import), falls back to the
+    REFLEX_STATE_AUTO_SETTERS env var, then the default (False). This never calls
+    get_config() or imports rxconfig, so it cannot re-enter config loading.
+
+    Returns:
+        Whether state auto-setters are enabled.
+    """
+    if _state_auto_setters is not None:
+        return _state_auto_setters
+    env_val = os.environ.get(Config._prefixes[0] + "STATE_AUTO_SETTERS")
+    if env_val and env_val.strip():
+        return interpret_env_var_value(env_val, bool, "state_auto_setters")
+    return False
 
 
 def get_config(reload: bool = False) -> Config:

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1139,7 +1139,7 @@ class BaseState(EvenMoreBasicBaseState):
         Raises:
             VarTypeError: if the variable has an incorrect type
         """
-        from reflex_base.config import get_config
+        from reflex_base.config import get_state_auto_setters
         from reflex_base.utils.exceptions import VarTypeError
 
         if not types.is_valid_var_type(prop._var_type):
@@ -1151,7 +1151,7 @@ class BaseState(EvenMoreBasicBaseState):
             )
             raise VarTypeError(msg)
         cls._set_var(name, prop)
-        if cls.is_user_defined() and get_config().state_auto_setters is True:
+        if cls.is_user_defined() and get_state_auto_setters() is True:
             cls._create_setter(name, prop)
         cls._set_default_value(name, prop)
 

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -4005,6 +4005,129 @@ config = rx.Config(
         assert "setvar" in TestState.event_handlers
 
 
+def test_state_defined_in_rxconfig_does_not_crash(tmp_path):
+    """A State subclass defined in rxconfig.py must not crash config loading.
+
+    Regression: _init_var read get_config().state_auto_setters at class-creation
+    time, which re-entered config loading while rxconfig was still importing and
+    raised AttributeError because the rxconfig module had no `config` attribute
+    yet.
+    """
+    proj_root = tmp_path / "project1"
+    proj_root.mkdir()
+
+    config_string = """
+import reflex as rx
+
+
+class RxconfigDefinedState(rx.State):
+    n: int = 0
+
+
+config = rx.Config(
+    app_name="project1",
+)
+"""
+
+    (proj_root / "rxconfig.py").write_text(dedent(config_string))
+
+    with chdir(proj_root):
+        # Must not raise (previously raised AttributeError mid-import).
+        reflex_base.config.get_config(reload=True)
+        del sys.modules[constants.Config.MODULE]
+
+
+def test_state_in_rxconfig_honors_env_auto_setters(tmp_path, monkeypatch):
+    """A State defined in rxconfig.py (pre-config) honors REFLEX_STATE_AUTO_SETTERS.
+
+    During rxconfig import the Config does not exist yet, so the cached value is
+    unset and get_state_auto_setters falls back to the env var.
+    """
+    # Simulate a fresh process where no Config has been built yet.
+    monkeypatch.setattr(reflex_base.config, "_state_auto_setters", None)
+    monkeypatch.setenv("REFLEX_STATE_AUTO_SETTERS", "true")
+
+    proj_root = tmp_path / "project1"
+    proj_root.mkdir()
+    config_string = """
+import reflex as rx
+
+
+class RxconfigEnvSetterState(rx.State):
+    n: int = 0
+
+
+config = rx.Config(app_name="project1")
+"""
+    (proj_root / "rxconfig.py").write_text(dedent(config_string))
+
+    with chdir(proj_root):
+        reflex_base.config.get_config(reload=True)
+        state_cls = sys.modules[constants.Config.MODULE].RxconfigEnvSetterState
+        assert "set_n" in state_cls.event_handlers
+        del sys.modules[constants.Config.MODULE]
+
+
+def test_state_in_rxconfig_defaults_to_no_auto_setters(tmp_path, monkeypatch):
+    """A State defined in rxconfig.py gets no auto-setters by default (pre-config)."""
+    monkeypatch.setattr(reflex_base.config, "_state_auto_setters", None)
+    monkeypatch.delenv("REFLEX_STATE_AUTO_SETTERS", raising=False)
+
+    proj_root = tmp_path / "project1"
+    proj_root.mkdir()
+    config_string = """
+import reflex as rx
+
+
+class RxconfigNoSetterState(rx.State):
+    n: int = 0
+
+
+config = rx.Config(app_name="project1")
+"""
+    (proj_root / "rxconfig.py").write_text(dedent(config_string))
+
+    with chdir(proj_root):
+        reflex_base.config.get_config(reload=True)
+        state_cls = sys.modules[constants.Config.MODULE].RxconfigNoSetterState
+        assert list(state_cls.event_handlers) == ["setvar"]
+        del sys.modules[constants.Config.MODULE]
+
+
+def test_state_auto_setters_cache_tracks_reload(tmp_path):
+    """The cached state_auto_setters value follows config reloads (no stale flag)."""
+    proj_root = tmp_path / "project1"
+    proj_root.mkdir()
+    rxconfig_path = proj_root / "rxconfig.py"
+    off_config = """
+import reflex as rx
+config = rx.Config(app_name="project1", state_auto_setters=False)
+"""
+    on_config = """
+import reflex as rx
+config = rx.Config(app_name="project1", state_auto_setters=True)
+"""
+
+    with chdir(proj_root):
+        rxconfig_path.write_text(dedent(off_config))
+        reflex_base.config.get_config(reload=True)
+        from reflex.state import State
+
+        class ReloadOffState(State):
+            num: int = 0
+
+        assert list(ReloadOffState.event_handlers) == ["setvar"]
+
+        rxconfig_path.write_text(dedent(on_config))
+        reflex_base.config.get_config(reload=True)
+
+        class ReloadOnState(State):
+            num: int = 0
+
+        assert "set_num" in ReloadOnState.event_handlers
+        del sys.modules[constants.Config.MODULE]
+
+
 class MixinState(State, mixin=True):
     """A mixin state for testing."""
 


### PR DESCRIPTION
State-class creation read get_config().state_auto_setters at class-creation time, which re-entered config loading while rxconfig.py was still importing and raised AttributeError. Cache the flag when the Config is built and read it via get_state_auto_setters(), falling back to the env var before any Config exists.

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?



### Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

- [x] This change requires a documentation update

### New Feature Submission:

- [x] Does your submission pass the tests?
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

closes #6661
