### PR TITLE
Skip deep type-validation on state var hot paths

### DIFF
--- a/news/6738.performance.md
+++ b/news/6738.performance.md
@@ -1,0 +1,1 @@
+Skip deep element-wise type validation on state var hot paths: computed var return types are only checked on recompute (not on cache hits), and production mode no longer walks every element of assigned containers for the log-only type check.

--- a/packages/reflex-base/news/6738.performance.md
+++ b/packages/reflex-base/news/6738.performance.md
@@ -1,0 +1,1 @@
+Skip deep element-wise type validation on state var hot paths: computed var return types are only checked on recompute (not on cache hits), and production mode no longer walks every element of assigned containers for the log-only type check.

--- a/packages/reflex-base/src/reflex_base/utils/types.py
+++ b/packages/reflex-base/src/reflex_base/utils/types.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import os
 import sys
 import types
 from collections.abc import Callable, Iterable, Mapping, Sequence
@@ -634,20 +635,33 @@ def does_obj_satisfy_typed_dict(
 
 
 @lru_cache
+def _validation_depth_for_mode(raw_mode: str | None) -> int:
+    """Get the validation depth for a raw REFLEX_ENV_MODE value.
+
+    Args:
+        raw_mode: The raw environment variable value (or None if unset).
+
+    Returns:
+        The `nested` depth to pass to `_isinstance`.
+    """
+    return 0 if raw_mode == constants.Env.PROD.value else 1
+
+
 def _validation_depth() -> int:
     """Get the container depth for hot-path state var type validation.
 
     The result of these checks only gates a diagnostic log, so production
     mode skips the per-element walk of large containers and only validates
-    the outer type.
+    the outer type. The environment is re-read on every call so in-process
+    mode changes take effect immediately.
 
     Returns:
         The `nested` depth to pass to `_isinstance`.
     """
-    from reflex_base import constants
-    from reflex_base.environment import environment
-
-    return 0 if environment.REFLEX_ENV_MODE.get() == constants.Env.PROD else 1
+    # Read the raw env var directly: interpreting it through
+    # environment.REFLEX_ENV_MODE.get() on this hot path would re-parse the
+    # enum on every state var assignment (and the import would be circular).
+    return _validation_depth_for_mode(os.environ.get("REFLEX_ENV_MODE"))
 
 
 def _isinstance(

--- a/packages/reflex-base/src/reflex_base/utils/types.py
+++ b/packages/reflex-base/src/reflex_base/utils/types.py
@@ -633,6 +633,23 @@ def does_obj_satisfy_typed_dict(
     return required_keys.issubset(frozenset(obj))
 
 
+@lru_cache
+def _validation_depth() -> int:
+    """Get the container depth for hot-path state var type validation.
+
+    The result of these checks only gates a diagnostic log, so production
+    mode skips the per-element walk of large containers and only validates
+    the outer type.
+
+    Returns:
+        The `nested` depth to pass to `_isinstance`.
+    """
+    from reflex_base import constants
+    from reflex_base.environment import environment
+
+    return 0 if environment.REFLEX_ENV_MODE.get() == constants.Env.PROD else 1
+
+
 def _isinstance(
     obj: Any,
     cls: GenericType,

--- a/packages/reflex-base/src/reflex_base/vars/base.py
+++ b/packages/reflex-base/src/reflex_base/vars/base.py
@@ -65,6 +65,7 @@ from reflex_base.utils.types import (
     GenericType,
     Self,
     _isinstance,
+    _validation_depth,
     get_origin,
     has_args,
     safe_issubclass,
@@ -2586,23 +2587,28 @@ class ComputedVar(Var[RETURN_TYPE]):
 
         if not self._cache:
             value = self.fget(instance)
-        else:
-            # handle caching
-            if not hasattr(instance, self._cache_attr) or self.needs_update(instance):
-                # Set cache attr on state instance.
-                setattr(instance, self._cache_attr, self.fget(instance))
-                # Ensure the computed var gets serialized to redis.
-                instance._was_touched = True
-                # Set the last updated timestamp on the state instance.
-                setattr(instance, self._last_updated_attr, datetime.datetime.now())
+            self._check_deprecated_return_type(instance, value)
+            return value
+
+        # handle caching
+        if not hasattr(instance, self._cache_attr) or self.needs_update(instance):
+            # Set cache attr on state instance.
+            setattr(instance, self._cache_attr, self.fget(instance))
+            # Ensure the computed var gets serialized to redis.
+            instance._was_touched = True
+            # Set the last updated timestamp on the state instance.
+            setattr(instance, self._last_updated_attr, datetime.datetime.now())
             value = getattr(instance, self._cache_attr)
+            # Only validate the return type when the value was just computed.
+            self._check_deprecated_return_type(instance, value)
+            return value
 
-        self._check_deprecated_return_type(instance, value)
-
-        return value
+        return getattr(instance, self._cache_attr)
 
     def _check_deprecated_return_type(self, instance: BaseState, value: Any) -> None:
-        if not _isinstance(value, self._var_type, nested=1, treat_var_as_type=False):
+        if not _isinstance(
+            value, self._var_type, nested=_validation_depth(), treat_var_as_type=False
+        ):
             console.error(
                 f"Computed var '{type(instance).__name__}.{self._name}' must return"
                 f" a value of type '{escape(str(self._var_type))}', got '{value!s}' of type {type(value)}."
@@ -2857,9 +2863,11 @@ class AsyncComputedVar(ComputedVar[RETURN_TYPE]):
                 instance._was_touched = True
                 # Set the last updated timestamp on the state instance.
                 setattr(instance, self._last_updated_attr, datetime.datetime.now())
-            value = getattr(instance, self._cache_attr)
-            self._check_deprecated_return_type(instance, value)
-            return value
+                value = getattr(instance, self._cache_attr)
+                # Only validate the return type when the value was just computed.
+                self._check_deprecated_return_type(instance, value)
+                return value
+            return getattr(instance, self._cache_attr)
 
         return _awaitable_result()
 

--- a/packages/reflex-base/src/reflex_base/vars/base.py
+++ b/packages/reflex-base/src/reflex_base/vars/base.py
@@ -66,6 +66,7 @@ from reflex_base.utils.types import (
     GenericType,
     Self,
     _isinstance,
+    _validation_depth,
     get_origin,
     has_args,
     safe_issubclass,
@@ -2587,23 +2588,28 @@ class ComputedVar(Var[RETURN_TYPE]):
 
         if not self._cache:
             value = self.fget(instance)
-        else:
-            # handle caching
-            if not hasattr(instance, self._cache_attr) or self.needs_update(instance):
-                # Set cache attr on state instance.
-                setattr(instance, self._cache_attr, self.fget(instance))
-                # Ensure the computed var gets serialized to redis.
-                instance._was_touched = True
-                # Set the last updated timestamp on the state instance.
-                setattr(instance, self._last_updated_attr, datetime.datetime.now())
+            self._check_deprecated_return_type(instance, value)
+            return value
+
+        # handle caching
+        if not hasattr(instance, self._cache_attr) or self.needs_update(instance):
+            # Set cache attr on state instance.
+            setattr(instance, self._cache_attr, self.fget(instance))
+            # Ensure the computed var gets serialized to redis.
+            instance._was_touched = True
+            # Set the last updated timestamp on the state instance.
+            setattr(instance, self._last_updated_attr, datetime.datetime.now())
             value = getattr(instance, self._cache_attr)
+            # Only validate the return type when the value was just computed.
+            self._check_deprecated_return_type(instance, value)
+            return value
 
-        self._check_deprecated_return_type(instance, value)
-
-        return value
+        return getattr(instance, self._cache_attr)
 
     def _check_deprecated_return_type(self, instance: BaseState, value: Any) -> None:
-        if not _isinstance(value, self._var_type, nested=1, treat_var_as_type=False):
+        if not _isinstance(
+            value, self._var_type, nested=_validation_depth(), treat_var_as_type=False
+        ):
             console.error(
                 f"Computed var '{type(instance).__name__}.{self._name}' must return"
                 f" a value of type '{escape(str(self._var_type))}', got '{value!s}' of type {type(value)}."
@@ -2858,9 +2864,11 @@ class AsyncComputedVar(ComputedVar[RETURN_TYPE]):
                 instance._was_touched = True
                 # Set the last updated timestamp on the state instance.
                 setattr(instance, self._last_updated_attr, datetime.datetime.now())
-            value = getattr(instance, self._cache_attr)
-            self._check_deprecated_return_type(instance, value)
-            return value
+                value = getattr(instance, self._cache_attr)
+                # Only validate the return type when the value was just computed.
+                self._check_deprecated_return_type(instance, value)
+                return value
+            return getattr(instance, self._cache_attr)
 
         return _awaitable_result()
 

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -53,7 +53,7 @@ from reflex_base.utils.exceptions import (
 )
 from reflex_base.utils.exceptions import ImmutableStateError as ImmutableStateError
 from reflex_base.utils.serializers import serializer
-from reflex_base.utils.types import _isinstance
+from reflex_base.utils.types import _isinstance, _validation_depth
 from reflex_base.vars import Field, VarData, field
 from reflex_base.vars.base import (
     ComputedVar,
@@ -1531,7 +1531,9 @@ class BaseState(EvenMoreBasicBaseState):
 
         if (field := fields.get(name)) is not None and field.is_var:
             field_type = field.outer_type_
-            if not _isinstance(value, field_type, nested=1, treat_var_as_type=False):
+            if not _isinstance(
+                value, field_type, nested=_validation_depth(), treat_var_as_type=False
+            ):
                 console.error(
                     f"Expected field '{type(self).__name__}.{name}' to receive type '{escape(str(field_type))}',"
                     f" but got '{value}' of type '{type(value)}'."

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -54,7 +54,7 @@ from reflex_base.utils.exceptions import (
 )
 from reflex_base.utils.exceptions import ImmutableStateError as ImmutableStateError
 from reflex_base.utils.serializers import serializer
-from reflex_base.utils.types import _isinstance
+from reflex_base.utils.types import _isinstance, _validation_depth
 from reflex_base.vars import Field, VarData, field
 from reflex_base.vars.base import (
     ComputedVar,
@@ -1538,7 +1538,9 @@ class BaseState(EvenMoreBasicBaseState):
 
         if (field := fields.get(name)) is not None and field.is_var:
             field_type = field.outer_type_
-            if not _isinstance(value, field_type, nested=1, treat_var_as_type=False):
+            if not _isinstance(
+                value, field_type, nested=_validation_depth(), treat_var_as_type=False
+            ):
                 console.error(
                     f"Expected field '{type(self).__name__}.{name}' to receive type '{escape(str(field_type))}',"
                     f" but got '{value}' of type '{type(value)}'."

--- a/tests/units/reflex_base/utils/test_types.py
+++ b/tests/units/reflex_base/utils/test_types.py
@@ -26,15 +26,16 @@ def test_asgi_aliases_keep_their_names():
 
 
 def test_validation_depth_by_env_mode():
-    """Hot-path validation walks containers in dev but stays shallow in prod."""
+    """Hot-path validation walks containers in dev but stays shallow in prod.
+
+    In-process environment mode changes must take effect immediately, without
+    any cache invalidation by the caller.
+    """
     initial = environment.REFLEX_ENV_MODE.getenv()
-    _validation_depth.cache_clear()
     try:
         environment.REFLEX_ENV_MODE.set(constants.Env.PROD)
         assert _validation_depth() == 0
-        _validation_depth.cache_clear()
         environment.REFLEX_ENV_MODE.set(constants.Env.DEV)
         assert _validation_depth() == 1
     finally:
         environment.REFLEX_ENV_MODE.set(initial)
-        _validation_depth.cache_clear()

--- a/tests/units/reflex_base/utils/test_types.py
+++ b/tests/units/reflex_base/utils/test_types.py
@@ -1,6 +1,15 @@
 """Tests for reflex_base.utils.types."""
 
-from reflex_base.utils.types import ASGIApp, Message, Receive, Scope, Send
+from reflex_base import constants
+from reflex_base.environment import environment
+from reflex_base.utils.types import (
+    ASGIApp,
+    Message,
+    Receive,
+    Scope,
+    Send,
+    _validation_depth,
+)
 from typing_extensions import TypeAliasType
 
 
@@ -14,3 +23,18 @@ def test_asgi_aliases_keep_their_names():
     assert Receive.__name__ == "Receive"
     assert Send.__name__ == "Send"
     assert ASGIApp.__name__ == "ASGIApp"
+
+
+def test_validation_depth_by_env_mode():
+    """Hot-path validation walks containers in dev but stays shallow in prod."""
+    initial = environment.REFLEX_ENV_MODE.getenv()
+    _validation_depth.cache_clear()
+    try:
+        environment.REFLEX_ENV_MODE.set(constants.Env.PROD)
+        assert _validation_depth() == 0
+        _validation_depth.cache_clear()
+        environment.REFLEX_ENV_MODE.set(constants.Env.DEV)
+        assert _validation_depth() == 1
+    finally:
+        environment.REFLEX_ENV_MODE.set(initial)
+        _validation_depth.cache_clear()

--- a/tests/units/reflex_base/vars/test_base.py
+++ b/tests/units/reflex_base/vars/test_base.py
@@ -5,6 +5,9 @@ from typing import Any
 from reflex_base.utils.types import get_field_type
 from reflex_base.vars.base import EvenMoreBasicBaseState, field
 
+import reflex as rx
+from reflex.state import BaseState
+
 _MARKER_ATTR = "_marker"
 
 
@@ -78,3 +81,74 @@ def test_custom_mutable_attr_is_deepcopied():
     assert rebuilt._opts is not opts  # pyright: ignore[reportAttributeAccessIssue]
     opts["a"].append(2)
     assert rebuilt._opts == {"a": [1]}  # pyright: ignore[reportAttributeAccessIssue]
+
+
+def test_computed_var_return_type_checked_only_on_recompute(mocker):
+    """The return type of a cached computed var is only validated on recompute.
+
+    Args:
+        mocker: Pytest mocker object.
+    """
+
+    class ReturnTypeCheckState(BaseState):
+        v: int = 0
+
+        @rx.var
+        def wrong_typed(self) -> str:
+            return self.v  # pyright: ignore [reportReturnType]
+
+    state = ReturnTypeCheckState()
+    mock_error = mocker.patch("reflex_base.utils.console.error")
+    assert state.wrong_typed == 0
+    assert mock_error.call_count == 1
+    # Cache hits must not re-run the (potentially deep) type check.
+    assert state.wrong_typed == 0
+    assert mock_error.call_count == 1
+    # Invalidation triggers a recompute, which re-checks the return type.
+    state.v = 1
+    assert state.wrong_typed == 1
+    assert mock_error.call_count == 2
+
+
+def test_non_cached_computed_var_return_type_checked_every_access(mocker):
+    """A cache=False computed var recomputes, and is type-checked, on every access.
+
+    Args:
+        mocker: Pytest mocker object.
+    """
+
+    class NonCachedReturnTypeCheckState(BaseState):
+        v: int = 0
+
+        @rx.var(cache=False)
+        def wrong_typed(self) -> str:
+            return self.v  # pyright: ignore [reportReturnType]
+
+    state = NonCachedReturnTypeCheckState()
+    mock_error = mocker.patch("reflex_base.utils.console.error")
+    assert state.wrong_typed == 0
+    assert state.wrong_typed == 0
+    assert mock_error.call_count == 2
+
+
+async def test_async_computed_var_return_type_checked_only_on_recompute(mocker):
+    """The return type of a cached async computed var is only validated on recompute.
+
+    Args:
+        mocker: Pytest mocker object.
+    """
+
+    class AsyncReturnTypeCheckState(BaseState):
+        v: int = 0
+
+        @rx.var
+        async def wrong_typed(self) -> str:
+            return self.v  # pyright: ignore [reportReturnType]
+
+    state = AsyncReturnTypeCheckState()
+    mock_error = mocker.patch("reflex_base.utils.console.error")
+    assert await state.wrong_typed == 0
+    assert mock_error.call_count == 1
+    # Cache hits must not re-run the (potentially deep) type check.
+    assert await state.wrong_typed == 0
+    assert mock_error.call_count == 1

--- a/tests/units/reflex_base/vars/test_base.py
+++ b/tests/units/reflex_base/vars/test_base.py
@@ -6,6 +6,9 @@ from typing import Any
 from reflex_base.utils.types import get_field_type
 from reflex_base.vars.base import EvenMoreBasicBaseState, field
 
+import reflex as rx
+from reflex.state import BaseState
+
 _MARKER_ATTR = "_marker"
 
 
@@ -87,3 +90,74 @@ def test_custom_attr_is_carried_by_reference():
 
     rebuilt = MyState.get_fields()["name"]
     assert rebuilt._check is check  # pyright: ignore[reportAttributeAccessIssue]
+
+
+def test_computed_var_return_type_checked_only_on_recompute(mocker):
+    """The return type of a cached computed var is only validated on recompute.
+
+    Args:
+        mocker: Pytest mocker object.
+    """
+
+    class ReturnTypeCheckState(BaseState):
+        v: int = 0
+
+        @rx.var
+        def wrong_typed(self) -> str:
+            return self.v  # pyright: ignore [reportReturnType]
+
+    state = ReturnTypeCheckState()
+    mock_error = mocker.patch("reflex_base.utils.console.error")
+    assert state.wrong_typed == 0
+    assert mock_error.call_count == 1
+    # Cache hits must not re-run the (potentially deep) type check.
+    assert state.wrong_typed == 0
+    assert mock_error.call_count == 1
+    # Invalidation triggers a recompute, which re-checks the return type.
+    state.v = 1
+    assert state.wrong_typed == 1
+    assert mock_error.call_count == 2
+
+
+def test_non_cached_computed_var_return_type_checked_every_access(mocker):
+    """A cache=False computed var recomputes, and is type-checked, on every access.
+
+    Args:
+        mocker: Pytest mocker object.
+    """
+
+    class NonCachedReturnTypeCheckState(BaseState):
+        v: int = 0
+
+        @rx.var(cache=False)
+        def wrong_typed(self) -> str:
+            return self.v  # pyright: ignore [reportReturnType]
+
+    state = NonCachedReturnTypeCheckState()
+    mock_error = mocker.patch("reflex_base.utils.console.error")
+    assert state.wrong_typed == 0
+    assert state.wrong_typed == 0
+    assert mock_error.call_count == 2
+
+
+async def test_async_computed_var_return_type_checked_only_on_recompute(mocker):
+    """The return type of a cached async computed var is only validated on recompute.
+
+    Args:
+        mocker: Pytest mocker object.
+    """
+
+    class AsyncReturnTypeCheckState(BaseState):
+        v: int = 0
+
+        @rx.var
+        async def wrong_typed(self) -> str:
+            return self.v  # pyright: ignore [reportReturnType]
+
+    state = AsyncReturnTypeCheckState()
+    mock_error = mocker.patch("reflex_base.utils.console.error")
+    assert await state.wrong_typed == 0
+    assert mock_error.call_count == 1
+    # Cache hits must not re-run the (potentially deep) type check.
+    assert await state.wrong_typed == 0
+    assert mock_error.call_count == 1

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -1437,6 +1437,22 @@ def test_computed_var_cached():
     assert comp_v_calls == 2
 
 
+def test_setattr_wrong_type_logs_error(mocker):
+    """Assigning a value of the wrong type to a base var logs an error in dev mode.
+
+    Args:
+        mocker: Pytest mocker object.
+    """
+
+    class WrongTypeState(BaseState):
+        n: int = 0
+
+    state = WrongTypeState()
+    mock_error = mocker.patch("reflex.utils.console.error")
+    setattr(state, "n", "not an int")  # noqa: B010
+    assert mock_error.call_count == 1
+
+
 def test_computed_var_cached_depends_on_non_cached():
     """Test that a cached var is recalculated if it depends on non-cached ComputedVar."""
 

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -1436,6 +1436,22 @@ def test_computed_var_cached():
     assert comp_v_calls == 2
 
 
+def test_setattr_wrong_type_logs_error(mocker):
+    """Assigning a value of the wrong type to a base var logs an error in dev mode.
+
+    Args:
+        mocker: Pytest mocker object.
+    """
+
+    class WrongTypeState(BaseState):
+        n: int = 0
+
+    state = WrongTypeState()
+    mock_error = mocker.patch("reflex.utils.console.error")
+    setattr(state, "n", "not an int")  # noqa: B010
+    assert mock_error.call_count == 1
+
+
 def test_computed_var_cached_depends_on_non_cached():
     """Test that a cached var is recalculated if it depends on non-cached ComputedVar."""
 


### PR DESCRIPTION
Linear: [ENG-10093](https://linear.app/reflex-dev/issue/ENG-10093/deep-type-validation-on-assignment-and-cached-reads-never-gates)

### Description

Two hot paths ran `_isinstance(value, type, nested=1)`, which walks every element of list/dict values, only to gate a diagnostic log that never changes behavior:

- `BaseState.__setattr__` validated the full container on every assignment.
- `ComputedVar.__get__` / `AsyncComputedVar.__get__` validated the return type on **every** access, including cache hits.

Changes:

- Computed var return types are now validated only when the value is actually recomputed (sync and async). Cache hits skip the check entirely.
- Element-wise validation depth is now `1` in dev and `0` in prod (new cached `_validation_depth()` helper in `reflex_base.utils.types`), so production only checks the outer type. Dev keeps the exact same diagnostics as before.

### Benchmarks (GitHub Actions runner, [run](https://github.com/reflex-dev/reflex/actions/runs/29118932603), 2 passes each)

| Case | main | this PR | speedup |
|---|---|---|---|
| read cached computed var returning 10k dicts (dev) | 13.81 / 14.05 ms | **0.0015 / 0.0015 ms** | ~9,200x |
| read cached computed var (prod) | 13.66 / 13.93 ms | **0.0013 / 0.0015 ms** | ~9,300x |
| assign 100k-int list (prod) | 90.89 / 90.96 ms | **0.020 / 0.024 ms** | ~4,000x |
| assign 100k-int list (dev) | 90.74 / 92.67 ms | 91.76 / 94.74 ms | unchanged (by design) |

cProfile (3 assigns + 20 cached reads, dev): main spends 3.06s in 10.5M calls dominated by `_isinstance` (510k calls); with this PR the cached-read side disappears (`_check_deprecated_return_type` no longer on the cache-hit path) and in prod the whole workload is 538 function calls / 0.003s.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
  - `tests/units/reflex_base/vars/test_base.py`: return type checked on recompute, not on cache hits (sync, async, and `cache=False`).
  - `tests/units/reflex_base/utils/test_types.py`: `_validation_depth()` is 0 in prod / 1 in dev.
  - `tests/units/test_state.py`: wrong-typed assignment still logs an error in dev.
- [x] Have you successfully ran tests with your changes locally?

Note: behavior-wise, a wrong-typed computed var now logs once per recompute instead of once per access, and prod no longer walks container elements for the log-only check. No exceptions or control flow depend on these checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8cXh3TUbNtbjm2ERqE62X

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8cXh3TUbNtbjm2ERqE62X)_