### PR TITLE
Fix flaky test_hybrid_properties controlled-input race

### DIFF
--- a/tests/integration/test_hybrid_properties.py
+++ b/tests/integration/test_hybrid_properties.py
@@ -233,9 +233,17 @@ def test_hybrid_properties(
     set_info_a = driver.find_element(By.ID, "set_info_a")
     set_info_a.send_keys(Keys.CONTROL + "a")
     set_info_a.send_keys(Keys.DELETE)
-    set_info_a.send_keys("z")
+    # Wait for the cleared value to round-trip before typing. The input is controlled
+    # by State.info.a, so typing while the clear is still in flight is racy: a late
+    # empty-state delta can drop the new key ("- b") or it can be appended to a stale
+    # "a" ("az - b"). Polling the backend-derived text gates on the clear landing.
     assert (
         hybrid_properties.poll_for_content(info_a_b, exp_not_equal="info_a_b: a - b")
+        == "info_a_b: - b"
+    )
+    set_info_a.send_keys("z")
+    assert (
+        hybrid_properties.poll_for_content(info_a_b, exp_not_equal="info_a_b: - b")
         == "info_a_b: z - b"
     )
 


### PR DESCRIPTION
`tests/integration/test_hybrid_properties.py::test_hybrid_properties` is flaky on the `integration-app-harness` shards (seen on #6680/#6681 and reproducible across runs).

### Root cause

The test clears the `set_info_a` input (`Ctrl+A`, `Delete`) and **immediately** types `"z"`:

```python
set_info_a.send_keys(Keys.CONTROL + "a")
set_info_a.send_keys(Keys.DELETE)
set_info_a.send_keys("z")
assert poll_for_content(info_a_b, exp_not_equal="info_a_b: a - b") == "info_a_b: z - b"
```

`set_info_a` is a **controlled input** (`value=State.info.a`, `on_change=State.update_info_a`), so each keystroke round-trips through the backend. Firing the clear and the type back-to-back races that async sync, intermittently producing:

- `info_a_b: az - b` — the `"z"` is typed onto a stale `"a"` (clear hadn't re-rendered yet)
- `info_a_b: - b` — the `"z"` is dropped by a late empty-state delta

…instead of the expected `info_a_b: z - b`. The non-deterministic values (two different wrong answers) confirm it's a timing race, not a logic bug. `pytest-rerunfailures` already retries 3× and still flakes.

### Fix

Serialize the interaction — wait for the cleared value to round-trip to the backend (poll the backend-derived `info_a_b` text for `"info_a_b: - b"`) **before** typing `"z"`, then poll for the final `"info_a_b: z - b"`. This mirrors the poll-between-interactions pattern already used in `test_event_chain.py` and removes the race without changing the app under test. The intermediate value (`"info_a_b: - b"`) is exactly what Selenium returned in the observed failure.

### Validation

`ruff` (format + check), `pyright`, and pytest collection pass locally. Behavioral validation is the `integration-app-harness` shards in CI — this PR exercises them directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ELfV78gRoQiknTTEXctPs

---
_Generated by [Claude Code](https://claude.ai/code/session_017ELfV78gRoQiknTTEXctPs)_