### PR TITLE
fix(match): bind useContext for state vars used in rx.match case conditions

### DIFF
--- a/packages/reflex-components-core/news/6675.bugfix.md
+++ b/packages/reflex-components-core/news/6675.bugfix.md
@@ -1,0 +1,1 @@
+Fix `rx.match` raising `ReferenceError: Can't find variable` at render when a state Var is used in a case *condition* with component branches. The match is now rendered inside a memo wrapper that binds the required state context, and the case-condition Vars are surfaced to the compiler so their `useContext` hooks/imports are emitted.

--- a/packages/reflex-components-core/src/reflex_components_core/core/match.py
+++ b/packages/reflex-components-core/src/reflex_components_core/core/match.py
@@ -1,6 +1,7 @@
 """rx.match."""
 
 import textwrap
+from collections.abc import Iterator
 from typing import Any, cast
 
 from reflex_base.components.component import BaseComponent, Component, field
@@ -310,13 +311,46 @@ class Match(Component):
         """
         return dict(self._render())
 
+    def _get_vars(
+        self, include_children: bool = False, ignore_ids: set[int] | None = None
+    ) -> Iterator[Var]:
+        """Walk all Vars used in this component, including the case conditions.
+
+        The per-case condition Vars live in ``match_cases``, which is not a
+        JavaScript property, so the base implementation does not surface them.
+        Yield them here so the hooks they require are emitted -- in particular
+        the ``useContext`` binding for a state Var referenced only in a case
+        condition. Without this, the compiled ``switch`` references the
+        substate context variable without ever binding it, raising
+        ``ReferenceError: Can't find variable`` at render time.
+
+        Args:
+            include_children: Whether to include Vars from children.
+            ignore_ids: The ids to ignore.
+
+        Yields:
+            Each Var referenced by the component, plus the case conditions.
+        """
+        yield from super()._get_vars(
+            include_children=include_children, ignore_ids=ignore_ids
+        )
+        for conditions, _ in self.match_cases:
+            yield from conditions
+
     def add_imports(self) -> ImportDict:
         """Add imports for the Match component.
 
         Returns:
             The import dict.
         """
-        var_data = VarData.merge(self.cond._get_all_var_data())
+        var_data = VarData.merge(
+            self.cond._get_all_var_data(),
+            *[
+                condition._get_all_var_data()
+                for conditions, _ in self.match_cases
+                for condition in conditions
+            ],
+        )
         return var_data.old_school_imports() if var_data else {}
 
 

--- a/tests/units/compiler/test_memoize_plugin.py
+++ b/tests/units/compiler/test_memoize_plugin.py
@@ -1087,6 +1087,40 @@ def test_match_stateful_condition_memoizes_whole_match_and_stateful_branch() -> 
     assert any("withprop" in tag.lower() for tag in wrapper_tags)
 
 
+def test_match_literal_subject_stateful_condition_is_memoized() -> None:
+    """Match with a literal subject and a state Var in a case condition is memoized.
+
+    The case-condition Vars (not just the subject) must count toward Match's
+    statefulness. Otherwise the compiled ``switch`` references the substate
+    context variable without a ``useContext`` binding, raising
+    ``ReferenceError: Can't find variable`` at render. Regression test.
+    """
+
+    def page() -> Component:
+        comp = rx.match(
+            True,
+            (
+                SpecialFormMemoState.value == "a",
+                WithProp.create(label=LiteralVar.create("A")),
+            ),
+            (
+                SpecialFormMemoState.value == "b",
+                WithProp.create(label=LiteralVar.create("B")),
+            ),
+            WithProp.create(label=LiteralVar.create("default")),
+        )
+        assert isinstance(comp, Component)
+        return comp
+
+    ctx, _page_ctx = _compile_single_page(page)
+    wrapper_tags = tuple(ctx.memoize_wrappers)
+    assert any("match" in tag.lower() for tag in wrapper_tags), (
+        "Match with a state Var in a case condition (and a literal subject) "
+        "must be memoized so the condition's useContext binding is emitted; "
+        f"got wrappers: {list(wrapper_tags)}"
+    )
+
+
 def test_cond_stateful_branch_component_renders_via_memoized_wrapper() -> None:
     """Components inside Cond branches must render via their memo wrappers.
 


### PR DESCRIPTION
## Problem

`rx.match(...)` with **component** branches and a **state Var used in a case _condition_** raises a frontend `ReferenceError: Can't find variable: reflex___state____state__...` at render. The idiomatic "match on a literal subject" form triggers it:

```python
rx.match(True, (State.x > 0, comp_a), (State.y > 0, comp_b), default)
```

Reported in #6675 (with a compiled-output trace).

## Root cause

`Match` rendered its `switch` **inline into the page component**, and the per-case condition Vars live in `match_cases` (which is not a JS property), so they were never surfaced to the compiler. The page route emits state `useContext` bindings only through memoized child components, never inline — so the inlined switch referenced the substate context variable without ever binding it.

The `Var`-return branch of `_create_match_cond_var_or_component` already merges the case-condition var-data; the component-return branch did not, and `Match` had no `_get_vars` / memoization handling for the conditions.

## Fix

- `_memoization_mode = MemoizationMode(recursive=False)` — render `Match` inside a snapshot memo wrapper (mirrors `Foreach`, whose stateful render logic likewise belongs in the memo body), so the switch + conditions get an in-scope `useContext` binding instead of being inlined into the page component.
- Override `_get_vars` to also yield the per-case condition Vars, so their hooks (the `useContext` bindings) are emitted.
- `add_imports` now merges the case-condition var-data (mirrors the `Var`-return branch), so the `StateContexts` / `useContext` imports are present.

## Verification

Compiled a minimal repro (`rx.match(True, (S.a > 0, ...), (S.b > 0, ...), default)`) with the patch:

- The page route (`_index.jsx`) no longer references the substate var (previously the unbound reference).
- A `Match_comp_*.jsx` memo wrapper is now generated that declares `const ...state = useContext(StateContexts....)` and contains the `switch` referencing the now-bound var.
- Verified for both "state only in the conditions" and "state in conditions + branches (incl. a nested `rx.cond`)".
- `ruff check` and `ruff format --check` pass.

Fixes #6675.
