### PR TITLE
docs(wrapping-react): remove broken EventHandler import in props example

### DIFF
--- a/docs/wrapping-react/props.md
+++ b/docs/wrapping-react/props.md
@@ -100,7 +100,6 @@ class ComponentPropsComponent(MyBaseComponent):
 Event handlers are props that expect to receive a function that will be called when an event occurs. They are defined as `rx.EventHandler` with a signature function to define the spec of the event.
 
 ```python
-from reflex.vars.event_handler import EventHandler
 from reflex.vars.function import FunctionVar
 from reflex.vars.object import ObjectVar
 


### PR DESCRIPTION


The "Event Handlers" example in `docs/wrapping-react/props.md` starts its Python
code block with:

```python
from reflex.vars.event_handler import EventHandler
```

There is no `reflex.vars.event_handler` module (`reflex/vars/` only contains
`base`, `color`, `datetime`, `dep_tracking`, `function`, `number`, `object`, and
`sequence`), so a reader copying the snippet hits an immediate error:

```
ModuleNotFoundError: No module named 'reflex.vars.event_handler'
```

The imported `EventHandler` symbol is also unused in the example: the block
defines its event handlers with `rx.EventHandler[...]`, never the bare
`EventHandler`. The line is therefore both broken and dead, so this PR simply
removes it. The other two imports in the block (`from reflex.vars.function import
FunctionVar` and `from reflex.vars.object import ObjectVar`) are valid and left
untouched.

If an explicit `EventHandler` import were ever wanted here, the canonical path is
`from reflex.event import EventHandler`, but the example does not need it.

### Type of change

- [x] This change requires a documentation update (documentation-only fix)

### All Submissions:

- [x] Have you followed the guidelines in CONTRIBUTING.md?
- [x] Have you checked that there aren't other open PRs for the same change?
      (Searched open and closed PRs for `reflex.vars.event_handler`,
      `wrapping-react EventHandler import`, and `props.md`; none found.)

### Verification

No doc-snippet execution/doctest harness runs this Markdown, so there is no
automated regression surface. Verified manually under the project venv:

```console
$ python -c "from reflex.vars.event_handler import EventHandler"
ModuleNotFoundError: No module named 'reflex.vars.event_handler'   # before

$ python -c "from reflex.vars.function import FunctionVar; from reflex.vars.object import ObjectVar"
# succeeds  (the imports kept in the example)
```

Lint/format clean on the changed file:

```console
$ ruff check docs/
All checks passed!
$ ruff format --check docs/wrapping-react/props.md
1 file already formatted
```
