### PR TITLE
docs: GitHub and Git provider integration docs (ENG-9906)

### DIFF
--- a/docs/ai_builder/features/connect_to_git_providers.md
+++ b/docs/ai_builder/features/connect_to_git_providers.md
@@ -1,11 +1,11 @@
 ---
 tags: DevTools
-description: Connect Reflex Build to GitLab, Bitbucket, or any Git remote using a repository URL and personal access token.
+description: Connect Reflex Build to GitLab, Bitbucket, or any Git remote using a repository URL and fine-grained access token.
 ---
 
 # Connecting to Git Providers
 
-Besides the [GitHub integration](/docs/ai/features/connect-to-github/), Reflex Build can sync to any Git remote, including GitLab, Bitbucket, a self-hosted server, or an existing GitHub repository. You connect it with a repository URL and a personal access token, then push and pull the same way you would with GitHub.
+Besides the [GitHub integration](/docs/ai/features/connect-to-github/), Reflex Build can sync to any Git remote, including GitLab, Bitbucket, a self-hosted server, or an existing GitHub repository. You connect it with a repository URL and a fine-grained access token, then push and pull the same way you would with GitHub.
 
 ## What You Need
 
@@ -13,9 +13,9 @@ To connect, provide:
 
 - **Remote URL**: the HTTPS clone URL of the repository (for example `https://gitlab.com/your-org/your-app.git`).
 - **Branch**: the branch to sync with. Point at an existing branch, or name a new branch for an empty repository.
-- **Personal access token (PAT)**: a token from your provider with permission to read and write the repository. It authenticates pushes and pulls.
+- **Fine-grained access token**: a token from your provider with permission to read and write the repository. It authenticates pushes and pulls.
 
-Unlike the GitHub integration, which each user authorizes with their own account, the PAT is saved as one of the app's secrets (`GIT_PAT_TOKEN`). Anyone working on the app pushes and pulls with that stored token, so use a token whose repository access is appropriate to share with the app's collaborators.
+Unlike the GitHub integration, which each user authorizes with their own account, the token is saved as one of the app's secrets (`GIT_PAT_TOKEN`). Anyone working on the app pushes and pulls with that stored token, so use a token whose repository access is appropriate to share with the app's collaborators.
 
 ## How It Works
 
@@ -24,7 +24,7 @@ The connection tracks two separate repositories: the internal history Reflex Bui
 ## Connecting
 
 1. Open the Git connection dialog in the editor and choose the generic Git option.
-2. Enter the remote URL, the branch, and your personal access token.
+2. Enter the remote URL, the branch, and your fine-grained access token.
 3. Choose whether to pull the remote's files into the editor immediately after connecting.
 
 After connecting, the **Push** and **Pull** actions work the same as with GitHub.

--- a/docs/ai_builder/features/connect_to_git_providers.md
+++ b/docs/ai_builder/features/connect_to_git_providers.md
@@ -1,0 +1,44 @@
+---
+tags: DevTools
+description: Connect Reflex Build to GitLab, Bitbucket, or any Git remote using a repository URL and personal access token.
+---
+
+# Connecting to Git Providers
+
+```python exec
+import reflex as rx
+```
+
+Besides the [GitHub integration](/docs/ai/features/connect-to-github/), Reflex Build can sync to any Git remote, including GitLab, Bitbucket, a self-hosted server, or an existing GitHub repository. You connect it with a repository URL and a personal access token, then push and pull the same way you would with GitHub.
+
+## What You Need
+
+To connect, provide:
+
+- **Remote URL**: the HTTPS clone URL of the repository (for example `https://gitlab.com/your-org/your-app.git`).
+- **Branch**: the branch to sync with. Point at an existing branch, or name a new branch for an empty repository.
+- **Personal access token (PAT)**: a token from your provider with permission to read and write the repository. It authenticates pushes and pulls.
+
+Unlike the GitHub integration, which each user authorizes with their own account, the PAT is saved as one of the app's secrets (`GIT_PAT_TOKEN`). Anyone working on the app pushes and pulls with that stored token, so use a token whose repository access is appropriate to share with the app's collaborators.
+
+## How It Works
+
+The connection tracks two separate repositories: the internal history Reflex Build keeps for your app, and your external remote. Pushing copies your app's current files to the remote as a commit; pulling copies the remote's latest files back into the editor. The two histories stay independent, so a sync copies the files across, not the individual commits.
+
+## Connecting
+
+1. Open the Git connection dialog in the editor and choose the generic Git option.
+2. Enter the remote URL, the branch, and your personal access token.
+3. Choose whether to pull the remote's files into the editor immediately after connecting.
+
+After connecting, the **Push** and **Pull** actions work the same as with GitHub.
+
+## Connecting to an Existing Repository
+
+To bring in an existing repository, enter its remote URL and a token with access to it, then pull its files into the editor. Reflex Build syncs against that branch from then on.
+
+If the repository is empty, name a new branch instead of an existing one, and Reflex Build initializes it on the first push.
+
+## Requirements
+
+Git integration is available on plans that include the Git connection feature. If your plan does not include it, connecting will prompt you to upgrade.

--- a/docs/ai_builder/features/connect_to_git_providers.md
+++ b/docs/ai_builder/features/connect_to_git_providers.md
@@ -5,10 +5,6 @@ description: Connect Reflex Build to GitLab, Bitbucket, or any Git remote using 
 
 # Connecting to Git Providers
 
-```python exec
-import reflex as rx
-```
-
 Besides the [GitHub integration](/docs/ai/features/connect-to-github/), Reflex Build can sync to any Git remote, including GitLab, Bitbucket, a self-hosted server, or an existing GitHub repository. You connect it with a repository URL and a personal access token, then push and pull the same way you would with GitHub.
 
 ## What You Need

--- a/docs/ai_builder/features/connect_to_github.md
+++ b/docs/ai_builder/features/connect_to_github.md
@@ -1,16 +1,15 @@
 ---
 tags: DevTools
-description: Integrate with GitHub to automate workflows and interact with your code repositories.
+description: Connect Reflex Build to GitHub to version your app, sync code locally, and revert to previous checkpoints.
 ---
 
-# Connecting to Github
+# Connecting to GitHub
 
 ```python exec
 import reflex as rx
 ```
 
-The Github integration is important to make sure that you don't lose your progress. It also allows you to revert to previous versions of your app.
-
+Connecting your app to GitHub gives it a version history and lets you edit the code locally. Each sync is a commit in an ordinary Git repository.
 
 ```python eval
 rx.el.div(
@@ -25,11 +24,45 @@ rx.el.div(
 
 The GitHub integration allows you to:
 
-- Save your app progress
-- Work on your code locally and push your local changes back to Reflex.Build
+- Save your app progress as commits you control
+- Work on your code locally and push your local changes back to Reflex Build
+- Pull changes made elsewhere back into the editor
+- Revert to any previous version of your app
 
+## How the Connection Works
 
-## Github Commit History
+Reflex Build connects to GitHub through the `reflex-build` GitHub App using OAuth. The first time you connect, GitHub prompts you to install the app and authorize access. It then links your GitHub account to Reflex Build, which stores an encrypted access token and uses it to create repositories and push commits for you.
+
+Pushes, pulls, and reverts use short-lived GitHub App installation tokens that Reflex Build requests as needed. Your personal OAuth token identifies you and refreshes access. Both are encrypted at rest.
+
+## Team and Multi-User Access
+
+**Each user connects their own GitHub account.** Connections are stored per user; there is no shared or organization-level token. If one teammate connects GitHub, another teammate who wants to push or pull has to run the same connect flow and authorize the `reflex-build` app with their own account.
+
+Commits are attributed to the GitHub user who made them, and each person's access to a repository follows their own GitHub permissions.
+
+The GitHub App installation is separate from per-user authorization. An organization owner can install the `reflex-build` app once and choose which repositories it may access, which controls what is reachable from Reflex Build. Each user still authorizes the app once to link their own account before they can push or pull.
+
+## Where Repositories Are Created
+
+When you connect a Build app to GitHub, Reflex Build creates a Git repository for it:
+
+- If the `reflex-build` app is installed on a **GitHub organization**, the repository is created inside that organization.
+- Otherwise, the repository is created under your **personal GitHub account**.
+
+New repositories use the `main` branch and are private, unless you make them public when connecting.
+
+## Pushing and Pulling Changes
+
+The GitHub popover in the editor syncs in both directions:
+
+- **Push**: commit the current state of your app and push it to GitHub.
+- **Pull**: fetch the latest commits from GitHub and update the files in the editor.
+- **Switch branch**: check out a different branch and sync its files into the editor.
+
+You can also clone the repository, edit it locally, and push your changes back.
+
+## GitHub Commit History
 
 The commit history is a great way to see the changes that you have made to your app. You can also revert to previous versions of your app from here.
 
@@ -44,3 +77,12 @@ rx.el.div(
 )
 ```
 
+Reverting resets your app's files to an earlier commit.
+
+## Other Git Providers
+
+To connect a repository hosted somewhere other than GitHub, such as GitLab, Bitbucket, or a self-hosted Git server, use the generic Git connection instead. See [Connecting to Git Providers](/docs/ai/features/connect-to-git-providers/) for details.
+
+## Requirements
+
+Git integration is available on plans that include the Git connection feature. If your plan does not include it, connecting will prompt you to upgrade.

--- a/docs/app/reflex_docs/templates/docpage/sidebar/sidebar_items/ai.py
+++ b/docs/app/reflex_docs/templates/docpage/sidebar/sidebar_items/ai.py
@@ -26,6 +26,7 @@ def get_sidebar_items_ai_builder_overview():
                 ai_builder.features.installing_external_packages,
                 ai_builder.features.integration_shortcut,
                 ai_builder.features.connect_to_github,
+                ai_builder.features.connect_to_git_providers,
                 ai_builder.features.knowledge,
                 ai_builder.features.image_as_prompt,
                 # ai_builder.features.automated_testing,


### PR DESCRIPTION
## What

Documents the Git integration for Reflex Build, prompted by [ENG-9906](https://linear.app/reflex-dev/issue/ENG-9906/git-integration-documentation). Content verified against the flexgen implementation.

- **Rewrote `connect_to_github.md`** (was a two-paragraph stub) to cover:
  - How the connection works: OAuth via the `reflex-build` GitHub App, short-lived installation tokens for repo operations.
  - **Team / multi-user access** — the crux of the issue. Connections are stored **per user**; there is no shared or org-level token. Each teammate must authorize the app with their own GitHub account. The GitHub App *installation* (org-wide, controls which repos are reachable) is distinguished from per-user *authorization*.
  - Where repositories are created (personal account vs. organization), push/pull/branch-switch, commit history & revert.
- **Added `connect_to_git_providers.md`** for connecting generic Git remotes (GitLab, Bitbucket, self-hosted, or an existing repo) via remote URL + PAT. Notes that, unlike the GitHub OAuth flow, the PAT is stored as a **shared app secret** (`GIT_PAT_TOKEN`), so all collaborators on the app use the one token.
- Registered the new page in the AI Builder Features sidebar.

## Answers to the questions in the issue

- *"If one user connects the integration, does a second user share it?"* — For **GitHub**, no: each user authenticates separately (matches the customer's report). For **generic Git**, the PAT is shared at the app level.
- *"Importing existing apps from GitHub has not worked."* — There is no GitHub repo-picker/import UI; existing external repos are supported only through the generic-Git PAT flow. This looks like a **product gap/bug** rather than a docs issue and may warrant a separate ticket.

## Notes

- Docs-only change; no components touched, so no `.pyi`/`pyi_hashes.json` updates.
- Screenshots for the new sections are not yet added (reused existing hosted images on the GitHub page).