### PR TITLE
perf: cut state hot-path overhead — deep-validation skip, proxy caching, dirty-propagation frontier

### DIFF
--- a/news/6738.performance.md
+++ b/news/6738.performance.md
@@ -1,0 +1,1 @@
+Skip deep element-wise type validation on state var hot paths: computed var return types are only checked on recompute (not on cache hits), and production mode no longer walks every element of assigned containers for the log-only type check.

--- a/news/6740.performance.md
+++ b/news/6740.performance.md
@@ -1,0 +1,1 @@
+Speed up MutableProxy: immutable elements retrieved through a proxy skip the dataclasses frame-walk check, and the proxy for each mutable state var is cached per instance instead of rebuilt on every attribute read.

--- a/news/6743.performance.md
+++ b/news/6743.performance.md
@@ -1,0 +1,1 @@
+Dirty propagation now only walks newly-dirty vars per mutation and skips the computed var expiry scan for classes with no interval vars, roughly halving per-mutation overhead in states with computed vars.

--- a/packages/reflex-base/news/6738.performance.md
+++ b/packages/reflex-base/news/6738.performance.md
@@ -1,0 +1,1 @@
+Skip deep element-wise type validation on state var hot paths: computed var return types are only checked on recompute (not on cache hits), and production mode no longer walks every element of assigned containers for the log-only type check.

--- a/packages/reflex-base/news/6740.performance.md
+++ b/packages/reflex-base/news/6740.performance.md
@@ -1,0 +1,1 @@
+Reserve the internal `_mutable_proxy_cache` state field name so user vars cannot collide with the per-instance proxy cache.

--- a/packages/reflex-base/news/6743.performance.md
+++ b/packages/reflex-base/news/6743.performance.md
@@ -1,0 +1,1 @@
+Dirty propagation now only walks newly-dirty vars per mutation and skips the computed var expiry scan for classes with no interval vars, roughly halving per-mutation overhead in states with computed vars.

--- a/packages/reflex-base/src/reflex_base/utils/types.py
+++ b/packages/reflex-base/src/reflex_base/utils/types.py
@@ -162,7 +162,13 @@ PrimitiveToAnnotation = {
     dict: Dict,  # noqa: UP006
 }
 
-RESERVED_BACKEND_VAR_NAMES = {"_abc_impl", "_backend_vars", "_was_touched", "_mixin"}
+RESERVED_BACKEND_VAR_NAMES = {
+    "_abc_impl",
+    "_backend_vars",
+    "_was_touched",
+    "_mixin",
+    "_mutable_proxy_cache",
+}
 
 
 class Unset:

--- a/packages/reflex-base/src/reflex_base/utils/types.py
+++ b/packages/reflex-base/src/reflex_base/utils/types.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
+import os
 import sys
 import types
 from collections.abc import Callable, Iterable, Mapping, Sequence
@@ -634,20 +635,33 @@ def does_obj_satisfy_typed_dict(
 
 
 @lru_cache
+def _validation_depth_for_mode(raw_mode: str | None) -> int:
+    """Get the validation depth for a raw REFLEX_ENV_MODE value.
+
+    Args:
+        raw_mode: The raw environment variable value (or None if unset).
+
+    Returns:
+        The `nested` depth to pass to `_isinstance`.
+    """
+    return 0 if raw_mode == constants.Env.PROD.value else 1
+
+
 def _validation_depth() -> int:
     """Get the container depth for hot-path state var type validation.
 
     The result of these checks only gates a diagnostic log, so production
     mode skips the per-element walk of large containers and only validates
-    the outer type.
+    the outer type. The environment is re-read on every call so in-process
+    mode changes take effect immediately.
 
     Returns:
         The `nested` depth to pass to `_isinstance`.
     """
-    from reflex_base import constants
-    from reflex_base.environment import environment
-
-    return 0 if environment.REFLEX_ENV_MODE.get() == constants.Env.PROD else 1
+    # Read the raw env var directly: interpreting it through
+    # environment.REFLEX_ENV_MODE.get() on this hot path would re-parse the
+    # enum on every state var assignment (and the import would be circular).
+    return _validation_depth_for_mode(os.environ.get("REFLEX_ENV_MODE"))
 
 
 def _isinstance(

--- a/packages/reflex-base/src/reflex_base/utils/types.py
+++ b/packages/reflex-base/src/reflex_base/utils/types.py
@@ -633,6 +633,23 @@ def does_obj_satisfy_typed_dict(
     return required_keys.issubset(frozenset(obj))
 
 
+@lru_cache
+def _validation_depth() -> int:
+    """Get the container depth for hot-path state var type validation.
+
+    The result of these checks only gates a diagnostic log, so production
+    mode skips the per-element walk of large containers and only validates
+    the outer type.
+
+    Returns:
+        The `nested` depth to pass to `_isinstance`.
+    """
+    from reflex_base import constants
+    from reflex_base.environment import environment
+
+    return 0 if environment.REFLEX_ENV_MODE.get() == constants.Env.PROD else 1
+
+
 def _isinstance(
     obj: Any,
     cls: GenericType,

--- a/packages/reflex-base/src/reflex_base/utils/types.py
+++ b/packages/reflex-base/src/reflex_base/utils/types.py
@@ -168,6 +168,8 @@ RESERVED_BACKEND_VAR_NAMES = {
     "_was_touched",
     "_mixin",
     "_mutable_proxy_cache",
+    "_propagated_dirty_vars",
+    "_propagated_generation",
 }
 
 

--- a/packages/reflex-base/src/reflex_base/utils/types.py
+++ b/packages/reflex-base/src/reflex_base/utils/types.py
@@ -643,11 +643,11 @@ def does_obj_satisfy_typed_dict(
 
 
 @lru_cache
-def _validation_depth_for_mode(raw_mode: str | None) -> int:
+def _validation_depth_for_mode(raw_mode: str) -> int:
     """Get the validation depth for a raw REFLEX_ENV_MODE value.
 
     Args:
-        raw_mode: The raw environment variable value (or None if unset).
+        raw_mode: The stripped environment variable value ("" if unset).
 
     Returns:
         The `nested` depth to pass to `_isinstance`.
@@ -669,7 +669,8 @@ def _validation_depth() -> int:
     # Read the raw env var directly: interpreting it through
     # environment.REFLEX_ENV_MODE.get() on this hot path would re-parse the
     # enum on every state var assignment (and the import would be circular).
-    return _validation_depth_for_mode(os.environ.get("REFLEX_ENV_MODE"))
+    # Strip to match the canonical parser's whitespace tolerance.
+    return _validation_depth_for_mode(os.environ.get("REFLEX_ENV_MODE", "").strip())
 
 
 def _isinstance(

--- a/packages/reflex-base/src/reflex_base/vars/base.py
+++ b/packages/reflex-base/src/reflex_base/vars/base.py
@@ -2255,6 +2255,19 @@ def is_computed_var(obj: Any) -> TypeGuard[ComputedVar]:
     return isinstance(obj, FakeComputedVarBaseClass)
 
 
+# Incremented whenever a cached computed var is recomputed. State dirty
+# propagation uses this to know when an already-propagated dependency needs to
+# be re-propagated (a recompute re-materializes a cache that a later mutation
+# of its dependencies must invalidate again).
+_computed_var_recompute_generation: int = 0
+
+
+def _bump_computed_var_recompute_generation() -> None:
+    """Record that a cached computed var was recomputed."""
+    global _computed_var_recompute_generation
+    _computed_var_recompute_generation += 1
+
+
 @dataclasses.dataclass(
     eq=False,
     frozen=True,
@@ -2598,6 +2611,7 @@ class ComputedVar(Var[RETURN_TYPE]):
             instance._was_touched = True
             # Set the last updated timestamp on the state instance.
             setattr(instance, self._last_updated_attr, datetime.datetime.now())
+            _bump_computed_var_recompute_generation()
             value = getattr(instance, self._cache_attr)
             # Only validate the return type when the value was just computed.
             self._check_deprecated_return_type(instance, value)
@@ -2863,6 +2877,7 @@ class AsyncComputedVar(ComputedVar[RETURN_TYPE]):
                 instance._was_touched = True
                 # Set the last updated timestamp on the state instance.
                 setattr(instance, self._last_updated_attr, datetime.datetime.now())
+                _bump_computed_var_recompute_generation()
                 value = getattr(instance, self._cache_attr)
                 # Only validate the return type when the value was just computed.
                 self._check_deprecated_return_type(instance, value)

--- a/packages/reflex-base/src/reflex_base/vars/base.py
+++ b/packages/reflex-base/src/reflex_base/vars/base.py
@@ -2256,6 +2256,19 @@ def is_computed_var(obj: Any) -> TypeGuard[ComputedVar]:
     return isinstance(obj, FakeComputedVarBaseClass)
 
 
+# Incremented whenever a cached computed var is recomputed. State dirty
+# propagation uses this to know when an already-propagated dependency needs to
+# be re-propagated (a recompute re-materializes a cache that a later mutation
+# of its dependencies must invalidate again).
+_computed_var_recompute_generation: int = 0
+
+
+def _bump_computed_var_recompute_generation() -> None:
+    """Record that a cached computed var was recomputed."""
+    global _computed_var_recompute_generation
+    _computed_var_recompute_generation += 1
+
+
 @dataclasses.dataclass(
     eq=False,
     frozen=True,
@@ -2599,6 +2612,7 @@ class ComputedVar(Var[RETURN_TYPE]):
             instance._was_touched = True
             # Set the last updated timestamp on the state instance.
             setattr(instance, self._last_updated_attr, datetime.datetime.now())
+            _bump_computed_var_recompute_generation()
             value = getattr(instance, self._cache_attr)
             # Only validate the return type when the value was just computed.
             self._check_deprecated_return_type(instance, value)
@@ -2864,6 +2878,7 @@ class AsyncComputedVar(ComputedVar[RETURN_TYPE]):
                 instance._was_touched = True
                 # Set the last updated timestamp on the state instance.
                 setattr(instance, self._last_updated_attr, datetime.datetime.now())
+                _bump_computed_var_recompute_generation()
                 value = getattr(instance, self._cache_attr)
                 # Only validate the return type when the value was just computed.
                 self._check_deprecated_return_type(instance, value)

--- a/packages/reflex-base/src/reflex_base/vars/base.py
+++ b/packages/reflex-base/src/reflex_base/vars/base.py
@@ -66,6 +66,7 @@ from reflex_base.utils.types import (
     GenericType,
     Self,
     _isinstance,
+    _validation_depth,
     get_origin,
     has_args,
     safe_issubclass,
@@ -2587,23 +2588,28 @@ class ComputedVar(Var[RETURN_TYPE]):
 
         if not self._cache:
             value = self.fget(instance)
-        else:
-            # handle caching
-            if not hasattr(instance, self._cache_attr) or self.needs_update(instance):
-                # Set cache attr on state instance.
-                setattr(instance, self._cache_attr, self.fget(instance))
-                # Ensure the computed var gets serialized to redis.
-                instance._was_touched = True
-                # Set the last updated timestamp on the state instance.
-                setattr(instance, self._last_updated_attr, datetime.datetime.now())
+            self._check_deprecated_return_type(instance, value)
+            return value
+
+        # handle caching
+        if not hasattr(instance, self._cache_attr) or self.needs_update(instance):
+            # Set cache attr on state instance.
+            setattr(instance, self._cache_attr, self.fget(instance))
+            # Ensure the computed var gets serialized to redis.
+            instance._was_touched = True
+            # Set the last updated timestamp on the state instance.
+            setattr(instance, self._last_updated_attr, datetime.datetime.now())
             value = getattr(instance, self._cache_attr)
+            # Only validate the return type when the value was just computed.
+            self._check_deprecated_return_type(instance, value)
+            return value
 
-        self._check_deprecated_return_type(instance, value)
-
-        return value
+        return getattr(instance, self._cache_attr)
 
     def _check_deprecated_return_type(self, instance: BaseState, value: Any) -> None:
-        if not _isinstance(value, self._var_type, nested=1, treat_var_as_type=False):
+        if not _isinstance(
+            value, self._var_type, nested=_validation_depth(), treat_var_as_type=False
+        ):
             console.error(
                 f"Computed var '{type(instance).__name__}.{self._name}' must return"
                 f" a value of type '{escape(str(self._var_type))}', got '{value!s}' of type {type(value)}."
@@ -2858,9 +2864,11 @@ class AsyncComputedVar(ComputedVar[RETURN_TYPE]):
                 instance._was_touched = True
                 # Set the last updated timestamp on the state instance.
                 setattr(instance, self._last_updated_attr, datetime.datetime.now())
-            value = getattr(instance, self._cache_attr)
-            self._check_deprecated_return_type(instance, value)
-            return value
+                value = getattr(instance, self._cache_attr)
+                # Only validate the return type when the value was just computed.
+                self._check_deprecated_return_type(instance, value)
+                return value
+            return getattr(instance, self._cache_attr)
 
         return _awaitable_result()
 

--- a/reflex/istate/proxy.py
+++ b/reflex/istate/proxy.py
@@ -668,10 +668,6 @@ class MutableProxy(wrapt.ObjectProxy):
         # reference is up to date.
         if isinstance(value, MutableProxy):
             value = value.__wrapped__
-        # Immutable values (the common case when iterating a container of
-        # scalars) never need wrapping nor the frame inspection below.
-        if not is_mutable_type(type(value)):
-            return value
         # When called from dataclasses internal code, return the unwrapped value
         if self._is_called_from_dataclasses_internal():
             return value

--- a/reflex/istate/proxy.py
+++ b/reflex/istate/proxy.py
@@ -664,13 +664,18 @@ class MutableProxy(wrapt.ObjectProxy):
         Returns:
             The wrapped value.
         """
-        # When called from dataclasses internal code, return the unwrapped value
-        if self._is_called_from_dataclasses_internal():
-            return value
         # If we already have a proxy, unwrap and rewrap to make sure the state
         # reference is up to date.
         if isinstance(value, MutableProxy):
             value = value.__wrapped__
+        # Immutable values (the common case when iterating a container of
+        # scalars) never need wrapping nor the frame inspection below.
+        if not is_mutable_type(type(value)):
+            return value
+        # When called from dataclasses internal code, return the unwrapped value
+        if self._is_called_from_dataclasses_internal():
+            return value
+        # Recursively wrap mutable types.
         return globals()[self.__base_proxy__](
             wrapped=value,
             state=self._self_state,

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -55,6 +55,7 @@ from reflex_base.utils.exceptions import ImmutableStateError as ImmutableStateEr
 from reflex_base.utils.serializers import serializer
 from reflex_base.utils.types import _isinstance, _validation_depth
 from reflex_base.vars import Field, VarData, field
+from reflex_base.vars import base as reflex_base_vars_base
 from reflex_base.vars.base import (
     ComputedVar,
     DynamicRouteVar,
@@ -368,6 +369,7 @@ CLASS_VAR_NAMES = frozenset({
     "_always_dirty_computed_vars",
     "_always_dirty_substates",
     "_potentially_dirty_states",
+    "_interval_computed_vars",
 })
 
 
@@ -406,6 +408,11 @@ class BaseState(EvenMoreBasicBaseState):
 
     # Set of states which might need to be recomputed if vars in this state change.
     _potentially_dirty_states: ClassVar[set[str]] = set()
+
+    # Names of computed vars with an update interval, refreshed whenever
+    # computed_vars changes. Empty for most classes, which lets dirty
+    # propagation skip the per-mutation expiry scan.
+    _interval_computed_vars: ClassVar[tuple[str, ...]] = ()
 
     # The parent state.
     parent_state: BaseState | None = field(default=None, is_var=False)
@@ -723,8 +730,21 @@ class BaseState(EvenMoreBasicBaseState):
         # Initialize per-class var dependency tracking.
         cls._var_dependencies = {}
         cls._init_var_dependency_dicts()
+        cls._refresh_interval_computed_vars()
 
         all_base_state_classes[cls.get_full_name()] = None
+
+    @classmethod
+    def _refresh_interval_computed_vars(cls) -> None:
+        """Recompute the names of computed vars that have an update interval.
+
+        Must be called whenever cls.computed_vars is modified.
+        """
+        cls._interval_computed_vars = tuple(
+            name
+            for name, cvar in cls.computed_vars.items()
+            if cvar._update_interval is not None
+        )
 
     @classmethod
     def _add_event_handler(
@@ -830,6 +850,7 @@ class BaseState(EvenMoreBasicBaseState):
 
         setattr(cls, unique_var_name, computed_var_func_arg)
         cls.computed_vars[unique_var_name] = computed_var_func_arg
+        cls._refresh_interval_computed_vars()
         cls.vars[unique_var_name] = computed_var_func_arg
         cls._update_substate_inherited_vars({unique_var_name: computed_var_func_arg})
         cls._always_dirty_computed_vars.add(unique_var_name)
@@ -1403,6 +1424,7 @@ class BaseState(EvenMoreBasicBaseState):
 
         # Update tracking dicts.
         cls.computed_vars.update(dynamic_vars)
+        cls._refresh_interval_computed_vars()
         cls.vars.update(dynamic_vars)
         cls._update_substate_inherited_vars(dynamic_vars)
 
@@ -1812,14 +1834,31 @@ class BaseState(EvenMoreBasicBaseState):
 
     def _mark_dirty_computed_vars(self) -> None:
         """Mark ComputedVars that need to be recalculated based on dirty_vars."""
-        # Append expired computed vars to dirty_vars to trigger recalculation
-        self.dirty_vars.update(self._expired_computed_vars())
+        if self._interval_computed_vars:
+            # Append expired computed vars to dirty_vars to trigger recalculation
+            self.dirty_vars.update(self._expired_computed_vars())
         # Append always dirty computed vars to dirty_vars to trigger recalculation
         self.dirty_vars.update(self._always_dirty_computed_vars)
 
-        dirty_vars = self.dirty_vars
-        while dirty_vars:
-            calc_vars, dirty_vars = dirty_vars, set()
+        # Track which dirty vars already had their dependency closure
+        # propagated, so repeated mutations only process newly-dirty vars.
+        # Recomputing any cached var re-materializes a cache that a later
+        # mutation must invalidate again, so the frontier is only valid for
+        # the recompute generation it was built in.
+        instance_dict = self.__dict__
+        propagated = instance_dict.get("_propagated_dirty_vars")
+        current_gen = reflex_base_vars_base._computed_var_recompute_generation
+        if propagated is None:
+            propagated = set()
+            object.__setattr__(self, "_propagated_dirty_vars", propagated)
+        elif instance_dict.get("_propagated_generation") != current_gen:
+            propagated.clear()
+        object.__setattr__(self, "_propagated_generation", current_gen)
+
+        new_dirty = self.dirty_vars - propagated
+        while new_dirty:
+            propagated |= new_dirty
+            calc_vars, new_dirty = new_dirty, set()
             for state_name, cvar in self._dirty_computed_vars(from_vars=calc_vars):
                 if state_name == self.get_full_name():
                     defining_state = self
@@ -1832,7 +1871,8 @@ class BaseState(EvenMoreBasicBaseState):
                 if actual_var is not None:
                     actual_var.mark_dirty(instance=defining_state)
                 if defining_state is self:
-                    dirty_vars.add(cvar)
+                    if cvar not in propagated:
+                        new_dirty.add(cvar)
                 else:
                     # mark dirty where this var is defined
                     defining_state._mark_dirty()
@@ -1843,10 +1883,11 @@ class BaseState(EvenMoreBasicBaseState):
         Returns:
             Set of computed vars to include in the delta.
         """
+        computed_vars = self.computed_vars
         return {
             cvar
-            for cvar, cvar_obj in self.computed_vars.items()
-            if cvar_obj.needs_update(instance=self)
+            for cvar in self._interval_computed_vars
+            if computed_vars[cvar].needs_update(instance=self)
         }
 
     def _dirty_computed_vars(
@@ -1966,6 +2007,8 @@ class BaseState(EvenMoreBasicBaseState):
         # Clean this state.
         self.dirty_vars = set()
         self.dirty_substates = set()
+        # Discard the propagation frontier along with the dirty vars it tracked.
+        self.__dict__.pop("_propagated_dirty_vars", None)
 
     def get_value(self, key: str) -> Any:
         """Get the value of a field (without proxying).
@@ -2085,6 +2128,9 @@ class BaseState(EvenMoreBasicBaseState):
         state.pop("_was_touched", None)
         # Proxies wrap live state references and are rebuilt on access.
         state.pop("_mutable_proxy_cache", None)
+        # The propagation frontier is transient and rebuilt on demand.
+        state.pop("_propagated_dirty_vars", None)
+        state.pop("_propagated_generation", None)
         # Remove all inherited vars.
         for inherited_var_name in self.inherited_vars:
             state.pop(inherited_var_name, None)

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -449,6 +449,12 @@ class BaseState(EvenMoreBasicBaseState):
     _mutable_proxy_cache: builtins.dict[str, MutableProxy] = field(
         default_factory=builtins.dict, is_var=False
     )
+    # Dirty vars whose dependency closure was already propagated this cycle.
+    # Transient: cleared by _clean and never pickled.
+    _propagated_dirty_vars: set[str] = field(default_factory=set, is_var=False)
+
+    # Recompute generation the propagation frontier was built in.
+    _propagated_generation: int = field(default=0, is_var=False)
 
     # A special event handler for setting base vars.
     setvar: ClassVar[EventHandler]
@@ -1846,14 +1852,11 @@ class BaseState(EvenMoreBasicBaseState):
         # mutation must invalidate again, so the frontier is only valid for
         # the recompute generation it was built in.
         instance_dict = self.__dict__
-        propagated = instance_dict.get("_propagated_dirty_vars")
+        propagated = instance_dict["_propagated_dirty_vars"]
         current_gen = reflex_base_vars_base._computed_var_recompute_generation
-        if propagated is None:
-            propagated = set()
-            object.__setattr__(self, "_propagated_dirty_vars", propagated)
-        elif instance_dict.get("_propagated_generation") != current_gen:
+        if instance_dict["_propagated_generation"] != current_gen:
             propagated.clear()
-        object.__setattr__(self, "_propagated_generation", current_gen)
+            object.__setattr__(self, "_propagated_generation", current_gen)
 
         new_dirty = self.dirty_vars - propagated
         while new_dirty:
@@ -2008,7 +2011,7 @@ class BaseState(EvenMoreBasicBaseState):
         self.dirty_vars = set()
         self.dirty_substates = set()
         # Discard the propagation frontier along with the dirty vars it tracked.
-        self.__dict__.pop("_propagated_dirty_vars", None)
+        self.__dict__["_propagated_dirty_vars"].clear()
 
     def get_value(self, key: str) -> Any:
         """Get the value of a field (without proxying).
@@ -2148,6 +2151,9 @@ class BaseState(EvenMoreBasicBaseState):
         state["substates"] = {}
         # The proxy cache is never pickled; recreate it on the restored instance.
         state.setdefault("_mutable_proxy_cache", {})
+        # The propagation frontier is never pickled; recreate it on restore.
+        state.setdefault("_propagated_dirty_vars", set())
+        state.setdefault("_propagated_generation", 0)
         for key, value in state.items():
             object.__setattr__(self, key, value)
 

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1859,7 +1859,7 @@ class BaseState(EvenMoreBasicBaseState):
         current_gen = reflex_base_vars_base._computed_var_recompute_generation
         if instance_dict["_propagated_generation"] != current_gen:
             propagated.clear()
-            instance_dict["_propagated_generation"] = current_gen
+            instance_dict["_propagated_generation"] = current_gen  # pyright: ignore[reportIndexIssue]
 
         new_dirty = self.dirty_vars - propagated
         while new_dirty:

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1851,12 +1851,15 @@ class BaseState(EvenMoreBasicBaseState):
         # Recomputing any cached var re-materializes a cache that a later
         # mutation must invalidate again, so the frontier is only valid for
         # the recompute generation it was built in.
+        # Go through __dict__ (not setattr) so this also works when self is a
+        # StateProxy: the proxy exposes the wrapped state's __dict__, while
+        # object.__setattr__ is rejected by wrapt's C ObjectProxy.
         instance_dict = self.__dict__
         propagated = instance_dict["_propagated_dirty_vars"]
         current_gen = reflex_base_vars_base._computed_var_recompute_generation
         if instance_dict["_propagated_generation"] != current_gen:
             propagated.clear()
-            object.__setattr__(self, "_propagated_generation", current_gen)
+            instance_dict["_propagated_generation"] = current_gen
 
         new_dirty = self.dirty_vars - propagated
         while new_dirty:

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1526,6 +1526,9 @@ class BaseState(EvenMoreBasicBaseState):
 
         if name in self.backend_vars:
             self._backend_vars.__setitem__(name, value)
+            if (cache := self.__dict__.get("_mutable_proxy_cache")) is not None:
+                # Drop the proxy wrapping the replaced value.
+                cache.pop(name, None)
             self.dirty_vars.add(name)
             self._mark_dirty()
             return
@@ -1558,6 +1561,10 @@ class BaseState(EvenMoreBasicBaseState):
 
         # Set the attribute.
         object.__setattr__(self, name, value)
+
+        if (cache := self.__dict__.get("_mutable_proxy_cache")) is not None:
+            # Drop the proxy wrapping the replaced value.
+            cache.pop(name, None)
 
         # Add the var to the dirty list.
         if name in self.base_vars:

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1858,12 +1858,15 @@ class BaseState(EvenMoreBasicBaseState):
         # Recomputing any cached var re-materializes a cache that a later
         # mutation must invalidate again, so the frontier is only valid for
         # the recompute generation it was built in.
+        # Go through __dict__ (not setattr) so this also works when self is a
+        # StateProxy: the proxy exposes the wrapped state's __dict__, while
+        # object.__setattr__ is rejected by wrapt's C ObjectProxy.
         instance_dict = self.__dict__
         propagated = instance_dict["_propagated_dirty_vars"]
         current_gen = reflex_base_vars_base._computed_var_recompute_generation
         if instance_dict["_propagated_generation"] != current_gen:
             propagated.clear()
-            object.__setattr__(self, "_propagated_generation", current_gen)
+            instance_dict["_propagated_generation"] = current_gen
 
         new_dirty = self.dirty_vars - propagated
         while new_dirty:

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1866,7 +1866,7 @@ class BaseState(EvenMoreBasicBaseState):
         current_gen = reflex_base_vars_base._computed_var_recompute_generation
         if instance_dict["_propagated_generation"] != current_gen:
             propagated.clear()
-            instance_dict["_propagated_generation"] = current_gen
+            instance_dict["_propagated_generation"] = current_gen  # pyright: ignore[reportIndexIssue]
 
         new_dirty = self.dirty_vars - propagated
         while new_dirty:

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -54,7 +54,7 @@ from reflex_base.utils.exceptions import (
 )
 from reflex_base.utils.exceptions import ImmutableStateError as ImmutableStateError
 from reflex_base.utils.serializers import serializer
-from reflex_base.utils.types import _isinstance
+from reflex_base.utils.types import _isinstance, _validation_depth
 from reflex_base.vars import Field, VarData, field
 from reflex_base.vars.base import (
     ComputedVar,
@@ -1538,7 +1538,9 @@ class BaseState(EvenMoreBasicBaseState):
 
         if (field := fields.get(name)) is not None and field.is_var:
             field_type = field.outer_type_
-            if not _isinstance(value, field_type, nested=1, treat_var_as_type=False):
+            if not _isinstance(
+                value, field_type, nested=_validation_depth(), treat_var_as_type=False
+            ):
                 console.error(
                     f"Expected field '{type(self).__name__}.{name}' to receive type '{escape(str(field_type))}',"
                     f" but got '{value}' of type '{type(value)}'."

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -438,6 +438,12 @@ class BaseState(EvenMoreBasicBaseState):
     # Whether the state has ever been touched since instantiation.
     _was_touched: bool = field(default=False, is_var=False)
 
+    # Per-field cache of the MutableProxy wrapping each mutable var, so
+    # repeated reads don't rebuild the proxy. Never pickled.
+    _mutable_proxy_cache: builtins.dict[str, MutableProxy] = field(
+        default_factory=builtins.dict, is_var=False
+    )
+
     # A special event handler for setting base vars.
     setvar: ClassVar[EventHandler]
 
@@ -1481,14 +1487,9 @@ class BaseState(EvenMoreBasicBaseState):
             name in super().__getattribute__("base_vars") or name in backend_vars
         ):
             # track changes in mutable containers (list, dict, set, etc)
-            cache = super().__getattribute__("__dict__").get("_mutable_proxy_cache")
-            if cache is None:
-                cache = {}
-                object.__setattr__(self, "_mutable_proxy_cache", cache)
+            cache = super().__getattribute__("_mutable_proxy_cache")
             proxy = cache.get(name)
-            # isinstance also rejects entries degraded by deepcopy, which
-            # copies a MutableProxy as its unwrapped value.
-            if not isinstance(proxy, MutableProxy) or proxy.__wrapped__ is not value:
+            if proxy is None or proxy.__wrapped__ is not value:
                 proxy = MutableProxy(wrapped=value, state=self, field_name=name)
                 cache[name] = proxy
             return proxy
@@ -1526,9 +1527,8 @@ class BaseState(EvenMoreBasicBaseState):
 
         if name in self.backend_vars:
             self._backend_vars.__setitem__(name, value)
-            if (cache := self.__dict__.get("_mutable_proxy_cache")) is not None:
-                # Drop the proxy wrapping the replaced value.
-                cache.pop(name, None)
+            # Drop the proxy wrapping the replaced value.
+            self.__dict__["_mutable_proxy_cache"].pop(name, None)
             self.dirty_vars.add(name)
             self._mark_dirty()
             return
@@ -1562,9 +1562,8 @@ class BaseState(EvenMoreBasicBaseState):
         # Set the attribute.
         object.__setattr__(self, name, value)
 
-        if (cache := self.__dict__.get("_mutable_proxy_cache")) is not None:
-            # Drop the proxy wrapping the replaced value.
-            cache.pop(name, None)
+        # Drop the proxy wrapping the replaced value.
+        self.__dict__["_mutable_proxy_cache"].pop(name, None)
 
         # Add the var to the dirty list.
         if name in self.base_vars:
@@ -2108,6 +2107,8 @@ class BaseState(EvenMoreBasicBaseState):
         """
         state["parent_state"] = None
         state["substates"] = {}
+        # The proxy cache is never pickled; recreate it on the restored instance.
+        state.setdefault("_mutable_proxy_cache", {})
         for key, value in state.items():
             object.__setattr__(self, key, value)
 

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -450,6 +450,12 @@ class BaseState(EvenMoreBasicBaseState):
     _mutable_proxy_cache: builtins.dict[str, MutableProxy] = field(
         default_factory=builtins.dict, is_var=False
     )
+    # Dirty vars whose dependency closure was already propagated this cycle.
+    # Transient: cleared by _clean and never pickled.
+    _propagated_dirty_vars: set[str] = field(default_factory=set, is_var=False)
+
+    # Recompute generation the propagation frontier was built in.
+    _propagated_generation: int = field(default=0, is_var=False)
 
     # A special event handler for setting base vars.
     setvar: ClassVar[EventHandler]
@@ -1853,14 +1859,11 @@ class BaseState(EvenMoreBasicBaseState):
         # mutation must invalidate again, so the frontier is only valid for
         # the recompute generation it was built in.
         instance_dict = self.__dict__
-        propagated = instance_dict.get("_propagated_dirty_vars")
+        propagated = instance_dict["_propagated_dirty_vars"]
         current_gen = reflex_base_vars_base._computed_var_recompute_generation
-        if propagated is None:
-            propagated = set()
-            object.__setattr__(self, "_propagated_dirty_vars", propagated)
-        elif instance_dict.get("_propagated_generation") != current_gen:
+        if instance_dict["_propagated_generation"] != current_gen:
             propagated.clear()
-        object.__setattr__(self, "_propagated_generation", current_gen)
+            object.__setattr__(self, "_propagated_generation", current_gen)
 
         new_dirty = self.dirty_vars - propagated
         while new_dirty:
@@ -2015,7 +2018,7 @@ class BaseState(EvenMoreBasicBaseState):
         self.dirty_vars = set()
         self.dirty_substates = set()
         # Discard the propagation frontier along with the dirty vars it tracked.
-        self.__dict__.pop("_propagated_dirty_vars", None)
+        self.__dict__["_propagated_dirty_vars"].clear()
 
     def get_value(self, key: str) -> Any:
         """Get the value of a field (without proxying).
@@ -2155,6 +2158,9 @@ class BaseState(EvenMoreBasicBaseState):
         state["substates"] = {}
         # The proxy cache is never pickled; recreate it on the restored instance.
         state.setdefault("_mutable_proxy_cache", {})
+        # The propagation frontier is never pickled; recreate it on restore.
+        state.setdefault("_propagated_dirty_vars", set())
+        state.setdefault("_propagated_generation", 0)
         for key, value in state.items():
             object.__setattr__(self, key, value)
 

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -1481,7 +1481,17 @@ class BaseState(EvenMoreBasicBaseState):
             name in super().__getattribute__("base_vars") or name in backend_vars
         ):
             # track changes in mutable containers (list, dict, set, etc)
-            return MutableProxy(wrapped=value, state=self, field_name=name)
+            cache = super().__getattribute__("__dict__").get("_mutable_proxy_cache")
+            if cache is None:
+                cache = {}
+                object.__setattr__(self, "_mutable_proxy_cache", cache)
+            proxy = cache.get(name)
+            # isinstance also rejects entries degraded by deepcopy, which
+            # copies a MutableProxy as its unwrapped value.
+            if not isinstance(proxy, MutableProxy) or proxy.__wrapped__ is not value:
+                proxy = MutableProxy(wrapped=value, state=self, field_name=name)
+                cache[name] = proxy
+            return proxy
 
         return value
 
@@ -2074,6 +2084,8 @@ class BaseState(EvenMoreBasicBaseState):
         state.pop("parent_state", None)
         state.pop("substates", None)
         state.pop("_was_touched", None)
+        # Proxies wrap live state references and are rebuilt on access.
+        state.pop("_mutable_proxy_cache", None)
         # Remove all inherited vars.
         for inherited_var_name in self.inherited_vars:
             state.pop(inherited_var_name, None)

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -56,6 +56,7 @@ from reflex_base.utils.exceptions import ImmutableStateError as ImmutableStateEr
 from reflex_base.utils.serializers import serializer
 from reflex_base.utils.types import _isinstance, _validation_depth
 from reflex_base.vars import Field, VarData, field
+from reflex_base.vars import base as reflex_base_vars_base
 from reflex_base.vars.base import (
     ComputedVar,
     DynamicRouteVar,
@@ -369,6 +370,7 @@ CLASS_VAR_NAMES = frozenset({
     "_always_dirty_computed_vars",
     "_always_dirty_substates",
     "_potentially_dirty_states",
+    "_interval_computed_vars",
 })
 
 
@@ -407,6 +409,11 @@ class BaseState(EvenMoreBasicBaseState):
 
     # Set of states which might need to be recomputed if vars in this state change.
     _potentially_dirty_states: ClassVar[set[str]] = set()
+
+    # Names of computed vars with an update interval, refreshed whenever
+    # computed_vars changes. Empty for most classes, which lets dirty
+    # propagation skip the per-mutation expiry scan.
+    _interval_computed_vars: ClassVar[tuple[str, ...]] = ()
 
     # The parent state.
     parent_state: BaseState | None = field(default=None, is_var=False)
@@ -723,8 +730,21 @@ class BaseState(EvenMoreBasicBaseState):
         # Initialize per-class var dependency tracking.
         cls._var_dependencies = {}
         cls._init_var_dependency_dicts()
+        cls._refresh_interval_computed_vars()
 
         all_base_state_classes[cls.get_full_name()] = None
+
+    @classmethod
+    def _refresh_interval_computed_vars(cls) -> None:
+        """Recompute the names of computed vars that have an update interval.
+
+        Must be called whenever cls.computed_vars is modified.
+        """
+        cls._interval_computed_vars = tuple(
+            name
+            for name, cvar in cls.computed_vars.items()
+            if cvar._update_interval is not None
+        )
 
     @classmethod
     def _add_event_handler(
@@ -830,6 +850,7 @@ class BaseState(EvenMoreBasicBaseState):
 
         setattr(cls, unique_var_name, computed_var_func_arg)
         cls.computed_vars[unique_var_name] = computed_var_func_arg
+        cls._refresh_interval_computed_vars()
         cls.vars[unique_var_name] = computed_var_func_arg
         cls._update_substate_inherited_vars({unique_var_name: computed_var_func_arg})
         cls._always_dirty_computed_vars.add(unique_var_name)
@@ -1410,6 +1431,7 @@ class BaseState(EvenMoreBasicBaseState):
 
         # Update tracking dicts.
         cls.computed_vars.update(dynamic_vars)
+        cls._refresh_interval_computed_vars()
         cls.vars.update(dynamic_vars)
         cls._update_substate_inherited_vars(dynamic_vars)
 
@@ -1819,14 +1841,31 @@ class BaseState(EvenMoreBasicBaseState):
 
     def _mark_dirty_computed_vars(self) -> None:
         """Mark ComputedVars that need to be recalculated based on dirty_vars."""
-        # Append expired computed vars to dirty_vars to trigger recalculation
-        self.dirty_vars.update(self._expired_computed_vars())
+        if self._interval_computed_vars:
+            # Append expired computed vars to dirty_vars to trigger recalculation
+            self.dirty_vars.update(self._expired_computed_vars())
         # Append always dirty computed vars to dirty_vars to trigger recalculation
         self.dirty_vars.update(self._always_dirty_computed_vars)
 
-        dirty_vars = self.dirty_vars
-        while dirty_vars:
-            calc_vars, dirty_vars = dirty_vars, set()
+        # Track which dirty vars already had their dependency closure
+        # propagated, so repeated mutations only process newly-dirty vars.
+        # Recomputing any cached var re-materializes a cache that a later
+        # mutation must invalidate again, so the frontier is only valid for
+        # the recompute generation it was built in.
+        instance_dict = self.__dict__
+        propagated = instance_dict.get("_propagated_dirty_vars")
+        current_gen = reflex_base_vars_base._computed_var_recompute_generation
+        if propagated is None:
+            propagated = set()
+            object.__setattr__(self, "_propagated_dirty_vars", propagated)
+        elif instance_dict.get("_propagated_generation") != current_gen:
+            propagated.clear()
+        object.__setattr__(self, "_propagated_generation", current_gen)
+
+        new_dirty = self.dirty_vars - propagated
+        while new_dirty:
+            propagated |= new_dirty
+            calc_vars, new_dirty = new_dirty, set()
             for state_name, cvar in self._dirty_computed_vars(from_vars=calc_vars):
                 if state_name == self.get_full_name():
                     defining_state = self
@@ -1839,7 +1878,8 @@ class BaseState(EvenMoreBasicBaseState):
                 if actual_var is not None:
                     actual_var.mark_dirty(instance=defining_state)
                 if defining_state is self:
-                    dirty_vars.add(cvar)
+                    if cvar not in propagated:
+                        new_dirty.add(cvar)
                 else:
                     # mark dirty where this var is defined
                     defining_state._mark_dirty()
@@ -1850,10 +1890,11 @@ class BaseState(EvenMoreBasicBaseState):
         Returns:
             Set of computed vars to include in the delta.
         """
+        computed_vars = self.computed_vars
         return {
             cvar
-            for cvar, cvar_obj in self.computed_vars.items()
-            if cvar_obj.needs_update(instance=self)
+            for cvar in self._interval_computed_vars
+            if computed_vars[cvar].needs_update(instance=self)
         }
 
     def _dirty_computed_vars(
@@ -1973,6 +2014,8 @@ class BaseState(EvenMoreBasicBaseState):
         # Clean this state.
         self.dirty_vars = set()
         self.dirty_substates = set()
+        # Discard the propagation frontier along with the dirty vars it tracked.
+        self.__dict__.pop("_propagated_dirty_vars", None)
 
     def get_value(self, key: str) -> Any:
         """Get the value of a field (without proxying).
@@ -2092,6 +2135,9 @@ class BaseState(EvenMoreBasicBaseState):
         state.pop("_was_touched", None)
         # Proxies wrap live state references and are rebuilt on access.
         state.pop("_mutable_proxy_cache", None)
+        # The propagation frontier is transient and rebuilt on demand.
+        state.pop("_propagated_dirty_vars", None)
+        state.pop("_propagated_generation", None)
         # Remove all inherited vars.
         for inherited_var_name in self.inherited_vars:
             state.pop(inherited_var_name, None)

--- a/tests/units/istate/test_proxy.py
+++ b/tests/units/istate/test_proxy.py
@@ -736,6 +736,33 @@ def test_mutable_proxy_cached_per_field():
     assert "items" not in state.__dict__["_mutable_proxy_cache"]
 
 
+@pytest.mark.asyncio
+async def test_state_proxy_reassignment_evicts_cached_proxy(
+    attached_mock_event_context: EventContext,
+):
+    """Reassignment through a background-task StateProxy evicts the cached proxy.
+
+    StateProxy.__setattr__ delegates to setattr on the wrapped state, so the
+    eviction in BaseState.__setattr__ must also cover writes made inside an
+    `async with self` block.
+    """
+    state = ProxyTestState()
+    first = state.items
+    assert isinstance(first, MutableProxy)
+    assert state.__dict__["_mutable_proxy_cache"]["items"] is first
+
+    state_proxy = StateProxy(state)
+    # Simulate holding the lock inside `async with self`.
+    state_proxy._self_mutable = True
+    state_proxy.items = [Item(9)]
+    # The write reaches BaseState.__setattr__ on the wrapped state, evicting
+    # the proxy that wrapped the replaced list.
+    assert "items" not in state.__dict__["_mutable_proxy_cache"]
+    second = state.items
+    assert second is not first
+    assert second[0].id == 9
+
+
 def test_mutable_proxy_cache_not_serialized():
     """The per-instance proxy cache never leaks into pickles or copies."""
     state = ProxyTestState()

--- a/tests/units/istate/test_proxy.py
+++ b/tests/units/istate/test_proxy.py
@@ -740,11 +740,12 @@ def test_mutable_proxy_cache_not_serialized():
     """The per-instance proxy cache never leaks into pickles or copies."""
     state = ProxyTestState()
     state.items.append(Item(1))  # populate the proxy cache
-    assert "_mutable_proxy_cache" in state.__dict__
+    assert state.__dict__["_mutable_proxy_cache"]
     assert "_mutable_proxy_cache" not in state.__getstate__()
 
     restored = pickle.loads(pickle.dumps(state))
-    assert "_mutable_proxy_cache" not in restored.__dict__
+    # The cache is recreated empty on the restored instance.
+    assert restored.__dict__["_mutable_proxy_cache"] == {}
     restored_items = restored.items
     assert isinstance(restored_items, MutableProxy)
     # The restored proxy tracks the restored state, not the original.

--- a/tests/units/istate/test_proxy.py
+++ b/tests/units/istate/test_proxy.py
@@ -730,6 +730,10 @@ def test_mutable_proxy_cached_per_field():
     # In-place mutation keeps the same wrapped object, so the proxy is reused.
     second.append(Item(3))
     assert state.items is second
+    # Reassignment immediately evicts the cache entry, so no strong reference
+    # to the replaced value lingers until the next read.
+    state.items = [Item(4)]
+    assert "items" not in state.__dict__["_mutable_proxy_cache"]
 
 
 def test_mutable_proxy_cache_not_serialized():

--- a/tests/units/istate/test_proxy.py
+++ b/tests/units/istate/test_proxy.py
@@ -713,3 +713,46 @@ async def test_mutable_proxy_custom_get_method_path_tracking(
     ) as state:
         assert isinstance(state, CustomGetState)
         assert state.registry.entries == {"a": [1, 2]}
+
+
+def test_mutable_proxy_cached_per_field():
+    """Repeated reads of a mutable var reuse the proxy until reassignment."""
+    state = ProxyTestState()
+    first = state.items
+    assert isinstance(first, MutableProxy)
+    assert state.items is first
+    # Reassignment invalidates the cached proxy.
+    state.items = [Item(2)]
+    second = state.items
+    assert isinstance(second, MutableProxy)
+    assert second is not first
+    assert second[0].id == 2
+    # In-place mutation keeps the same wrapped object, so the proxy is reused.
+    second.append(Item(3))
+    assert state.items is second
+
+
+def test_mutable_proxy_cache_not_serialized():
+    """The per-instance proxy cache never leaks into pickles or copies."""
+    state = ProxyTestState()
+    state.items.append(Item(1))  # populate the proxy cache
+    assert "_mutable_proxy_cache" in state.__dict__
+    assert "_mutable_proxy_cache" not in state.__getstate__()
+
+    restored = pickle.loads(pickle.dumps(state))
+    assert "_mutable_proxy_cache" not in restored.__dict__
+    restored_items = restored.items
+    assert isinstance(restored_items, MutableProxy)
+    # The restored proxy tracks the restored state, not the original.
+    assert restored_items._self_state is restored
+
+
+def test_mutable_proxy_iteration_yields_plain_immutables():
+    """Iterating a proxied container returns immutable elements unwrapped."""
+    state = ProxyTestState()
+    state.items = [Item(1), Item(2)]
+    numbers = [item.id for item in state.items]
+    assert numbers == [1, 2]
+    assert all(type(n) is int for n in numbers)
+    # Mutable elements remain wrapped so nested mutations mark the state dirty.
+    assert all(isinstance(item, MutableProxy) for item in state.items)

--- a/tests/units/reflex_base/utils/test_types.py
+++ b/tests/units/reflex_base/utils/test_types.py
@@ -26,15 +26,16 @@ def test_asgi_aliases_keep_their_names():
 
 
 def test_validation_depth_by_env_mode():
-    """Hot-path validation walks containers in dev but stays shallow in prod."""
+    """Hot-path validation walks containers in dev but stays shallow in prod.
+
+    In-process environment mode changes must take effect immediately, without
+    any cache invalidation by the caller.
+    """
     initial = environment.REFLEX_ENV_MODE.getenv()
-    _validation_depth.cache_clear()
     try:
         environment.REFLEX_ENV_MODE.set(constants.Env.PROD)
         assert _validation_depth() == 0
-        _validation_depth.cache_clear()
         environment.REFLEX_ENV_MODE.set(constants.Env.DEV)
         assert _validation_depth() == 1
     finally:
         environment.REFLEX_ENV_MODE.set(initial)
-        _validation_depth.cache_clear()

--- a/tests/units/reflex_base/utils/test_types.py
+++ b/tests/units/reflex_base/utils/test_types.py
@@ -1,6 +1,15 @@
 """Tests for reflex_base.utils.types."""
 
-from reflex_base.utils.types import ASGIApp, Message, Receive, Scope, Send
+from reflex_base import constants
+from reflex_base.environment import environment
+from reflex_base.utils.types import (
+    ASGIApp,
+    Message,
+    Receive,
+    Scope,
+    Send,
+    _validation_depth,
+)
 from typing_extensions import TypeAliasType
 
 
@@ -14,3 +23,18 @@ def test_asgi_aliases_keep_their_names():
     assert Receive.__name__ == "Receive"
     assert Send.__name__ == "Send"
     assert ASGIApp.__name__ == "ASGIApp"
+
+
+def test_validation_depth_by_env_mode():
+    """Hot-path validation walks containers in dev but stays shallow in prod."""
+    initial = environment.REFLEX_ENV_MODE.getenv()
+    _validation_depth.cache_clear()
+    try:
+        environment.REFLEX_ENV_MODE.set(constants.Env.PROD)
+        assert _validation_depth() == 0
+        _validation_depth.cache_clear()
+        environment.REFLEX_ENV_MODE.set(constants.Env.DEV)
+        assert _validation_depth() == 1
+    finally:
+        environment.REFLEX_ENV_MODE.set(initial)
+        _validation_depth.cache_clear()

--- a/tests/units/reflex_base/utils/test_types.py
+++ b/tests/units/reflex_base/utils/test_types.py
@@ -1,5 +1,7 @@
 """Tests for reflex_base.utils.types."""
 
+import os
+
 from reflex_base import constants
 from reflex_base.environment import environment
 from reflex_base.utils.types import (
@@ -37,5 +39,9 @@ def test_validation_depth_by_env_mode():
         assert _validation_depth() == 0
         environment.REFLEX_ENV_MODE.set(constants.Env.DEV)
         assert _validation_depth() == 1
+        # The canonical parser tolerates surrounding whitespace; the hot-path
+        # reader must agree with it.
+        os.environ["REFLEX_ENV_MODE"] = f" {constants.Env.PROD.value} "
+        assert _validation_depth() == 0
     finally:
         environment.REFLEX_ENV_MODE.set(initial)

--- a/tests/units/reflex_base/vars/test_base.py
+++ b/tests/units/reflex_base/vars/test_base.py
@@ -6,6 +6,9 @@ from typing import Any
 from reflex_base.utils.types import get_field_type
 from reflex_base.vars.base import EvenMoreBasicBaseState, field
 
+import reflex as rx
+from reflex.state import BaseState
+
 _MARKER_ATTR = "_marker"
 
 
@@ -87,3 +90,74 @@ def test_custom_attr_is_carried_by_reference():
 
     rebuilt = MyState.get_fields()["name"]
     assert rebuilt._check is check  # pyright: ignore[reportAttributeAccessIssue]
+
+
+def test_computed_var_return_type_checked_only_on_recompute(mocker):
+    """The return type of a cached computed var is only validated on recompute.
+
+    Args:
+        mocker: Pytest mocker object.
+    """
+
+    class ReturnTypeCheckState(BaseState):
+        v: int = 0
+
+        @rx.var
+        def wrong_typed(self) -> str:
+            return self.v  # pyright: ignore [reportReturnType]
+
+    state = ReturnTypeCheckState()
+    mock_error = mocker.patch("reflex_base.utils.console.error")
+    assert state.wrong_typed == 0
+    assert mock_error.call_count == 1
+    # Cache hits must not re-run the (potentially deep) type check.
+    assert state.wrong_typed == 0
+    assert mock_error.call_count == 1
+    # Invalidation triggers a recompute, which re-checks the return type.
+    state.v = 1
+    assert state.wrong_typed == 1
+    assert mock_error.call_count == 2
+
+
+def test_non_cached_computed_var_return_type_checked_every_access(mocker):
+    """A cache=False computed var recomputes, and is type-checked, on every access.
+
+    Args:
+        mocker: Pytest mocker object.
+    """
+
+    class NonCachedReturnTypeCheckState(BaseState):
+        v: int = 0
+
+        @rx.var(cache=False)
+        def wrong_typed(self) -> str:
+            return self.v  # pyright: ignore [reportReturnType]
+
+    state = NonCachedReturnTypeCheckState()
+    mock_error = mocker.patch("reflex_base.utils.console.error")
+    assert state.wrong_typed == 0
+    assert state.wrong_typed == 0
+    assert mock_error.call_count == 2
+
+
+async def test_async_computed_var_return_type_checked_only_on_recompute(mocker):
+    """The return type of a cached async computed var is only validated on recompute.
+
+    Args:
+        mocker: Pytest mocker object.
+    """
+
+    class AsyncReturnTypeCheckState(BaseState):
+        v: int = 0
+
+        @rx.var
+        async def wrong_typed(self) -> str:
+            return self.v  # pyright: ignore [reportReturnType]
+
+    state = AsyncReturnTypeCheckState()
+    mock_error = mocker.patch("reflex_base.utils.console.error")
+    assert await state.wrong_typed == 0
+    assert mock_error.call_count == 1
+    # Cache hits must not re-run the (potentially deep) type check.
+    assert await state.wrong_typed == 0
+    assert mock_error.call_count == 1

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -1487,6 +1487,7 @@ def test_computed_var_recompute_after_mid_cycle_read_across_states():
 
     parent = FrontierParentState()
     child = parent.substates[FrontierChildState.get_name()]
+    assert isinstance(child, FrontierChildState)
     parent.v = 1
     assert child.doubled == 2
     parent.v = 2

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -1453,6 +1453,63 @@ def test_setattr_wrong_type_logs_error(mocker):
     assert mock_error.call_count == 1
 
 
+def test_computed_var_recompute_after_mid_cycle_read():
+    """A dependency mutated again after a mid-cycle read still invalidates the cache."""
+
+    class FrontierState(BaseState):
+        v: int = 0
+
+        @rx.var
+        def doubled(self) -> int:
+            return self.v * 2
+
+    s = FrontierState()
+    s.v = 1
+    # Reading mid-cycle recomputes and re-caches the value.
+    assert s.doubled == 2
+    # Mutating the same dependency again must invalidate the fresh cache,
+    # even though dirty_vars already contained it.
+    s.v = 2
+    assert s.doubled == 4
+    assert s.get_delta()[s.get_full_name()]["doubled" + FIELD_MARKER] == 4
+
+
+def test_computed_var_recompute_after_mid_cycle_read_across_states():
+    """Cross-state dependency invalidation survives a mid-cycle recompute."""
+
+    class FrontierParentState(BaseState):
+        v: int = 0
+
+    class FrontierChildState(FrontierParentState):
+        @rx.var
+        def doubled(self) -> int:
+            return self.v * 2
+
+    parent = FrontierParentState()
+    child = parent.substates[FrontierChildState.get_name()]
+    parent.v = 1
+    assert child.doubled == 2
+    parent.v = 2
+    assert child.doubled == 4
+
+
+def test_interval_computed_vars_precomputed():
+    """Classes precompute which computed vars carry an update interval."""
+
+    class IntervalFreeState(BaseState):
+        @rx.var
+        def untimed(self) -> int:
+            return 2
+
+    class IntervalState(BaseState):
+        @rx.var(interval=15)
+        def timed(self) -> int:
+            return 1
+
+    assert IntervalFreeState._interval_computed_vars == ()
+    assert IntervalState._interval_computed_vars == ("timed",)
+
+
 def test_computed_var_cached_depends_on_non_cached():
     """Test that a cached var is recalculated if it depends on non-cached ComputedVar."""
 

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -1436,6 +1436,22 @@ def test_computed_var_cached():
     assert comp_v_calls == 2
 
 
+def test_setattr_wrong_type_logs_error(mocker):
+    """Assigning a value of the wrong type to a base var logs an error in dev mode.
+
+    Args:
+        mocker: Pytest mocker object.
+    """
+
+    class WrongTypeState(BaseState):
+        n: int = 0
+
+    state = WrongTypeState()
+    mock_error = mocker.patch("reflex.utils.console.error")
+    setattr(state, "n", "not an int")  # noqa: B010
+    assert mock_error.call_count == 1
+
+
 def test_computed_var_cached_depends_on_non_cached():
     """Test that a cached var is recalculated if it depends on non-cached ComputedVar."""
 

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -3258,11 +3258,11 @@ def test_set_base_field_via_setter():
     bfss.dirty_vars.clear()
     assert "c1" not in bfss.dirty_vars
 
-    # Assert identity of MutableProxy
+    # Repeated reads reuse the cached MutableProxy for the same field.
     mp = bfss.c1
     assert isinstance(mp, MutableProxy)
     mp3 = bfss.c1
-    assert mp is not mp3
+    assert mp is mp3
     # Since none of these set calls had values, the state should not be dirty
     assert not bfss.dirty_vars
 

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -1486,6 +1486,7 @@ def test_computed_var_recompute_after_mid_cycle_read_across_states():
 
     parent = FrontierParentState()
     child = parent.substates[FrontierChildState.get_name()]
+    assert isinstance(child, FrontierChildState)
     parent.v = 1
     assert child.doubled == 2
     parent.v = 2

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -1452,6 +1452,63 @@ def test_setattr_wrong_type_logs_error(mocker):
     assert mock_error.call_count == 1
 
 
+def test_computed_var_recompute_after_mid_cycle_read():
+    """A dependency mutated again after a mid-cycle read still invalidates the cache."""
+
+    class FrontierState(BaseState):
+        v: int = 0
+
+        @rx.var
+        def doubled(self) -> int:
+            return self.v * 2
+
+    s = FrontierState()
+    s.v = 1
+    # Reading mid-cycle recomputes and re-caches the value.
+    assert s.doubled == 2
+    # Mutating the same dependency again must invalidate the fresh cache,
+    # even though dirty_vars already contained it.
+    s.v = 2
+    assert s.doubled == 4
+    assert s.get_delta()[s.get_full_name()]["doubled" + FIELD_MARKER] == 4
+
+
+def test_computed_var_recompute_after_mid_cycle_read_across_states():
+    """Cross-state dependency invalidation survives a mid-cycle recompute."""
+
+    class FrontierParentState(BaseState):
+        v: int = 0
+
+    class FrontierChildState(FrontierParentState):
+        @rx.var
+        def doubled(self) -> int:
+            return self.v * 2
+
+    parent = FrontierParentState()
+    child = parent.substates[FrontierChildState.get_name()]
+    parent.v = 1
+    assert child.doubled == 2
+    parent.v = 2
+    assert child.doubled == 4
+
+
+def test_interval_computed_vars_precomputed():
+    """Classes precompute which computed vars carry an update interval."""
+
+    class IntervalFreeState(BaseState):
+        @rx.var
+        def untimed(self) -> int:
+            return 2
+
+    class IntervalState(BaseState):
+        @rx.var(interval=15)
+        def timed(self) -> int:
+            return 1
+
+    assert IntervalFreeState._interval_computed_vars == ()
+    assert IntervalState._interval_computed_vars == ("timed",)
+
+
 def test_computed_var_cached_depends_on_non_cached():
     """Test that a cached var is recalculated if it depends on non-cached ComputedVar."""
 


### PR DESCRIPTION
Consolidates the state hot-path perf work from #6738 (ENG-10093), #6740 (ENG-10094), and the original scope of this PR (ENG-10095) into one review unit. All three edit the same few functions — `BaseState.__setattr__`, `_get_attribute`, `_mark_dirty*`, `ComputedVar.__get__` — so reviewing the final shape of those functions once beats reviewing three interleaved rewrites. Commits are preserved per original PR for per-commit review. Stacked on #6735; #6744 continues on top of this branch.

Motivation: profiling the event loop on current main, a trivial event (`counter += 1` from a button click) spends ~30% of framework CPU in `_get_attribute` (129 attribute reads, 121 `isinstance` calls per event) and ~25% in dirty-tracking/delta bookkeeping. This PR targets both buckets.

## 1. Skip deep type-validation on state var hot paths (from #6738)

`__setattr__` and `ComputedVar.__get__` ran `_isinstance(value, field_type, nested=1)` — walking every element of assigned/returned containers — only to gate a `console.error` diagnostic. Computed-var return types are now validated only on actual recompute (cache hits skip entirely), and element-wise validation depth becomes 1 in dev / 0 in prod via a cached `_validation_depth()` helper.

- read cached computed var returning 10k dicts: 13.8 ms → 0.0015 ms
- assign 100k-int list (prod): 90.9 ms → 0.02 ms
- cProfile of the same scenario: 10.5M calls / 3.06 s → 538 calls / 0.003 s

## 2. Cut MutableProxy per-element overhead; cache per-field proxies (from #6740)

The recursive wrap path walked 5 stack frames (dataclasses-internal check) for every element read through a proxy; immutable elements now skip wrapping and the frame walk entirely. `_get_attribute` built a fresh `MutableProxy` on every read of a mutable var; proxies are now cached per instance+field, invalidated by identity on reassignment, and excluded from pickling.

- iterate a 1000-int list via proxy: 0.98 ms → 0.22 ms (~4.5x)
- index 1000 elements: ~3.0x
- read a mutable var attribute: 2.8 us → 1.2 us (~2.4x)
- proxy micro-suite: 168k → 72k function calls

## 3. Only propagate newly-dirty vars in `_mark_dirty_computed_vars` (original scope)

Every setattr/proxied mutation re-scanned all computed vars for interval expiry and re-walked the dependency closure of the entire accumulated `dirty_vars` set. This adds per-class precomputed `_interval_computed_vars` (the expiry scan is skipped when none exist) and a per-instance propagated frontier so only newly-dirty vars are walked; a process-wide generation counter bumped on recompute resets the frontier to preserve mid-cycle invalidation correctness.

- proxied list append (state with 2 cached computed vars): 16.7 us → 8.6 us (~1.9x)
- int var setattr: 21.0 us → 9.3 us (~2.2x)
- `_mark_dirty_computed_vars` cumulative over 2000 appends: 0.102 s → 0.019 s

## Review feedback from the folded threads, already incorporated

- Internal tracking state is declared as **reserved state fields** rather than raw `__dict__` entries, per masenf's request on both #6740 and #6743: `_mutable_proxy_cache` and the propagation-frontier fields are declared fields (excluded from pickles, safe against user-var name collisions).
- The per-field proxy cache entry is dropped/updated when a mutable var is reassigned, so a replaced value cannot be kept alive through a stale proxy (flagged and confirmed fixed on #6740).
- Answering the open question on #6738 ("if we return early, how does the computed value get cached?"): the value is cached by the `setattr(instance, self._cache_attr, ...)` on the line immediately before that return — the early return only skips re-reading and re-validating the value that was just computed and stored.

Benchmark numbers are from the original PRs, measured on GitHub Actions runners over two passes.
