### PR TITLE
fix(state): reset disk write queue task on close

### DIFF
--- a/news/6715.bugfix.md
+++ b/news/6715.bugfix.md
@@ -1,0 +1,1 @@
+Reset the disk state manager write queue task after close.

--- a/reflex/istate/manager/disk.py
+++ b/reflex/istate/manager/disk.py
@@ -380,7 +380,7 @@ class StateManagerDisk(StateManager):
                 self._write_queue_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await self._write_queue_task
-                    self._write_queue_task = None
+                self._write_queue_task = None
             # Dump unlocked locks.
             for token, lock in tuple(self._states_locks.items()):
                 if not lock.locked():

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -4337,6 +4337,19 @@ async def test_deserialize_gc_state_disk(token):
     await dsm2.close()
 
 
+@pytest.mark.asyncio
+async def test_state_manager_disk_close_resets_write_queue_task():
+    """Test that closing the disk state manager clears its write queue task."""
+    state_manager = StateManagerDisk()
+    await state_manager._schedule_process_write_queue()
+
+    assert state_manager._write_queue_task is not None
+
+    await state_manager.close()
+
+    assert state_manager._write_queue_task is None
+
+
 class Obj(Base):
     """A object containing a callable for testing fallback pickle."""
 


### PR DESCRIPTION
## Summary

Reset `StateManagerDisk._write_queue_task` to `None` after `close()` cancels and
awaits the background write queue task.

The assignment was inside the `contextlib.suppress(asyncio.CancelledError)` block,
immediately after awaiting the cancelled task. Since the write queue task re-raises
`CancelledError` after flushing pending writes, the suppressed exception skipped
the assignment and left `_write_queue_task` pointing at a cancelled task.

This moves the reset outside the suppress block, matching the pattern already used
by `StateManagerMemory.close()`.

## Testing

- `uv run pytest tests/units/test_state.py::test_state_manager_disk_close_resets_write_queue_task -q`
- `uv run pytest tests/units/test_state.py -q`
- `uv run ruff check reflex/istate/manager/disk.py tests/units/test_state.py`
- `uv run ruff format reflex/istate/manager/disk.py tests/units/test_state.py --check`
- `uv run pyright reflex/istate/manager/disk.py tests/units/test_state.py`

The new regression test fails on the old indentation and passes with this change.
