### PR TITLE
perf: drop task wrapper in EventNamespace.emit_update, keep flush tick

### DIFF
--- a/news/6734.performance.md
+++ b/news/6734.performance.md
@@ -1,0 +1,1 @@
+Remove the per-update `asyncio.create_task` wrapper in `EventNamespace.emit_update`, cutting scheduling overhead roughly in half for every outgoing state update while keeping the event-loop tick that flushes interim updates before a sync handler resumes.

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -1712,11 +1712,15 @@ class EventNamespace(AsyncNamespace):
                     f"Attempting to send delta to disconnected client {token!r}"
                 )
             return
-        # Creating a task prevents the update from being blocked behind other coroutines.
-        await asyncio.create_task(
-            self.emit(str(constants.SocketEvent.EVENT), update, to=socket_record.sid),
-            name=f"reflex_emit_event|{token}|{socket_record.sid}|{time.time()}",
-        )
+        # Await the emit directly: wrapping it in a task does not unblock the
+        # caller (awaiting the task blocks just the same) and only adds task
+        # creation/scheduling overhead on every update.
+        await self.emit(str(constants.SocketEvent.EVENT), update, to=socket_record.sid)
+        # The emit may complete without suspending (the packet is queued, not
+        # sent). Yield one loop tick so the websocket writer can flush the
+        # packet before the caller potentially blocks the event loop (e.g. a
+        # sync event handler resuming after a yield).
+        await asyncio.sleep(0)
 
     async def on_event(self, sid: str, data: Any):
         """Event for receiving front-end websocket events.

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -2048,11 +2048,15 @@ class EventNamespace(AsyncNamespace):
                     f"Attempting to send delta to disconnected client {token!r}"
                 )
             return
-        # Creating a task prevents the update from being blocked behind other coroutines.
-        await asyncio.create_task(
-            self.emit(str(constants.SocketEvent.EVENT), update, to=socket_record.sid),
-            name=f"reflex_emit_event|{token}|{socket_record.sid}|{time.time()}",
-        )
+        # Await the emit directly: wrapping it in a task does not unblock the
+        # caller (awaiting the task blocks just the same) and only adds task
+        # creation/scheduling overhead on every update.
+        await self.emit(str(constants.SocketEvent.EVENT), update, to=socket_record.sid)
+        # The emit may complete without suspending (the packet is queued, not
+        # sent). Yield one loop tick so the websocket writer can flush the
+        # packet before the caller potentially blocks the event loop (e.g. a
+        # sync event handler resuming after a yield).
+        await asyncio.sleep(0)
 
     async def on_event(self, sid: str, data: Any):
         """Event for receiving front-end websocket events.


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?

`EventNamespace.emit_update` wrapped the socket emit in `asyncio.create_task(...)` and then immediately awaited it, with a comment claiming the task "prevents the update from being blocked behind other coroutines". Awaiting a freshly created task blocks the caller exactly like awaiting the coroutine directly — the wrapper never provided any concurrency; it only added per-update task creation/scheduling overhead (plus an f-string task name with a `time.time()` call). Since `emit_update` runs while the state lock is held (via `modify_state` / the event processor's `emit_delta` path), that overhead was paid on every outgoing state update.

**The one load-bearing side effect of the wrapper** (caught by `test_yield_state_update[click_yield_interim_value]` on the first iteration of this PR): awaiting a fresh task forces an event-loop tick, which lets engineio's per-connection writer task flush the queued packet before the caller resumes. `sio.emit` itself can complete without ever suspending (the packet is only put on a non-full queue), so a sync handler that blocks the loop right after yielding (e.g. `yield` → `time.sleep(...)`) would otherwise hold the interim update hostage in the write queue. The fix keeps that guarantee explicitly with `await asyncio.sleep(0)` after the emit, with a regression note explaining why the tick must stay.

**Micro-benchmark** (Python 3.13, replicating the exact await patterns with a stand-in emit coroutine, 20k iterations after warmup):

| variant | per update |
|---|---|
| before: `await asyncio.create_task(emit(...), name=f"...{time.time()}")` | 9.19 µs |
| after: `await emit(...)` + `await asyncio.sleep(0)` | 4.84 µs |

1.9x less overhead per outgoing update. A writer-task ordering simulation confirms the interim packet is flushed before a loop-blocking caller resumes in both the old and new versions (and is *not* flushed with a plain `await emit(...)` alone — which is why the sleep(0) is load-bearing).

Linear: [ENG-10110](https://linear.app/reflex-dev/issue/ENG-10110/bug-emit-update-awaits-a-task-it-creates-to-avoid-blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sns7EuBPYvfGCxRSRZ1bUx