### PR TITLE
Reduce MutableProxy per-element overhead and cache per-field proxies

### DIFF
--- a/news/6740.performance.md
+++ b/news/6740.performance.md
@@ -1,0 +1,1 @@
+Speed up MutableProxy: immutable elements retrieved through a proxy skip the dataclasses frame-walk check, and the proxy for each mutable state var is cached per instance instead of rebuilt on every attribute read.

--- a/packages/reflex-base/news/6740.performance.md
+++ b/packages/reflex-base/news/6740.performance.md
@@ -1,0 +1,1 @@
+Reserve the internal `_mutable_proxy_cache` state field name so user vars cannot collide with the per-instance proxy cache.

--- a/packages/reflex-base/src/reflex_base/utils/types.py
+++ b/packages/reflex-base/src/reflex_base/utils/types.py
@@ -162,7 +162,13 @@ PrimitiveToAnnotation = {
     dict: Dict,  # noqa: UP006
 }
 
-RESERVED_BACKEND_VAR_NAMES = {"_abc_impl", "_backend_vars", "_was_touched", "_mixin"}
+RESERVED_BACKEND_VAR_NAMES = {
+    "_abc_impl",
+    "_backend_vars",
+    "_was_touched",
+    "_mixin",
+    "_mutable_proxy_cache",
+}
 
 
 class Unset:

--- a/reflex/istate/proxy.py
+++ b/reflex/istate/proxy.py
@@ -522,22 +522,24 @@ class MutableProxy(wrapt.ObjectProxy):
         Returns:
             The wrapped value.
         """
-        # When called from dataclasses internal code, return the unwrapped value
-        if self._is_called_from_dataclasses_internal():
-            return value
         # If we already have a proxy, unwrap and rewrap to make sure the state
         # reference is up to date.
         if isinstance(value, MutableProxy):
             value = value.__wrapped__
+        # Immutable values (the common case when iterating a container of
+        # scalars) never need wrapping nor the frame inspection below.
+        if not is_mutable_type(type(value)):
+            return value
+        # When called from dataclasses internal code, return the unwrapped value
+        if self._is_called_from_dataclasses_internal():
+            return value
         # Recursively wrap mutable types.
-        if is_mutable_type(type(value)):
-            base_cls = globals()[self.__base_proxy__]
-            return base_cls(
-                wrapped=value,
-                state=self._self_state,
-                field_name=self._self_field_name,
-            )
-        return value
+        base_cls = globals()[self.__base_proxy__]
+        return base_cls(
+            wrapped=value,
+            state=self._self_state,
+            field_name=self._self_field_name,
+        )
 
     def _wrap_recursive_decorator(
         self, wrapped: Callable, instance: BaseState, args: list, kwargs: dict

--- a/reflex/istate/proxy.py
+++ b/reflex/istate/proxy.py
@@ -664,13 +664,18 @@ class MutableProxy(wrapt.ObjectProxy):
         Returns:
             The wrapped value.
         """
-        # When called from dataclasses internal code, return the unwrapped value
-        if self._is_called_from_dataclasses_internal():
-            return value
         # If we already have a proxy, unwrap and rewrap to make sure the state
         # reference is up to date.
         if isinstance(value, MutableProxy):
             value = value.__wrapped__
+        # Immutable values (the common case when iterating a container of
+        # scalars) never need wrapping nor the frame inspection below.
+        if not is_mutable_type(type(value)):
+            return value
+        # When called from dataclasses internal code, return the unwrapped value
+        if self._is_called_from_dataclasses_internal():
+            return value
+        # Recursively wrap mutable types.
         return globals()[self.__base_proxy__](
             wrapped=value,
             state=self._self_state,

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1519,6 +1519,9 @@ class BaseState(EvenMoreBasicBaseState):
 
         if name in self.backend_vars:
             self._backend_vars.__setitem__(name, value)
+            if (cache := self.__dict__.get("_mutable_proxy_cache")) is not None:
+                # Drop the proxy wrapping the replaced value.
+                cache.pop(name, None)
             self.dirty_vars.add(name)
             self._mark_dirty()
             return
@@ -1551,6 +1554,10 @@ class BaseState(EvenMoreBasicBaseState):
 
         # Set the attribute.
         object.__setattr__(self, name, value)
+
+        if (cache := self.__dict__.get("_mutable_proxy_cache")) is not None:
+            # Drop the proxy wrapping the replaced value.
+            cache.pop(name, None)
 
         # Add the var to the dirty list.
         if name in self.base_vars:

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -437,6 +437,12 @@ class BaseState(EvenMoreBasicBaseState):
     # Whether the state has ever been touched since instantiation.
     _was_touched: bool = field(default=False, is_var=False)
 
+    # Per-field cache of the MutableProxy wrapping each mutable var, so
+    # repeated reads don't rebuild the proxy. Never pickled.
+    _mutable_proxy_cache: builtins.dict[str, MutableProxy] = field(
+        default_factory=builtins.dict, is_var=False
+    )
+
     # A special event handler for setting base vars.
     setvar: ClassVar[EventHandler]
 
@@ -1474,14 +1480,9 @@ class BaseState(EvenMoreBasicBaseState):
             name in super().__getattribute__("base_vars") or name in backend_vars
         ):
             # track changes in mutable containers (list, dict, set, etc)
-            cache = super().__getattribute__("__dict__").get("_mutable_proxy_cache")
-            if cache is None:
-                cache = {}
-                object.__setattr__(self, "_mutable_proxy_cache", cache)
+            cache = super().__getattribute__("_mutable_proxy_cache")
             proxy = cache.get(name)
-            # isinstance also rejects entries degraded by deepcopy, which
-            # copies a MutableProxy as its unwrapped value.
-            if not isinstance(proxy, MutableProxy) or proxy.__wrapped__ is not value:
+            if proxy is None or proxy.__wrapped__ is not value:
                 proxy = MutableProxy(wrapped=value, state=self, field_name=name)
                 cache[name] = proxy
             return proxy
@@ -1519,9 +1520,8 @@ class BaseState(EvenMoreBasicBaseState):
 
         if name in self.backend_vars:
             self._backend_vars.__setitem__(name, value)
-            if (cache := self.__dict__.get("_mutable_proxy_cache")) is not None:
-                # Drop the proxy wrapping the replaced value.
-                cache.pop(name, None)
+            # Drop the proxy wrapping the replaced value.
+            self.__dict__["_mutable_proxy_cache"].pop(name, None)
             self.dirty_vars.add(name)
             self._mark_dirty()
             return
@@ -1555,9 +1555,8 @@ class BaseState(EvenMoreBasicBaseState):
         # Set the attribute.
         object.__setattr__(self, name, value)
 
-        if (cache := self.__dict__.get("_mutable_proxy_cache")) is not None:
-            # Drop the proxy wrapping the replaced value.
-            cache.pop(name, None)
+        # Drop the proxy wrapping the replaced value.
+        self.__dict__["_mutable_proxy_cache"].pop(name, None)
 
         # Add the var to the dirty list.
         if name in self.base_vars:
@@ -2101,6 +2100,8 @@ class BaseState(EvenMoreBasicBaseState):
         """
         state["parent_state"] = None
         state["substates"] = {}
+        # The proxy cache is never pickled; recreate it on the restored instance.
+        state.setdefault("_mutable_proxy_cache", {})
         for key, value in state.items():
             object.__setattr__(self, key, value)
 

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1474,7 +1474,17 @@ class BaseState(EvenMoreBasicBaseState):
             name in super().__getattribute__("base_vars") or name in backend_vars
         ):
             # track changes in mutable containers (list, dict, set, etc)
-            return MutableProxy(wrapped=value, state=self, field_name=name)
+            cache = super().__getattribute__("__dict__").get("_mutable_proxy_cache")
+            if cache is None:
+                cache = {}
+                object.__setattr__(self, "_mutable_proxy_cache", cache)
+            proxy = cache.get(name)
+            # isinstance also rejects entries degraded by deepcopy, which
+            # copies a MutableProxy as its unwrapped value.
+            if not isinstance(proxy, MutableProxy) or proxy.__wrapped__ is not value:
+                proxy = MutableProxy(wrapped=value, state=self, field_name=name)
+                cache[name] = proxy
+            return proxy
 
         return value
 
@@ -2067,6 +2077,8 @@ class BaseState(EvenMoreBasicBaseState):
         state.pop("parent_state", None)
         state.pop("substates", None)
         state.pop("_was_touched", None)
+        # Proxies wrap live state references and are rebuilt on access.
+        state.pop("_mutable_proxy_cache", None)
         # Remove all inherited vars.
         for inherited_var_name in self.inherited_vars:
             state.pop(inherited_var_name, None)

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1526,6 +1526,9 @@ class BaseState(EvenMoreBasicBaseState):
 
         if name in self.backend_vars:
             self._backend_vars.__setitem__(name, value)
+            if (cache := self.__dict__.get("_mutable_proxy_cache")) is not None:
+                # Drop the proxy wrapping the replaced value.
+                cache.pop(name, None)
             self.dirty_vars.add(name)
             self._mark_dirty()
             return
@@ -1558,6 +1561,10 @@ class BaseState(EvenMoreBasicBaseState):
 
         # Set the attribute.
         object.__setattr__(self, name, value)
+
+        if (cache := self.__dict__.get("_mutable_proxy_cache")) is not None:
+            # Drop the proxy wrapping the replaced value.
+            cache.pop(name, None)
 
         # Add the var to the dirty list.
         if name in self.base_vars:

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -438,6 +438,12 @@ class BaseState(EvenMoreBasicBaseState):
     # Whether the state has ever been touched since instantiation.
     _was_touched: bool = field(default=False, is_var=False)
 
+    # Per-field cache of the MutableProxy wrapping each mutable var, so
+    # repeated reads don't rebuild the proxy. Never pickled.
+    _mutable_proxy_cache: builtins.dict[str, MutableProxy] = field(
+        default_factory=builtins.dict, is_var=False
+    )
+
     # A special event handler for setting base vars.
     setvar: ClassVar[EventHandler]
 
@@ -1481,14 +1487,9 @@ class BaseState(EvenMoreBasicBaseState):
             name in super().__getattribute__("base_vars") or name in backend_vars
         ):
             # track changes in mutable containers (list, dict, set, etc)
-            cache = super().__getattribute__("__dict__").get("_mutable_proxy_cache")
-            if cache is None:
-                cache = {}
-                object.__setattr__(self, "_mutable_proxy_cache", cache)
+            cache = super().__getattribute__("_mutable_proxy_cache")
             proxy = cache.get(name)
-            # isinstance also rejects entries degraded by deepcopy, which
-            # copies a MutableProxy as its unwrapped value.
-            if not isinstance(proxy, MutableProxy) or proxy.__wrapped__ is not value:
+            if proxy is None or proxy.__wrapped__ is not value:
                 proxy = MutableProxy(wrapped=value, state=self, field_name=name)
                 cache[name] = proxy
             return proxy
@@ -1526,9 +1527,8 @@ class BaseState(EvenMoreBasicBaseState):
 
         if name in self.backend_vars:
             self._backend_vars.__setitem__(name, value)
-            if (cache := self.__dict__.get("_mutable_proxy_cache")) is not None:
-                # Drop the proxy wrapping the replaced value.
-                cache.pop(name, None)
+            # Drop the proxy wrapping the replaced value.
+            self.__dict__["_mutable_proxy_cache"].pop(name, None)
             self.dirty_vars.add(name)
             self._mark_dirty()
             return
@@ -1562,9 +1562,8 @@ class BaseState(EvenMoreBasicBaseState):
         # Set the attribute.
         object.__setattr__(self, name, value)
 
-        if (cache := self.__dict__.get("_mutable_proxy_cache")) is not None:
-            # Drop the proxy wrapping the replaced value.
-            cache.pop(name, None)
+        # Drop the proxy wrapping the replaced value.
+        self.__dict__["_mutable_proxy_cache"].pop(name, None)
 
         # Add the var to the dirty list.
         if name in self.base_vars:
@@ -2108,6 +2107,8 @@ class BaseState(EvenMoreBasicBaseState):
         """
         state["parent_state"] = None
         state["substates"] = {}
+        # The proxy cache is never pickled; recreate it on the restored instance.
+        state.setdefault("_mutable_proxy_cache", {})
         for key, value in state.items():
             object.__setattr__(self, key, value)
 

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1481,7 +1481,17 @@ class BaseState(EvenMoreBasicBaseState):
             name in super().__getattribute__("base_vars") or name in backend_vars
         ):
             # track changes in mutable containers (list, dict, set, etc)
-            return MutableProxy(wrapped=value, state=self, field_name=name)
+            cache = super().__getattribute__("__dict__").get("_mutable_proxy_cache")
+            if cache is None:
+                cache = {}
+                object.__setattr__(self, "_mutable_proxy_cache", cache)
+            proxy = cache.get(name)
+            # isinstance also rejects entries degraded by deepcopy, which
+            # copies a MutableProxy as its unwrapped value.
+            if not isinstance(proxy, MutableProxy) or proxy.__wrapped__ is not value:
+                proxy = MutableProxy(wrapped=value, state=self, field_name=name)
+                cache[name] = proxy
+            return proxy
 
         return value
 
@@ -2074,6 +2084,8 @@ class BaseState(EvenMoreBasicBaseState):
         state.pop("parent_state", None)
         state.pop("substates", None)
         state.pop("_was_touched", None)
+        # Proxies wrap live state references and are rebuilt on access.
+        state.pop("_mutable_proxy_cache", None)
         # Remove all inherited vars.
         for inherited_var_name in self.inherited_vars:
             state.pop(inherited_var_name, None)

--- a/tests/units/istate/test_proxy.py
+++ b/tests/units/istate/test_proxy.py
@@ -88,6 +88,10 @@ def test_mutable_proxy_cached_per_field():
     # In-place mutation keeps the same wrapped object, so the proxy is reused.
     second.append(Item(3))
     assert state.items is second
+    # Reassignment immediately evicts the cache entry, so no strong reference
+    # to the replaced value lingers until the next read.
+    state.items = [Item(4)]
+    assert "items" not in state.__dict__["_mutable_proxy_cache"]
 
 
 def test_mutable_proxy_cache_not_serialized():

--- a/tests/units/istate/test_proxy.py
+++ b/tests/units/istate/test_proxy.py
@@ -98,11 +98,12 @@ def test_mutable_proxy_cache_not_serialized():
     """The per-instance proxy cache never leaks into pickles or copies."""
     state = ProxyTestState()
     state.items.append(Item(1))  # populate the proxy cache
-    assert "_mutable_proxy_cache" in state.__dict__
+    assert state.__dict__["_mutable_proxy_cache"]
     assert "_mutable_proxy_cache" not in state.__getstate__()
 
     restored = pickle.loads(pickle.dumps(state))
-    assert "_mutable_proxy_cache" not in restored.__dict__
+    # The cache is recreated empty on the restored instance.
+    assert restored.__dict__["_mutable_proxy_cache"] == {}
     restored_items = restored.items
     assert isinstance(restored_items, MutableProxy)
     # The restored proxy tracks the restored state, not the original.

--- a/tests/units/istate/test_proxy.py
+++ b/tests/units/istate/test_proxy.py
@@ -71,3 +71,46 @@ async def test_state_proxy_recovery(
     # After the exception, we should be able to enter the context again without issues
     async with state_proxy:
         pass
+
+
+def test_mutable_proxy_cached_per_field():
+    """Repeated reads of a mutable var reuse the proxy until reassignment."""
+    state = ProxyTestState()
+    first = state.items
+    assert isinstance(first, MutableProxy)
+    assert state.items is first
+    # Reassignment invalidates the cached proxy.
+    state.items = [Item(2)]
+    second = state.items
+    assert isinstance(second, MutableProxy)
+    assert second is not first
+    assert second[0].id == 2
+    # In-place mutation keeps the same wrapped object, so the proxy is reused.
+    second.append(Item(3))
+    assert state.items is second
+
+
+def test_mutable_proxy_cache_not_serialized():
+    """The per-instance proxy cache never leaks into pickles or copies."""
+    state = ProxyTestState()
+    state.items.append(Item(1))  # populate the proxy cache
+    assert "_mutable_proxy_cache" in state.__dict__
+    assert "_mutable_proxy_cache" not in state.__getstate__()
+
+    restored = pickle.loads(pickle.dumps(state))
+    assert "_mutable_proxy_cache" not in restored.__dict__
+    restored_items = restored.items
+    assert isinstance(restored_items, MutableProxy)
+    # The restored proxy tracks the restored state, not the original.
+    assert restored_items._self_state is restored
+
+
+def test_mutable_proxy_iteration_yields_plain_immutables():
+    """Iterating a proxied container returns immutable elements unwrapped."""
+    state = ProxyTestState()
+    state.items = [Item(1), Item(2)]
+    numbers = [item.id for item in state.items]
+    assert numbers == [1, 2]
+    assert all(type(n) is int for n in numbers)
+    # Mutable elements remain wrapped so nested mutations mark the state dirty.
+    assert all(isinstance(item, MutableProxy) for item in state.items)

--- a/tests/units/istate/test_proxy.py
+++ b/tests/units/istate/test_proxy.py
@@ -740,11 +740,12 @@ def test_mutable_proxy_cache_not_serialized():
     """The per-instance proxy cache never leaks into pickles or copies."""
     state = ProxyTestState()
     state.items.append(Item(1))  # populate the proxy cache
-    assert "_mutable_proxy_cache" in state.__dict__
+    assert state.__dict__["_mutable_proxy_cache"]
     assert "_mutable_proxy_cache" not in state.__getstate__()
 
     restored = pickle.loads(pickle.dumps(state))
-    assert "_mutable_proxy_cache" not in restored.__dict__
+    # The cache is recreated empty on the restored instance.
+    assert restored.__dict__["_mutable_proxy_cache"] == {}
     restored_items = restored.items
     assert isinstance(restored_items, MutableProxy)
     # The restored proxy tracks the restored state, not the original.

--- a/tests/units/istate/test_proxy.py
+++ b/tests/units/istate/test_proxy.py
@@ -730,6 +730,10 @@ def test_mutable_proxy_cached_per_field():
     # In-place mutation keeps the same wrapped object, so the proxy is reused.
     second.append(Item(3))
     assert state.items is second
+    # Reassignment immediately evicts the cache entry, so no strong reference
+    # to the replaced value lingers until the next read.
+    state.items = [Item(4)]
+    assert "items" not in state.__dict__["_mutable_proxy_cache"]
 
 
 def test_mutable_proxy_cache_not_serialized():

--- a/tests/units/istate/test_proxy.py
+++ b/tests/units/istate/test_proxy.py
@@ -713,3 +713,46 @@ async def test_mutable_proxy_custom_get_method_path_tracking(
     ) as state:
         assert isinstance(state, CustomGetState)
         assert state.registry.entries == {"a": [1, 2]}
+
+
+def test_mutable_proxy_cached_per_field():
+    """Repeated reads of a mutable var reuse the proxy until reassignment."""
+    state = ProxyTestState()
+    first = state.items
+    assert isinstance(first, MutableProxy)
+    assert state.items is first
+    # Reassignment invalidates the cached proxy.
+    state.items = [Item(2)]
+    second = state.items
+    assert isinstance(second, MutableProxy)
+    assert second is not first
+    assert second[0].id == 2
+    # In-place mutation keeps the same wrapped object, so the proxy is reused.
+    second.append(Item(3))
+    assert state.items is second
+
+
+def test_mutable_proxy_cache_not_serialized():
+    """The per-instance proxy cache never leaks into pickles or copies."""
+    state = ProxyTestState()
+    state.items.append(Item(1))  # populate the proxy cache
+    assert "_mutable_proxy_cache" in state.__dict__
+    assert "_mutable_proxy_cache" not in state.__getstate__()
+
+    restored = pickle.loads(pickle.dumps(state))
+    assert "_mutable_proxy_cache" not in restored.__dict__
+    restored_items = restored.items
+    assert isinstance(restored_items, MutableProxy)
+    # The restored proxy tracks the restored state, not the original.
+    assert restored_items._self_state is restored
+
+
+def test_mutable_proxy_iteration_yields_plain_immutables():
+    """Iterating a proxied container returns immutable elements unwrapped."""
+    state = ProxyTestState()
+    state.items = [Item(1), Item(2)]
+    numbers = [item.id for item in state.items]
+    assert numbers == [1, 2]
+    assert all(type(n) is int for n in numbers)
+    # Mutable elements remain wrapped so nested mutations mark the state dirty.
+    assert all(isinstance(item, MutableProxy) for item in state.items)

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -3259,11 +3259,11 @@ def test_set_base_field_via_setter():
     bfss.dirty_vars.clear()
     assert "c1" not in bfss.dirty_vars
 
-    # Assert identity of MutableProxy
+    # Repeated reads reuse the cached MutableProxy for the same field.
     mp = bfss.c1
     assert isinstance(mp, MutableProxy)
     mp3 = bfss.c1
-    assert mp is not mp3
+    assert mp is mp3
     # Since none of these set calls had values, the state should not be dirty
     assert not bfss.dirty_vars
 

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -3258,11 +3258,11 @@ def test_set_base_field_via_setter():
     bfss.dirty_vars.clear()
     assert "c1" not in bfss.dirty_vars
 
-    # Assert identity of MutableProxy
+    # Repeated reads reuse the cached MutableProxy for the same field.
     mp = bfss.c1
     assert isinstance(mp, MutableProxy)
     mp3 = bfss.c1
-    assert mp is not mp3
+    assert mp is mp3
     # Since none of these set calls had values, the state should not be dirty
     assert not bfss.dirty_vars
 


### PR DESCRIPTION
Linear: [ENG-10094](https://linear.app/reflex-dev/issue/ENG-10094/mutableproxy-per-element-overhead-on-iteration-and-reads)

### Description

- `MutableProxy._wrap_recursive` walked 5 stack frames (`_is_called_from_dataclasses_internal`) for **every** element retrieved through a proxy, before the cheap `is_mutable_type` check that usually decides nothing needs wrapping. The checks are reordered so immutable elements (the common case: ints, strings in a proxied list) skip the frame walk entirely. The dataclasses-internal check still runs for mutable values, preserving `dataclasses.asdict`/`astuple` behavior.
- `BaseState._get_attribute` constructed a fresh `MutableProxy` on every read of a mutable state var. The proxy is now cached per instance and field name, invalidated by identity when the underlying value is reassigned. The cache is excluded from pickling (`__getstate__`), and `copy`/`deepcopy` already round-trip through `__getstate__`, so copies never share or carry proxies.

One deliberate nuance: when `_wrap_recursive` receives an already-proxied value *and* is called from dataclasses internals, it now returns the unwrapped value (previously the still-wrapped proxy), matching the documented intent of that path.

### Benchmarks (GitHub Actions runner, [run](https://github.com/reflex-dev/reflex/actions/runs/29119575765), 2 passes each)

| Case | main | this PR | speedup |
|---|---|---|---|
| iterate 1000-int list via proxy | 0.977 / 0.973 ms | **0.219 / 0.214 ms** | ~4.5x |
| index 1000 elements via proxy | 1.204 / 1.171 ms | **0.396 / 0.381 ms** | ~3.0x |
| read mutable var attribute | 2.82 / 2.87 us | **1.17 / 1.15 us** | ~2.4x |

cProfile (20 iterations + 2000 attr reads): `_is_called_from_dataclasses_internal` (20,000 calls, 0.028s cumulative) disappears from the profile; total function calls drop from 168k to 72k.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
  - `tests/units/istate/test_proxy.py`: proxy reused across reads and invalidated on reassignment; cache never serialized (pickle round-trip rebinds proxies to the restored state); iteration yields plain immutables while mutable elements stay wrapped.
- [x] Have you successfully ran tests with your changes locally?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8cXh3TUbNtbjm2ERqE62X

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8cXh3TUbNtbjm2ERqE62X)_