### PR TITLE
docs(mixins): fix contact form example to use asyncio.sleep

### DIFF
--- a/docs/state_structure/mixins.md
+++ b/docs/state_structure/mixins.md
@@ -240,6 +240,9 @@ State mixins are particularly useful for:
 - **Data Formatting**: Consistent data presentation across components
 
 ```python demo exec
+import asyncio
+
+
 class ValidationMixin(rx.State, mixin=True):
     errors: dict[str, str] = {}
     is_loading: bool = False
@@ -280,7 +283,7 @@ class ContactFormState(ValidationMixin, rx.State):
         self.message = value
 
     @rx.event
-    def submit_form(self):
+    async def submit_form(self):
         self.clear_errors()
         valid_name = self.validate_required("name", self.name)
         valid_email = self.validate_email(self.email)
@@ -288,7 +291,8 @@ class ContactFormState(ValidationMixin, rx.State):
 
         if valid_name and valid_email and valid_message:
             self.is_loading = True
-            yield rx.sleep(1)
+            yield
+            await asyncio.sleep(1)
             self.is_loading = False
             self.name = ""
             self.email = ""


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

### What and why

The state mixins guide (`docs/state_structure/mixins.md`) contains a live
`python demo exec` example whose `ContactFormState.submit_form` handler pauses
with `yield rx.sleep(1)` before clearing the form. `rx.sleep` is not part of the
Reflex API: accessing it raises `AttributeError: No reflex attribute sleep`
(there is no `sleep` in the framework). So a reader who copies this example and
clicks **Submit** hits a runtime error on that line.

This makes `submit_form` an `async` event handler and uses the delay idiom the
docs already teach: `yield` first to flush `is_loading = True` to the frontend,
then `await asyncio.sleep(1)`. It mirrors the loading-state example in
`docs/events/yield_events.md` (`ProgressExampleState.increment`), which uses the
same `import asyncio` + `async def` + `yield` + `await asyncio.sleep(...)` shape.

Docs-only change; no framework code is touched.

### How verified

- `import reflex as rx; hasattr(rx, "sleep")` is `False`, confirming the old
  call cannot work; `asyncio.sleep` is a coroutine function.
- The updated `python demo exec` block parses and executes under
  `import reflex as rx`; `submit_form` is a valid async generator event handler.
- Docs render test suite passes (`pytest tests/test_docgen_double_eval.py`,
  which renders every doc page), and `ruff format --check` / `ruff check` /
  `codespell` are clean on the changed file.

### Checklist

- [x] Followed the guidelines in CONTRIBUTING.md
- [x] Checked there is no other open PR for this change
- [x] Linted locally prior to submission