### PR TITLE
Add content hashes to asset URLs

### DIFF
--- a/docs/assets/overview.md
+++ b/docs/assets/overview.md
@@ -44,6 +44,8 @@ rx.image(
 
 The `rx.asset` function provides a more flexible way to reference assets in your app. It supports both local assets (in the app's `assets/` directory) and shared assets (placed next to your Python files).
 
+`rx.asset` appends a short content hash query parameter to the generated URL. For example, `rx.asset("logo.svg")` returns a URL like `/logo.svg?v=a1b2c3d4`, so browsers fetch a new version only when the file content changes.
+
 #### Local Assets
 
 Local assets are stored in the app's `assets/` directory and are referenced using `rx.asset`:

--- a/news/6550.feature.md
+++ b/news/6550.feature.md
@@ -1,0 +1,1 @@
+Added content-hash cache busting to `rx.asset` URLs.

--- a/reflex/assets.py
+++ b/reflex/assets.py
@@ -9,6 +9,9 @@ from reflex_base import constants
 from reflex_base.config import get_config
 from reflex_base.environment import EnvironmentVariables
 
+_HASH_CHUNK_SIZE = 1024 * 1024
+_MAX_HASH_ATTEMPTS = 3
+
 if TYPE_CHECKING:
     from typing_extensions import Buffer
 
@@ -123,7 +126,20 @@ def _short_content_hash(path: Path) -> str:
     Returns:
         The first 8 hex characters of the file's SHA-256 hash.
     """
-    return hashlib.sha256(path.read_bytes()).hexdigest()[:8]
+    digest = hashlib.sha256()
+    for _ in range(_MAX_HASH_ATTEMPTS):
+        digest = hashlib.sha256()
+        start_stat = path.stat()
+        with path.open("rb") as file:
+            while chunk := file.read(_HASH_CHUNK_SIZE):
+                digest.update(chunk)
+        end_stat = path.stat()
+        if (
+            start_stat.st_size == end_stat.st_size
+            and start_stat.st_mtime_ns == end_stat.st_mtime_ns
+        ):
+            break
+    return digest.hexdigest()[:8]
 
 
 def _versioned_asset_path(relative_path: str, source_file: Path) -> AssetPathStr:

--- a/reflex/assets.py
+++ b/reflex/assets.py
@@ -2,7 +2,6 @@
 
 import hashlib
 import inspect
-import os
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, overload
@@ -130,37 +129,31 @@ def _short_content_hash(path: Path) -> str:
         The first 8 hex characters of the file's SHA-256 hash.
     """
     for _ in range(_MAX_HASH_ATTEMPTS):
-        digest = hashlib.sha256()
-        with path.open("rb") as file:
-            start_stat = os.fstat(file.fileno())
-            while chunk := file.read(_HASH_CHUNK_SIZE):
-                digest.update(chunk)
-            read_stat = os.fstat(file.fileno())
-        end_stat = path.stat()
-        if (
-            _asset_stat_key(start_stat)
-            == _asset_stat_key(read_stat)
-            == _asset_stat_key(end_stat)
-        ):
+        digest = _content_digest(path)
+        if digest == _content_digest(path):
             break
     else:
         console.warn(
             f"{path} was modified {_MAX_HASH_ATTEMPTS} times while calculating hash."
         )
         return str(time.time())
-    return digest.hexdigest()[:8]
+    return digest[:8]
 
 
-def _asset_stat_key(stat: os.stat_result) -> tuple[int, int, int, int]:
-    """Return stat fields that identify a stable asset snapshot.
+def _content_digest(path: Path) -> str:
+    """Get the SHA-256 digest for the current file content.
 
     Args:
-        stat: Stat information for a file.
+        path: The file to hash.
 
     Returns:
-        Size, mtime, device, and inode/file-index fields.
+        The full SHA-256 digest for the file content.
     """
-    return (stat.st_size, stat.st_mtime_ns, stat.st_dev, stat.st_ino)
+    digest = hashlib.sha256()
+    with path.open("rb") as file:
+        while chunk := file.read(_HASH_CHUNK_SIZE):
+            digest.update(chunk)
+    return digest.hexdigest()
 
 
 def _versioned_asset_path(relative_path: str, source_file: Path) -> AssetPathStr:

--- a/reflex/assets.py
+++ b/reflex/assets.py
@@ -2,12 +2,14 @@
 
 import hashlib
 import inspect
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, overload
 
 from reflex_base import constants
 from reflex_base.config import get_config
 from reflex_base.environment import EnvironmentVariables
+from reflex_base.utils import console
 
 _HASH_CHUNK_SIZE = 1024 * 1024
 _MAX_HASH_ATTEMPTS = 3
@@ -126,7 +128,6 @@ def _short_content_hash(path: Path) -> str:
     Returns:
         The first 8 hex characters of the file's SHA-256 hash.
     """
-    digest = hashlib.sha256()
     for _ in range(_MAX_HASH_ATTEMPTS):
         digest = hashlib.sha256()
         start_stat = path.stat()
@@ -139,6 +140,11 @@ def _short_content_hash(path: Path) -> str:
             and start_stat.st_mtime_ns == end_stat.st_mtime_ns
         ):
             break
+    else:
+        console.warn(
+            f"{path} was modified {_MAX_HASH_ATTEMPTS} times while calculating hash."
+        )
+        return str(time.time())
     return digest.hexdigest()[:8]
 
 

--- a/reflex/assets.py
+++ b/reflex/assets.py
@@ -1,5 +1,6 @@
 """Helper functions for adding assets to the app."""
 
+import hashlib
 import inspect
 from pathlib import Path
 from typing import TYPE_CHECKING, overload
@@ -25,12 +26,20 @@ class AssetPathStr(str):
     construction time.
     """
 
-    __slots__ = ("importable_path",)
+    __slots__ = ("_raw_path", "importable_path")
 
+    _raw_path: str
     importable_path: str
 
     @overload
     def __new__(cls, object: object = "") -> "AssetPathStr": ...
+    @overload
+    def __new__(
+        cls,
+        object: object = "",
+        *,
+        importable_path: str | None = None,
+    ) -> "AssetPathStr": ...
     @overload
     def __new__(
         cls,
@@ -44,6 +53,8 @@ class AssetPathStr(str):
         object: object = "",
         encoding: str | None = None,
         errors: str | None = None,
+        *,
+        importable_path: str | None = None,
     ) -> "AssetPathStr":
         """Construct from an unprefixed, leading-slash asset path.
 
@@ -56,6 +67,7 @@ class AssetPathStr(str):
             object: The object to stringify (str, bytes, or any object).
             encoding: Encoding to decode ``object`` with when it is bytes-like.
             errors: Error handler for decoding.
+            importable_path: Optional unversioned path to use for build-time imports.
 
         Returns:
             A new ``AssetPathStr`` instance.
@@ -72,7 +84,8 @@ class AssetPathStr(str):
         instance = super().__new__(
             cls, get_config().prepend_frontend_path(relative_path)
         )
-        instance.importable_path = f"$/public{relative_path}"
+        instance._raw_path = relative_path
+        instance.importable_path = f"$/public{importable_path or relative_path}"
         return instance
 
     def __getnewargs__(self) -> tuple[str]:
@@ -87,7 +100,44 @@ class AssetPathStr(str):
         Returns:
             A one-tuple containing the unprefixed asset path.
         """
-        return (self.importable_path[len("$/public") :],)
+        return (self._raw_path,)
+
+    def __getnewargs_ex__(self) -> tuple[tuple[str], dict[str, str]]:
+        """Return constructor args and kwargs for pickle/copy reconstruction.
+
+        Returns:
+            Constructor args and kwargs preserving the unversioned import path.
+        """
+        return (
+            (self._raw_path,),
+            {"importable_path": self.importable_path[len("$/public") :]},
+        )
+
+
+def _short_content_hash(path: Path) -> str:
+    """Get a short content hash for an asset file.
+
+    Args:
+        path: The file to hash.
+
+    Returns:
+        The first 8 hex characters of the file's SHA-256 hash.
+    """
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:8]
+
+
+def _versioned_asset_path(relative_path: str, source_file: Path) -> AssetPathStr:
+    """Create an asset URL with a content-hash query parameter.
+
+    Args:
+        relative_path: The unprefixed public asset path.
+        source_file: The source file used to calculate the content hash.
+
+    Returns:
+        A versioned asset URL that preserves an unversioned import path.
+    """
+    versioned_path = f"{relative_path}?v={_short_content_hash(source_file)}"
+    return AssetPathStr(versioned_path, importable_path=relative_path)
 
 
 def remove_stale_external_asset_symlinks():
@@ -176,7 +226,10 @@ def asset(
         if not backend_only and not src_file_local.exists():
             msg = f"File not found: {src_file_local}"
             raise FileNotFoundError(msg)
-        return AssetPathStr(f"/{path}")
+        relative_path = f"/{path}"
+        if backend_only and not src_file_local.exists():
+            return AssetPathStr(relative_path)
+        return _versioned_asset_path(relative_path, src_file_local)
 
     # Shared asset handling
     # Determine the file by which the asset is exposed.
@@ -212,4 +265,7 @@ def asset(
                 dst_file.unlink()
                 dst_file.symlink_to(src_file_shared)
 
-    return AssetPathStr(f"/{external}/{subfolder}/{path}")
+    return _versioned_asset_path(
+        f"/{external}/{subfolder}/{path}",
+        src_file_shared,
+    )

--- a/reflex/assets.py
+++ b/reflex/assets.py
@@ -2,6 +2,7 @@
 
 import hashlib
 import inspect
+import os
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, overload
@@ -130,14 +131,16 @@ def _short_content_hash(path: Path) -> str:
     """
     for _ in range(_MAX_HASH_ATTEMPTS):
         digest = hashlib.sha256()
-        start_stat = path.stat()
         with path.open("rb") as file:
+            start_stat = os.fstat(file.fileno())
             while chunk := file.read(_HASH_CHUNK_SIZE):
                 digest.update(chunk)
+            read_stat = os.fstat(file.fileno())
         end_stat = path.stat()
         if (
-            start_stat.st_size == end_stat.st_size
-            and start_stat.st_mtime_ns == end_stat.st_mtime_ns
+            _asset_stat_key(start_stat)
+            == _asset_stat_key(read_stat)
+            == _asset_stat_key(end_stat)
         ):
             break
     else:
@@ -146,6 +149,18 @@ def _short_content_hash(path: Path) -> str:
         )
         return str(time.time())
     return digest.hexdigest()[:8]
+
+
+def _asset_stat_key(stat: os.stat_result) -> tuple[int, int, int, int]:
+    """Return stat fields that identify a stable asset snapshot.
+
+    Args:
+        stat: Stat information for a file.
+
+    Returns:
+        Size, mtime, device, and inode/file-index fields.
+    """
+    return (stat.st_size, stat.st_mtime_ns, stat.st_dev, stat.st_ino)
 
 
 def _versioned_asset_path(relative_path: str, source_file: Path) -> AssetPathStr:

--- a/tests/units/assets/test_assets.py
+++ b/tests/units/assets/test_assets.py
@@ -207,6 +207,45 @@ def test_asset_hash_retries_when_file_changes(
     )
 
 
+def test_asset_hash_uses_timestamp_when_file_never_stabilizes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hashing falls back to a timestamp if every read sees a file change.
+
+    Args:
+        monkeypatch: A pytest fixture for patching.
+    """
+    import reflex.assets as assets_module
+
+    @dataclass
+    class _Stat:
+        st_size: int
+        st_mtime_ns: int
+
+    class _ChangingPath:
+        stat_calls = 0
+
+        def stat(self) -> _Stat:
+            self.stat_calls += 1
+            return _Stat(st_size=1, st_mtime_ns=self.stat_calls)
+
+        def open(self, mode: str):
+            assert mode == "rb"
+            return io.BytesIO(b"x")
+
+    warn_calls: list[str] = []
+    monkeypatch.setattr(assets_module.time, "time", lambda: 1234.5)
+    monkeypatch.setattr(assets_module.console, "warn", warn_calls.append)
+
+    result = assets_module._short_content_hash(cast(Path, _ChangingPath()))
+
+    assert result == "1234.5"
+    assert len(warn_calls) == 1
+    assert warn_calls[0].endswith(
+        f"was modified {assets_module._MAX_HASH_ATTEMPTS} times while calculating hash."
+    )
+
+
 def test_asset_importable_path_local(custom_script_in_asset_dir: Path) -> None:
     """A local asset path exposes an `importable_path` prefixed with $/public.
 

--- a/tests/units/assets/test_assets.py
+++ b/tests/units/assets/test_assets.py
@@ -4,7 +4,6 @@ import io
 import pickle
 import shutil
 from collections.abc import Generator
-from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 
@@ -18,23 +17,6 @@ from reflex.assets import AssetPathStr, remove_stale_external_asset_symlinks
 def _asset_hash(path: Path) -> str:
     """Return the expected short content hash for an asset."""
     return hashlib.sha256(path.read_bytes()).hexdigest()[:8]
-
-
-@dataclass
-class _FakeStat:
-    st_size: int
-    st_mtime_ns: int
-    st_dev: int
-    st_ino: int
-
-
-class _FakeOpenFile(io.BytesIO):
-    def __init__(self, content: bytes, fd: int):
-        super().__init__(content)
-        self._fd = fd
-
-    def fileno(self) -> int:
-        return self._fd
 
 
 @pytest.fixture
@@ -197,35 +179,22 @@ def test_asset_hash_retries_when_file_changes(
 
     class _ChangingPath:
         open_calls = 0
-        stat_calls = 0
 
-        def stat(self) -> _FakeStat:
-            self.stat_calls += 1
-            if self.stat_calls == 1:
-                return _FakeStat(st_size=5, st_mtime_ns=2, st_dev=1, st_ino=2)
-            return _FakeStat(st_size=5, st_mtime_ns=1, st_dev=1, st_ino=2)
-
-        def open(self, mode: str) -> _FakeOpenFile:
+        def open(self, mode: str) -> io.BytesIO:
             assert mode == "rb"
             self.open_calls += 1
             if self.open_calls == 1:
-                return _FakeOpenFile(b"old", fd=1)
-            return _FakeOpenFile(b"final", fd=2)
-
-    def fake_fstat(fd: int) -> _FakeStat:
-        if fd == 1:
-            return _FakeStat(st_size=3, st_mtime_ns=1, st_dev=1, st_ino=1)
-        return _FakeStat(st_size=5, st_mtime_ns=1, st_dev=1, st_ino=2)
+                return io.BytesIO(b"old")
+            return io.BytesIO(b"final")
 
     monkeypatch.setattr(assets_module, "_HASH_CHUNK_SIZE", 2)
-    monkeypatch.setattr(assets_module.os, "fstat", fake_fstat)
     changing_path = _ChangingPath()
 
     assert (
         assets_module._short_content_hash(cast(Path, changing_path))
         == hashlib.sha256(b"final").hexdigest()[:8]
     )
-    assert changing_path.open_calls == 2
+    assert changing_path.open_calls == 4
 
 
 def test_asset_hash_retries_after_atomic_replacement(
@@ -241,28 +210,50 @@ def test_asset_hash_retries_after_atomic_replacement(
     class _ReplacingPath:
         open_calls = 0
 
-        def stat(self) -> _FakeStat:
-            return _FakeStat(st_size=3, st_mtime_ns=1, st_dev=1, st_ino=2)
-
-        def open(self, mode: str) -> _FakeOpenFile:
+        def open(self, mode: str) -> io.BytesIO:
             assert mode == "rb"
             self.open_calls += 1
             if self.open_calls == 1:
-                return _FakeOpenFile(b"old", fd=1)
-            return _FakeOpenFile(b"new", fd=2)
-
-    def fake_fstat(fd: int) -> _FakeStat:
-        return _FakeStat(st_size=3, st_mtime_ns=1, st_dev=1, st_ino=fd)
+                return io.BytesIO(b"old")
+            return io.BytesIO(b"new")
 
     monkeypatch.setattr(assets_module, "_HASH_CHUNK_SIZE", 2)
-    monkeypatch.setattr(assets_module.os, "fstat", fake_fstat)
     replacing_path = _ReplacingPath()
 
     assert (
         assets_module._short_content_hash(cast(Path, replacing_path))
         == hashlib.sha256(b"new").hexdigest()[:8]
     )
-    assert replacing_path.open_calls == 2
+    assert replacing_path.open_calls == 4
+
+
+def test_asset_hash_retries_after_in_place_rewrite(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hashing retries if an in-place rewrite changes bytes but preserves metadata.
+
+    Args:
+        monkeypatch: A pytest fixture for patching.
+    """
+    import reflex.assets as assets_module
+
+    class _RewritingPath:
+        open_calls = 0
+        reads = [b"oldnew", b"newnew", b"newnew", b"newnew"]
+
+        def open(self, mode: str) -> io.BytesIO:
+            assert mode == "rb"
+            self.open_calls += 1
+            return io.BytesIO(self.reads[self.open_calls - 1])
+
+    monkeypatch.setattr(assets_module, "_HASH_CHUNK_SIZE", 3)
+    rewriting_path = _RewritingPath()
+
+    assert (
+        assets_module._short_content_hash(cast(Path, rewriting_path))
+        == hashlib.sha256(b"newnew").hexdigest()[:8]
+    )
+    assert rewriting_path.open_calls == 4
 
 
 def test_asset_hash_uses_timestamp_when_file_never_stabilizes(
@@ -277,27 +268,13 @@ def test_asset_hash_uses_timestamp_when_file_never_stabilizes(
 
     class _ChangingPath:
         open_calls = 0
-        current_fd = 0
 
-        def stat(self) -> _FakeStat:
-            return _FakeStat(
-                st_size=1,
-                st_mtime_ns=1,
-                st_dev=1,
-                st_ino=self.current_fd + 10,
-            )
-
-        def open(self, mode: str) -> _FakeOpenFile:
+        def open(self, mode: str) -> io.BytesIO:
             assert mode == "rb"
             self.open_calls += 1
-            self.current_fd = self.open_calls
-            return _FakeOpenFile(b"x", fd=self.current_fd)
-
-    def fake_fstat(fd: int) -> _FakeStat:
-        return _FakeStat(st_size=1, st_mtime_ns=1, st_dev=1, st_ino=fd)
+            return io.BytesIO(str(self.open_calls).encode())
 
     warn_calls: list[str] = []
-    monkeypatch.setattr(assets_module.os, "fstat", fake_fstat)
     monkeypatch.setattr(assets_module.time, "time", lambda: 1234.5)
     monkeypatch.setattr(assets_module.console, "warn", warn_calls.append)
 

--- a/tests/units/assets/test_assets.py
+++ b/tests/units/assets/test_assets.py
@@ -20,6 +20,23 @@ def _asset_hash(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()[:8]
 
 
+@dataclass
+class _FakeStat:
+    st_size: int
+    st_mtime_ns: int
+    st_dev: int
+    st_ino: int
+
+
+class _FakeOpenFile(io.BytesIO):
+    def __init__(self, content: bytes, fd: int):
+        super().__init__(content)
+        self._fd = fd
+
+    def fileno(self) -> int:
+        return self._fd
+
+
 @pytest.fixture
 def mock_asset_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Create a mock asset file and patch the current working directory.
@@ -178,33 +195,74 @@ def test_asset_hash_retries_when_file_changes(
     """
     import reflex.assets as assets_module
 
-    @dataclass
-    class _Stat:
-        st_size: int
-        st_mtime_ns: int
-
     class _ChangingPath:
-        content = b"old"
+        open_calls = 0
         stat_calls = 0
 
-        def stat(self) -> _Stat:
+        def stat(self) -> _FakeStat:
             self.stat_calls += 1
-            if self.stat_calls == 2:
-                self.content = b"final"
-                return _Stat(st_size=3, st_mtime_ns=1)
-            return _Stat(st_size=len(self.content), st_mtime_ns=2)
+            if self.stat_calls == 1:
+                return _FakeStat(st_size=5, st_mtime_ns=2, st_dev=1, st_ino=2)
+            return _FakeStat(st_size=5, st_mtime_ns=1, st_dev=1, st_ino=2)
 
-        def open(self, mode: str):
+        def open(self, mode: str) -> _FakeOpenFile:
             assert mode == "rb"
-            return io.BytesIO(self.content)
+            self.open_calls += 1
+            if self.open_calls == 1:
+                return _FakeOpenFile(b"old", fd=1)
+            return _FakeOpenFile(b"final", fd=2)
+
+    def fake_fstat(fd: int) -> _FakeStat:
+        if fd == 1:
+            return _FakeStat(st_size=3, st_mtime_ns=1, st_dev=1, st_ino=1)
+        return _FakeStat(st_size=5, st_mtime_ns=1, st_dev=1, st_ino=2)
 
     monkeypatch.setattr(assets_module, "_HASH_CHUNK_SIZE", 2)
+    monkeypatch.setattr(assets_module.os, "fstat", fake_fstat)
     changing_path = _ChangingPath()
 
     assert (
         assets_module._short_content_hash(cast(Path, changing_path))
         == hashlib.sha256(b"final").hexdigest()[:8]
     )
+    assert changing_path.open_calls == 2
+
+
+def test_asset_hash_retries_after_atomic_replacement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hashing retries if the file is replaced with the same size and mtime.
+
+    Args:
+        monkeypatch: A pytest fixture for patching.
+    """
+    import reflex.assets as assets_module
+
+    class _ReplacingPath:
+        open_calls = 0
+
+        def stat(self) -> _FakeStat:
+            return _FakeStat(st_size=3, st_mtime_ns=1, st_dev=1, st_ino=2)
+
+        def open(self, mode: str) -> _FakeOpenFile:
+            assert mode == "rb"
+            self.open_calls += 1
+            if self.open_calls == 1:
+                return _FakeOpenFile(b"old", fd=1)
+            return _FakeOpenFile(b"new", fd=2)
+
+    def fake_fstat(fd: int) -> _FakeStat:
+        return _FakeStat(st_size=3, st_mtime_ns=1, st_dev=1, st_ino=fd)
+
+    monkeypatch.setattr(assets_module, "_HASH_CHUNK_SIZE", 2)
+    monkeypatch.setattr(assets_module.os, "fstat", fake_fstat)
+    replacing_path = _ReplacingPath()
+
+    assert (
+        assets_module._short_content_hash(cast(Path, replacing_path))
+        == hashlib.sha256(b"new").hexdigest()[:8]
+    )
+    assert replacing_path.open_calls == 2
 
 
 def test_asset_hash_uses_timestamp_when_file_never_stabilizes(
@@ -217,23 +275,29 @@ def test_asset_hash_uses_timestamp_when_file_never_stabilizes(
     """
     import reflex.assets as assets_module
 
-    @dataclass
-    class _Stat:
-        st_size: int
-        st_mtime_ns: int
-
     class _ChangingPath:
-        stat_calls = 0
+        open_calls = 0
+        current_fd = 0
 
-        def stat(self) -> _Stat:
-            self.stat_calls += 1
-            return _Stat(st_size=1, st_mtime_ns=self.stat_calls)
+        def stat(self) -> _FakeStat:
+            return _FakeStat(
+                st_size=1,
+                st_mtime_ns=1,
+                st_dev=1,
+                st_ino=self.current_fd + 10,
+            )
 
-        def open(self, mode: str):
+        def open(self, mode: str) -> _FakeOpenFile:
             assert mode == "rb"
-            return io.BytesIO(b"x")
+            self.open_calls += 1
+            self.current_fd = self.open_calls
+            return _FakeOpenFile(b"x", fd=self.current_fd)
+
+    def fake_fstat(fd: int) -> _FakeStat:
+        return _FakeStat(st_size=1, st_mtime_ns=1, st_dev=1, st_ino=fd)
 
     warn_calls: list[str] = []
+    monkeypatch.setattr(assets_module.os, "fstat", fake_fstat)
     monkeypatch.setattr(assets_module.time, "time", lambda: 1234.5)
     monkeypatch.setattr(assets_module.console, "warn", warn_calls.append)
 

--- a/tests/units/assets/test_assets.py
+++ b/tests/units/assets/test_assets.py
@@ -1,4 +1,5 @@
 import copy
+import hashlib
 import pickle
 import shutil
 from collections.abc import Generator
@@ -9,6 +10,11 @@ import pytest
 import reflex as rx
 import reflex.constants as constants
 from reflex.assets import AssetPathStr, remove_stale_external_asset_symlinks
+
+
+def _asset_hash(path: Path) -> str:
+    """Return the expected short content hash for an asset."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:8]
 
 
 @pytest.fixture
@@ -32,9 +38,14 @@ def mock_asset_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 def test_shared_asset(mock_asset_path: Path) -> None:
     """Test shared assets."""
+    source_file = Path(__file__).parent / "custom_script.js"
+    expected_hash = _asset_hash(source_file)
+
     # The asset function copies a file to the app's external assets directory.
     asset = rx.asset(path="custom_script.js", shared=True, subfolder="subfolder")
-    assert asset == "/external/test_assets/subfolder/custom_script.js"
+    assert (
+        asset == f"/external/test_assets/subfolder/custom_script.js?v={expected_hash}"
+    )
     result_file = Path(
         mock_asset_path,
         "assets",
@@ -50,7 +61,7 @@ def test_shared_asset(mock_asset_path: Path) -> None:
 
     # Test the asset function without a subfolder.
     asset = rx.asset(path="custom_script.js", shared=True)
-    assert asset == "/external/test_assets/custom_script.js"
+    assert asset == f"/external/test_assets/custom_script.js?v={expected_hash}"
     result_file = Path(
         mock_asset_path, "assets", "external", "test_assets", "custom_script.js"
     )
@@ -107,7 +118,30 @@ def test_local_asset(custom_script_in_asset_dir: Path) -> None:
 
     """
     asset = rx.asset("custom_script.js", shared=False)
-    assert asset == "/custom_script.js"
+    assert asset == f"/custom_script.js?v={_asset_hash(custom_script_in_asset_dir)}"
+
+
+def test_local_asset_hash_changes_with_content(
+    custom_script_in_asset_dir: Path,
+) -> None:
+    """The asset URL changes when the file content changes.
+
+    Args:
+        custom_script_in_asset_dir: Fixture that creates a custom_script.js file in the app's assets directory.
+    """
+    custom_script_in_asset_dir.write_text("first")
+    first_asset = rx.asset("custom_script.js", shared=False)
+
+    custom_script_in_asset_dir.write_text("second")
+    second_asset = rx.asset("custom_script.js", shared=False)
+
+    assert first_asset != second_asset
+    assert first_asset == (
+        f"/custom_script.js?v={hashlib.sha256(b'first').hexdigest()[:8]}"
+    )
+    assert second_asset == (
+        f"/custom_script.js?v={hashlib.sha256(b'second').hexdigest()[:8]}"
+    )
 
 
 def test_asset_importable_path_local(custom_script_in_asset_dir: Path) -> None:
@@ -117,6 +151,7 @@ def test_asset_importable_path_local(custom_script_in_asset_dir: Path) -> None:
         custom_script_in_asset_dir: Fixture that creates a custom_script.js file in the app's assets directory.
     """
     asset = rx.asset("custom_script.js", shared=False)
+    assert asset == f"/custom_script.js?v={_asset_hash(custom_script_in_asset_dir)}"
     assert isinstance(asset, AssetPathStr)
     assert asset.importable_path == "$/public/custom_script.js"
 
@@ -124,6 +159,8 @@ def test_asset_importable_path_local(custom_script_in_asset_dir: Path) -> None:
 def test_asset_importable_path_shared(mock_asset_path: Path) -> None:
     """A shared asset path exposes an `importable_path` prefixed with $/public."""
     asset = rx.asset(path="custom_script.js", shared=True)
+    expected_hash = _asset_hash(Path(__file__).parent / "custom_script.js")
+    assert asset == f"/external/test_assets/custom_script.js?v={expected_hash}"
     assert isinstance(asset, AssetPathStr)
     assert asset.importable_path == "$/public/external/test_assets/custom_script.js"
 
@@ -188,6 +225,28 @@ def test_asset_path_pickle_roundtrip(monkeypatch: pytest.MonkeyPatch) -> None:
         assert isinstance(clone, AssetPathStr)
         assert clone == "/my-app/external/mod/file.js"
         assert clone.importable_path == "$/public/external/mod/file.js"
+
+
+def test_versioned_asset_path_pickle_roundtrip(
+    custom_script_in_asset_dir: Path,
+) -> None:
+    """Pickle/copy round-trips preserve the versioned URL and unversioned import path.
+
+    Args:
+        custom_script_in_asset_dir: Fixture that creates a custom_script.js file in the app's assets directory.
+    """
+    original = rx.asset("custom_script.js")
+    assert original == f"/custom_script.js?v={_asset_hash(custom_script_in_asset_dir)}"
+    assert original.importable_path == "$/public/custom_script.js"
+
+    for clone in (
+        pickle.loads(pickle.dumps(original)),
+        copy.copy(original),
+        copy.deepcopy(original),
+    ):
+        assert isinstance(clone, AssetPathStr)
+        assert clone == original
+        assert clone.importable_path == original.importable_path
 
 
 def test_remove_stale_external_asset_symlinks(mock_asset_path: Path) -> None:

--- a/tests/units/assets/test_assets.py
+++ b/tests/units/assets/test_assets.py
@@ -1,9 +1,12 @@
 import copy
 import hashlib
+import io
 import pickle
 import shutil
 from collections.abc import Generator
+from dataclasses import dataclass
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -141,6 +144,66 @@ def test_local_asset_hash_changes_with_content(
     )
     assert second_asset == (
         f"/custom_script.js?v={hashlib.sha256(b'second').hexdigest()[:8]}"
+    )
+
+
+def test_asset_hash_reads_in_chunks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Hashing handles assets larger than one read chunk.
+
+    Args:
+        tmp_path: A temporary directory provided by pytest.
+        monkeypatch: A pytest fixture for patching.
+    """
+    import reflex.assets as assets_module
+
+    monkeypatch.setattr(assets_module, "_HASH_CHUNK_SIZE", 3)
+    asset_file = tmp_path / "large.bin"
+    asset_file.write_bytes(b"abcdefghi")
+
+    assert (
+        assets_module._short_content_hash(asset_file)
+        == hashlib.sha256(b"abcdefghi").hexdigest()[:8]
+    )
+
+
+def test_asset_hash_retries_when_file_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Hashing retries when the file changes while it is being read.
+
+    Args:
+        monkeypatch: A pytest fixture for patching.
+    """
+    import reflex.assets as assets_module
+
+    @dataclass
+    class _Stat:
+        st_size: int
+        st_mtime_ns: int
+
+    class _ChangingPath:
+        content = b"old"
+        stat_calls = 0
+
+        def stat(self) -> _Stat:
+            self.stat_calls += 1
+            if self.stat_calls == 2:
+                self.content = b"final"
+                return _Stat(st_size=3, st_mtime_ns=1)
+            return _Stat(st_size=len(self.content), st_mtime_ns=2)
+
+        def open(self, mode: str):
+            assert mode == "rb"
+            return io.BytesIO(self.content)
+
+    monkeypatch.setattr(assets_module, "_HASH_CHUNK_SIZE", 2)
+    changing_path = _ChangingPath()
+
+    assert (
+        assets_module._short_content_hash(cast(Path, changing_path))
+        == hashlib.sha256(b"final").hexdigest()[:8]
     )
 
 


### PR DESCRIPTION

  Closes #6550.

  Adds content-hash cache busting to `rx.asset` URLs by appending an 8-character SHA-256 query parameter based on the
  asset file contents.

  Example:
  `rx.asset("logo.svg")` now returns `/logo.svg?v=<hash>`.

  The hash changes only when the file content changes, allowing browsers to cache assets safely across deploys.

  Implementation notes:
  - Applies to both local and shared assets.
  - Keeps `AssetPathStr.importable_path` unversioned so existing build-time import behavior is preserved.
  - Preserves backend-only behavior for missing local assets.
  - Adds regression coverage for hash changes and pickle/copy round trips.
