### PR TITLE
docs: add missing chained event handler

### DIFF
--- a/docs/events/chaining_events.md
+++ b/docs/events/chaining_events.md
@@ -17,6 +17,10 @@ class CallHandlerState(rx.State):
     progress: int = 0
 
     @rx.event
+    def set_progress(self, value: int):
+        self.progress = value
+
+    @rx.event
     async def run(self):
         # Reset the count.
         self.set_progress(0)


### PR DESCRIPTION

  Closes reflex-dev/reflex#6694

  ## Summary
  - Add the missing `set_progress` event handler to the chaining events docs example.
  - Keep the example focused on calling one event handler from another.

  ## Tests
  - `git diff --check`