### PR TITLE
Cancel stale on_load event chains

### DIFF
--- a/news/6593.bugfix.md
+++ b/news/6593.bugfix.md
@@ -1,0 +1,1 @@
+Cancel stale page load events when a newer page navigation starts.

--- a/packages/reflex-base/src/reflex_base/event/processor/event_processor.py
+++ b/packages/reflex-base/src/reflex_base/event/processor/event_processor.py
@@ -20,6 +20,7 @@ from typing_extensions import Self
 from reflex.app_mixins.middleware import MiddlewareMixin
 from reflex.istate.manager import StateManager
 from reflex.utils import console
+from reflex_base import constants
 from reflex_base.event.context import EventContext
 from reflex_base.event.processor.compat import as_completed
 from reflex_base.event.processor.future import EventFuture
@@ -118,6 +119,9 @@ class EventProcessor:
         default_factory=dict, init=False
     )
     _futures: dict[str, EventFuture] = dataclasses.field(
+        default_factory=dict, init=False
+    )
+    _active_on_load_futures: dict[str, EventFuture] = dataclasses.field(
         default_factory=dict, init=False
     )
     _token_queues: dict[
@@ -311,6 +315,7 @@ class EventProcessor:
             self._queue_task = None
         # Discard any pending per-token queue entries.
         self._token_queues.clear()
+        self._active_on_load_futures.clear()
         # Cancel any remaining unresolved futures.
         for future in self._futures.values():
             if not future.done():
@@ -396,6 +401,8 @@ class EventProcessor:
         # If this context has a parent, register as a child of the parent's future.
         if parent_future is not None:
             parent_future.add_child(tracked)
+        if self._is_on_load_internal_event(event):
+            self._cancel_stale_on_load(token=token, current=tracked)
         await queue.put(EventQueueEntry(event=event, ctx=ev_ctx))
         return tracked
 
@@ -496,8 +503,45 @@ class EventProcessor:
             return
         parent = future.parent
         self._futures.pop(future.txid, None)
+        self._try_clean_active_on_load_future(future)
         if parent is not None and parent.txid:
             self._try_clean_future(parent)
+
+    @staticmethod
+    def _is_on_load_internal_event(event: Event) -> bool:
+        """Check whether an event is the internal page-load dispatcher.
+
+        Args:
+            event: The event to check.
+
+        Returns:
+            True if the event dispatches page on_load handlers.
+        """
+        return event.name.endswith(f".{constants.CompileVars.ON_LOAD_INTERNAL}")
+
+    def _cancel_stale_on_load(self, *, token: str, current: EventFuture) -> None:
+        """Cancel any older on_load chain for the token.
+
+        Args:
+            token: The client token for the page load event.
+            current: The newly enqueued on_load future.
+        """
+        previous = self._active_on_load_futures.get(token)
+        if previous is not None and previous is not current and not previous.all_done():
+            previous.cancel()
+        self._active_on_load_futures[token] = current
+
+    def _try_clean_active_on_load_future(self, future: EventFuture) -> None:
+        """Remove a completed active on_load future.
+
+        Args:
+            future: The future to remove if it is no longer active.
+        """
+        if not future.all_done():
+            return
+        for token, active_future in list(self._active_on_load_futures.items()):
+            if active_future is future:
+                self._active_on_load_futures.pop(token, None)
 
     def _on_future_done(self, future: EventFuture) -> None:  # type: ignore[override]
         """Callback invoked when an enqueued future completes.

--- a/packages/reflex-base/src/reflex_base/event/processor/event_processor.py
+++ b/packages/reflex-base/src/reflex_base/event/processor/event_processor.py
@@ -124,6 +124,9 @@ class EventProcessor:
     _active_on_load_futures: dict[str, EventFuture] = dataclasses.field(
         default_factory=dict, init=False
     )
+    _active_on_load_tokens: dict[str, str] = dataclasses.field(
+        default_factory=dict, init=False
+    )
     _token_queues: dict[
         str,
         collections.deque[tuple[EventQueueEntry, RegisteredEventHandler]],
@@ -316,6 +319,7 @@ class EventProcessor:
         # Discard any pending per-token queue entries.
         self._token_queues.clear()
         self._active_on_load_futures.clear()
+        self._active_on_load_tokens.clear()
         # Cancel any remaining unresolved futures.
         for future in self._futures.values():
             if not future.done():
@@ -527,9 +531,12 @@ class EventProcessor:
             current: The newly enqueued on_load future.
         """
         previous = self._active_on_load_futures.get(token)
-        if previous is not None and previous is not current and not previous.all_done():
-            previous.cancel()
+        if previous is not None and previous is not current:
+            self._active_on_load_tokens.pop(previous.txid, None)
+            if not previous.all_done():
+                previous.cancel()
         self._active_on_load_futures[token] = current
+        self._active_on_load_tokens[current.txid] = token
 
     def _try_clean_active_on_load_future(self, future: EventFuture) -> None:
         """Remove a completed active on_load future.
@@ -539,9 +546,9 @@ class EventProcessor:
         """
         if not future.all_done():
             return
-        for token, active_future in list(self._active_on_load_futures.items()):
-            if active_future is future:
-                self._active_on_load_futures.pop(token, None)
+        token = self._active_on_load_tokens.pop(future.txid, None)
+        if token is not None and self._active_on_load_futures.get(token) is future:
+            self._active_on_load_futures.pop(token, None)
 
     def _on_future_done(self, future: EventFuture) -> None:  # type: ignore[override]
         """Callback invoked when an enqueued future completes.

--- a/packages/reflex-base/src/reflex_base/event/processor/future.py
+++ b/packages/reflex-base/src/reflex_base/event/processor/future.py
@@ -31,6 +31,16 @@ class EventFuture(asyncio.Future):
         default_factory=asyncio.get_running_loop, repr=False
     )
 
+    # Whether cancellation should apply to children added after this future is done.
+    _cascade_cancel_requested: bool = dataclasses.field(
+        default=False, init=False, repr=False
+    )
+
+    # Preserve the cancellation message for children attached after cancellation.
+    _cascade_cancel_message: object = dataclasses.field(
+        default=None, init=False, repr=False
+    )
+
     def __post_init__(self) -> None:
         """Call Future.__init__ for the EventFuture."""
         super(EventFuture, self).__init__(loop=self.loop)
@@ -42,12 +52,14 @@ class EventFuture(asyncio.Future):
             child: The child EventFuture to add.
 
         Raises:
-            RuntimeError: If this future is already done.
+            RuntimeError: If this future is already done without a cancellation cascade.
         """
-        if self.done():
+        if self.done() and not self._cascade_cancel_requested:
             msg = "Cannot add a child to an EventFuture that is already done."
             raise RuntimeError(msg)
         self.children.append(child)
+        if self._cascade_cancel_requested:
+            child.cancel(self._cascade_cancel_message)
 
     def all_done(self) -> bool:
         """Check if this future and all descendant futures are done.
@@ -89,6 +101,8 @@ class EventFuture(asyncio.Future):
         Returns:
             True if the future was successfully cancelled.
         """
+        self._cascade_cancel_requested = True
+        self._cascade_cancel_message = msg
         result = super(EventFuture, self).cancel(msg)
         for child in self.children:
             child.cancel(msg)

--- a/tests/units/reflex_base/event/processor/test_event_processor.py
+++ b/tests/units/reflex_base/event/processor/test_event_processor.py
@@ -5,13 +5,14 @@ import contextlib
 from typing import Any
 
 import pytest
+from reflex_base import constants
 from reflex_base.event.context import EventContext
 from reflex_base.event.processor.event_processor import (
     EventProcessor,
     QueueShutDown,
     _stream_queue_until_done,
 )
-from reflex_base.registry import RegistrationContext
+from reflex_base.registry import RegisteredEventHandler, RegistrationContext
 
 from reflex.event import Event, EventHandler
 
@@ -443,6 +444,63 @@ async def test_error_does_not_stop_queue(
         await ep.enqueue(token, Event.from_event_type(error_event())[0])
         await ep.enqueue(token, Event.from_event_type(logging_event("after_error"))[0])
     assert _CALL_LOG == [{"value": "after_error"}]
+
+
+async def test_new_on_load_internal_cancels_previous_chain(
+    processor: EventProcessor,
+    token: str,
+):
+    """A newer navigation cancels stale on_load work for the same token.
+
+    Args:
+        processor: The event processor fixture.
+        token: The client token.
+    """
+    stale_started = asyncio.Event()
+    on_load_event_name = f"state.{constants.CompileVars.ON_LOAD_INTERNAL}"
+    load_handler_event_name = "state.load_page"
+
+    async def on_load_internal_handler(value: str):
+        ctx = EventContext.get()
+        await ctx.enqueue(Event(name=load_handler_event_name, payload={"value": value}))
+
+    async def load_handler(value: str):
+        if value == "stale":
+            stale_started.set()
+            try:
+                await asyncio.sleep(10)
+            except asyncio.CancelledError:
+                _CALL_LOG.append({"value": "stale_cancelled"})
+                raise
+        _CALL_LOG.append({"value": value})
+
+    registration_context = RegistrationContext.get()
+    registration_context.event_handlers[on_load_event_name] = RegisteredEventHandler(
+        handler=EventHandler(fn=on_load_internal_handler),
+        states=(),
+    )
+    registration_context.event_handlers[load_handler_event_name] = (
+        RegisteredEventHandler(
+            handler=EventHandler(fn=load_handler),
+            states=(),
+        )
+    )
+
+    processor.configure()
+    async with processor as ep:
+        await ep.enqueue(
+            token,
+            Event(name=on_load_event_name, payload={"value": "stale"}),
+        )
+        await asyncio.wait_for(stale_started.wait(), timeout=1)
+
+        current = await ep.enqueue(
+            token,
+            Event(name=on_load_event_name, payload={"value": "fresh"}),
+        )
+        await asyncio.wait_for(current.wait_all(), timeout=1)
+
+    assert _CALL_LOG == [{"value": "stale_cancelled"}, {"value": "fresh"}]
 
 
 async def test_chained_event_processed(token: str):

--- a/tests/units/reflex_base/event/processor/test_event_processor.py
+++ b/tests/units/reflex_base/event/processor/test_event_processor.py
@@ -488,11 +488,13 @@ async def test_new_on_load_internal_cancels_previous_chain(
 
     processor.configure()
     async with processor as ep:
-        await ep.enqueue(
+        stale = await ep.enqueue(
             token,
             Event(name=on_load_event_name, payload={"value": "stale"}),
         )
         await asyncio.wait_for(stale_started.wait(), timeout=1)
+        assert stale.done()
+        assert not stale.all_done()
 
         current = await ep.enqueue(
             token,

--- a/tests/units/reflex_base/event/processor/test_future.py
+++ b/tests/units/reflex_base/event/processor/test_future.py
@@ -51,13 +51,34 @@ async def test_add_child_to_done_future_raises():  # noqa: RUF029
 
 
 @pytest.mark.asyncio
-async def test_add_child_to_cancelled_future_raises():  # noqa: RUF029
-    """add_child raises RuntimeError if the parent future is cancelled."""
+async def test_add_child_to_cancelled_future_cancels_child():  # noqa: RUF029
+    """add_child immediately cancels children when a cascade was requested."""
     parent = EventFuture(txid="parent")
-    parent.cancel()
+    parent.cancel("stale")
     child = EventFuture(txid="child")
-    with pytest.raises(RuntimeError, match="already done"):
-        parent.add_child(child)
+
+    parent.add_child(child)
+
+    assert parent.children == [child]
+    assert child.cancelled()
+    with pytest.raises(asyncio.CancelledError, match="stale"):
+        child.result()
+
+
+@pytest.mark.asyncio
+async def test_add_child_after_done_parent_cancel_request_cancels_child():  # noqa: RUF029
+    """A late child is cancelled if cascade cancellation was requested after completion."""
+    parent = EventFuture(txid="parent")
+    parent.set_result(None)
+    assert not parent.cancel("stale")
+    child = EventFuture(txid="child")
+
+    parent.add_child(child)
+
+    assert parent.children == [child]
+    assert child.cancelled()
+    with pytest.raises(asyncio.CancelledError, match="stale"):
+        child.result()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
  Fixes #6593
 

## Summary
  - Track the active internal `on_load` event chain per client token.
  - Cancel the previous `on_load` chain when a newer page navigation starts for the same token.
  - Add regression coverage for stale page-load work being cancelled while the newer load completes.


  ## Testing
  - `uv run pytest tests/units/reflex_base/event/processor/test_event_processor.py -q`
  - `uv run --no-sync ruff check packages/reflex-base/src/reflex_base/event/processor/event_processor.py tests/units/
  reflex_base/event/processor/test_event_processor.py`
  - `uv run --no-sync ruff format --check packages/reflex-base/src/reflex_base/event/processor/event_processor.py tests/
  units/reflex_base/event/processor/test_event_processor.py`
  - `uv run --no-sync pyright packages/reflex-base/src/reflex_base/event/processor/event_processor.py tests/units/
  reflex_base/event/processor/test_event_processor.py`