### PR TITLE
docs: clarify non-finite float sync behavior

### DIFF
--- a/docs/vars/base_vars.md
+++ b/docs/vars/base_vars.md
@@ -45,6 +45,14 @@ In this example `ticker` and `price` are base vars in the app, which can be modi
 Vars are used to communicate between the frontend and backend. They must be primitive Python types, Plotly figures, Pandas dataframes, or [a custom defined type](/docs/vars/custom-vars).
 ```
 
+```md alert info
+# Non-finite float values
+
+Python float values such as `float("nan")`, `float("inf")`, and `float("-inf")`
+are synchronized with compatibility handling. On the frontend, they are represented
+as the corresponding JavaScript values: `NaN`, `Infinity`, and `-Infinity`.
+```
+
 ## Accessing state variables on different pages
 
 State is just a python class and so can be defined on one page and then imported and used on another. Below we define `TickerState` class on the page `state.py` and then import it and use it on the page `index.py`.

--- a/tests/integration/test_computed_vars.py
+++ b/tests/integration/test_computed_vars.py
@@ -232,6 +232,10 @@ async def test_computed_vars(
 
     special_floats = driver.find_element(By.ID, "special_floats")
     assert special_floats
+
+    # Compatibility contract for non-finite floats:
+    # Python NaN/±Infinity values should sync to the frontend and render as the
+    # corresponding JavaScript values instead of being converted to null or strings.
     assert special_floats.text == "42.9, NaN, Infinity, -Infinity"
 
     increment = driver.find_element(By.ID, "increment")


### PR DESCRIPTION
## Summary

This PR clarifies the expected sync/rendering behavior for non-finite float values in Reflex state vars.

## Changes

- Added a docs note in `docs/vars/base_vars.md` explaining how `NaN`, `Infinity`, and `-Infinity` are represented on the frontend.
- Added an explicit compatibility comment near the `special_floats` integration assertion.

## Related Issue

Closes #6386

## Testing

- Ran `git diff --check`