### PR TITLE
fix(vars): match Python round semantics

### DIFF
--- a/packages/reflex-base/news/6757.bugfix.md
+++ b/packages/reflex-base/news/6757.bugfix.md
@@ -1,0 +1,1 @@
+`NumberVar` rounding now matches Python's round-half-even behavior and supports negative `ndigits` values in compiled frontend expressions.

--- a/packages/reflex-base/src/reflex_base/.templates/web/utils/helpers/round.js
+++ b/packages/reflex-base/src/reflex_base/.templates/web/utils/helpers/round.js
@@ -1,0 +1,43 @@
+/**
+ * Round a number using Python's round-half-even semantics.
+ * Decompose the IEEE 754 value into a rational so ties are compared exactly.
+ *
+ * @param {number} value The value to round.
+ * @param {number} ndigits The decimal precision.
+ * @returns {number} The rounded value.
+ */
+export default function pyRound(value, ndigits) {
+  if (!Number.isFinite(value) || ndigits > 323) return value;
+  if (ndigits < -308) return value * 0;
+
+  const view = new DataView(new ArrayBuffer(8));
+  view.setFloat64(0, Math.abs(value));
+  const bits = view.getBigUint64(0);
+  const exponent = Number((bits >> 52n) & 0x7ffn);
+  const fraction = bits & 0xfffffffffffffn;
+  const significand = exponent === 0 ? fraction : fraction | 0x10000000000000n;
+  const binaryExponent = exponent === 0 ? -1074 : exponent - 1075;
+  const fivePower = 5n ** BigInt(Math.abs(ndigits));
+
+  let numerator = significand * (ndigits >= 0 ? fivePower : 1n);
+  let denominator = ndigits < 0 ? fivePower : 1n;
+  const shift = binaryExponent + ndigits;
+  if (shift >= 0) {
+    numerator <<= BigInt(shift);
+  } else {
+    denominator <<= BigInt(-shift);
+  }
+
+  let rounded = numerator / denominator;
+  const doubledRemainder = (numerator % denominator) * 2n;
+  if (
+    doubledRemainder > denominator ||
+    (doubledRemainder === denominator && rounded % 2n === 1n)
+  ) {
+    rounded += 1n;
+  }
+
+  const sign = value < 0 || Object.is(value, -0) ? "-" : "";
+  const result = Number(`${sign}${rounded}e${-ndigits}`);
+  return result === 0 && sign ? -0 : result;
+}

--- a/packages/reflex-base/src/reflex_base/.templates/web/utils/helpers/round.js
+++ b/packages/reflex-base/src/reflex_base/.templates/web/utils/helpers/round.js
@@ -7,6 +7,9 @@
  * @returns {number} The rounded value.
  */
 export default function pyRound(value, ndigits) {
+  if (!Number.isInteger(ndigits)) {
+    throw new TypeError("ndigits must be an integer");
+  }
   if (!Number.isFinite(value) || ndigits > 323) return value;
   if (ndigits < -308) return value * 0;
 
@@ -39,5 +42,8 @@ export default function pyRound(value, ndigits) {
 
   const sign = value < 0 || Object.is(value, -0) ? "-" : "";
   const result = Number(`${sign}${rounded}e${-ndigits}`);
+  if (!Number.isFinite(result)) {
+    throw new RangeError("rounded value is too large to represent");
+  }
   return result === 0 && sign ? -0 : result;
 }

--- a/packages/reflex-base/src/reflex_base/vars/number.py
+++ b/packages/reflex-base/src/reflex_base/vars/number.py
@@ -656,6 +656,13 @@ def number_exponent_operation(lhs: NumberVar, rhs: NumberVar):
     return f"({lhs} ** {rhs})"
 
 
+_PY_ROUND_IMPORT: ImportDict = {
+    "$/utils/helpers/round.js": [
+        ImportVar(tag="pyRound", is_default=True, install=False)
+    ],
+}
+
+
 @var_operation
 def number_round_operation(value: NumberVar, ndigits: NumberVar | int):
     """Round the number.
@@ -670,9 +677,13 @@ def number_round_operation(value: NumberVar, ndigits: NumberVar | int):
     if (isinstance(ndigits, LiteralNumberVar) and ndigits._var_value == 0) or (
         isinstance(ndigits, int) and ndigits == 0
     ):
-        return var_operation_return(js_expression=f"Math.round({value})", var_type=int)
+        var_type = int
+    else:
+        var_type = float
     return var_operation_return(
-        js_expression=f"(+{value}.toFixed({ndigits}))", var_type=float
+        js_expression=f"pyRound({value}, {ndigits})",
+        var_type=var_type,
+        var_data=VarData(imports=_PY_ROUND_IMPORT),
     )
 
 

--- a/tests/units/test_var.py
+++ b/tests/units/test_var.py
@@ -2,8 +2,10 @@ import decimal
 import json
 import math
 import re
+import subprocess
 import typing
 from collections.abc import Mapping, Sequence
+from pathlib import Path
 from typing import cast
 
 import pytest
@@ -54,8 +56,13 @@ from reflex.state import BaseState
 
 pytest.importorskip("pydantic")
 
-
 from pydantic import BaseModel as Base
+
+ROUND_HELPER = (
+    Path(__file__).parents[2]
+    / "packages/reflex-base/src/reflex_base/.templates/web/utils/helpers/round.js"
+)
+
 
 test_vars = [
     Var(_js_expr="prop1", _var_type=int),
@@ -1038,7 +1045,7 @@ def test_all_number_operations():
 
     assert (
         str(even_more_complicated_number)
-        == "!(isTrue(pyOr(Math.abs(Math.floor(((Math.floor(((-((-5.4 + 1)) * 2) / 3) / 2) % 3) ** 2))), () => (pyAnd(2, () => (Math.round(((Math.floor(((-((-5.4 + 1)) * 2) / 3) / 2) % 3) ** 2))))))))"
+        == "!(isTrue(pyOr(Math.abs(Math.floor(((Math.floor(((-((-5.4 + 1)) * 2) / 3) / 2) % 3) ** 2))), () => (pyAnd(2, () => (pyRound(((Math.floor(((-((-5.4 + 1)) * 2) / 3) / 2) % 3) ** 2), 0)))))))"
     )
 
     assert str(LiteralNumberVar.create(5) > False) == "(5 > 0)"
@@ -1047,6 +1054,51 @@ def test_all_number_operations():
         str(LiteralBooleanVar.create(False) < LiteralBooleanVar.create(True))
         == "(Number(false) < Number(true))"
     )
+
+
+@pytest.mark.parametrize(
+    ("value", "ndigits", "expected"),
+    [
+        (2.5, 0, "2"),
+        (3.5, 0, "4"),
+        (-2.5, 0, "-2"),
+        (-3.5, 0, "-4"),
+        (3.6, 0, "4"),
+        (250, -2, "200"),
+        (350, -2, "400"),
+        (-250, -2, "-200"),
+        (-350, -2, "-400"),
+        (2.675, 2, "2.67"),
+        (5e-324, 323, "0"),
+        (1e20, 0, "100000000000000000000"),
+        (1.2345, 324, "1.2345"),
+        (-1.2345, -309, "-0"),
+        (float("inf"), 2, "Infinity"),
+    ],
+)
+def test_number_round_python_semantics(value, ndigits, expected):
+    rounded = round(LiteralNumberVar.create(value), ndigits)
+    var_data = rounded._get_all_var_data()
+    assert var_data is not None
+    assert any(
+        imported.tag == "pyRound" and imported.is_default
+        for imported in dict(var_data.imports)["$/utils/helpers/round.js"]
+    )
+
+    result = subprocess.run(
+        [
+            "node",
+            "--input-type=module",
+            "--eval",
+            f"{ROUND_HELPER.read_text(encoding='utf-8')}\nconsole.log({rounded!s})",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.strip() == expected
+    assert rounded._var_type is (int if ndigits == 0 else float)
 
 
 @pytest.mark.parametrize(

--- a/tests/units/test_var.py
+++ b/tests/units/test_var.py
@@ -1071,6 +1071,8 @@ def test_all_number_operations():
         (2.675, 2, "2.67"),
         (5e-324, 323, "0"),
         (1e20, 0, "100000000000000000000"),
+        (1.7976931348623157e308, -308, "RangeError"),
+        (1.5, 2.5, "TypeError"),
         (1.2345, 324, "1.2345"),
         (-1.2345, -309, "-0"),
         (float("inf"), 2, "Infinity"),
@@ -1090,7 +1092,8 @@ def test_number_round_python_semantics(value, ndigits, expected):
             "node",
             "--input-type=module",
             "--eval",
-            f"{ROUND_HELPER.read_text(encoding='utf-8')}\nconsole.log({rounded!s})",
+            f"""{ROUND_HELPER.read_text(encoding="utf-8")}
+try {{ console.log({rounded!s}); }} catch (error) {{ console.log(error.name); }}""",
         ],
         check=True,
         capture_output=True,


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

Compiled `NumberVar` rounding previously used JavaScript `Math.round` and
`Number.prototype.toFixed`. These APIs differ from Python on half ties, and
`toFixed` rejects negative `ndigits` values.

This change routes compiled rounding through a frontend helper that decomposes
IEEE 754 values into exact rational numbers and applies round-half-even. It adds
support for negative precision while preserving the existing static result types.

### Testing

- `uv run pytest tests/units/test_var.py -q` (223 passed)
- `uv run pytest tests/units --cov --no-cov-on-fail --cov-report=` (6664 passed, 17 skipped, 78.09% coverage)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pyright reflex tests` (0 errors)
- `uv run pre-commit run --files packages/reflex-base/src/reflex_base/.templates/web/utils/helpers/round.js packages/reflex-base/src/reflex_base/vars/number.py packages/reflex-base/news/6757.bugfix.md tests/units/test_var.py`
- `node --check packages/reflex-base/src/reflex_base/.templates/web/utils/helpers/round.js`
- `uv run towncrier check --config pyproject.toml --dir packages/reflex-base --compare-with origin/main`

The regression test executes the generated JavaScript in Node and covers positive
and negative half ties, negative precision, binary-float edge cases, extreme
precision, signed zero, non-finite values, helper imports, and result types.

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?
