### PR TITLE
docs(select): fix rx.select.root reference (was rx.select_root)

### DIFF
--- a/docs/library/forms/select-ll.md
+++ b/docs/library/forms/select-ll.md
@@ -113,7 +113,7 @@ rx.select.root(
 ## Fully controlled
 
 The `on_change` event trigger is fired when the value of the select changes.
-In this example the `rx.select_root` `value` prop specifies which item is selected, and this
+In this example the `rx.select.root` `value` prop specifies which item is selected, and this
 can also be controlled using state and a button without direct interaction with the select component.
 
 ```python demo exec


### PR DESCRIPTION

The "Fully controlled" section of the low-level `select` docs referred to
`rx.select_root`, which is not a valid public API. Copying that name into an app
raises `AttributeError: No reflex attribute select_root`.

The correct, namespaced component is `rx.select.root` (it resolves to
`SelectRoot`), which is exactly what the rest of the same page already uses,
including its frontmatter and every other code and prose reference. This corrects
the single outlier on that line.

```diff
-In this example the `rx.select_root` `value` prop specifies which item is selected, and this
+In this example the `rx.select.root` `value` prop specifies which item is selected, and this
```

### Verification

- `rx.select.root` resolves to `SelectRoot.create`; `rx.select_root` raises
  `AttributeError`.
- `ruff format --check` and `codespell` on the changed file are clean.
- The docs app test suite (`pytest tests/` in `docs/app`) passes: 354 passed,
  1 skipped, 1 xfailed.

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?
