### PR TITLE
Handle AwaitingApproval status in watch_deployment_status

### DIFF
--- a/packages/reflex-hosting-cli/news/6797.feature.md
+++ b/packages/reflex-hosting-cli/news/6797.feature.md
@@ -1,0 +1,1 @@
+When a deployment requires approval, `reflex deploy` now reports that the build was submitted for approval and will deploy automatically once approved, instead of polling indefinitely.

--- a/packages/reflex-hosting-cli/src/reflex_cli/utils/hosting.py
+++ b/packages/reflex-hosting-cli/src/reflex_cli/utils/hosting.py
@@ -1993,6 +1993,11 @@ def watch_deployment_status(deployment_id: str, client: AuthenticatedClient) -> 
             if "completed successfully" in status:
                 console.success(status)
                 break
+            if "AwaitingApproval" in status:
+                console.success(
+                    "build submitted for approval; it will deploy automatically once an approver approves it."
+                )
+                break
             if "build error" in status:
                 console.warn(status)
                 console.warn(
@@ -2008,10 +2013,9 @@ def watch_deployment_status(deployment_id: str, client: AuthenticatedClient) -> 
             if "bad response" in status:
                 console.warn(status)
                 return True
-            if status == current_status:
-                continue
-            current_status = status
-            console.info(status)
+            if status != current_status:
+                current_status = status
+                console.info(status)
             time.sleep(0.5)
     return True
 


### PR DESCRIPTION
## What

When watching a hosting deployment, handle the `AwaitingApproval` status: report that the build was submitted for approval (and will deploy automatically once approved) and stop watching, rather than looping indefinitely.

Also simplifies the status-change loop to only log when the status actually changes.

## Why

Deployments that require approval previously never reached a terminal state in `watch_deployment_status`, so the CLI would keep polling with no useful feedback.