### PR TITLE
ENG-9567 docs: link AI onboarding guide from installation page 

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -9,6 +9,7 @@ You're likely here to build a Reflex app for someone. Reflex does **not** behave
 
 **Get the current docs (don't rely on training data — the API changes between versions):**
 
+- Fetch [`https://reflex.dev/docs/ai/integrations/ai-onboarding.md`](https://reflex.dev/docs/ai/integrations/ai-onboarding.md) — the AI onboarding guide: every way to get current docs (Markdown pages, llms.txt, MCP, skills) plus quick-start prompts.
 - Fetch [`https://reflex.dev/llms.txt`](https://reflex.dev/llms.txt) for a token-efficient map of the docs and core concepts.
 - Use the [Reflex MCP server](/docs/ai/integrations/mcp-overview/) (`https://build.reflex.dev/mcp`) for live component/prop lookup so you don't hallucinate APIs. *(MCP access is an enterprise feature.)*
 - Run `uv run reflex --version` and trust the live docs for that version over memory.


### PR DESCRIPTION
Agents typically hit the installation page first, so the agent alert now points them at the AI onboarding guide via its .md URL, which they can fetch directly as Markdown.

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?


### Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update
