### PR TITLE
fix: avoid re-evaluating stateful pages twice in one process

### DIFF
--- a/news/6710.bugfix.md
+++ b/news/6710.bugfix.md
@@ -1,0 +1,1 @@
+Fix stateful pages being evaluated twice in one process (forked prod workers and same-process export+serve), which created duplicate `ComponentState` classes and broke frontend hydration (`TypeError: d is not a function`).

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -395,6 +395,13 @@ class App(MiddlewareMixin, LifespanMixin):
     # A mapping of pages which created states as they were being evaluated.
     _stateful_pages: dict[str, None] = dataclasses.field(default_factory=dict)
 
+    # Routes whose page function has already been evaluated in this process.
+    # Evaluating a page has global side effects (e.g. ComponentState.create
+    # registers dynamic state classes), so a route must not be evaluated twice
+    # in one process. A forked prod worker inherits this set from the parent
+    # that already compiled and skips re-evaluation.
+    _evaluated_pages: set[str] = dataclasses.field(default_factory=set)
+
     # The backend API object.
     _api: Starlette | None = None
 
@@ -980,6 +987,11 @@ class App(MiddlewareMixin, LifespanMixin):
             route: The route of the page to compile.
             save_page: If True, the compiled page is saved to self._pages.
         """
+        # Evaluating a page has global side effects (dynamic state creation), so
+        # skip routes already evaluated in this process to avoid duplicating them.
+        if route in self._evaluated_pages:
+            return
+
         n_states_before = len(all_base_state_classes)
         component = compiler.compile_unevaluated_page(
             route,
@@ -991,6 +1003,8 @@ class App(MiddlewareMixin, LifespanMixin):
         # Indicate that evaluating this page creates one or more state classes.
         if len(all_base_state_classes) > n_states_before:
             self._stateful_pages[route] = None
+
+        self._evaluated_pages.add(route)
 
         # Add the page.
         self._check_routes_conflict(route)

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -989,7 +989,10 @@ class App(MiddlewareMixin, LifespanMixin):
         """
         # Evaluating a page has global side effects (dynamic state creation), so
         # skip routes already evaluated in this process to avoid duplicating them.
-        if route in self._evaluated_pages:
+        # Only skip when there is nothing left to do: the caller does not want the
+        # page saved, or it is already saved. Otherwise fall through to build and
+        # store the component so ``save_page=True`` still populates ``_pages``.
+        if route in self._evaluated_pages and (not save_page or route in self._pages):
             return
 
         n_states_before = len(all_base_state_classes)

--- a/reflex/compiler/compiler.py
+++ b/reflex/compiler/compiler.py
@@ -1187,6 +1187,7 @@ def compile_app(
             raise TypeError(msg)
         app._pages[route] = page_ctx.root_component
 
+    app._evaluated_pages.update(compile_ctx.compiled_pages)
     app._stateful_pages.update(compile_ctx.stateful_routes)
     app._write_stateful_pages_marker()
     app._add_optional_endpoints()

--- a/tests/units/test_app.py
+++ b/tests/units/test_app.py
@@ -2591,6 +2591,44 @@ def test_compile_dry_run_does_not_prune_or_write_manifest(
     )
 
 
+def test_compile_page_is_idempotent_for_component_state(
+    compilable_app: tuple[App, Path],
+    mocker,
+) -> None:
+    """Re-evaluating a stateful page in one process must not duplicate states.
+
+    In prod, granian forks workers that re-run the stateful-pages marker after
+    the parent process already compiled the page. Because ``ComponentState.create``
+    mutates a process-global counter and registry, an unguarded re-evaluation
+    creates a second set of dynamic state classes (the "2x states" bug).
+    """
+    import reflex.istate.dynamic as dynamic_mod
+
+    conf = rx.Config(app_name="testing")
+    mocker.patch("reflex_base.config._get_config", return_value=conf)
+    app, _ = compilable_app
+
+    class DupCounter(rx.ComponentState):
+        count: int = 0
+
+        @classmethod
+        def get_component(cls, **props):
+            return rx.el.div(**props)
+
+    app.add_page(lambda: rx.vstack(DupCounter.create(), DupCounter.create()), route="/")
+    route = next(iter(app._unevaluated_pages))
+
+    # Parent process: full compile evaluates the page once.
+    app._compile(dry_run=True)
+    assert DupCounter._per_component_state_instance_count == 2
+
+    # Forked worker: re-running the stateful-pages marker via _compile_page must
+    # reuse the already-created state classes instead of creating new ones.
+    app._compile_page(route, save_page=False)
+    assert DupCounter._per_component_state_instance_count == 2
+    assert not hasattr(dynamic_mod, "DupCounter_n3")
+
+
 def test_compile_writes_upload_files_provider_app_wrap(
     compilable_app: tuple[App, Path],
     mocker,

--- a/tests/units/test_app.py
+++ b/tests/units/test_app.py
@@ -2628,6 +2628,14 @@ def test_compile_page_is_idempotent_for_component_state(
     assert DupCounter._per_component_state_instance_count == 2
     assert not hasattr(dynamic_mod, "DupCounter_n3")
 
+    # A save_page=True call for an already-compiled route must still leave the
+    # component in _pages (the skip must honour the save_page contract) without
+    # duplicating states.
+    assert route in app._pages
+    app._compile_page(route, save_page=True)
+    assert route in app._pages
+    assert DupCounter._per_component_state_instance_count == 2
+
 
 def test_compile_writes_upload_files_provider_app_wrap(
     compilable_app: tuple[App, Path],


### PR DESCRIPTION
## Problem

When a page uses `ComponentState.create()` (or defines state inline), evaluating that page registers dynamic state classes (`Counter_n1`, `Counter_n2`, …) into a process-global registry via a **monotonic counter that is never reset**. If the same process evaluates a stateful page more than once, it appends a *second* set of classes (`Counter_n3`, `Counter_n4`, …).

The frontend JS is compiled against only the first set, so when the backend's state tree contains the extra classes, hydration/state deltas reference states the client never defined, and the client throws:

```
[Reflex Frontend Exception] TypeError: d is not a function
```

Two real flows trigger a second in-process evaluation:

1. **Forked prod workers.** `reflex run --env prod` compiles in the CLI process (registering `_n1/_n2`), then serves. When the server (granian/gunicorn) starts a worker by **forking** that process, the worker inherits the populated registry and re-runs the stateful-pages marker path → `_n3/_n4`. Whether workers fork vs. spawn depends on the multiprocessing start method (`fork` on Python ≤3.13; `forkserver` on 3.14+), which is why it's environment-dependent.

2. **Same-process export + serve (version-independent).** Harnesses like `reflex.testing.AppHarness` (and flexgen's `AppHarnessProdOnePort`) run a full compile (`export`, `_n1/_n2`) and then, in the **same** process with `REFLEX_SKIP_COMPILE` set, call `app()` → the skip/marker path re-evaluates the stateful pages → `_n3/_n4`. This happens regardless of Python version.

## Fix

Make page evaluation idempotent within a process. `App` tracks evaluated routes in `_evaluated_pages`; `_compile_page` skips a route already evaluated and reuses the existing state classes. The full compile marks its routes so a subsequent skip/marker-path evaluation (forked worker or same-instance serve) reuses them instead of creating new ones. A freshly spawned/re-imported app starts with an empty set and evaluates once, as before.

## Verification

- New regression test `test_compile_page_is_idempotent_for_component_state` (fails before, passes after).
- Reproduced flexgen's exact pattern (shared `App` instance, export compile + skip-compile serve): `Counter_n1..n4` without the fix, `Counter_n1/_n2` with it.
- Reproduced the forked-worker prod path via `reflex run --env prod` (forcing `fork`): 4 states without the fix, 2 with it.

## Known limitation

Two *full* compiles in one process (neither going through the skip/marker path) still double, because the full-compile eval loop isn't guarded. This isn't an existing runtime flow (both prod serving and AppHarness use `REFLEX_SKIP_COMPILE` for the second evaluation), but it's worth noting.