### PR TITLE
ENG-9923: Add REFLEX_EXTRA_PLUGINS env var to append to plugin list

### DIFF
--- a/packages/reflex-base/CHANGELOG.md
+++ b/packages/reflex-base/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v0.9.6.post1 (2026-06-26)
+
+### Features
+
+- Added the `REFLEX_EXTRA_PLUGINS` environment variable, a colon-separated list of fully qualified plugin import paths appended to the config's `plugins` list. Unlike `REFLEX_PLUGINS`, which replaces the list entirely, this preserves plugins configured in `rxconfig.py`; an entry is skipped when a plugin of the same type is already present or when its type is listed in `disable_plugins`. ([#6685](https://github.com/reflex-dev/reflex/issues/6685))
+
+### Bug Fixes
+
+- Stop warning when a non-built-in plugin is listed in `disable_plugins`, so config can opt out of an env-provided plugin without a spurious warning. ([#6685](https://github.com/reflex-dev/reflex/issues/6685))
+
+
 ## v0.9.6 (2026-06-25)
 
 ### Features

--- a/packages/reflex-base/CHANGELOG.md
+++ b/packages/reflex-base/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
 - Stop warning when a non-built-in plugin is listed in `disable_plugins`, so config can opt out of an env-provided plugin without a spurious warning. ([#6685](https://github.com/reflex-dev/reflex/issues/6685))
+- Improve error message when plugin spec from environment cannot be used. ([#6685](https://github.com/reflex-dev/reflex/issues/6685))
 
 
 ## v0.9.6 (2026-06-25)

--- a/packages/reflex-base/src/reflex_base/config.py
+++ b/packages/reflex-base/src/reflex_base/config.py
@@ -368,6 +368,10 @@ class Config(BaseConfig):
         # Normalize disable_plugins: convert strings and Plugin subclasses to instances.
         self._normalize_disable_plugins()
 
+        # Append any plugins declared via the REFLEX_EXTRA_PLUGINS env var (honoring
+        # disable_plugins, which is normalized above).
+        self._add_extra_plugins()
+
         # Add builtin plugins if not disabled.
         if not self._skip_plugins_checks:
             self._add_builtin_plugins()
@@ -436,6 +440,27 @@ class Config(BaseConfig):
                 )
                 raise ConfigError(msg)
         self.plugins = normalized
+
+    def _add_extra_plugins(self):
+        """Append plugins declared via the ``REFLEX_EXTRA_PLUGINS`` env var.
+
+        Unlike ``REFLEX_PLUGINS``, which *replaces* ``plugins`` entirely, this env
+        var appends to the existing list so plugins configured in ``rxconfig.py``
+        are preserved. Each entry is a fully qualified import path and is resolved
+        to a Plugin instance by the env var machinery. An entry is skipped when a
+        plugin of the same type is already present (so a plugin is never run twice)
+        or when its type is listed in ``disable_plugins`` (so config can opt out of
+        an env-provided plugin).
+        """
+        for plugin in environment.REFLEX_EXTRA_PLUGINS.get():
+            if any(isinstance(plugin, disabled) for disabled in self.disable_plugins):
+                console.debug(
+                    f"Skipping REFLEX_EXTRA_PLUGINS entry {type(plugin).__name__!r} "
+                    "because its type is listed in disable_plugins.",
+                )
+                continue
+            if not any(isinstance(existing, type(plugin)) for existing in self.plugins):
+                self.plugins.append(plugin)
 
     def _normalize_disable_plugins(self):
         """Normalize disable_plugins list entries to Plugin subclasses.

--- a/packages/reflex-base/src/reflex_base/config.py
+++ b/packages/reflex-base/src/reflex_base/config.py
@@ -444,14 +444,14 @@ class Config(BaseConfig):
                         f"instantiated and may require arguments; pass an instance "
                         f"instead, e.g. plugins=[{entry.__name__}(...)]."
                     )
-                    raise ConfigError(msg) from exc
+                    raise InvalidPluginConfigError(msg) from exc
             else:
                 msg = (
                     f"reflex.Config.plugins must contain Plugin instances, but got "
                     f"{entry!r} of type {type(entry).__name__}. "
                     f"Pass an instance, e.g. plugins=[SitemapPlugin()]."
                 )
-                raise ConfigError(msg)
+                raise InvalidPluginConfigError(msg)
         if invalid:
             details = ", ".join(p.describe() for p in invalid)
             msg = (

--- a/packages/reflex-base/src/reflex_base/config.py
+++ b/packages/reflex-base/src/reflex_base/config.py
@@ -548,13 +548,6 @@ class Config(BaseConfig):
                         "Please remove it from the `plugins` list in your config inside of `rxconfig.py`.",
                     )
 
-        for disabled_plugin in self.disable_plugins:
-            if disabled_plugin not in _PLUGINS_ENABLED_BY_DEFAULT:
-                console.warn(
-                    f"`{disabled_plugin!r}` is disabled in the config, but it is not a built-in plugin. "
-                    "Please remove it from the `disable_plugins` list in your config inside of `rxconfig.py`.",
-                )
-
     @classmethod
     def class_fields(cls) -> set[str]:
         """Get the fields of the config class.

--- a/packages/reflex-base/src/reflex_base/config.py
+++ b/packages/reflex-base/src/reflex_base/config.py
@@ -19,6 +19,7 @@ from reflex_base.environment import EnvVar as EnvVar
 from reflex_base.environment import (
     ExistingPath,
     SequenceOptions,
+    _InvalidPlugin,
     _load_dotenv_from_files,
     _paths_from_env_files,
     interpret_env_var_value,
@@ -28,7 +29,7 @@ from reflex_base.environment import environment as environment
 from reflex_base.plugins import Plugin
 from reflex_base.plugins.sitemap import SitemapPlugin
 from reflex_base.utils import console
-from reflex_base.utils.exceptions import ConfigError
+from reflex_base.utils.exceptions import ConfigError, InvalidPluginConfigError
 
 
 @dataclasses.dataclass(kw_only=True)
@@ -417,10 +418,22 @@ class Config(BaseConfig):
         subclass nor a Plugin instance raises ``ConfigError`` with a message
         that names the offending value, instead of failing later in the
         compiler with a confusing ``TypeError`` about a missing ``self``.
+
+        An ``_InvalidPlugin`` (produced when a ``REFLEX_PLUGINS`` import path
+        cannot be resolved) is fatal here: ``plugins`` is an explicit list of
+        plugins the app needs, so a bad entry raises ``InvalidPluginConfigError``
+        and the app cannot start.
+
+        Raises:
+            ConfigError: If an entry is neither a Plugin instance nor subclass.
+            InvalidPluginConfigError: If an entry could not be loaded.
         """
         normalized: list[Plugin] = []
+        invalid: list[_InvalidPlugin] = []
         for entry in self.plugins:
-            if isinstance(entry, Plugin):
+            if isinstance(entry, _InvalidPlugin):
+                invalid.append(entry)
+            elif isinstance(entry, Plugin):
                 normalized.append(entry)
             elif isinstance(entry, type) and issubclass(entry, Plugin):
                 try:
@@ -439,6 +452,13 @@ class Config(BaseConfig):
                     f"Pass an instance, e.g. plugins=[SitemapPlugin()]."
                 )
                 raise ConfigError(msg)
+        if invalid:
+            details = ", ".join(p.describe() for p in invalid)
+            msg = (
+                f"reflex.Config.plugins contains plugin(s) that could not be loaded "
+                f"(check REFLEX_PLUGINS import paths): {details}."
+            )
+            raise InvalidPluginConfigError(msg)
         self.plugins = normalized
 
     def _add_extra_plugins(self):
@@ -446,31 +466,58 @@ class Config(BaseConfig):
 
         Unlike ``REFLEX_PLUGINS``, which *replaces* ``plugins`` entirely, this env
         var appends to the existing list so plugins configured in ``rxconfig.py``
-        are preserved. Each entry is a fully qualified import path and is resolved
-        to a Plugin instance by the env var machinery. An entry is skipped when a
-        plugin of the same type is already present (so a plugin is never run twice)
-        or when its type is listed in ``disable_plugins`` (so config can opt out of
-        an env-provided plugin).
+        are preserved. Each entry is a fully qualified import path resolved to a
+        Plugin *subclass* (not instantiated by the env machinery). For each class:
+
+        - An invalid import path is warned about and skipped (a bad env entry is
+          never fatal, since the app still has its configured plugins).
+        - A type listed in ``disable_plugins`` is skipped *without* instantiating
+          it, so a disabled plugin never runs its constructor.
+        - A type already present in ``plugins`` is skipped, so a plugin is never
+          run twice.
+        - Otherwise the class is instantiated and appended; a constructor failure
+          is warned about and skipped.
         """
-        for plugin in environment.REFLEX_EXTRA_PLUGINS.get():
-            if any(isinstance(plugin, disabled) for disabled in self.disable_plugins):
+        for plugin_class in environment.REFLEX_EXTRA_PLUGINS.get():
+            if isinstance(plugin_class, _InvalidPlugin):
+                console.warn(
+                    f"Ignoring invalid REFLEX_EXTRA_PLUGINS entry {plugin_class.describe()}."
+                )
+                continue
+            if any(
+                issubclass(plugin_class, disabled) for disabled in self.disable_plugins
+            ):
                 console.debug(
-                    f"Skipping REFLEX_EXTRA_PLUGINS entry {type(plugin).__name__!r} "
+                    f"Skipping REFLEX_EXTRA_PLUGINS entry {plugin_class.__name__!r} "
                     "because its type is listed in disable_plugins.",
                 )
                 continue
-            if not any(isinstance(existing, type(plugin)) for existing in self.plugins):
-                self.plugins.append(plugin)
+            if any(isinstance(existing, plugin_class) for existing in self.plugins):
+                continue
+            try:
+                self.plugins.append(plugin_class())
+            except Exception as exc:
+                console.warn(
+                    f"Ignoring REFLEX_EXTRA_PLUGINS entry {plugin_class.__name__!r} "
+                    f"that could not be instantiated: {exc}"
+                )
 
     def _normalize_disable_plugins(self):
         """Normalize disable_plugins list entries to Plugin subclasses.
 
         Handles backward compatibility by converting strings (fully qualified
-        import paths) and Plugin instances to their associated classes.
+        import paths) and Plugin instances to their associated classes. An
+        ``_InvalidPlugin`` (from an unresolvable ``REFLEX_DISABLE_PLUGINS`` import
+        path) is warned about and dropped rather than crashing config load.
         """
         normalized: list[type[Plugin]] = []
         for entry in self.disable_plugins:
-            if isinstance(entry, type) and issubclass(entry, Plugin):
+            if isinstance(entry, _InvalidPlugin):
+                console.warn(
+                    f"Ignoring invalid disable_plugins entry {entry.describe()}. "
+                    "Check the REFLEX_DISABLE_PLUGINS import path(s)."
+                )
+            elif isinstance(entry, type) and issubclass(entry, Plugin):
                 normalized.append(entry)
             elif isinstance(entry, Plugin):
                 normalized.append(type(entry))

--- a/packages/reflex-base/src/reflex_base/environment.py
+++ b/packages/reflex-base/src/reflex_base/environment.py
@@ -710,6 +710,10 @@ class EnvironmentVariables:
     # How long to opportunistically hold the redis lock in milliseconds (must be less than the token expiration).
     REFLEX_OPLOCK_HOLD_TIME_MS: EnvVar[int] = env_var(0)
 
+    # Extra plugins to append to the config's plugins list. Fully qualified
+    # import paths separated by a colon.
+    REFLEX_EXTRA_PLUGINS: EnvVar[list[Plugin]] = env_var([])
+
 
 environment = EnvironmentVariables()
 

--- a/packages/reflex-base/src/reflex_base/environment.py
+++ b/packages/reflex-base/src/reflex_base/environment.py
@@ -741,10 +741,7 @@ class EnvironmentVariables:
     # How long to opportunistically hold the redis lock in milliseconds (must be less than the token expiration).
     REFLEX_OPLOCK_HOLD_TIME_MS: EnvVar[int] = env_var(0)
 
-    # Extra plugins to append to the config's plugins list (unlike REFLEX_PLUGINS,
-    # which replaces them). Fully qualified import paths separated by a colon.
-    # Resolved to classes here; Config instantiates them only after the
-    # disable/dedupe checks pass, so a disabled plugin is never instantiated.
+    # Extra plugins to append to the config's plugins list.
     REFLEX_EXTRA_PLUGINS: EnvVar[list[type[Plugin]]] = env_var([])
 
 

--- a/packages/reflex-base/src/reflex_base/environment.py
+++ b/packages/reflex-base/src/reflex_base/environment.py
@@ -146,6 +146,29 @@ def interpret_path_env(value: str, field_name: str) -> Path:
     return Path(value)
 
 
+@dataclasses.dataclass
+class _InvalidPlugin(Plugin):
+    """Placeholder for a plugin spec that could not be resolved or instantiated.
+
+    Returned by the plugin env-var interpreters instead of raising, so a single
+    bad entry does not abort interpretation of an entire plugin list. ``Config``
+    inspects the resulting list and either raises ``ConfigError`` (for
+    ``Config.plugins`` / ``REFLEX_PLUGINS``) or warns and drops the entry (for
+    ``REFLEX_EXTRA_PLUGINS`` and ``disable_plugins``).
+    """
+
+    spec: str
+    error: str
+
+    def describe(self) -> str:
+        """Describe the failed plugin spec for warning/error messages.
+
+        Returns:
+            A string combining the import path and the recorded error.
+        """
+        return f"{self.spec!r} ({self.error})"
+
+
 def interpret_plugin_class_env(value: str, field_name: str) -> type[Plugin]:
     """Interpret an environment variable value as a Plugin subclass.
 
@@ -190,24 +213,29 @@ def interpret_plugin_env(value: str, field_name: str) -> Plugin:
     """Interpret a plugin environment variable value.
 
     Resolves a fully qualified import path and returns an instance of the Plugin.
+    On failure (bad import path or instantiation error) an ``_InvalidPlugin``
+    recording the error is returned instead of raising, so callers can decide
+    whether a bad entry is fatal.
 
     Args:
         value: The environment variable value (e.g. "reflex.plugins.sitemap.SitemapPlugin").
         field_name: The field name.
 
     Returns:
-        An instance of the Plugin subclass.
-
-    Raises:
-        EnvironmentVarValueError: If the value is invalid.
+        An instance of the Plugin subclass, or an ``_InvalidPlugin`` on failure.
     """
-    plugin_class = interpret_plugin_class_env(value, field_name)
+    try:
+        plugin_class = interpret_plugin_class_env(value, field_name)
+    except EnvironmentVarValueError as e:
+        return _InvalidPlugin(spec=value, error=str(e))
 
     try:
         return plugin_class()
     except Exception as e:
-        msg = f"Failed to instantiate plugin {plugin_class.__name__!r} for {field_name}: {e}"
-        raise EnvironmentVarValueError(msg) from e
+        return _InvalidPlugin(
+            spec=value,
+            error=f"failed to instantiate plugin {plugin_class.__name__!r}: {e}",
+        )
 
 
 def interpret_enum_env(value: str, field_type: GenericType, field_name: str) -> Any:
@@ -310,7 +338,10 @@ def interpret_env_var_value(
             and isinstance(type_args[0], type)
             and issubclass(type_args[0], Plugin)
         ):
-            return interpret_plugin_class_env(value, field_name)
+            try:
+                return interpret_plugin_class_env(value, field_name)
+            except EnvironmentVarValueError as e:
+                return _InvalidPlugin(spec=value, error=str(e))
     if get_origin(field_type) is Literal:
         literal_values = get_args(field_type)
         for literal_value in literal_values:
@@ -710,9 +741,11 @@ class EnvironmentVariables:
     # How long to opportunistically hold the redis lock in milliseconds (must be less than the token expiration).
     REFLEX_OPLOCK_HOLD_TIME_MS: EnvVar[int] = env_var(0)
 
-    # Extra plugins to append to the config's plugins list. Fully qualified
-    # import paths separated by a colon.
-    REFLEX_EXTRA_PLUGINS: EnvVar[list[Plugin]] = env_var([])
+    # Extra plugins to append to the config's plugins list (unlike REFLEX_PLUGINS,
+    # which replaces them). Fully qualified import paths separated by a colon.
+    # Resolved to classes here; Config instantiates them only after the
+    # disable/dedupe checks pass, so a disabled plugin is never instantiated.
+    REFLEX_EXTRA_PLUGINS: EnvVar[list[type[Plugin]]] = env_var([])
 
 
 environment = EnvironmentVariables()

--- a/packages/reflex-base/src/reflex_base/environment.py
+++ b/packages/reflex-base/src/reflex_base/environment.py
@@ -197,7 +197,7 @@ def interpret_plugin_class_env(value: str, field_name: str) -> type[Plugin]:
         raise EnvironmentVarValueError(msg) from e
 
     try:
-        plugin_class = getattr(module, plugin_name, None)
+        plugin_class = getattr(module, plugin_name)
     except Exception as e:
         msg = f"Failed to get plugin class {plugin_name!r} from module {import_path!r} for {field_name}: {e}"
         raise EnvironmentVarValueError(msg) from e

--- a/packages/reflex-base/src/reflex_base/utils/exceptions.py
+++ b/packages/reflex-base/src/reflex_base/utils/exceptions.py
@@ -16,6 +16,10 @@ class ConfigError(ReflexError):
     """Custom exception for config related errors."""
 
 
+class InvalidPluginConfigError(ConfigError):
+    """Raised when ``Config.plugins`` contains a plugin that could not be loaded."""
+
+
 class InvalidStateManagerModeError(ReflexError, ValueError):
     """Raised when an invalid state manager mode is provided."""
 

--- a/tests/units/test_config.py
+++ b/tests/units/test_config.py
@@ -9,7 +9,7 @@ from pytest_mock import MockerFixture
 from reflex_base.constants import Endpoint, Env
 from reflex_base.plugins import Plugin
 from reflex_base.plugins.sitemap import SitemapPlugin
-from reflex_base.utils.exceptions import ConfigError
+from reflex_base.utils.exceptions import ConfigError, InvalidPluginConfigError
 
 import reflex as rx
 from reflex.environment import (
@@ -642,8 +642,35 @@ class ExtraPluginB(Plugin):
     """Second plugin used to exercise REFLEX_EXTRA_PLUGINS."""
 
 
+# Records every instantiation so tests can assert a disabled plugin is never built.
+_extra_plugin_instantiations: list[str] = []
+
+
+class TrackedExtraPlugin(Plugin):
+    """Plugin that records when its constructor runs."""
+
+    def __init__(self):
+        """Record that this plugin was instantiated."""
+        _extra_plugin_instantiations.append(type(self).__name__)
+
+
+class NeedsArgsExtraPlugin(Plugin):
+    """Plugin whose constructor requires an argument, so it cannot be auto-built."""
+
+    def __init__(self, required):
+        """Initialize, requiring an argument.
+
+        Args:
+            required: A required positional argument.
+        """
+        self.required = required
+
+
 _EXTRA_PLUGIN_A = "tests.units.test_config.ExtraPluginA"
 _EXTRA_PLUGIN_B = "tests.units.test_config.ExtraPluginB"
+_TRACKED_EXTRA_PLUGIN = "tests.units.test_config.TrackedExtraPlugin"
+_NEEDS_ARGS_EXTRA_PLUGIN = "tests.units.test_config.NeedsArgsExtraPlugin"
+_BAD_PLUGIN_SPEC = "tests.units.test_config.NoSuchPlugin"
 
 
 def test_extra_plugins_appends_single_plugin(monkeypatch: pytest.MonkeyPatch):
@@ -716,3 +743,75 @@ def test_extra_plugins_appends_on_top_of_reflex_plugins(
     config = rx.Config(app_name="test", plugins=[SitemapPlugin()])
     assert any(isinstance(p, ExtraPluginA) for p in config.plugins)
     assert any(isinstance(p, ExtraPluginB) for p in config.plugins)
+
+
+def test_extra_plugins_enabled_is_instantiated(monkeypatch: pytest.MonkeyPatch):
+    """A non-disabled extra plugin has its constructor run exactly once."""
+    _extra_plugin_instantiations.clear()
+    monkeypatch.setenv("REFLEX_EXTRA_PLUGINS", _TRACKED_EXTRA_PLUGIN)
+    config = rx.Config(app_name="test")
+    assert any(isinstance(p, TrackedExtraPlugin) for p in config.plugins)
+    assert _extra_plugin_instantiations == ["TrackedExtraPlugin"]
+
+
+def test_extra_plugins_disabled_is_never_instantiated(monkeypatch: pytest.MonkeyPatch):
+    """A disabled extra plugin is imported but its constructor never runs."""
+    _extra_plugin_instantiations.clear()
+    monkeypatch.setenv("REFLEX_EXTRA_PLUGINS", _TRACKED_EXTRA_PLUGIN)
+    config = rx.Config(app_name="test", disable_plugins=[TrackedExtraPlugin])
+    assert not any(isinstance(p, TrackedExtraPlugin) for p in config.plugins)
+    # The constructor must never have run for the disabled plugin.
+    assert _extra_plugin_instantiations == []
+
+
+def test_extra_plugins_bad_spec_warns_and_keeps_valid(
+    monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+):
+    """A bad REFLEX_EXTRA_PLUGINS entry warns but valid entries are still added."""
+    warn = mocker.patch("reflex_base.config.console.warn")
+    monkeypatch.setenv("REFLEX_EXTRA_PLUGINS", f"{_BAD_PLUGIN_SPEC}:{_EXTRA_PLUGIN_A}")
+    config = rx.Config(app_name="test")
+    # The valid entry survives despite the bad one (no all-or-nothing failure).
+    assert any(isinstance(p, ExtraPluginA) for p in config.plugins)
+    assert any(
+        "REFLEX_EXTRA_PLUGINS" in str(call.args[0]) for call in warn.call_args_list
+    )
+
+
+def test_extra_plugins_uninstantiable_warns_and_skips(
+    monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+):
+    """An extra plugin that cannot be instantiated warns and is skipped, not fatal."""
+    warn = mocker.patch("reflex_base.config.console.warn")
+    monkeypatch.setenv("REFLEX_EXTRA_PLUGINS", _NEEDS_ARGS_EXTRA_PLUGIN)
+    config = rx.Config(app_name="test")
+    assert not any(isinstance(p, NeedsArgsExtraPlugin) for p in config.plugins)
+    assert any(
+        "could not be instantiated" in str(call.args[0]) for call in warn.call_args_list
+    )
+
+
+def test_plugins_bad_env_spec_raises_invalid_plugin_config_error(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """An invalid REFLEX_PLUGINS import path raises InvalidPluginConfigError.
+
+    The dedicated subclass lets error tracking catch plugin-load failures
+    specifically, while still subclassing ConfigError for existing handlers.
+    """
+    monkeypatch.setenv("REFLEX_PLUGINS", _BAD_PLUGIN_SPEC)
+    with pytest.raises(InvalidPluginConfigError, match="could not be loaded"):
+        rx.Config(app_name="test")
+    assert issubclass(InvalidPluginConfigError, ConfigError)
+
+
+def test_disable_plugins_bad_env_spec_warns(
+    monkeypatch: pytest.MonkeyPatch, mocker: MockerFixture
+):
+    """An invalid REFLEX_DISABLE_PLUGINS import path warns but does not crash."""
+    warn = mocker.patch("reflex_base.config.console.warn")
+    monkeypatch.setenv("REFLEX_DISABLE_PLUGINS", _BAD_PLUGIN_SPEC)
+    rx.Config(app_name="test")
+    assert any(
+        "REFLEX_DISABLE_PLUGINS" in str(call.args[0]) for call in warn.call_args_list
+    )

--- a/tests/units/test_config.py
+++ b/tests/units/test_config.py
@@ -615,3 +615,88 @@ def test_plugins_class_requiring_args_raises_config_error():
 
     with pytest.raises(ConfigError, match="NeedsArgs"):
         rx.Config(app_name="test", plugins=[NeedsArgs])  # pyright: ignore[reportArgumentType]
+
+
+# Module-level plugins so REFLEX_EXTRA_PLUGINS can resolve them by import path.
+class ExtraPluginA(Plugin):
+    """First plugin used to exercise REFLEX_EXTRA_PLUGINS."""
+
+
+class ExtraPluginB(Plugin):
+    """Second plugin used to exercise REFLEX_EXTRA_PLUGINS."""
+
+
+_EXTRA_PLUGIN_A = "tests.units.test_config.ExtraPluginA"
+_EXTRA_PLUGIN_B = "tests.units.test_config.ExtraPluginB"
+
+
+def test_extra_plugins_appends_single_plugin(monkeypatch: pytest.MonkeyPatch):
+    """A single extra plugin is appended to the plugins list."""
+    monkeypatch.setenv("REFLEX_EXTRA_PLUGINS", _EXTRA_PLUGIN_A)
+    config = rx.Config(app_name="test")
+    assert any(isinstance(p, ExtraPluginA) for p in config.plugins)
+
+
+def test_extra_plugins_appends_multiple_plugins(monkeypatch: pytest.MonkeyPatch):
+    """Multiple colon-separated extra plugins are all appended."""
+    monkeypatch.setenv("REFLEX_EXTRA_PLUGINS", f"{_EXTRA_PLUGIN_A}:{_EXTRA_PLUGIN_B}")
+    config = rx.Config(app_name="test")
+    assert any(isinstance(p, ExtraPluginA) for p in config.plugins)
+    assert any(isinstance(p, ExtraPluginB) for p in config.plugins)
+
+
+def test_extra_plugins_preserves_config_plugins(monkeypatch: pytest.MonkeyPatch):
+    """Extra plugins are appended without replacing plugins from the config."""
+    monkeypatch.setenv("REFLEX_EXTRA_PLUGINS", _EXTRA_PLUGIN_B)
+    instance = ExtraPluginA()
+    config = rx.Config(app_name="test", plugins=[instance])
+    # The config-provided instance is preserved...
+    assert instance in config.plugins
+    # ...and the extra plugin from the env var is appended.
+    assert any(isinstance(p, ExtraPluginB) for p in config.plugins)
+
+
+def test_extra_plugins_unset_appends_nothing(monkeypatch: pytest.MonkeyPatch):
+    """When unset, no extra plugins leak into the plugins list."""
+    monkeypatch.delenv("REFLEX_EXTRA_PLUGINS", raising=False)
+    config = rx.Config(app_name="test")
+    assert not any(isinstance(p, (ExtraPluginA, ExtraPluginB)) for p in config.plugins)
+
+
+def test_extra_plugins_does_not_duplicate_existing_type(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """An extra plugin whose type is already configured is not added twice."""
+    monkeypatch.setenv("REFLEX_EXTRA_PLUGINS", _EXTRA_PLUGIN_A)
+    config = rx.Config(app_name="test", plugins=[ExtraPluginA()])
+    instances = [p for p in config.plugins if isinstance(p, ExtraPluginA)]
+    assert len(instances) == 1
+
+
+def test_extra_plugins_respects_disable_plugins(monkeypatch: pytest.MonkeyPatch):
+    """An extra plugin disabled via disable_plugins is not appended."""
+    monkeypatch.setenv("REFLEX_EXTRA_PLUGINS", _EXTRA_PLUGIN_A)
+    config = rx.Config(app_name="test", disable_plugins=[ExtraPluginA])
+    assert not any(isinstance(p, ExtraPluginA) for p in config.plugins)
+
+
+def test_extra_plugins_does_not_replace_like_reflex_plugins(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """REFLEX_PLUGINS replaces config plugins, unlike REFLEX_EXTRA_PLUGINS."""
+    monkeypatch.setenv("REFLEX_PLUGINS", _EXTRA_PLUGIN_A)
+    config = rx.Config(app_name="test", plugins=[ExtraPluginB()])
+    # The config plugin is dropped by the REFLEX_PLUGINS replacement.
+    assert not any(isinstance(p, ExtraPluginB) for p in config.plugins)
+    assert any(isinstance(p, ExtraPluginA) for p in config.plugins)
+
+
+def test_extra_plugins_appends_on_top_of_reflex_plugins(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """REFLEX_EXTRA_PLUGINS appends on top of the REFLEX_PLUGINS replacement."""
+    monkeypatch.setenv("REFLEX_PLUGINS", _EXTRA_PLUGIN_A)
+    monkeypatch.setenv("REFLEX_EXTRA_PLUGINS", _EXTRA_PLUGIN_B)
+    config = rx.Config(app_name="test", plugins=[SitemapPlugin()])
+    assert any(isinstance(p, ExtraPluginA) for p in config.plugins)
+    assert any(isinstance(p, ExtraPluginB) for p in config.plugins)

--- a/tests/units/test_config.py
+++ b/tests/units/test_config.py
@@ -583,6 +583,22 @@ class TestDisablePlugins:
         config = rx.Config(app_name="test")
         assert any(isinstance(p, SitemapPlugin) for p in config.plugins)
 
+    def test_disable_non_builtin_plugin_does_not_warn(self, mocker: MockerFixture):
+        """Disabling a non-builtin plugin emits no warning.
+
+        Non-builtin plugins (e.g. ones added via REFLEX_EXTRA_PLUGINS) can be
+        disabled through this same mechanism, so disabling a plugin that is not
+        enabled-by-default must not warn.
+        """
+
+        class CustomPlugin(Plugin): ...
+
+        warn = mocker.patch("reflex_base.config.console.warn")
+        rx.Config(app_name="test", disable_plugins=[CustomPlugin])
+        assert not any(
+            "not a built-in plugin" in str(call.args[0]) for call in warn.call_args_list
+        )
+
 
 def test_plugins_instance_passthrough():
     """A Plugin instance is kept as-is (issue #6440)."""

--- a/tests/units/test_environment.py
+++ b/tests/units/test_environment.py
@@ -15,6 +15,7 @@ from reflex_base.environment import (
     ExistingPath,
     PerformanceMode,
     SequenceOptions,
+    _InvalidPlugin,
     _load_dotenv_from_files,
     _paths_from_env_files,
     _paths_from_environment,
@@ -37,6 +38,18 @@ from reflex_base.utils.exceptions import EnvironmentVarValueError
 
 class TestPlugin(Plugin):
     """Test plugin for testing purposes."""
+
+
+class NeedsArgsPlugin(Plugin):
+    """Test plugin whose constructor requires arguments (cannot auto-instantiate)."""
+
+    def __init__(self, required):
+        """Initialize, requiring an argument.
+
+        Args:
+            required: A required positional argument.
+        """
+        self.required = required
 
 
 class _TestEnum(enum.Enum):
@@ -103,26 +116,49 @@ class TestInterpretFunctions:
         assert isinstance(result, TestPlugin)
 
     def test_interpret_plugin_env_invalid_format(self):
-        """Test plugin interpretation with invalid format."""
-        with pytest.raises(EnvironmentVarValueError, match="Invalid plugin value"):
-            interpret_plugin_env("invalid_format", "TEST_FIELD")
+        """Test plugin interpretation with invalid format returns an _InvalidPlugin."""
+        result = interpret_plugin_env("invalid_format", "TEST_FIELD")
+        assert isinstance(result, _InvalidPlugin)
+        assert result.spec == "invalid_format"
+        assert "Invalid plugin value" in result.error
 
     def test_interpret_plugin_env_import_error(self):
-        """Test plugin interpretation with import error."""
-        with pytest.raises(EnvironmentVarValueError, match="Failed to import module"):
-            interpret_plugin_env("non.existent.module.Plugin", "TEST_FIELD")
+        """Test plugin interpretation with import error returns an _InvalidPlugin."""
+        result = interpret_plugin_env("non.existent.module.Plugin", "TEST_FIELD")
+        assert isinstance(result, _InvalidPlugin)
+        assert "Failed to import module" in result.error
 
     def test_interpret_plugin_env_missing_class(self):
-        """Test plugin interpretation with missing class."""
-        with pytest.raises(EnvironmentVarValueError, match="Invalid plugin class"):
-            interpret_plugin_env(
-                "tests.units.test_environment.NonExistentPlugin", "TEST_FIELD"
-            )
+        """Test plugin interpretation with missing class returns an _InvalidPlugin."""
+        result = interpret_plugin_env(
+            "tests.units.test_environment.NonExistentPlugin", "TEST_FIELD"
+        )
+        assert isinstance(result, _InvalidPlugin)
+        assert "Invalid plugin class" in result.error
 
     def test_interpret_plugin_env_invalid_class(self):
-        """Test plugin interpretation with invalid class."""
-        with pytest.raises(EnvironmentVarValueError, match="Invalid plugin class"):
-            interpret_plugin_env("tests.units.test_environment.TestEnum", "TEST_FIELD")
+        """Test plugin interpretation with invalid class returns an _InvalidPlugin."""
+        result = interpret_plugin_env(
+            "tests.units.test_environment.TestEnum", "TEST_FIELD"
+        )
+        assert isinstance(result, _InvalidPlugin)
+        assert "Invalid plugin class" in result.error
+
+    def test_interpret_plugin_env_instantiation_error(self):
+        """A plugin whose constructor fails returns an _InvalidPlugin, not a raise."""
+        result = interpret_plugin_env(
+            "tests.units.test_environment.NeedsArgsPlugin", "TEST_FIELD"
+        )
+        assert isinstance(result, _InvalidPlugin)
+        assert "failed to instantiate" in result.error
+
+    def test_interpret_plugin_env_valid_does_not_return_invalid(self):
+        """A valid plugin spec still returns a real instance, never an _InvalidPlugin."""
+        result = interpret_plugin_env(
+            "tests.units.test_environment.TestPlugin", "TEST_FIELD"
+        )
+        assert isinstance(result, TestPlugin)
+        assert not isinstance(result, _InvalidPlugin)
 
     def test_interpret_plugin_class_env_valid(self):
         """Test plugin class interpretation returns the class, not an instance."""
@@ -203,6 +239,26 @@ class TestInterpretEnvVarValue:
             "TEST_FIELD",
         )
         assert result is TestPlugin
+
+    def test_interpret_plugin_class_invalid_returns_invalid_plugin(self):
+        """Test type[Plugin] interpretation returns _InvalidPlugin on a bad path."""
+        result = interpret_env_var_value(
+            "non.existent.module.Plugin",
+            type[Plugin],
+            "TEST_FIELD",
+        )
+        assert isinstance(result, _InvalidPlugin)
+        assert "Failed to import module" in result.error
+
+    def test_interpret_plugin_list_collects_invalid_per_entry(self):
+        """A bad entry in a list[type[Plugin]] becomes _InvalidPlugin, not a raise."""
+        result = interpret_env_var_value(
+            "tests.units.test_environment.TestPlugin:bad.path.Plugin",
+            list[type[Plugin]],
+            "TEST_FIELD",
+        )
+        assert result[0] is TestPlugin
+        assert isinstance(result[1], _InvalidPlugin)
 
     def test_interpret_list(self):
         """Test list interpretation."""

--- a/tests/units/test_environment.py
+++ b/tests/units/test_environment.py
@@ -129,17 +129,17 @@ class TestInterpretFunctions:
         assert "Failed to import module" in result.error
 
     def test_interpret_plugin_env_missing_class(self):
-        """Test plugin interpretation with missing class returns an _InvalidPlugin."""
+        """A missing attribute returns an _InvalidPlugin recording the lookup failure."""
         result = interpret_plugin_env(
             "tests.units.test_environment.NonExistentPlugin", "TEST_FIELD"
         )
         assert isinstance(result, _InvalidPlugin)
-        assert "Invalid plugin class" in result.error
+        assert "Failed to get plugin class" in result.error
 
     def test_interpret_plugin_env_invalid_class(self):
-        """Test plugin interpretation with invalid class returns an _InvalidPlugin."""
+        """An existing non-Plugin class returns an _InvalidPlugin."""
         result = interpret_plugin_env(
-            "tests.units.test_environment.TestEnum", "TEST_FIELD"
+            "tests.units.test_environment._TestEnum", "TEST_FIELD"
         )
         assert isinstance(result, _InvalidPlugin)
         assert "Invalid plugin class" in result.error
@@ -178,10 +178,10 @@ class TestInterpretFunctions:
             interpret_plugin_class_env("non.existent.module.Plugin", "TEST_FIELD")
 
     def test_interpret_plugin_class_env_invalid_class(self):
-        """Test plugin class interpretation with invalid class."""
+        """Test plugin class interpretation with an existing non-Plugin class."""
         with pytest.raises(EnvironmentVarValueError, match="Invalid plugin class"):
             interpret_plugin_class_env(
-                "tests.units.test_environment.TestEnum", "TEST_FIELD"
+                "tests.units.test_environment._TestEnum", "TEST_FIELD"
             )
 
     def test_interpret_enum_env_valid(self):


### PR DESCRIPTION
REFLEX_EXTRA_PLUGINS defined plugin import paths that will be added to the Config.plugins list if the list does not already contain a plugin of that type.

When adding extra plugins, the `disable_plugins` config field is respected, so explicitly disabled plugins cannot be injected from the environment.