### PR TITLE
Fix _get_all_hooks_internal mutating the shared per-node hooks cache

### DIFF
--- a/packages/reflex-base/news/6741.bugfix.md
+++ b/packages/reflex-base/news/6741.bugfix.md
@@ -1,0 +1,1 @@
+Fix `_get_all_hooks_internal` mutating each component's cached internal hooks with its descendants' hooks, which made memo tag hashes order-dependent and duplicated hooks into memo bodies.

--- a/packages/reflex-base/src/reflex_base/components/component.py
+++ b/packages/reflex-base/src/reflex_base/components/component.py
@@ -2136,8 +2136,9 @@ class Component(BaseComponent, ABC):
         Returns:
             The code that should appear just before user-defined hooks.
         """
-        # Store the code in a set to avoid duplicates.
-        code = self._get_hooks_internal()
+        # Copy the cached dict from _get_hooks_internal so updating it with
+        # the children's hooks below does not pollute this node's cache.
+        code = dict(self._get_hooks_internal())
 
         # Add the hook code for the children.
         for child in self.children:

--- a/tests/units/components/test_component.py
+++ b/tests/units/components/test_component.py
@@ -2322,3 +2322,22 @@ def test_deepcopy_produces_independent_children() -> None:
 
     assert len(original.children) == 1
     assert len(clone.children) == 2
+
+
+def test_get_all_hooks_internal_does_not_mutate_hooks_cache():
+    """Collecting subtree hooks must not pollute each node's own hooks cache."""
+    child = Box.create(id="hooks_cache_child")
+    parent = Box.create(child, id="hooks_cache_parent")
+
+    parent_own_hooks = dict(parent._get_hooks_internal())
+    child_own_hooks = dict(child._get_hooks_internal())
+    combined = parent._get_all_hooks_internal()
+
+    # The subtree collection includes both nodes' hooks.
+    for hook in (*parent_own_hooks, *child_own_hooks):
+        assert hook in combined
+
+    # The parent's per-node cache must not absorb the child's hooks.
+    assert dict(parent._get_hooks_internal()) == parent_own_hooks
+    # And repeated collection yields the same result.
+    assert parent._get_all_hooks_internal() == combined


### PR DESCRIPTION
Linear: [ENG-10108](https://linear.app/reflex-dev/issue/ENG-10108/bug-get-all-hooks-internal-mutates-the-shared-per-node-hooks-cache)

### Description

`Component._get_all_hooks_internal` called `.update()` directly on the dict returned by `_get_hooks_internal()`, which is the node's cached `_hooks_internal_cache`. Collecting hooks for a subtree therefore permanently polluted every intermediate node's cache with its descendants' hooks. The same cached dict was further mutated through `|=` in `Bare._get_all_hooks_internal`.

Consequences of the pollution:

- Hook collection became order-dependent: whichever traversal ran first baked descendant hooks into ancestors' caches, so memo tag hashes over internal hooks (`_update_deterministic_hash`) could differ for otherwise-identical subtrees, defeating memo dedup.
- Per-node hook queries (`_get_hooks_internal`) returned descendants' hooks, duplicating hooks into memo bodies and skewing subtree reactivity classification.

Fix: copy the cached dict before merging children's hooks into it. `Bare`'s `|=` then mutates the fresh copy returned by `super()`, so it needs no change.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
  - `tests/units/components/test_component.py::test_get_all_hooks_internal_does_not_mutate_hooks_cache`: asserts subtree collection includes both nodes' hooks while each node's own cache stays unpolluted, and that repeated collection is stable. Fails before this fix.
- [x] Have you successfully ran tests with your changes locally?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G8cXh3TUbNtbjm2ERqE62X

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8cXh3TUbNtbjm2ERqE62X)_