### PR TITLE
docs(plotly): optimize page for Plotly Python SEO terms

### DIFF
--- a/docs/library/graphing/other-charts/plotly.md
+++ b/docs/library/graphing/other-charts/plotly.md
@@ -1,9 +1,10 @@
 ---
+description: Build interactive Plotly charts in pure Python with Reflex. Render line, scatter, histogram, and 3D surface plots as live web components, no JavaScript required.
 components:
   - rx.plotly
 ---
 
-# Plotly
+# Plotly in Python: Interactive Charts with Reflex
 
 ```python exec
 import reflex as rx
@@ -12,15 +13,15 @@ import plotly.express as px
 import plotly.graph_objects as go
 ```
 
-Plotly is a graphing library that can be used to create interactive graphs. Use the rx.plotly component to wrap Plotly as a component for use in your web page. Checkout [Plotly](https://plotly.com/graphing-libraries/) for more information.
+[Plotly](https://plotly.com/graphing-libraries/) is a popular Python graphing library for creating interactive, publication-quality charts. Reflex wraps it with the `rx.plotly` component so you can embed any Plotly figure — line charts, scatter plots, histograms, or 3D surface plots — directly into a Python web app with no JavaScript. Because Reflex compiles to a full-stack web app, these charts stay interactive in the browser and can update live from your app state.
 
 ```md alert info
 # When integrating Plotly graphs into your UI code, note that the method for displaying the graph differs from a regular Python script. Instead of using `fig.show()`, use `rx.plotly(data=fig)` within your UI code to ensure the graph is properly rendered and displayed within the user interface
 ```
 
-## Basic Example
+## Line Chart
 
-Let's create a line graph of life expectancy in Canada.
+Let's start with a basic Plotly line chart of life expectancy in Canada.
 
 ```python demo exec
 import plotly.express as px
@@ -30,6 +31,43 @@ fig = px.line(df, x="year", y="lifeExp", title="Life expectancy in Canada")
 
 
 def line_chart():
+    return rx.center(
+        rx.plotly(data=fig),
+    )
+```
+
+## Scatter Plot
+
+Scatter plots are useful for showing the relationship between two variables. Here we plot the Iris dataset, coloring each point by species.
+
+```python demo exec
+def scatter_plot():
+    df = px.data.iris()
+    fig = px.scatter(
+        df,
+        x="sepal_width",
+        y="sepal_length",
+        color="species",
+        title="Iris sepal dimensions",
+    )
+    return rx.center(
+        rx.plotly(data=fig),
+    )
+```
+
+## Histogram
+
+Histograms show the distribution of a single variable. This example plots the distribution of restaurant bill totals.
+
+```python demo exec
+def histogram():
+    df = px.data.tips()
+    fig = px.histogram(
+        df,
+        x="total_bill",
+        nbins=30,
+        title="Distribution of restaurant bills",
+    )
     return rx.center(
         rx.plotly(data=fig),
     )
@@ -55,7 +93,7 @@ def localized_line_chart():
 
 You can still pass `config`; when both are provided, `locale=` is applied as the final locale value.
 
-## 3D graphing example
+## 3D Surface Plot
 
 Let's create a 3D surface plot of Mount Bruno. This is a slightly more complicated example, but it wraps in Reflex using the same method. In fact, you can wrap any figure using the same approach.
 

--- a/docs/library/graphing/other-charts/plotly.md
+++ b/docs/library/graphing/other-charts/plotly.md
@@ -41,15 +41,17 @@ def line_chart():
 Scatter plots are useful for showing the relationship between two variables. Here we plot the Iris dataset, coloring each point by species.
 
 ```python demo exec
+df = px.data.iris()
+fig = px.scatter(
+    df,
+    x="sepal_width",
+    y="sepal_length",
+    color="species",
+    title="Iris sepal dimensions",
+)
+
+
 def scatter_plot():
-    df = px.data.iris()
-    fig = px.scatter(
-        df,
-        x="sepal_width",
-        y="sepal_length",
-        color="species",
-        title="Iris sepal dimensions",
-    )
     return rx.center(
         rx.plotly(data=fig),
     )
@@ -60,14 +62,16 @@ def scatter_plot():
 Histograms show the distribution of a single variable. This example plots the distribution of restaurant bill totals.
 
 ```python demo exec
+df = px.data.tips()
+fig = px.histogram(
+    df,
+    x="total_bill",
+    nbins=30,
+    title="Distribution of restaurant bills",
+)
+
+
 def histogram():
-    df = px.data.tips()
-    fig = px.histogram(
-        df,
-        x="total_bill",
-        nbins=30,
-        title="Distribution of restaurant bills",
-    )
     return rx.center(
         rx.plotly(data=fig),
     )


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

- [x] This change requires a documentation update

### Description

The Plotly docs page (`docs/library/graphing/other-charts/plotly/`) currently ranks for essentially nothing — Ahrefs shows a single keyword ("reflex charts", volume 10). This reframes it as the canonical **"interactive Plotly charts in Python"** example hub to capture winnable long-tail terms, rather than chasing the branded head term "plotly python" (whose SERP is locked up by plotly.com's own docs + GitHub).

**On-page SEO changes to `docs/library/graphing/other-charts/plotly.md`:**

- **Added a frontmatter `description`** — the page previously had none and fell back to generic boilerplate for its meta description.
- **Rewrote the H1** to `Plotly in Python: Interactive Charts with Reflex`, so the auto-generated `<title>` (built in `docpage.py`) carries "Python" and intent terms instead of the bare `Plotly · Other Charts · Reflex Docs`.
- **Added a keyword-rich intro paragraph** covering Plotly / Python / interactive / web app.
- **Renamed sections to match chart-type queries** (`Line Chart`, `3D Surface Plot`) and **added `Scatter Plot` and `Histogram` example sections** targeting low-difficulty terms (KD 1–3).

**Target keywords** (from Ahrefs): `python interactive charts` (KD 14, the term Reflex can realistically win), plus the chart-type long tail — `plotly line chart` (KD 1), `plotly scatter plot python` (KD 2), `plotly 3d surface plot` (KD 3), `plotly histogram python`.

### Notes for reviewers

- The two new demo blocks (Scatter Plot, Histogram) use canonical Plotly Express APIs (`px.data.iris()`, `px.data.tips()`, `px.scatter`, `px.histogram`) mirroring the existing gapminder examples. I was unable to execute them in the CI-less authoring environment, so please confirm they render with a local docs run before merge.
- Docs-only change: no framework code, components, or `.pyi` stubs affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PbVJc3WvEpK4QRXPxiVc2M

---
_Generated by [Claude Code](https://claude.ai/code/session_01PbVJc3WvEpK4QRXPxiVc2M)_