### PR TITLE
docs: SEO optimization for AG Grid enterprise docs

### DIFF
--- a/docs/app/reflex_docs/pages/docs/__init__.py
+++ b/docs/app/reflex_docs/pages/docs/__init__.py
@@ -160,6 +160,14 @@ manual_titles = {
     "docs/library/graphing/general/tooltip.md": "Graphing Tooltip",
     "docs/recipes/content/grid.md": "Grid Recipe",
     "docs/hosting/deploy-to-gcp.md": "Deploy to GCP",
+    "docs/enterprise/ag_grid/index.md": "AG Grid in Python: Interactive Data Grid",
+    "docs/enterprise/ag_grid/column-defs.md": "AG Grid Column Definitions in Python",
+    "docs/enterprise/ag_grid/pivot-mode.md": "AG Grid Pivot Mode in Python",
+    "docs/enterprise/ag_grid/cell-selection.md": "AG Grid Cell Selection in Python",
+    "docs/enterprise/ag_grid/theme.md": "AG Grid Themes in Python",
+    "docs/enterprise/ag_grid/model-wrapper.md": "AG Grid with a Pandas DataFrame in Python",
+    "docs/enterprise/ag_grid/value-transformers.md": "AG Grid Value Transformers in Python",
+    "docs/enterprise/ag_grid/aligned-grids.md": "AG Grid Aligned Grids in Python",
 }
 
 

--- a/docs/enterprise/ag_grid/aligned-grids.md
+++ b/docs/enterprise/ag_grid/aligned-grids.md
@@ -1,4 +1,5 @@
 ---
+meta_description: "Build aligned grids with AG Grid in Reflex. Synchronize columns and horizontal scrolling across multiple data grids in Python, no JavaScript required."
 title: Aligned Grids
 ---
 

--- a/docs/enterprise/ag_grid/cell-selection.md
+++ b/docs/enterprise/ag_grid/cell-selection.md
@@ -1,4 +1,5 @@
 ---
+meta_description: "Configure cell and range selection in AG Grid with Reflex. Track selected cells and ranges in your Python data grid, all in pure Python, no JavaScript required."
 title: "Cell Selection"
 order: 8
 ---

--- a/docs/enterprise/ag_grid/column-defs.md
+++ b/docs/enterprise/ag_grid/column-defs.md
@@ -1,4 +1,5 @@
 ---
+meta_description: "Define AG Grid columns in Python with Reflex. Configure column definitions — field, header, type, sorting, filtering, width, and formatting — for your data grid, all in pure Python."
 order: 1
 ---
 

--- a/docs/enterprise/ag_grid/column-defs.md
+++ b/docs/enterprise/ag_grid/column-defs.md
@@ -1,5 +1,5 @@
 ---
-meta_description: "Define AG Grid columns in Python with Reflex. Configure column definitions — field, header, type, sorting, filtering, width, and formatting — for your data grid, all in pure Python."
+meta_description: "Define AG Grid columns in Python with Reflex. Configure column definitions — field, header, type, sorting, filtering, and width — all in pure Python."
 order: 1
 ---
 

--- a/docs/enterprise/ag_grid/index.md
+++ b/docs/enterprise/ag_grid/index.md
@@ -1,11 +1,12 @@
 ---
 title: "AgGrid Overview"
 order: 3
+meta_description: "Use AG Grid in Python with Reflex. Build interactive, enterprise-grade data grids — sorting, filtering, pagination, pivoting, and cell selection — from a pandas DataFrame or Reflex state, no JavaScript required."
 ---
 
 # AG Grid
 
-AG Grid is a powerful, feature-rich data grid component that brings enterprise-grade table functionality to your Reflex applications. With support for sorting, filtering, pagination, row selection, and much more, AG Grid transforms how you display and interact with tabular data.
+AG Grid (also written **ag-grid** or **aggrid**) is a powerful, feature-rich React data grid, and Reflex lets you use it entirely in Python — no JavaScript required. It brings enterprise-grade table functionality to your Reflex applications: with support for sorting, filtering, pagination, row selection, pivoting, and much more, AG Grid transforms how you display and interact with tabular data, whether it comes from a pandas DataFrame or your app's state.
 
 [Explore the full AG Grid showcase and examples](https://aggrid.reflex.run/)
 

--- a/docs/enterprise/ag_grid/index.md
+++ b/docs/enterprise/ag_grid/index.md
@@ -1,7 +1,7 @@
 ---
 title: "AgGrid Overview"
 order: 3
-meta_description: "Use AG Grid in Python with Reflex. Build interactive, enterprise-grade data grids — sorting, filtering, pagination, pivoting, and cell selection — from a pandas DataFrame or Reflex state, no JavaScript required."
+meta_description: "Use AG Grid in Python with Reflex. Build interactive, enterprise-grade data grids with sorting, filtering, pagination, and pivoting — all in pure Python."
 ---
 
 # AG Grid

--- a/docs/enterprise/ag_grid/model-wrapper.md
+++ b/docs/enterprise/ag_grid/model-wrapper.md
@@ -1,4 +1,5 @@
 ---
+meta_description: "Wire AG Grid to a pandas DataFrame or a Reflex database model in Python. The model wrapper renders and edits your data in an interactive data grid, all in pure Python."
 order: 6
 ---
 

--- a/docs/enterprise/ag_grid/pivot-mode.md
+++ b/docs/enterprise/ag_grid/pivot-mode.md
@@ -1,3 +1,7 @@
+---
+meta_description: "Enable pivot mode in AG Grid with Reflex. Build pivot tables in Python — group rows, pivot columns, and aggregate values in an interactive data grid, no JavaScript required."
+---
+
 ```python exec
 import reflex as rx
 import reflex_enterprise as rxe

--- a/docs/enterprise/ag_grid/theme.md
+++ b/docs/enterprise/ag_grid/theme.md
@@ -1,4 +1,5 @@
 ---
+meta_description: "Theme and style AG Grid in Python with Reflex. Customize your data grid with built-in AG Grid themes and custom styling — all in pure Python, no JavaScript required."
 order: 3
 ---
 

--- a/docs/enterprise/ag_grid/value-transformers.md
+++ b/docs/enterprise/ag_grid/value-transformers.md
@@ -1,4 +1,5 @@
 ---
+meta_description: "Transform and format AG Grid cell values in Python with Reflex. Use value getters, formatters, and setters to control how data displays in your data grid."
 order: 2
 ---
 


### PR DESCRIPTION
## Summary

SEO pass over the AG Grid enterprise docs (`/docs/enterprise/ag-grid/` + 7 sub-pages) so Reflex surfaces for **AG Grid + Python** searches. Grounded in Ahrefs: `ag grid` (5.5K/mo, KD 20), `aggrid` (1K), `ag-grid` (900), `ag grid react` (300, KD 4), plus low-difficulty feature terms `ag grid pagination`/`ag grid pivot` (KD 0). The Python-specific variants (`ag grid python`, `aggrid python`, `python data grid`) are low-volume but exactly the audience — so the goal is to cover the variations across title, meta description, and body.

## Type of change

- [x] This change requires a documentation update (it *is* a documentation update)

## What changed

- **`index.md`** — keyword-rich meta description; intro rewritten to naturally cover **AG Grid / ag-grid / aggrid**, "React data grid," "Python," and "pandas DataFrame."
- **Sub-pages** (`column-defs`, `pivot-mode`, `cell-selection`, `theme`, `model-wrapper`, `value-transformers`, `aligned-grids`) — page-specific meta descriptions mapped to their feature keywords (`ag grid column definitions`, `ag grid pivot`, `ag grid cell selection`, …).
- **`manual_titles`** — every AG Grid page now gets a keyword-rich `<title>` ("AG Grid … in Python"). The overview page previously rendered as **"Index · Ag_Grid · Reflex Docs"** because the normal doc path derives titles from the filename, not frontmatter `title`.

## Why no infra/parser changes (unlike #6703 / #6704)

Enterprise docs render via the **normal doc path**, which already runs `extract_doc_description` — so frontmatter `meta_description` flows through with no `multi_docs`/parser changes. No page here has `components:` frontmatter, and no new routes are added, so neither the duplicate-route nor the changelog check applies. The only non-markdown change is adding entries to the `manual_titles` dict.

## Testing

- [x] `ruff check` / `ruff format --check` pass on the changed Python file.
- [x] All 8 pages' frontmatter validated as YAML (incl. the newly-added block on `pivot-mode.md`); meta descriptions 150–211 chars.
- [ ] ⚠️ Could not run the full `pytest` / `reflex compile` in the sandbox (pinned Python toolchain unavailable). Please let CI validate the docs build.

## Notes

The head term `ag grid` (5.5K) is dominated by ag-grid.com; realistic near-term wins are the Python/feature long-tail (`ag grid python`, `aggrid python`, `ag grid react`, `ag grid pagination`, `ag grid pivot`). This is independent of #6703/#6704 — no shared-infra overlap, so it can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ez43BK9AhhMPMdRcFmMEPR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ez43BK9AhhMPMdRcFmMEPR)_