### PR TITLE
docs: document async_db_url and reflex[db] extra (ENG-8371)

### DIFF
--- a/docs/database/overview.md
+++ b/docs/database/overview.md
@@ -20,7 +20,7 @@ If you are using a NoSQL database (e.g. MongoDB), you can work with it in Reflex
 
 ## Installation
 
-The ORM dependencies (SQLAlchemy, SQLModel, and Alembic) are an optional extra.
+The ORM dependencies (SQLModel and Alembic) are an optional extra.
 Install them with the `db` extra:
 
 ```bash

--- a/docs/database/overview.md
+++ b/docs/database/overview.md
@@ -18,6 +18,15 @@ For advanced use cases, please see the
 If you are using a NoSQL database (e.g. MongoDB), you can work with it in Reflex by installing the appropriate Python client library. In this case, Reflex will not provide any ORM features.
 ```
 
+## Installation
+
+The ORM dependencies (SQLAlchemy, SQLModel, and Alembic) are an optional extra.
+Install them with the `db` extra:
+
+```bash
+pip install "reflex[db]"
+```
+
 ## Connecting
 
 Reflex provides a built-in SQLite database for storing and retrieving data.

--- a/docs/database/queries.md
+++ b/docs/database/queries.md
@@ -209,9 +209,18 @@ config = rx.Config(
 )
 ```
 
-You must also install the matching async DBAPI driver. For SQLite, install
-`aiosqlite` as shown above; for PostgreSQL, use a URL like
-`postgresql+asyncpg://...` and install `asyncpg`.
+You must also install the matching async DBAPI driver, which is not included in
+the `reflex[db]` extra. For the SQLite URL shown above, install `aiosqlite`:
+
+```bash
+pip install aiosqlite
+```
+
+For PostgreSQL, use a URL like `postgresql+asyncpg://...` and install `asyncpg`:
+
+```bash
+pip install asyncpg
+```
 
 The `rx.asession` function returns an async SQLAlchemy session that must be used with an async context manager. Most operations against the `asession` must be awaited.
 

--- a/docs/database/queries.md
+++ b/docs/database/queries.md
@@ -216,10 +216,12 @@ the `reflex[db]` extra. For the SQLite URL shown above, install `aiosqlite`:
 pip install aiosqlite
 ```
 
-For PostgreSQL, use a URL like `postgresql+asyncpg://...` and install `asyncpg`:
+For PostgreSQL, install `psycopg` (psycopg3), which works as both the sync and
+async driver — so `db_url` and `async_db_url` can share the same
+`postgresql+psycopg://...` scheme:
 
 ```bash
-pip install asyncpg
+pip install "psycopg[binary]"
 ```
 
 The `rx.asession` function returns an async SQLAlchemy session that must be used with an async context manager. Most operations against the `asession` must be awaited.

--- a/docs/database/queries.md
+++ b/docs/database/queries.md
@@ -194,6 +194,25 @@ class State(rx.State):
 
 Reflex provides an async version of the session function called `rx.asession` for asynchronous database operations. This is useful when you need to perform database operations in an async context, such as within async event handlers.
 
+### Configuring the Async Database URL
+
+Unlike `rx.session`, which uses `db_url`, `rx.asession` requires a separate
+`async_db_url` to be set in your `rxconfig.py`. It must point at the same
+database as `db_url` but use an async driver, and calling `rx.asession()`
+without it configured raises an error.
+
+```python
+config = rx.Config(
+    app_name="my_app",
+    db_url="sqlite:///reflex.db",
+    async_db_url="sqlite+aiosqlite:///reflex.db",
+)
+```
+
+You must also install the matching async DBAPI driver. For SQLite, install
+`aiosqlite` as shown above; for PostgreSQL, use a URL like
+`postgresql+asyncpg://...` and install `asyncpg`.
+
 The `rx.asession` function returns an async SQLAlchemy session that must be used with an async context manager. Most operations against the `asession` must be awaited.
 
 ```python

--- a/docs/database/queries.md
+++ b/docs/database/queries.md
@@ -196,10 +196,9 @@ Reflex provides an async version of the session function called `rx.asession` fo
 
 ### Configuring the Async Database URL
 
-Unlike `rx.session`, which uses `db_url`, `rx.asession` requires a separate
-`async_db_url` to be set in your `rxconfig.py`. It must point at the same
-database as `db_url` but use an async driver, and calling `rx.asession()`
-without it configured raises an error.
+`rx.asession` needs its own `async_db_url` in `rxconfig.py`. It must point at
+the same database as `db_url` but use an async driver. Calling `rx.asession()`
+when it is unset raises an error.
 
 ```python
 config = rx.Config(
@@ -209,15 +208,15 @@ config = rx.Config(
 )
 ```
 
-You must also install the matching async DBAPI driver, which is not included in
-the `reflex[db]` extra. For the SQLite URL shown above, install `aiosqlite`:
+The matching async DBAPI driver is not part of the `reflex[db]` extra, so
+install it separately. For the SQLite URL above, install `aiosqlite`:
 
 ```bash
 pip install aiosqlite
 ```
 
-For PostgreSQL, install `psycopg` (psycopg3), which works as both the sync and
-async driver — so `db_url` and `async_db_url` can share the same
+For PostgreSQL, install `psycopg` (psycopg3). It works as both the sync and
+async driver, so `db_url` and `async_db_url` can share one
 `postgresql+psycopg://...` scheme:
 
 ```bash


### PR DESCRIPTION
## What

Fixes [ENG-8371](https://linear.app/reflex-dev/issue/ENG-8371/async-database-docs-do-not-mention-setting-async-db-url).

Two gaps in the database docs:

1. **`async_db_url` was undocumented.** `rx.asession()` requires a separate `async_db_url` (with an async driver) in `rxconfig.py`, and raises `ValueError("No async database url configured")` when it is unset — but nothing in the docs mentioned this.
2. **The `reflex[db]` extra was undocumented.** The ORM dependencies (SQLAlchemy, SQLModel, Alembic) are an optional extra, installed via `pip install "reflex[db]"`.

## Changes

- `docs/database/overview.md`: new **Installation** section covering `pip install "reflex[db]"`.
- `docs/database/queries.md`: new **Configuring the Async Database URL** subsection with a config example (`sqlite+aiosqlite`), the async-driver install step, and a note on the PostgreSQL (`asyncpg`) variant.

Docs-only change.