### PR TITLE
docs(form): fix rx.text_area reference in form docs (was rx.textarea)

### DIFF
--- a/docs/library/forms/form.md
+++ b/docs/library/forms/form.md
@@ -119,7 +119,7 @@ import reflex as rx
 
 Forms are used to collect user input. The `rx.form` component is used to group inputs and submit them together.
 
-The form component's children can be form controls such as `rx.input`, `rx.checkbox`, `rx.slider`, `rx.textarea`, `rx.radio_group`, `rx.select` or `rx.switch`. The controls should have a `name` attribute that is used to identify the control in the form data. The `on_submit` event trigger submits the form data as a dictionary to the `handle_submit` event handler.
+The form component's children can be form controls such as `rx.input`, `rx.checkbox`, `rx.slider`, `rx.text_area`, `rx.radio_group`, `rx.select` or `rx.switch`. The controls should have a `name` attribute that is used to identify the control in the form data. The `on_submit` event trigger submits the form data as a dictionary to the `handle_submit` event handler.
 
 The form is submitted when the user clicks the submit button or presses enter on the form controls.
 


### PR DESCRIPTION


The Forms documentation prose lists `rx.textarea` as one of the form controls
you can nest inside `rx.form`, but that name is not part of the public API. The
actual export is `rx.text_area` (with an underscore), so a reader who copies the
name from the docs hits an error:

```pycon
>>> import reflex as rx
>>> rx.textarea
AttributeError: No reflex attribute textarea. Did you mean: 'text_area'?
```

This corrects the single wrong name in the sentence at
`docs/library/forms/form.md`. Every other control named alongside it
(`rx.input`, `rx.checkbox`, `rx.slider`, `rx.radio_group`, `rx.select`,
`rx.switch`) is already correct, and the same page's code demo further down
already uses `rx.text_area`, so the prose and the example are now consistent.

### Type of change

- [x] This change requires a documentation update

### All Submissions:

- [x] Have you followed the guidelines in CONTRIBUTING.md?
- [x] Have you checked there aren't other open PRs for this change?

<!-- Not applicable: docs-only prose change, no code paths or tests affected. -->
