### PR TITLE
docs: database efficiency and table recipes

### DIFF
--- a/docs/database/queries.md
+++ b/docs/database/queries.md
@@ -227,9 +227,12 @@ class OrderStats(rx.State):
             self.order_count = session.exec(select(func.count(Order.id))).one()
 
             # One row per group, ready for a chart or summary table.
-            self.orders_by_status = session.exec(
-                select(Order.status, func.count(Order.id)).group_by(Order.status)
-            ).all()
+            self.orders_by_status = [
+                tuple(row)
+                for row in session.exec(
+                    select(Order.status, func.count(Order.id)).group_by(Order.status)
+                ).all()
+            ]
 ```
 
 Related metrics can be computed in a single query with conditional

--- a/docs/database/queries.md
+++ b/docs/database/queries.md
@@ -293,7 +293,7 @@ import sqlalchemy
 
 with rx.session() as session:
     rows = session.execute(
-        sqlalchemy.text("SELECT * FROM user WHERE id IN :user_ids").bindparams(
+        sqlalchemy.text("SELECT * FROM users WHERE id IN :user_ids").bindparams(
             sqlalchemy.bindparam("user_ids", expanding=True)
         ),
         {"user_ids": [1, 2, 3]},

--- a/docs/database/queries.md
+++ b/docs/database/queries.md
@@ -190,6 +190,175 @@ class State(rx.State):
             return [list(row) for row in session.execute("SELECT * FROM user").all()]
 ```
 
+## Writing Efficient Queries
+
+The database is much better at filtering, joining, and aggregating than Python.
+Every row returned by a query is sent over the network and held in memory as
+part of the state — for every user with an open session. Do the work in the
+query itself and return only display-ready results.
+
+The examples below use a simple `Order` model.
+
+```python
+class Order(rx.Model, table=True):
+    user_id: int
+    status: str
+    amount: float | None = None
+```
+
+### Aggregate in SQL, not Python
+
+Avoid fetching a whole table just to compute a summary in Python. Use the
+database's aggregate functions (`COUNT`, `SUM`, `AVG`, `MIN`, `MAX`) with
+`GROUP BY` so only the summary rows come back.
+
+```python
+from sqlmodel import select, func
+
+
+class OrderStats(rx.State):
+    order_count: int = 0
+    orders_by_status: list[tuple[str, int]] = []
+
+    @rx.event
+    def load_stats(self):
+        with rx.session() as session:
+            # Count rows in the database instead of len() on a full fetch.
+            self.order_count = session.exec(select(func.count(Order.id))).one()
+
+            # One row per group, ready for a chart or summary table.
+            self.orders_by_status = session.exec(
+                select(Order.status, func.count(Order.id)).group_by(Order.status)
+            ).all()
+```
+
+Related metrics can be computed in a single query with conditional
+aggregation, instead of issuing one query per metric:
+
+```python
+import sqlalchemy
+from sqlmodel import select, func
+
+
+class OrderKPIs(rx.State):
+    total_orders: int = 0
+    completed_orders: int = 0
+    total_amount: float = 0.0
+
+    @rx.event
+    def load_kpis(self):
+        with rx.session() as session:
+            total, completed, amount = session.exec(
+                select(
+                    func.count(Order.id),
+                    func.sum(
+                        sqlalchemy.case((Order.status == "completed", 1), else_=0)
+                    ),
+                    func.coalesce(func.sum(Order.amount), 0.0),
+                )
+            ).one()
+        self.total_orders = total
+        self.completed_orders = completed or 0
+        self.total_amount = float(amount)
+```
+
+### Avoid Queries Inside Loops
+
+Issuing a query per item — the "N+1" pattern — multiplies network round trips.
+Fetch everything in one statement with a `JOIN`, an `IN (...)` list, or
+`GROUP BY`.
+
+```python
+# Inefficient: one query per user (N+1).
+with rx.session() as session:
+    for user in users:
+        orders = session.exec(Order.select().where(Order.user_id == user.id)).all()
+
+# Efficient: one query for all users at once.
+with rx.session() as session:
+    orders = session.exec(
+        Order.select().where(Order.user_id.in_([user.id for user in users]))
+    ).all()
+```
+
+The `.in_()` method binds each value as a separate query parameter, so it is
+safe to use with user-provided values. In raw SQL, use an *expanding* bind
+parameter for the same effect — never join the values into the SQL string:
+
+```python
+import sqlalchemy
+
+with rx.session() as session:
+    rows = session.execute(
+        sqlalchemy.text("SELECT * FROM user WHERE id IN :user_ids").bindparams(
+            sqlalchemy.bindparam("user_ids", expanding=True)
+        ),
+        {"user_ids": [1, 2, 3]},
+    ).all()
+```
+
+If the related objects are linked with foreign keys, the
+[relationship loading techniques](/docs/database/relationships) can also fetch
+linked objects without extra queries.
+
+### Return Only What the UI Needs
+
+- Select only the columns the UI displays when tables are wide, instead of
+  whole rows.
+- Give every query that returns detail rows a `.limit()`, and use
+  offset-based [pagination](/docs/library/tables-and-data-grids/table) when
+  the user needs more rows.
+- Load static data (dropdown options, date bounds) once in an `on_load` event
+  handler. When a filter changes, re-run only the filtered queries — not the
+  option lookups.
+- Avoid caching large raw query results in state vars to work around a slow
+  query: per-user state duplicates that data in server memory for every
+  session. Fix the query instead — aggregate in SQL, add a limit, combine
+  round trips. Keeping small, display-ready results in state (chart rows, KPI
+  values, one page of a table) is the intended pattern.
+
+## Handling NULL Values
+
+Database columns may contain `NULL`, which arrives in Python as `None`.
+Aggregates like `SUM` and `AVG` also return `NULL` when they run over zero
+rows. Casting such results directly will crash:
+
+```python
+float(row[0])  # TypeError: float() argument must be ... not 'NoneType'
+```
+
+There are two ways to handle this.
+
+### Coalesce in the Query (Preferred)
+
+`COALESCE` returns its first non-`NULL` argument, so the query itself
+guarantees a usable value. This is especially important for nullable numeric
+columns and for aggregates that may run over empty groups.
+
+```python
+from sqlmodel import select, func
+
+with rx.session() as session:
+    total = session.exec(select(func.coalesce(func.sum(Order.amount), 0.0))).one()
+```
+
+The same works in raw SQL: `SELECT COALESCE(SUM(amount), 0) FROM ...`.
+
+### Guard in Python
+
+When consuming rows that may contain `NULL`s, fall back explicitly while
+building the values:
+
+```python
+orders = [
+    {
+        "status": str(row[0] or ""),
+        "amount": float(row[1]) if row[1] is not None else 0.0,
+    }
+    for row in rows
+]
+```
+
 ## Async Database Operations
 
 Reflex provides an async version of the session function called `rx.asession` for asynchronous database operations. This is useful when you need to perform database operations in an async context, such as within async event handlers.

--- a/docs/database/queries.md
+++ b/docs/database/queries.md
@@ -192,7 +192,7 @@ class State(rx.State):
 
 ## Writing Efficient Queries
 
-The database is much better at filtering, joining, and aggregating than Python.
+Databases are generally much better at filtering, joining, and aggregating than Python.
 Every row returned by a query is sent over the network and held in memory as
 part of the state — for every user with an open session. Do the work in the
 query itself and return only display-ready results.
@@ -272,16 +272,16 @@ Fetch everything in one statement with a `JOIN`, an `IN (...)` list, or
 `GROUP BY`.
 
 ```python
-# Inefficient: one query per user (N+1).
-with rx.session() as session:
-    for user in users:
-        orders = session.exec(Order.select().where(Order.user_id == user.id)).all()
-
 # Efficient: one query for all users at once.
 with rx.session() as session:
     orders = session.exec(
         Order.select().where(Order.user_id.in_([user.id for user in users]))
     ).all()
+
+# Inefficient: one query per user (N+1).
+with rx.session() as session:
+    for user in users:
+        orders = session.exec(Order.select().where(Order.user_id == user.id)).all()
 ```
 
 The `.in_()` method binds each value as a separate query parameter, so it is

--- a/docs/database/queries.md
+++ b/docs/database/queries.md
@@ -38,7 +38,7 @@ class QueryUser(rx.State):
     def get_users(self):
         with rx.session() as session:
             self.users = session.exec(
-                User.select().where(User.username.contains(self.name))
+                select(User).where(User.username.contains(self.name))
             ).all()
 ```
 
@@ -76,7 +76,7 @@ class ChangeEmail(rx.State):
     def modify_user(self):
         with rx.session() as session:
             user = session.exec(
-                User.select().where((User.username == self.username))
+                select(User).where((User.username == self.username))
             ).first()
             user.email = self.email
             session.add(user)
@@ -96,7 +96,7 @@ class RemoveUser(rx.State):
     def delete_user(self):
         with rx.session() as session:
             user = session.exec(
-                User.select().where(User.username == self.username)
+                select(User).where(User.username == self.username)
             ).first()
             session.delete(user)
             session.commit()
@@ -275,18 +275,24 @@ Fetch everything in one statement with a `JOIN`, an `IN (...)` list, or
 # Efficient: one query for all users at once.
 with rx.session() as session:
     orders = session.exec(
-        Order.select().where(Order.user_id.in_([user.id for user in users]))
+        select(Order).where(Order.user_id.in_([user.id for user in users]))
     ).all()
 
 # Inefficient: one query per user (N+1).
 with rx.session() as session:
     for user in users:
-        orders = session.exec(Order.select().where(Order.user_id == user.id)).all()
+        orders = session.exec(select(Order).where(Order.user_id == user.id)).all()
 ```
 
 The `.in_()` method binds each value as a separate query parameter, so it is
-safe to use with user-provided values. In raw SQL, use an *expanding* bind
-parameter for the same effect — never join the values into the SQL string:
+safe to use with user-provided values.
+
+```md alert info
+# Raw SQL: pass lists with an expanding bind parameter
+In raw SQL, use an *expanding* bind parameter for an `IN` list — never join the values into the SQL string, which exposes the query to SQL injection.
+```
+
+The example below binds the list with an expanding parameter:
 
 ```python
 import sqlalchemy
@@ -410,7 +416,7 @@ class AsyncUserState(rx.State):
     @rx.event(background=True)
     async def get_users_async(self):
         async with rx.asession() as asession:
-            result = await asession.execute(User.select())
+            result = await asession.execute(select(User))
             async with self:
                 self.users = result.all()
 ```
@@ -427,7 +433,7 @@ class AsyncQueryUser(rx.State):
     @rx.event(background=True)
     async def get_users(self):
         async with rx.asession() as asession:
-            stmt = User.select().where(User.username.contains(self.name))
+            stmt = select(User).where(User.username.contains(self.name))
             result = await asession.execute(stmt)
             async with self:
                 self.users = result.all()
@@ -461,7 +467,7 @@ class AsyncChangeEmail(rx.State):
     @rx.event(background=True)
     async def modify_user(self):
         async with rx.asession() as asession:
-            stmt = User.select().where(User.username == self.username)
+            stmt = select(User).where(User.username == self.username)
             result = await asession.execute(stmt)
             user = result.first()
             if user:
@@ -481,7 +487,7 @@ class AsyncRemoveUser(rx.State):
     @rx.event(background=True)
     async def delete_user(self):
         async with rx.asession() as asession:
-            stmt = User.select().where(User.username == self.username)
+            stmt = select(User).where(User.username == self.username)
             result = await asession.execute(stmt)
             user = result.first()
             if user:

--- a/docs/database/relationships.md
+++ b/docs/database/relationships.md
@@ -44,7 +44,7 @@ class User(rx.Model, table=True):
 
 
 class Flag(rx.Model, table=True):
-    post_id: int = sqlmodel.Field(foreign_key="post.id")
+    post_id: int = sqlmodel.Field(foreign_key="post.id", index=True)
     user_id: int = sqlmodel.Field(foreign_key="user.id")
     message: str
 
@@ -194,7 +194,9 @@ class PostFlagsState(rx.State):
 ```
 
 This runs a single indexed query per selection and avoids holding every child
-row in state. Avoid the inverse pattern of querying children in a Python loop
+row in state — the `index=True` on `Flag.post_id` keeps the foreign-key lookup
+off a full table scan (adding the index to an existing table requires a
+migration). Avoid the inverse pattern of querying children in a Python loop
 over parents (the "N+1" pattern) — when the children of many parents are
 needed at once, use one query with `.in_()` on the foreign key, or one of the
 eager loading options above.

--- a/docs/database/relationships.md
+++ b/docs/database/relationships.md
@@ -160,3 +160,42 @@ class Post(rx.Model, table=True):
         sa_relationship_kwargs={"lazy": "selectin"},
     )
 ```
+
+### Querying Related Rows on Demand
+
+For master-detail interfaces — a table of parent rows where selecting a row
+reveals its related rows — it is not necessary to eager load every
+relationship up front. Store the selected id in state and query only the
+related rows for that selection, filtering on the foreign key.
+
+```python
+class PostFlagsState(rx.State):
+    posts: List[Post] = []
+    selected_post_id: Optional[int] = None
+    selected_flags: List[Flag] = []
+
+    @rx.event
+    def load_posts(self):
+        with rx.session() as session:
+            self.posts = session.exec(Post.select().limit(15)).all()
+
+    @rx.event
+    def select_post(self, post_id: int):
+        self.selected_post_id = post_id
+        with rx.session() as session:
+            self.selected_flags = session.exec(
+                Flag.select().where(Flag.post_id == post_id)
+            ).all()
+```
+
+This runs a single indexed query per selection and avoids holding every child
+row in state. Avoid the inverse pattern of querying children in a Python loop
+over parents (the "N+1" pattern) — when the children of many parents are
+needed at once, use one query with `.in_()` on the foreign key, or one of the
+eager loading options above.
+
+```python
+post_ids = [post.id for post in self.posts]
+with rx.session() as session:
+    flags = session.exec(Flag.select().where(Flag.post_id.in_(post_ids))).all()
+```

--- a/docs/database/relationships.md
+++ b/docs/database/relationships.md
@@ -169,6 +169,11 @@ relationship up front. Store the selected id in state and query only the
 related rows for that selection, filtering on the foreign key.
 
 ```python
+from typing import List, Optional
+
+import reflex as rx
+
+
 class PostFlagsState(rx.State):
     posts: List[Post] = []
     selected_post_id: Optional[int] = None

--- a/docs/database/relationships.md
+++ b/docs/database/relationships.md
@@ -172,6 +172,7 @@ related rows for that selection, filtering on the foreign key.
 from typing import List, Optional
 
 import reflex as rx
+from sqlmodel import select
 
 
 class PostFlagsState(rx.State):
@@ -182,14 +183,14 @@ class PostFlagsState(rx.State):
     @rx.event
     def load_posts(self):
         with rx.session() as session:
-            self.posts = session.exec(Post.select().limit(15)).all()
+            self.posts = session.exec(select(Post).limit(15)).all()
 
     @rx.event
     def select_post(self, post_id: int):
         self.selected_post_id = post_id
         with rx.session() as session:
             self.selected_flags = session.exec(
-                Flag.select().where(Flag.post_id == post_id)
+                select(Flag).where(Flag.post_id == post_id)
             ).all()
 ```
 
@@ -204,5 +205,5 @@ eager loading options above.
 ```python
 post_ids = [post.id for post in self.posts]
 with rx.session() as session:
-    flags = session.exec(Flag.select().where(Flag.post_id.in_(post_ids))).all()
+    flags = session.exec(select(Flag).where(Flag.post_id.in_(post_ids))).all()
 ```

--- a/docs/library/tables-and-data-grids/table.md
+++ b/docs/library/tables-and-data-grids/table.md
@@ -188,6 +188,7 @@ rx.table.root(
 
 ```md alert info
 # Set the table `width` to fit within its container and prevent it from overflowing.
+If the table has too many columns to fit, wrap the `rx.table.root` in a container with `overflow_x="auto"` (e.g. `rx.box(rx.table.root(...), overflow_x="auto", width="100%")`) so the table scrolls horizontally inside the container instead of stretching the page.
 ```
 
 ## Showing State data (using foreach)
@@ -342,7 +343,7 @@ def database_table_example():
         ),
         rx.input(
             placeholder="Search here...",
-            on_change=lambda value: DatabaseTableState.filter_values(value),
+            on_change=DatabaseTableState.filter_values.debounce(500),
         ),
         rx.table.root(
             rx.table.header(
@@ -607,6 +608,11 @@ For filtering the `rx.input` component is used. The data is filtered based on th
 
 The `%` character before and after `search_value` makes it a wildcard pattern that matches any sequence of characters before or after the `search_value`. `query.where(...)` modifies the existing query to include a filtering condition. The `or_` operator is a logical OR operator that combines multiple conditions. The query will return results that match any of these conditions. `Customer.name.ilike(search_value)` checks if the `name` column of the `Customer` table matches the `search_value` pattern in a case-insensitive manner (`ilike` stands for "case-insensitive like").
 
+```md alert info
+# Debounce the search input
+`on_change` fires on every keystroke, and each event here runs a database query. Chaining `.debounce(500)` on the event handler waits until the user pauses typing for 500ms, so one query runs per search instead of one per character. See [event actions](/docs/events/event-actions) for details.
+```
+
 ```python
 class Customer(rx.Model, table=True):
     """The customer model."""
@@ -712,7 +718,7 @@ def loading_data_table_example_2():
         ),
         rx.input(
             placeholder="Search here...",
-            on_change=lambda value: DatabaseTableState2.filter_values(value),
+            on_change=DatabaseTableState2.filter_values.debounce(500),
         ),
         rx.table.root(
             rx.table.header(
@@ -802,7 +808,7 @@ def loading_data_table_example2():
         ),
         rx.input(
             placeholder="Search here...",
-            on_change=lambda value: DatabaseTableState2.filter_values(value),
+            on_change=DatabaseTableState2.filter_values.debounce(500),
         ),
         rx.table.root(
             rx.table.header(
@@ -1042,6 +1048,11 @@ def loading_data_table_example3():
         ),
         width="100%",
     )
+```
+
+```md alert info
+# Combining pagination with search and sorting
+Give each paginated table its own state vars (`offset`, `limit`, `total_items`) so multiple tables on a page paginate independently, and reset `offset` to `0` whenever the search or sort value changes — otherwise the user may be left on a page number beyond the end of the newly filtered results.
 ```
 
 ## More advanced examples

--- a/docs/library/tables-and-data-grids/table.md
+++ b/docs/library/tables-and-data-grids/table.md
@@ -1055,6 +1055,8 @@ def loading_data_table_example3():
 Give each paginated table its own state vars (`offset`, `limit`, `total_items`) so multiple tables on a page paginate independently, and reset `offset` to `0` whenever the search or sort value changes — otherwise the user may be left on a page number beyond the end of the newly filtered results.
 ```
 
+For a reusable paginated table, define it with [`ComponentState`](/docs/state-structure/component-state/): each instance automatically gets its own `offset`, `limit`, and `total_items`, so you can place several independent paginated tables on a page without hand-managing separate state vars for each.
+
 ## More advanced examples
 
 The real power of the `rx.table` comes where you are able to visualise, add and edit data live in your app. Check out these apps and code to see how this is done: app: https://customer-data-app.reflex.run code: https://github.com/reflex-dev/templates/tree/main/customer_data_app and code: https://github.com/reflex-dev/templates/tree/main/sales.


### PR DESCRIPTION
Fifth batch of upstreaming Reflex Build's AI-builder knowledge base. Database/table techniques, translated into the docs' own ORM idiom:

- **database/queries**: new "Writing Efficient Queries" section — aggregate in SQL not Python (`func.count`/`group_by`, conditional aggregation with `case`), avoid N+1 with `.in_()` (plus a raw-SQL `expanding=True` bindparam alternative), return only what the UI needs (column selection, LIMIT, load-once options, don't cache whole tables in per-user state); new "Handling NULL Values" section (`func.coalesce`, Python-side guards)
- **database/relationships**: "Querying Related Rows on Demand" — master-detail selection querying children by FK instead of eager-loading everything
- **tables-and-data-grids/table**: `overflow_x` container guidance, per-table pagination state (reset offset on filter change), debounced search inputs (`.debounce(500)`) with a per-keystroke-query warning

Flexgen-environment rules (raw-SQL-only mandates, schema conventions) were deliberately not upstreamed. Pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)