### PR TITLE
fix(exec): correct stale 0.8.0 reference in Uvicorn/Granian warning

### DIFF
--- a/news/6720.bugfix.md
+++ b/news/6720.bugfix.md
@@ -1,0 +1,1 @@
+Corrected the Uvicorn backend warning that claimed the switch to Granian as the default would happen in `0.8.0`, a version that has already shipped; it now describes the change as coming in a future release and points to `REFLEX_USE_GRANIAN=1` to opt in early.

--- a/news/6720.bugfix.md
+++ b/news/6720.bugfix.md
@@ -1,1 +1,0 @@
-Corrected the Uvicorn backend warning that claimed the switch to Granian as the default would happen in `0.8.0`, a version that has already shipped; it now describes the change as coming in a future release and points to `REFLEX_USE_GRANIAN=1` to opt in early.

--- a/news/6758.bugfix.md
+++ b/news/6758.bugfix.md
@@ -1,0 +1,1 @@
+Corrected the Uvicorn backend warning to describe when the compatibility fallback is selected and how to choose Granian explicitly.

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -377,7 +377,7 @@ def run_frontend_prod(host: str, port: int):
 @once
 def _warn_user_about_uvicorn():
     console.warn(
-        "Using Uvicorn for backend as it is installed. This behavior will change in 0.8.0 to use Granian by default."
+        "Using Uvicorn for backend as it is installed. Reflex will switch to Granian by default in a future release; set REFLEX_USE_GRANIAN=1 to opt in now."
     )
 
 

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -377,7 +377,7 @@ def run_frontend_prod(host: str, port: int):
 @once
 def _warn_user_about_uvicorn():
     console.warn(
-        "Using Uvicorn because both Uvicorn and Gunicorn are installed. "
+        "Using Uvicorn for the backend. "
         "Set REFLEX_USE_GRANIAN=1 to use Granian instead."
     )
 

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -377,7 +377,8 @@ def run_frontend_prod(host: str, port: int):
 @once
 def _warn_user_about_uvicorn():
     console.warn(
-        "Using Uvicorn for backend as it is installed. Reflex will switch to Granian by default in a future release; set REFLEX_USE_GRANIAN=1 to opt in now."
+        "Using Uvicorn because both Uvicorn and Gunicorn are installed. "
+        "Set REFLEX_USE_GRANIAN=1 to use Granian instead."
     )
 
 

--- a/tests/units/utils/test_exec.py
+++ b/tests/units/utils/test_exec.py
@@ -1,5 +1,6 @@
 """Tests for development backend launchers in ``reflex.utils.exec``."""
 
+import inspect
 import os
 from pathlib import Path
 
@@ -78,3 +79,17 @@ def test_run_granian_backend_sets_reload_env_var_and_clears_marker(
     )
 
     assert seen["value"] == "True"
+
+
+def test_warn_user_about_uvicorn_does_not_reference_past_version(
+    mocker: MockerFixture,
+):
+    """The Uvicorn/Granian warning must not cite a version that has already shipped."""
+    warn = mocker.patch.object(exec_utils.console, "warn")
+
+    inspect.unwrap(exec_utils._warn_user_about_uvicorn)()
+
+    warn.assert_called_once()
+    message = warn.call_args.args[0]
+    assert "0.8.0" not in message
+    assert "Granian" in message

--- a/tests/units/utils/test_exec.py
+++ b/tests/units/utils/test_exec.py
@@ -81,15 +81,21 @@ def test_run_granian_backend_sets_reload_env_var_and_clears_marker(
     assert seen["value"] == "True"
 
 
-def test_warn_user_about_uvicorn_does_not_reference_past_version(
-    mocker: MockerFixture,
+def test_should_use_granian_warns_when_falling_back_to_uvicorn(
+    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
 ):
-    """The Uvicorn/Granian warning must not cite a version that has already shipped."""
+    """The automatic Uvicorn fallback explains how to select Granian."""
+    monkeypatch.delenv(environment.REFLEX_USE_GRANIAN.name, raising=False)
+    mocker.patch.object(exec_utils.importlib.util, "find_spec", return_value=object())
     warn = mocker.patch.object(exec_utils.console, "warn")
+    mocker.patch.object(
+        exec_utils,
+        "_warn_user_about_uvicorn",
+        side_effect=inspect.unwrap(exec_utils._warn_user_about_uvicorn),
+    )
 
-    inspect.unwrap(exec_utils._warn_user_about_uvicorn)()
-
-    warn.assert_called_once()
-    message = warn.call_args.args[0]
-    assert "0.8.0" not in message
-    assert "Granian" in message
+    assert exec_utils.should_use_granian() is False
+    warn.assert_called_once_with(
+        "Using Uvicorn because both Uvicorn and Gunicorn are installed. "
+        "Set REFLEX_USE_GRANIAN=1 to use Granian instead."
+    )

--- a/tests/units/utils/test_exec.py
+++ b/tests/units/utils/test_exec.py
@@ -96,6 +96,6 @@ def test_should_use_granian_warns_when_falling_back_to_uvicorn(
 
     assert exec_utils.should_use_granian() is False
     warn.assert_called_once_with(
-        "Using Uvicorn because both Uvicorn and Gunicorn are installed. "
+        "Using Uvicorn for the backend. "
         "Set REFLEX_USE_GRANIAN=1 to use Granian instead."
     )


### PR DESCRIPTION
```markdown
## What / why

When the backend starts with Uvicorn (uvicorn and gunicorn installed,
`REFLEX_USE_GRANIAN` unset), Reflex warns:

> Using Uvicorn for backend as it is installed. This behavior will change in 0.8.0 to use Granian by default.

That message is stale in two ways:

- `0.8.0` shipped long ago (current release is 0.9.x), so it points users at a
  version that is already in the past.
- The switch never actually happened at 0.8.0. The very function that emits the
  warning, `should_use_granian()`, still returns `False` (Uvicorn) in this case,
  so the message contradicts the code that prints it.

The `0.8.0` string is a leftover from the Granian-as-default work that was moved
back to the sidelines and re-gated behind `REFLEX_USE_GRANIAN`; the target
version was never updated when the change was deferred.

## Change

Reword the single warning string to be version-agnostic and actionable, without
committing to a maintainer-owned target version:

> Using Uvicorn for backend as it is installed. Reflex will switch to Granian by default in a future release; set REFLEX_USE_GRANIAN=1 to opt in now.

`REFLEX_USE_GRANIAN=1` is a correct opt-in: `should_use_granian()` honors the env
var when it is set. No behavior change; only the string literal is different.

If you would rather name a concrete target version (e.g. the next major) instead
of "a future release", I am happy to adjust the wording.

## Tests

Added `test_warn_user_about_uvicorn_does_not_reference_past_version` in
`tests/units/utils/test_exec.py`. It unwraps the `@once` cache so the warning
fires, then asserts the message no longer contains `0.8.0` and still mentions
`Granian`. It fails against the old string and passes with the fix.

- `uv run pytest tests/units/utils/test_exec.py -q` -> 3 passed
- `uv run ruff check .` / `uv run ruff format .` -> clean
- `uv run pyright reflex tests` -> 0 errors

Added a `news/` bugfix fragment for the CHANGELOG check.
```

## news fragment

`news/6720.bugfix.md` (placeholder PR number 6720). MUST be renamed to the real
PR number after the PR is opened, otherwise the CHANGELOG CI gate stays keyed to
the wrong number. Content:

> Corrected the Uvicorn backend warning that claimed the switch to Granian as the default would happen in `0.8.0`, a version that has already shipped; it now describes the change as coming in a future release and points to `REFLEX_USE_GRANIAN=1` to opt in early.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects the Uvicorn fallback warning and adds coverage for the updated message. The main changes are:

- Removes the stale `0.8.0` reference.
- Explains how to select Granian with `REFLEX_USE_GRANIAN=1`.
- Tests the automatic Uvicorn fallback and warning text.
- Adds a bugfix changelog fragment.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.
- The warning matches the backend-selection path.
- The Granian opt-in value is handled by the existing environment-variable logic.
- The test reaches the intended fallback branch and checks the emitted message.
- No blocking issues were found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| reflex/utils/exec.py | Replaces the stale version-specific warning with accurate Granian opt-in guidance. |
| tests/units/utils/test_exec.py | Adds a focused test for backend selection and the revised warning. |
| news/6758.bugfix.md | Documents the corrected Uvicorn compatibility warning. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(exec): simplify Uvicorn warning"](https://github.com/reflex-dev/reflex/commit/44cb7c8caec163aef2d687a6fb278dfa4d310f5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44056675)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/reflex-org-2/github/reflex-dev/reflex/-/custom-context?memory=dd7376b8-2e38-4344-9cf4-16bc528d214a))
- Context used - AGENTS.md ([source](https://app.greptile.com/reflex-org-2/github/reflex-dev/reflex/-/custom-context?memory=c4407402-1557-4a61-a349-e9795b5b2fa9))

<!-- /greptile_comment -->