### PR TITLE
docs(browser_storage): fix rx.remove_cookie header (was remove_cookies)

### DIFF
--- a/docs/api-reference/browser_storage.md
+++ b/docs/api-reference/browser_storage.md
@@ -52,7 +52,7 @@ Additionally, updating the cookie value in one state will not automatically
 update the value in the other state without a page refresh or navigation event.
 ```
 
-## rx.remove_cookies
+## rx.remove_cookie
 
 Remove a cookie from the client's browser.
 


### PR DESCRIPTION

The cookie-removal section in the browser storage API reference is titled
`## rx.remove_cookies`, but there is no such API. The exported event is the
singular `rx.remove_cookie`, and the section's own examples already call it:

```python
rx.button("Remove cookie", on_click=rx.remove_cookie("key"))
```
```python
return rx.remove_cookie("auth_token")
```

The two parallel sections on the same page are also singular
(`## rx.remove_local_storage`, `## rx.remove_session_storage`), so the plural
header is the outlier. Since the header is the name readers scan, search, and
copy for this feature, the wrong name is misleading. This corrects the header to
`## rx.remove_cookie` so it matches the body and the sibling sections.

Docs-only change; no code or behavior is affected.

### All Submissions:

- [x] Have you followed the guidelines stated in CONTRIBUTING.md?
- [x] Have you checked to ensure there aren't any other open Pull Requests for the desired change?

### Type of change

- [x] This change requires a documentation update (docs-only fix)
