### PR TITLE
Process persisted package json before web sync

### DIFF
--- a/news/6765.bugfix.md
+++ b/news/6765.bugfix.md
@@ -1,0 +1,1 @@
+Process persisted package.json files before mirroring them into the web directory.

--- a/reflex/utils/frontend_skeleton.py
+++ b/reflex/utils/frontend_skeleton.py
@@ -368,6 +368,7 @@ def sync_root_package_json_to_web() -> bool:
         return False
 
     changed = output_path.exists()
+    path_ops.mkdir(output_path.parent)
     output_path.write_text(rendered)
     return changed
 

--- a/reflex/utils/frontend_skeleton.py
+++ b/reflex/utils/frontend_skeleton.py
@@ -345,6 +345,33 @@ def sync_root_lockfile_to_web(filename: str, prune: bool = True) -> bool:
     )
 
 
+def sync_root_package_json_to_web() -> bool:
+    """Render the persisted root package.json into ``.web``.
+
+    ``package.json`` is not a plain lockfile: Reflex owns required fields such
+    as the dev/build scripts, while the persisted root copy carries dependency
+    pins and user-added metadata. Re-render it instead of byte-copying so a
+    damaged root copy cannot remove required framework entries from ``.web``.
+
+    Returns:
+        True if an existing ``.web/package.json`` was meaningfully changed.
+        Initial creation does not count as a meaningful change since no install
+        cache could exist yet.
+    """
+    root_package_json_path = get_root_lockfile_path(constants.PackageJson.PATH)
+    if not root_package_json_path.exists():
+        return sync_root_lockfile_to_web(constants.PackageJson.PATH, prune=False)
+
+    output_path = get_web_lockfile_path(constants.PackageJson.PATH)
+    rendered = _compile_package_json()
+    if output_path.exists() and output_path.read_text() == rendered:
+        return False
+
+    changed = output_path.exists()
+    output_path.write_text(rendered)
+    return changed
+
+
 def sync_root_lockfiles_to_web() -> bool:
     """Mirror every persisted lockfile into ``.web``.
 
@@ -353,7 +380,7 @@ def sync_root_lockfiles_to_web() -> bool:
     """
     # Materialize results so every lockfile is synced
     changed = [sync_root_lockfile_to_web(name) for name in LOCKFILE_NAMES] + [
-        sync_root_lockfile_to_web(name, prune=False) for name in NO_PRUNE_LOCKFILE_NAMES
+        sync_root_package_json_to_web()
     ]
     return any(changed)
 

--- a/tests/units/test_prerequisites.py
+++ b/tests/units/test_prerequisites.py
@@ -334,6 +334,25 @@ def test_sync_root_lockfiles_to_web_keeps_web_package_json(tmp_path, monkeypatch
     assert not web_lock.exists()
 
 
+def test_sync_root_lockfiles_to_web_processes_package_json(tmp_path, monkeypatch):
+    """Persisted package.json is rendered into .web instead of byte-copied."""
+    web_dir = tmp_path / constants.Dirs.WEB
+    web_dir.mkdir()
+    _patch_web_dir(monkeypatch, web_dir)
+
+    root_pkg = tmp_path / constants.Bun.ROOT_LOCKFILE_DIR / constants.PackageJson.PATH
+    root_pkg.parent.mkdir(parents=True, exist_ok=True)
+    root_pkg.write_text(json.dumps({"dependencies": {"react": "19.2.5"}}))
+
+    with chdir(tmp_path):
+        frontend_skeleton.sync_root_lockfiles_to_web()
+
+    web_pkg = json.loads((web_dir / constants.PackageJson.PATH).read_text())
+    assert web_pkg["dependencies"] == {"react": "19.2.5"}
+    assert web_pkg["scripts"]["dev"] == constants.PackageJson.Commands.DEV
+    assert web_pkg["scripts"]["export"] == constants.PackageJson.Commands.EXPORT
+
+
 def test_install_frontend_packages_syncs_root_bun_lock(
     install_packages_env: InstallPackagesEnv,
 ):
@@ -905,6 +924,26 @@ def test_install_frontend_packages_persists_package_json_to_root(
     assert env.root_package_json.read_text() == (
         '{"name": "reflex", "dependencies": {}}'
     )
+
+
+def test_install_frontend_packages_repairs_missing_package_json_scripts(
+    install_packages_env: InstallPackagesEnv,
+):
+    """A damaged persisted package.json is repaired before it reaches .web."""
+    env = install_packages_env
+    env.root_package_json.write_text(json.dumps({}))
+    calls = _record_calls(env)
+
+    env.install()
+
+    web_package_json = json.loads(env.web_package_json.read_text())
+    root_package_json = json.loads(env.root_package_json.read_text())
+    assert web_package_json["scripts"]["dev"] == constants.PackageJson.Commands.DEV
+    assert (
+        web_package_json["scripts"]["export"] == constants.PackageJson.Commands.EXPORT
+    )
+    assert root_package_json == web_package_json
+    assert calls == []
 
 
 def test_compile_package_json_recovers_dependencies(tmp_path, monkeypatch):


### PR DESCRIPTION
  ## Summary

  Fixes #6765.

  This updates the root lockfile sync path so `package.json` is processed before being mirrored into `.web/`.

  Previously, a stale or corrupted `reflex.lock/package.json` could be copied directly into `.web/package.json`, which
  could drop Reflex-managed scripts like `dev` and `export`.

  ## Changes

  - Add a dedicated package.json sync helper instead of treating it like a raw lockfile.
  - Re-render persisted package.json content through Reflex’s package JSON compiler.
  - Preserve the existing `.web/package.json` when no root persisted package.json exists.
  - Add regression coverage for both direct sync and frontend install repair behavior.
