### PR TITLE
Add frozen_lockfile config to control bun lockfile enforcement

### DIFF
--- a/news/6763.feature.md
+++ b/news/6763.feature.md
@@ -1,0 +1,1 @@
+The new `frozen_lockfile` config option is now honored during frontend package installation: when enabled (the default), bun's initial install runs with `--frozen-lockfile` so a lockfile out of sync with `package.json` fails fast. Set `frozen_lockfile=False` to let the lockfile update in place instead. npm has no equivalent install flag today, so the option is a no-op there.

--- a/packages/reflex-base/news/6763.feature.md
+++ b/packages/reflex-base/news/6763.feature.md
@@ -1,0 +1,1 @@
+Added `frozen_lockfile` to `rx.Config` (default `True`, also settable via `REFLEX_FROZEN_LOCKFILE`), controlling whether the frontend package manager runs in lockfile-enforcing mode. Reflex still creates, manages, and syncs the lockfile regardless; the option only controls whether a lockfile/`package.json` mismatch is treated as an error.

--- a/packages/reflex-base/src/reflex_base/config.py
+++ b/packages/reflex-base/src/reflex_base/config.py
@@ -165,6 +165,7 @@ class BaseConfig:
         redis_url: The redis url.
         telemetry_enabled: Telemetry opt-in.
         bun_path: The bun path.
+        frozen_lockfile: Whether to run the package manager in lockfile-enforcing mode, making it an error when the lockfile and package.json are out of sync. Reflex still creates, manages, and syncs the lockfile regardless of this setting; it only controls whether a mismatch is fatal. Currently only honored by bun.
         static_page_generation_timeout: Timeout to do a production build of a frontend page.
         cors_allowed_origins: Comma separated list of origins that are allowed to connect to the backend API.
         vite_allowed_hosts: Allowed hosts for the Vite dev server. Set to True to allow all hosts, or provide a list of hostnames (e.g. ["myservice.local"]) to allow specific ones. Prevents 403 errors in Docker, Codespaces, reverse proxies, etc.
@@ -216,6 +217,8 @@ class BaseConfig:
     telemetry_enabled: bool = True
 
     bun_path: ExistingPath = constants.Bun.DEFAULT_PATH
+
+    frozen_lockfile: bool = True
 
     static_page_generation_timeout: int = 60
 

--- a/packages/reflex-base/src/reflex_base/config.py
+++ b/packages/reflex-base/src/reflex_base/config.py
@@ -165,7 +165,7 @@ class BaseConfig:
         redis_url: The redis url.
         telemetry_enabled: Telemetry opt-in.
         bun_path: The bun path.
-        frozen_lockfile: Whether to run the package manager in lockfile-enforcing mode, making it an error when the lockfile and package.json are out of sync. Reflex still creates, manages, and syncs the lockfile regardless of this setting; it only controls whether a mismatch is fatal. Currently only honored by bun.
+        frozen_lockfile: Run frontend package manager in lockfile-enforcing mode (only honored by bun).
         static_page_generation_timeout: Timeout to do a production build of a frontend page.
         cors_allowed_origins: Comma separated list of origins that are allowed to connect to the backend API.
         vite_allowed_hosts: Allowed hosts for the Vite dev server. Set to True to allow all hosts, or provide a list of hostnames (e.g. ["myservice.local"]) to allow specific ones. Prevents 403 errors in Docker, Codespaces, reverse proxies, etc.

--- a/reflex/utils/js_runtimes.py
+++ b/reflex/utils/js_runtimes.py
@@ -460,18 +460,22 @@ def _is_bun_package_manager(package_manager: str) -> bool:
     return Path(package_manager).stem.lower() == "bun"
 
 
-def _run_initial_install(primary_package_manager: str, env: dict) -> None:
-    """Run the initial frozen-lockfile install with a friendly recovery hint.
+def _run_initial_install(
+    primary_package_manager: str, env: dict, frozen_lockfile: bool
+) -> None:
+    """Run the initial install with a friendly recovery hint.
 
-    bun reports ``error: lockfile had changes, but lockfile is frozen`` when
-    the persisted lockfile cannot satisfy the recovered package.json. When
-    that happens, point the user at ``reflex.lock/package.json`` so they can
-    delete it and let Reflex regenerate the dep set from scratch on the
-    next run.
+    When ``frozen_lockfile`` is set, bun reports ``error: lockfile had
+    changes, but lockfile is frozen`` if the persisted lockfile cannot
+    satisfy the recovered package.json. When that happens, point the user at
+    ``reflex.lock/package.json`` so they can delete it and let Reflex
+    regenerate the dep set from scratch on the next run.
 
     Args:
         primary_package_manager: Path to the package manager executable.
         env: Extra environment variables for the subprocess.
+        frozen_lockfile: Whether to enforce the lockfile, erroring when it is
+            out of sync with package.json instead of updating it in place.
 
     Raises:
         SystemExit: If the install fails. The exit message tells the user
@@ -482,7 +486,7 @@ def _run_initial_install(primary_package_manager: str, env: dict) -> None:
         "install",
         "--legacy-peer-deps",
     ]
-    if _is_bun_package_manager(primary_package_manager):
+    if frozen_lockfile and _is_bun_package_manager(primary_package_manager):
         # ``--frozen-lockfile`` is bun-only; npm ignores it today and the
         # next major rejects unknown flags outright.
         install_args.append("--frozen-lockfile")
@@ -700,7 +704,7 @@ def _install_frontend_packages(
         frontend_skeleton.get_web_lockfile_path(name).exists()
         for name in frontend_skeleton.LOCKFILE_NAMES
     ):
-        _run_initial_install(primary_package_manager, env)
+        _run_initial_install(primary_package_manager, env, config.frozen_lockfile)
 
     pinned_packages, unpinned_packages = _split_by_version_specifier(packages)
     pinned_dev_deps, unpinned_dev_deps = _split_by_version_specifier(development_deps)

--- a/tests/units/test_config.py
+++ b/tests/units/test_config.py
@@ -48,6 +48,16 @@ def test_default_color_mode_default(base_config_values):
     assert config.default_color_mode == "system"
 
 
+def test_frozen_lockfile_default(base_config_values):
+    """Test that frozen_lockfile defaults to True (lockfile enforcement on).
+
+    Args:
+        base_config_values: Config values.
+    """
+    config = rx.Config(**base_config_values)
+    assert config.frozen_lockfile is True
+
+
 @pytest.mark.parametrize(
     ("env_var", "value"),
     [
@@ -63,6 +73,8 @@ def test_default_color_mode_default(base_config_values):
         ("REFLEX_REDIS_URL", "redis://localhost:6379"),
         ("REFLEX_TELEMETRY_ENABLED", False),
         ("REFLEX_TELEMETRY_ENABLED", True),
+        ("REFLEX_FROZEN_LOCKFILE", False),
+        ("REFLEX_FROZEN_LOCKFILE", True),
         ("REFLEX_DEFAULT_COLOR_MODE", "dark"),
     ],
 )

--- a/tests/units/test_prerequisites.py
+++ b/tests/units/test_prerequisites.py
@@ -49,9 +49,9 @@ def _patch_frontend_package_manager(
 
     # Forward the initial-install helper through the same stub so tests can
     # inspect the install args without mocking subprocess primitives.
-    def _stub_initial_install(primary_pm, env):
+    def _stub_initial_install(primary_pm, env, frozen_lockfile):
         args = [primary_pm, "install", "--legacy-peer-deps"]
-        if js_runtimes._is_bun_package_manager(primary_pm):
+        if frozen_lockfile and js_runtimes._is_bun_package_manager(primary_pm):
             args.append("--frozen-lockfile")
         run_package_manager(
             args,
@@ -874,6 +874,23 @@ def test_install_frontend_packages_bun_keeps_frozen_lockfile(
     assert any("--frozen-lockfile" in c for c in install_calls)
 
 
+def test_install_frontend_packages_bun_skips_frozen_lockfile_when_disabled(
+    install_packages_env: InstallPackagesEnv,
+):
+    """``frozen_lockfile=False`` drops ``--frozen-lockfile`` even for bun."""
+    env = install_packages_env
+    env.config.frozen_lockfile = False
+    env.root_lock.write_text("bun-lock")
+    calls = _record_calls_with_pm(env, "bun")
+
+    env.install({"some-pkg"})
+
+    install_calls = [c for c in calls if "install" in c]
+    assert install_calls, "expected an initial `bun install` call"
+    for call in install_calls:
+        assert "--frozen-lockfile" not in call
+
+
 def test_install_frontend_packages_persists_package_json_to_root(
     install_packages_env: InstallPackagesEnv,
 ):
@@ -1297,7 +1314,7 @@ def test_run_initial_install_frozen_lockfile_error_helpful_message(monkeypatch, 
     )
 
     with pytest.raises(SystemExit):
-        js_runtimes._run_initial_install("bun", env={})
+        js_runtimes._run_initial_install("bun", env={}, frozen_lockfile=True)
 
     captured = capsys.readouterr()
     output = captured.out + captured.err
@@ -1326,7 +1343,7 @@ def test_run_initial_install_other_error_replays_logs(monkeypatch, capsys):
     )
 
     with pytest.raises(SystemExit):
-        js_runtimes._run_initial_install("bun", env={})
+        js_runtimes._run_initial_install("bun", env={}, frozen_lockfile=True)
 
     captured = capsys.readouterr()
     assert "network unreachable" in captured.out + captured.err


### PR DESCRIPTION
### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Description

Adds a new `frozen_lockfile` configuration option to allow users to control whether the frontend package manager (bun) enforces lockfile constraints during installation.

**Changes:**

1. **New config option** (`packages/reflex-base/src/reflex_base/config.py`):
   - Added `frozen_lockfile: bool = True` field to `BaseConfig`
   - Defaults to `True` to maintain current behavior (lockfile enforcement enabled)
   - Allows users to set `frozen_lockfile = False` to permit lockfile updates during install

2. **Updated package manager logic** (`reflex/utils/js_runtimes.py`):
   - Modified `_run_initial_install()` to accept a `frozen_lockfile` parameter
   - Only appends `--frozen-lockfile` flag to bun when `frozen_lockfile=True`
   - Updated docstring to clarify the parameter's purpose

3. **Test infrastructure** (`tests/units/test_prerequisites.py`):
   - Updated `_stub_initial_install()` helper to accept and respect `frozen_lockfile` parameter
   - Updated existing test calls to pass the parameter

4. **New test coverage** (`tests/units/test_prerequisites.py` and `tests/units/test_config.py`):
   - Added `test_install_frontend_packages_bun_skips_frozen_lockfile_when_disabled()` to verify `--frozen-lockfile` is omitted when disabled
   - Added `test_frozen_lockfile_default()` to verify the config defaults to `True`
   - Added environment variable tests for `REFLEX_FROZEN_LOCKFILE`

### Rationale

This change provides flexibility for users whose lockfiles may become out of sync with their `package.json`. When `frozen_lockfile=False`, bun will update the lockfile in place rather than erroring, allowing for smoother dependency management in certain workflows while maintaining strict lockfile enforcement by default.

### Testing

- [x] Added unit tests for the new config option and its behavior
- [x] Existing tests updated to pass the new parameter
- [x] Default behavior (frozen_lockfile=True) maintains backward compatibility

https://claude.ai/code/session_01LsCpapC9gpftmHMqdrqBUo