### PR TITLE
Let marketing_navbar take an optional banner

### DIFF
--- a/packages/reflex-site-shared/src/reflex_site_shared/views/marketing_navbar.py
+++ b/packages/reflex-site-shared/src/reflex_site_shared/views/marketing_navbar.py
@@ -825,8 +825,23 @@ def navigation_menu() -> rx.Component:
 
 
 @rx.memo
-def marketing_navbar() -> rx.Component:
-    """Fixed header: hosting banner plus logo and full navigation.
+def _navbar_header() -> rx.Component:
+    """Logo and navigation menu, memoized for reuse across pages.
+
+    Returns:
+        The component.
+    """
+    return rx.el.header(
+        logo(),
+        navigation_menu(),
+        class_name="w-full max-w-[81rem] h-[4.5rem] mx-auto flex flex-row items-center p-5 rounded-b-xl backdrop-blur-[16px] shadow-[0_-2px_2px_1px_rgba(0,0,0,0.02),0_1px_1px_0_rgba(0,0,0,0.08),0_4px_8px_0_rgba(0,0,0,0.03),0_0_0_1px_#FFF_inset] dark:shadow-none dark:border-x dark:border-b dark:border-secondary-4 bg-gradient-to-b from-secondary-2 to-secondary-1",
+    )
+
+
+@rx.memo
+def _default_marketing_navbar() -> rx.Component:
+    """Marketing navbar with the default shared hosting banner, memoized so it
+    is emitted once across the many pages that use the default banner.
 
     Returns:
         The component.
@@ -835,10 +850,26 @@ def marketing_navbar() -> rx.Component:
 
     return rx.el.div(
         hosting_banner(),
-        rx.el.header(
-            logo(),
-            navigation_menu(),
-            class_name="w-full max-w-[81rem] h-[4.5rem] mx-auto flex flex-row items-center p-5 rounded-b-xl backdrop-blur-[16px] shadow-[0_-2px_2px_1px_rgba(0,0,0,0.02),0_1px_1px_0_rgba(0,0,0,0.08),0_4px_8px_0_rgba(0,0,0,0.03),0_0_0_1px_#FFF_inset] dark:shadow-none dark:border-x dark:border-b dark:border-secondary-4 bg-gradient-to-b from-secondary-2 to-secondary-1",
-        ),
+        _navbar_header(),
+        class_name="flex flex-col w-full top-0 z-[9999] fixed self-center",
+    )
+
+
+def marketing_navbar(banner: rx.Component | None = None) -> rx.Component:
+    """Fixed header: hosting banner plus logo and full navigation.
+
+    Args:
+        banner: Banner to render above the header. Defaults to the shared
+            hosting banner.
+
+    Returns:
+        The component.
+    """
+    if banner is None:
+        return _default_marketing_navbar()
+
+    return rx.el.div(
+        banner,
+        _navbar_header(),
         class_name="flex flex-col w-full top-0 z-[9999] fixed self-center",
     )

--- a/packages/reflex-site-shared/src/reflex_site_shared/views/marketing_navbar.py
+++ b/packages/reflex-site-shared/src/reflex_site_shared/views/marketing_navbar.py
@@ -824,6 +824,9 @@ def navigation_menu() -> rx.Component:
     )
 
 
+_NAVBAR_WRAPPER_CLASS = "flex flex-col w-full top-0 z-[9999] fixed self-center"
+
+
 @rx.memo
 def _navbar_header() -> rx.Component:
     """Logo and navigation menu, memoized for reuse across pages.
@@ -851,7 +854,7 @@ def _default_marketing_navbar() -> rx.Component:
     return rx.el.div(
         hosting_banner(),
         _navbar_header(),
-        class_name="flex flex-col w-full top-0 z-[9999] fixed self-center",
+        class_name=_NAVBAR_WRAPPER_CLASS,
     )
 
 
@@ -871,5 +874,5 @@ def marketing_navbar(banner: rx.Component | None = None) -> rx.Component:
     return rx.el.div(
         banner,
         _navbar_header(),
-        class_name="flex flex-col w-full top-0 z-[9999] fixed self-center",
+        class_name=_NAVBAR_WRAPPER_CLASS,
     )


### PR DESCRIPTION
Adds an optional `banner` argument to the shared `marketing_navbar()` so a site can supply its own top banner without editing the shared component.

## Change — one file (`packages/reflex-site-shared/src/reflex_site_shared/views/marketing_navbar.py`)
- `marketing_navbar(banner: rx.Component | None = None)` — optional banner; defaults to the shared `hosting_banner()` (unchanged behavior for docs/blog).
- Split logo + nav into a memoized `_navbar_header()`.
- Default-banner path kept memoized via `_default_marketing_navbar()`, so pages using the default lose no dedup.

## Why
reflex.dev wants a site-specific promo banner, but the banner is currently welded inside this shared navbar (used by reflex.dev, docs, and blog). This adds an optional override; the marketing repo passes its own banner while docs/blog keep the default.

## Compatibility
- Additive and backward-compatible: both existing callers use `marketing_navbar()` with no args → default path, identical output.
- Heavy nav subtree and the default banner remain emitted once (memoized), so no per-page bundle regression.

## Testing
- `uv run ruff check` + `ruff format --check`: clean.
- `uv run pyright`: 0 errors.
- Builds with default and custom banner. No `.pyi` changes (no component classes/props changed).

Linear: [ENG-9994](https://linear.app/reflex-dev/issue/ENG-9994/show-the-dollar3-until-july-6th-pro-promo-banner-on-reflexdev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
