### PR TITLE
fix(rename): read and write source files as UTF-8

### DIFF
--- a/news/6714.bugfix.md
+++ b/news/6714.bugfix.md
@@ -1,0 +1,1 @@
+Fixed `reflex rename` corrupting or failing on UTF-8 source files on non-UTF-8 platform locales (e.g. Windows cp1252) by reading and writing files as UTF-8.

--- a/news/6714.bugfix.md
+++ b/news/6714.bugfix.md
@@ -1,1 +1,0 @@
-Fixed `reflex rename` corrupting or failing on UTF-8 source files on non-UTF-8 platform locales (e.g. Windows cp1252) by reading and writing files as UTF-8.

--- a/news/6761.bugfix.md
+++ b/news/6761.bugfix.md
@@ -1,0 +1,1 @@
+Fixed `reflex rename` corrupting or failing on source files on non-UTF-8 platform locales while preserving declared Python source encodings and line endings.

--- a/reflex/utils/rename.py
+++ b/reflex/utils/rename.py
@@ -97,7 +97,7 @@ def rename_imports_and_app_name(file_path: str | Path, old_name: str, new_name: 
         new_name: The new name to use.
     """
     file_path = Path(file_path)
-    content = file_path.read_text()
+    content = file_path.read_text(encoding="utf-8")
 
     # Replace `from old_name.` or `from old_name` with `from new_name`
     content = re.sub(
@@ -127,7 +127,7 @@ def rename_imports_and_app_name(file_path: str | Path, old_name: str, new_name: 
         content,
     )
 
-    file_path.write_text(content)
+    file_path.write_text(content, encoding="utf-8")
 
 
 def process_directory(

--- a/reflex/utils/rename.py
+++ b/reflex/utils/rename.py
@@ -2,6 +2,7 @@
 
 import re
 import sys
+import tokenize
 from pathlib import Path
 
 from reflex_base import constants
@@ -97,7 +98,12 @@ def rename_imports_and_app_name(file_path: str | Path, old_name: str, new_name: 
         new_name: The new name to use.
     """
     file_path = Path(file_path)
-    content = file_path.read_text(encoding="utf-8")
+    if file_path.suffix == constants.Ext.PY:
+        with file_path.open("rb") as source:
+            encoding = tokenize.detect_encoding(source.readline)[0]
+    else:
+        encoding = "utf-8"
+    content = file_path.read_text(encoding=encoding)
 
     # Replace `from old_name.` or `from old_name` with `from new_name`
     content = re.sub(
@@ -127,7 +133,7 @@ def rename_imports_and_app_name(file_path: str | Path, old_name: str, new_name: 
         content,
     )
 
-    file_path.write_text(content, encoding="utf-8")
+    file_path.write_text(content, encoding=encoding)
 
 
 def process_directory(

--- a/reflex/utils/rename.py
+++ b/reflex/utils/rename.py
@@ -103,7 +103,8 @@ def rename_imports_and_app_name(file_path: str | Path, old_name: str, new_name: 
             encoding = tokenize.detect_encoding(source.readline)[0]
     else:
         encoding = "utf-8"
-    content = file_path.read_text(encoding=encoding)
+    with file_path.open("r", encoding=encoding, newline="") as source:
+        content = source.read()
 
     # Replace `from old_name.` or `from old_name` with `from new_name`
     content = re.sub(
@@ -133,7 +134,7 @@ def rename_imports_and_app_name(file_path: str | Path, old_name: str, new_name: 
         content,
     )
 
-    file_path.write_text(content, encoding=encoding)
+    file_path.write_text(content, encoding=encoding, newline="")
 
 
 def process_directory(

--- a/tests/units/test_prerequisites.py
+++ b/tests/units/test_prerequisites.py
@@ -1474,6 +1474,53 @@ from new_name
     assert updated_content == expected_content
 
 
+def test_rename_imports_and_app_name_preserves_utf8(
+    temp_directory, monkeypatch: pytest.MonkeyPatch
+):
+    """UTF-8 source is preserved even when the platform default encoding is not UTF-8.
+
+    Simulates a Western Windows locale (cp1252) where ``Path.read_text`` /
+    ``write_text`` without an explicit ``encoding`` would mis-decode UTF-8 source,
+    silently corrupting or aborting on non-ASCII characters (curly quotes, accents).
+
+    Args:
+        temp_directory: A temporary directory fixture.
+        monkeypatch: The pytest monkeypatch fixture.
+    """
+    original_read_text = Path.read_text
+    original_write_text = Path.write_text
+
+    def read_text(self, encoding=None, errors=None):
+        return original_read_text(
+            self, encoding=encoding if encoding is not None else "cp1252", errors=errors
+        )
+
+    def write_text(self, data, encoding=None, errors=None, newline=None):
+        return original_write_text(
+            self,
+            data,
+            encoding=encoding if encoding is not None else "cp1252",
+            errors=errors,
+            newline=newline,
+        )
+
+    monkeypatch.setattr(Path, "read_text", read_text)
+    monkeypatch.setattr(Path, "write_text", write_text)
+
+    source = (
+        "import old_name  # \u201cquoted\u201d caf\u00e9 na\u00efve r\u00e9sum\u00e9\n"
+    )
+    file_path = temp_directory / "example.py"
+    file_path.write_bytes(source.encode("utf-8"))
+
+    rename_imports_and_app_name(file_path, "old_name", "new_name")
+
+    expected = (
+        "import new_name  # \u201cquoted\u201d caf\u00e9 na\u00efve r\u00e9sum\u00e9\n"
+    )
+    assert file_path.read_bytes() == expected.encode("utf-8")
+
+
 def test_cli_rename_command(temp_directory):
     foo_dir = temp_directory / "foo"
     foo_dir.mkdir()

--- a/tests/units/test_prerequisites.py
+++ b/tests/units/test_prerequisites.py
@@ -1,4 +1,5 @@
 import json
+import os
 import shutil
 import tempfile
 import uuid
@@ -1514,7 +1515,7 @@ def test_rename_imports_and_app_name_preserves_utf8(
     rename_imports_and_app_name(file_path, "old_name", "new_name")
 
     expected = "import new_name  # \u201cquoted\u201d caf\u00e9 na\u00efve r\u00e9sum\u00e9\n"  # codespell:ignore
-    assert file_path.read_bytes() == expected.encode("utf-8")
+    assert file_path.read_bytes() == expected.replace("\n", os.linesep).encode("utf-8")
 
 
 def test_rename_imports_and_app_name_preserves_declared_encoding(temp_directory):
@@ -1534,7 +1535,7 @@ def test_rename_imports_and_app_name_preserves_declared_encoding(temp_directory)
     expected = (
         "# -*- coding: cp1252 -*-\nimport new_name  # caf\u00e9\n"  # codespell:ignore
     )
-    assert file_path.read_bytes() == expected.encode("cp1252")
+    assert file_path.read_bytes() == expected.replace("\n", os.linesep).encode("cp1252")
 
 
 def test_cli_rename_command(temp_directory):

--- a/tests/units/test_prerequisites.py
+++ b/tests/units/test_prerequisites.py
@@ -1,5 +1,4 @@
 import json
-import os
 import shutil
 import tempfile
 import uuid
@@ -1488,25 +1487,21 @@ def test_rename_imports_and_app_name_preserves_utf8(
         temp_directory: A temporary directory fixture.
         monkeypatch: The pytest monkeypatch fixture.
     """
-    original_read_text = Path.read_text
-    original_write_text = Path.write_text
+    original_open = Path.open
 
-    def read_text(self, encoding=None, errors=None):
-        return original_read_text(
-            self, encoding=encoding if encoding is not None else "cp1252", errors=errors
-        )
-
-    def write_text(self, data, encoding=None, errors=None, newline=None):
-        return original_write_text(
+    def open_file(
+        self, mode="r", buffering=-1, encoding=None, errors=None, newline=None
+    ):
+        return original_open(
             self,
-            data,
-            encoding=encoding if encoding is not None else "cp1252",
+            mode=mode,
+            buffering=buffering,
+            encoding=(encoding if encoding is not None or "b" in mode else "cp1252"),
             errors=errors,
             newline=newline,
         )
 
-    monkeypatch.setattr(Path, "read_text", read_text)
-    monkeypatch.setattr(Path, "write_text", write_text)
+    monkeypatch.setattr(Path, "open", open_file)
 
     source = "import old_name  # \u201cquoted\u201d caf\u00e9 na\u00efve r\u00e9sum\u00e9\n"  # codespell:ignore
     file_path = temp_directory / "example.py"
@@ -1515,7 +1510,7 @@ def test_rename_imports_and_app_name_preserves_utf8(
     rename_imports_and_app_name(file_path, "old_name", "new_name")
 
     expected = "import new_name  # \u201cquoted\u201d caf\u00e9 na\u00efve r\u00e9sum\u00e9\n"  # codespell:ignore
-    assert file_path.read_bytes() == expected.replace("\n", os.linesep).encode("utf-8")
+    assert file_path.read_bytes() == expected.encode("utf-8")
 
 
 def test_rename_imports_and_app_name_preserves_declared_encoding(temp_directory):
@@ -1535,7 +1530,27 @@ def test_rename_imports_and_app_name_preserves_declared_encoding(temp_directory)
     expected = (
         "# -*- coding: cp1252 -*-\nimport new_name  # caf\u00e9\n"  # codespell:ignore
     )
-    assert file_path.read_bytes() == expected.replace("\n", os.linesep).encode("cp1252")
+    assert file_path.read_bytes() == expected.encode("cp1252")
+
+
+@pytest.mark.parametrize("line_ending", ["\n", "\r\n"])
+def test_rename_imports_and_app_name_preserves_line_endings(
+    temp_directory, line_ending
+):
+    """Source line endings are preserved during rename.
+
+    Args:
+        temp_directory: A temporary directory fixture.
+        line_ending: The line ending used in the source file.
+    """
+    source = line_ending.join(("import old_name", "# comment", ""))
+    file_path = temp_directory / "example.py"
+    file_path.write_bytes(source.encode())
+
+    rename_imports_and_app_name(file_path, "old_name", "new_name")
+
+    expected = line_ending.join(("import new_name", "# comment", ""))
+    assert file_path.read_bytes() == expected.encode()
 
 
 def test_cli_rename_command(temp_directory):

--- a/tests/units/test_prerequisites.py
+++ b/tests/units/test_prerequisites.py
@@ -1507,18 +1507,34 @@ def test_rename_imports_and_app_name_preserves_utf8(
     monkeypatch.setattr(Path, "read_text", read_text)
     monkeypatch.setattr(Path, "write_text", write_text)
 
-    source = (
-        "import old_name  # \u201cquoted\u201d caf\u00e9 na\u00efve r\u00e9sum\u00e9\n"
-    )
+    source = "import old_name  # \u201cquoted\u201d caf\u00e9 na\u00efve r\u00e9sum\u00e9\n"  # codespell:ignore
     file_path = temp_directory / "example.py"
     file_path.write_bytes(source.encode("utf-8"))
 
     rename_imports_and_app_name(file_path, "old_name", "new_name")
 
-    expected = (
-        "import new_name  # \u201cquoted\u201d caf\u00e9 na\u00efve r\u00e9sum\u00e9\n"
-    )
+    expected = "import new_name  # \u201cquoted\u201d caf\u00e9 na\u00efve r\u00e9sum\u00e9\n"  # codespell:ignore
     assert file_path.read_bytes() == expected.encode("utf-8")
+
+
+def test_rename_imports_and_app_name_preserves_declared_encoding(temp_directory):
+    """Python source encoding cookies are honored during rename.
+
+    Args:
+        temp_directory: A temporary directory fixture.
+    """
+    source = (
+        "# -*- coding: cp1252 -*-\nimport old_name  # caf\u00e9\n"  # codespell:ignore
+    )
+    file_path = temp_directory / "example.py"
+    file_path.write_bytes(source.encode("cp1252"))
+
+    rename_imports_and_app_name(file_path, "old_name", "new_name")
+
+    expected = (
+        "# -*- coding: cp1252 -*-\nimport new_name  # caf\u00e9\n"  # codespell:ignore
+    )
+    assert file_path.read_bytes() == expected.encode("cp1252")
 
 
 def test_cli_rename_command(temp_directory):


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### What and why

`reflex rename <new_name>` walks the user's app and rewrites imports and the app
name in every `.py` and `.md` file. The read/modify/write in
`rename_imports_and_app_name` (`reflex/utils/rename.py`) used
`Path.read_text()` and `Path.write_text()` with no `encoding=` argument, so both
default to the platform's locale encoding. On a Western Windows locale that is
`cp1252`, not UTF-8.

The consequences on non-UTF-8 locales:

- **Silent corruption (Western Windows, cp1252):** a UTF-8-authored file that
  contains non-ASCII bytes (curly quotes in docstrings, accented identifiers or
  string literals, emoji) is decoded as cp1252, rewritten, and written back as
  cp1252, mangling the user's own source.
- **Hard failure (CJK codepages):** `read_text()` raises `UnicodeDecodeError`,
  aborting the rename partway through the tree and leaving some files already
  rewritten and others not, i.e. an inconsistent app.

On a POSIX UTF-8 locale it round-trips, so this is effectively Windows-specific.

The fix passes `encoding="utf-8"` on both calls. This mirrors the repo's own
`reflex/utils/path_ops.py` `find_replace`, which already reads and writes the same
read/replace/write pattern with `encoding="utf-8"`; `rename.py` was the outlier.

### Changes

- `reflex/utils/rename.py`: add `encoding="utf-8"` to the `read_text()` and
  `write_text()` calls in `rename_imports_and_app_name` (+2 / -2).
- `tests/units/test_prerequisites.py`: add regression test
  `test_rename_imports_and_app_name_preserves_utf8`, colocated with the existing
  rename tests. It simulates a cp1252 default (monkeypatching `Path.read_text` /
  `write_text` so a missing `encoding` falls back to cp1252, while an explicit
  `encoding=` still passes through), writes a UTF-8 file with realistic non-ASCII
  content, runs the rename, and asserts the bytes are preserved exactly and the
  rename still happened. The test fails before the fix (`UnicodeDecodeError`) and
  passes after.
- `news/<pr>.bugfix.md`: towncrier changelog fragment.

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them? (above)
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

Locally (all green):

- `uv run pytest tests/units/test_prerequisites.py -k rename` -> 6 passed
- `uv run pytest tests/units/test_prerequisites.py tests/units/utils` -> 677 passed, 4 skipped
- `uv run ruff check .` (changed files) -> All checks passed
- `uv run ruff format --check .` (changed files) -> already formatted
- `uv run pyright reflex/utils/rename.py tests/units/test_prerequisites.py` -> 0 errors
- `uv run towncrier check --compare-with origin/main` -> fragment found

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes `reflex rename` preserve source-file text across platform locales. The main changes are:

- Detect and preserve declared Python source encodings.
- Read and write other supported files as UTF-8.
- Preserve LF and CRLF line endings.
- Add tests for UTF-8, cp1252, and line-ending behavior.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.
- The declared-encoding failure is addressed with Python's standard encoding detection.
- Reads and writes use the same detected encoding.
- Tests cover the affected encoding and line-ending paths.
- No blocking issues remain in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| reflex/utils/rename.py | Detects declared Python encodings and preserves the selected encoding and original line endings during rename. |
| tests/units/test_prerequisites.py | Adds tests for UTF-8 under a non-UTF-8 locale, declared cp1252 source, and LF/CRLF preservation. |
| news/6761.bugfix.md | Documents the source-encoding and line-ending preservation fix. |

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(rename): preserve source line ending..."](https://github.com/reflex-dev/reflex/commit/16372ab8c60254183562bf487f1b07bf51a8eb5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44070190)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/reflex-org-2/github/reflex-dev/reflex/-/custom-context?memory=dd7376b8-2e38-4344-9cf4-16bc528d214a))
- Context used - AGENTS.md ([source](https://app.greptile.com/reflex-org-2/github/reflex-dev/reflex/-/custom-context?memory=c4407402-1557-4a61-a349-e9795b5b2fa9))

<!-- /greptile_comment -->