### PR TITLE
fix(plotly): extract z-bbox from point.bbox.z, not point.bbox.y

### DIFF
--- a/packages/reflex-components-plotly/news/6722.bugfix.md
+++ b/packages/reflex-components-plotly/news/6722.bugfix.md
@@ -1,0 +1,1 @@
+Fixed `rx.plotly` `on_hover`/`on_click`/`on_unhover` event data reporting the wrong z bounding box for 3D traces: `bbox.z0`/`bbox.z1` had been duplicating the y-extent instead of surfacing the real z-extent.

--- a/packages/reflex-components-plotly/src/reflex_components_plotly/plotly.py
+++ b/packages/reflex-components-plotly/src/reflex_components_plotly/plotly.py
@@ -214,8 +214,8 @@ const extractPoints = (points) => {
             x1: point.bbox.x1,
             y0: point.bbox.y0,
             y1: point.bbox.y1,
-            z0: point.bbox.y0,
-            z1: point.bbox.y1,
+            z0: point.bbox.z0,
+            z1: point.bbox.z1,
         }) : undefined;
         return removeUndefined({
             x: point.x,

--- a/tests/units/components/graphing/test_plotly.py
+++ b/tests/units/components/graphing/test_plotly.py
@@ -75,3 +75,22 @@ def test_plotly_basic_locale_option_merges_into_config(plotly_fig: go.Figure):
     assert "locale" not in rendered.props
     assert "_rxGetPlotlyLocaleConfig" in str(config_var)
     assert "fr" in str(config_var)
+
+
+def test_plotly_extract_points_bbox_z_source(plotly_fig: go.Figure):
+    """Test that the point extractor reads the z-bbox from the z fields.
+
+    The generated ``extractPoints`` helper must source the ``z0``/``z1`` bounding
+    box members from ``point.bbox.z0``/``point.bbox.z1`` so 3D-plot event data
+    reports the real z-extent instead of duplicating the y-extent.
+
+    Args:
+        plotly_fig: The figure to display.
+    """
+    component = rx.plotly(data=plotly_fig)
+    custom_code = "\n".join(component.add_custom_code())
+
+    assert "z0: point.bbox.z0" in custom_code
+    assert "z1: point.bbox.z1" in custom_code
+    assert "z0: point.bbox.y0" not in custom_code
+    assert "z1: point.bbox.y1" not in custom_code


### PR DESCRIPTION

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

---

The client-side `extractPoints` helper injected by `rx.plotly`
(`packages/reflex-components-plotly/src/reflex_components_plotly/plotly.py`, in
`add_custom_code()`) reshapes each plotly.js hover/click point into reflex's
`Point`/`BBox` shape before it is sent to the Python `on_hover`/`on_click`/`on_unhover`
event handlers. When it builds the bounding box, the `z0`/`z1` members were copied from
the y fields:

```js
z0: point.bbox.y0,
z1: point.bbox.y1,
```

so for 3D traces (`scatter3d`/`mesh3d`/`surface`) the reported `bbox.z0`/`bbox.z1`
always duplicated the y-extent, and the real z bounding box was never surfaced. This is a
copy-paste typo: the two lines are identical to the `y0`/`y1` lines above them except for
the destination key. reflex's own contract confirms the intent, the `BBox` TypedDict
declares `z0`/`z1` as fields distinct from `y0`/`y1`, and `Point` has a `z` field.

The fix sources them from the matching z fields:

```js
z0: point.bbox.z0,
z1: point.bbox.z1,
```

2D traces are unaffected: their `point.bbox` has no z fields, so `removeUndefined` drops
the extra keys either way.

**Testing**

Added `test_plotly_extract_points_bbox_z_source` in
`tests/units/components/graphing/test_plotly.py`, which renders the component, joins the
generated `add_custom_code()`, and asserts the snippet reads `z0: point.bbox.z0` /
`z1: point.bbox.z1` (and no longer `z0: point.bbox.y0` / `z1: point.bbox.y1`). It fails
before the fix and passes after.

```
uv run pytest tests/units/components/graphing/test_plotly.py -q   # 5 passed
uv run ruff check .                                               # clean
uv run ruff format --check .                                      # clean
uv run pyright reflex tests                                       # clean (changed files)
```

A towncrier changelog fragment is included under
`packages/reflex-components-plotly/news/`.
