### PR TITLE
Bypass f-string tag round-trip for var operation operands

### DIFF
--- a/packages/reflex-base/news/6747.performance.md
+++ b/packages/reflex-base/news/6747.performance.md
@@ -1,0 +1,1 @@
+`@var_operation` operands no longer pay the f-string tag round-trip (hash + permanent `_global_vars` registration + regex decode), cutting ~30-40% of var-operation construction cost and stopping internal operations from growing the never-evicting `_global_vars` dict.

--- a/packages/reflex-base/news/6747.performance.md
+++ b/packages/reflex-base/news/6747.performance.md
@@ -1,1 +1,0 @@
-`@var_operation` operands no longer pay the f-string tag round-trip (hash + permanent `_global_vars` registration + regex decode), cutting ~30-40% of var-operation construction cost and stopping internal operations from growing the never-evicting `_global_vars` dict.

--- a/packages/reflex-base/news/6798.performance.md
+++ b/packages/reflex-base/news/6798.performance.md
@@ -1,1 +1,1 @@
-`@var_operation` no longer registers its operands in the never-evicting `_global_vars` dict (a memory leak, worst under dev hot-reload), and skipping the f-string tag round-trip makes var-operation construction ~25% faster.
+`@var_operation` no longer registers its operands in the never-evicting `_global_vars` dict (a memory leak, worst under dev hot-reload), and skipping the f-string tag round-trip makes var-operation construction ~25% faster for plain vars and ~2.6x faster for state-var operands.

--- a/packages/reflex-base/news/6798.performance.md
+++ b/packages/reflex-base/news/6798.performance.md
@@ -1,0 +1,1 @@
+`@var_operation` no longer registers its operands in the never-evicting `_global_vars` dict (a memory leak, worst under dev hot-reload), and skipping the f-string tag round-trip makes var-operation construction ~25% faster.

--- a/packages/reflex-base/src/reflex_base/vars/base.py
+++ b/packages/reflex-base/src/reflex_base/vars/base.py
@@ -935,7 +935,7 @@ class Var(Generic[VAR_TYPE], metaclass=MetaclassVar):
         # ``_args``, so the tag round-trip (and its permanent ``_global_vars``
         # entry) is pure overhead there. See ``var_operation``.
         if self.__dict__.get("_format_without_tagging"):
-            return self._js_expr
+            return str(self)
 
         hashed_var = hash(self)
 

--- a/packages/reflex-base/src/reflex_base/vars/base.py
+++ b/packages/reflex-base/src/reflex_base/vars/base.py
@@ -930,6 +930,13 @@ class Var(Generic[VAR_TYPE], metaclass=MetaclassVar):
         Returns:
             The formatted var.
         """
+        # Operands of a running ``var_operation`` body interpolate as their
+        # raw JS expression: their VarData flows through the operation's
+        # ``_args``, so the tag round-trip (and its permanent ``_global_vars``
+        # entry) is pure overhead there. See ``var_operation``.
+        if self.__dict__.get("_format_without_tagging"):
+            return self._js_expr
+
         hashed_var = hash(self)
 
         _global_vars[hashed_var] = self
@@ -1941,10 +1948,34 @@ def var_operation(  # pyright: ignore [reportInconsistentOverload]
             for key, value in kwargs.items()
         }
 
+        operands = [*args_vars.values(), *kwargs_vars.values()]
+        # Suppress f-string tagging for the operands while the body runs:
+        # their VarData reaches the operation through ``_args`` below, so the
+        # tag round-trip (hash + permanent ``_global_vars`` entry + regex
+        # decode of the return expression) is pure overhead. The suppression
+        # is ref-counted so a nested operation on the same var cannot clear
+        # an outer suppression early; vars created inside the body still tag
+        # normally and keep contributing VarData via the return expression.
+        for operand in operands:
+            operand_dict = operand.__dict__
+            operand_dict["_format_without_tagging"] = (
+                operand_dict.get("_format_without_tagging", 0) + 1
+            )
+        try:
+            return_var = func(*args_vars.values(), **kwargs_vars)  # pyright: ignore [reportCallIssue]
+        finally:
+            for operand in operands:
+                operand_dict = operand.__dict__
+                remaining = operand_dict["_format_without_tagging"] - 1
+                if remaining:
+                    operand_dict["_format_without_tagging"] = remaining
+                else:
+                    del operand_dict["_format_without_tagging"]
+
         return CustomVarOperation.create(
             name=func.__name__,
             args=tuple(list(args_vars.items()) + list(kwargs_vars.items())),
-            return_var=func(*args_vars.values(), **kwargs_vars),  # pyright: ignore [reportCallIssue, reportReturnType]
+            return_var=return_var,  # pyright: ignore [reportArgumentType]
         ).guess_type()
 
     return wrapper

--- a/packages/reflex-base/src/reflex_base/vars/base.py
+++ b/packages/reflex-base/src/reflex_base/vars/base.py
@@ -1958,7 +1958,7 @@ def var_operation(  # pyright: ignore [reportInconsistentOverload]
         # normally and keep contributing VarData via the return expression.
         for operand in operands:
             operand_dict = operand.__dict__
-            operand_dict["_format_without_tagging"] = (
+            operand_dict["_format_without_tagging"] = (  # pyright: ignore[reportIndexIssue]
                 operand_dict.get("_format_without_tagging", 0) + 1
             )
         try:
@@ -1968,9 +1968,9 @@ def var_operation(  # pyright: ignore [reportInconsistentOverload]
                 operand_dict = operand.__dict__
                 remaining = operand_dict["_format_without_tagging"] - 1
                 if remaining:
-                    operand_dict["_format_without_tagging"] = remaining
+                    operand_dict["_format_without_tagging"] = remaining  # pyright: ignore[reportIndexIssue]
                 else:
-                    del operand_dict["_format_without_tagging"]
+                    del operand_dict["_format_without_tagging"]  # pyright: ignore[reportIndexIssue]
 
         return CustomVarOperation.create(
             name=func.__name__,

--- a/packages/reflex-base/src/reflex_base/vars/base.py
+++ b/packages/reflex-base/src/reflex_base/vars/base.py
@@ -936,7 +936,7 @@ class Var(Generic[VAR_TYPE], metaclass=MetaclassVar):
         # ``_args``, so the tag round-trip (and its permanent ``_global_vars``
         # entry) is pure overhead there. See ``var_operation``.
         if self.__dict__.get("_format_without_tagging"):
-            return self._js_expr
+            return str(self)
 
         hashed_var = hash(self)
 

--- a/packages/reflex-base/src/reflex_base/vars/base.py
+++ b/packages/reflex-base/src/reflex_base/vars/base.py
@@ -16,6 +16,7 @@ import uuid
 import warnings
 from abc import ABCMeta
 from collections.abc import Callable, Coroutine, Iterable, Mapping, Sequence
+from contextvars import ContextVar
 from dataclasses import _MISSING_TYPE, MISSING
 from decimal import Decimal
 from types import CodeType, FunctionType
@@ -935,7 +936,7 @@ class Var(Generic[VAR_TYPE], metaclass=MetaclassVar):
         # raw JS expression: their VarData flows through the operation's
         # ``_args``, so the tag round-trip (and its permanent ``_global_vars``
         # entry) is pure overhead there. See ``var_operation``.
-        if self.__dict__.get("_format_without_tagging"):
+        if id(self) in _format_without_tagging.get():
             return str(self)
 
         hashed_var = hash(self)
@@ -1953,25 +1954,22 @@ def var_operation(  # pyright: ignore [reportInconsistentOverload]
         # Suppress f-string tagging for the operands while the body runs:
         # their VarData reaches the operation through ``_args`` below, so the
         # tag round-trip (hash + permanent ``_global_vars`` entry + regex
-        # decode of the return expression) is pure overhead. The suppression
-        # is ref-counted so a nested operation on the same var cannot clear
-        # an outer suppression early; vars created inside the body still tag
-        # normally and keep contributing VarData via the return expression.
-        for operand in operands:
-            operand_dict = operand.__dict__
-            operand_dict["_format_without_tagging"] = (  # pyright: ignore[reportIndexIssue]
-                operand_dict.get("_format_without_tagging", 0) + 1
-            )
+        # decode of the return expression) is pure overhead. Suppression is
+        # context-local rather than stored on the (shared, otherwise
+        # immutable) operands, so a concurrent thread or task formatting the
+        # same var still gets its tag. Restoring the previous set on exit
+        # keeps nesting correct: an inner operation cannot clear an outer
+        # one's suppression. Vars created inside the body still tag normally
+        # and keep contributing VarData via the return expression.
+        token = _format_without_tagging.set(
+            _format_without_tagging.get().union(map(id, operands))
+        )
+        # ``operands`` stays referenced for the whole body, so no unrelated
+        # var can reuse a suppressed id() while the suppression is active.
         try:
             return_var = func(*args_vars.values(), **kwargs_vars)  # pyright: ignore [reportCallIssue]
         finally:
-            for operand in operands:
-                operand_dict = operand.__dict__
-                remaining = operand_dict["_format_without_tagging"] - 1
-                if remaining:
-                    operand_dict["_format_without_tagging"] = remaining  # pyright: ignore[reportIndexIssue]
-                else:
-                    del operand_dict["_format_without_tagging"]  # pyright: ignore[reportIndexIssue]
+            _format_without_tagging.reset(token)
 
         return CustomVarOperation.create(
             name=func.__name__,
@@ -3379,6 +3377,14 @@ _decode_var_pattern = re.compile(_decode_var_pattern_re, flags=re.DOTALL)
 
 # Defined global immutable vars.
 _global_vars: dict[int, Var] = {}
+
+# ``id()`` of the vars whose ``__format__`` should skip the tag round-trip,
+# for the duration of the ``var_operation`` body that owns them. Context-local
+# so suppression never leaks to another thread or task formatting the same
+# shared var. See ``Var.__format__`` and ``var_operation``.
+_format_without_tagging: ContextVar[frozenset[int]] = ContextVar(
+    "_format_without_tagging", default=frozenset()
+)
 
 
 dispatchers: dict[GenericType, Callable[[Var], Var]] = {}

--- a/packages/reflex-base/src/reflex_base/vars/base.py
+++ b/packages/reflex-base/src/reflex_base/vars/base.py
@@ -1959,7 +1959,7 @@ def var_operation(  # pyright: ignore [reportInconsistentOverload]
         # normally and keep contributing VarData via the return expression.
         for operand in operands:
             operand_dict = operand.__dict__
-            operand_dict["_format_without_tagging"] = (
+            operand_dict["_format_without_tagging"] = (  # pyright: ignore[reportIndexIssue]
                 operand_dict.get("_format_without_tagging", 0) + 1
             )
         try:
@@ -1969,9 +1969,9 @@ def var_operation(  # pyright: ignore [reportInconsistentOverload]
                 operand_dict = operand.__dict__
                 remaining = operand_dict["_format_without_tagging"] - 1
                 if remaining:
-                    operand_dict["_format_without_tagging"] = remaining
+                    operand_dict["_format_without_tagging"] = remaining  # pyright: ignore[reportIndexIssue]
                 else:
-                    del operand_dict["_format_without_tagging"]
+                    del operand_dict["_format_without_tagging"]  # pyright: ignore[reportIndexIssue]
 
         return CustomVarOperation.create(
             name=func.__name__,

--- a/packages/reflex-base/src/reflex_base/vars/base.py
+++ b/packages/reflex-base/src/reflex_base/vars/base.py
@@ -931,6 +931,13 @@ class Var(Generic[VAR_TYPE], metaclass=MetaclassVar):
         Returns:
             The formatted var.
         """
+        # Operands of a running ``var_operation`` body interpolate as their
+        # raw JS expression: their VarData flows through the operation's
+        # ``_args``, so the tag round-trip (and its permanent ``_global_vars``
+        # entry) is pure overhead there. See ``var_operation``.
+        if self.__dict__.get("_format_without_tagging"):
+            return self._js_expr
+
         hashed_var = hash(self)
 
         _global_vars[hashed_var] = self
@@ -1942,10 +1949,34 @@ def var_operation(  # pyright: ignore [reportInconsistentOverload]
             for key, value in kwargs.items()
         }
 
+        operands = [*args_vars.values(), *kwargs_vars.values()]
+        # Suppress f-string tagging for the operands while the body runs:
+        # their VarData reaches the operation through ``_args`` below, so the
+        # tag round-trip (hash + permanent ``_global_vars`` entry + regex
+        # decode of the return expression) is pure overhead. The suppression
+        # is ref-counted so a nested operation on the same var cannot clear
+        # an outer suppression early; vars created inside the body still tag
+        # normally and keep contributing VarData via the return expression.
+        for operand in operands:
+            operand_dict = operand.__dict__
+            operand_dict["_format_without_tagging"] = (
+                operand_dict.get("_format_without_tagging", 0) + 1
+            )
+        try:
+            return_var = func(*args_vars.values(), **kwargs_vars)  # pyright: ignore [reportCallIssue]
+        finally:
+            for operand in operands:
+                operand_dict = operand.__dict__
+                remaining = operand_dict["_format_without_tagging"] - 1
+                if remaining:
+                    operand_dict["_format_without_tagging"] = remaining
+                else:
+                    del operand_dict["_format_without_tagging"]
+
         return CustomVarOperation.create(
             name=func.__name__,
             args=tuple(list(args_vars.items()) + list(kwargs_vars.items())),
-            return_var=func(*args_vars.values(), **kwargs_vars),  # pyright: ignore [reportCallIssue, reportReturnType]
+            return_var=return_var,  # pyright: ignore [reportArgumentType]
         ).guess_type()
 
     return wrapper

--- a/tests/units/vars/test_base.py
+++ b/tests/units/vars/test_base.py
@@ -1,7 +1,16 @@
 from collections.abc import Mapping, Sequence
 
 import pytest
-from reflex_base.vars.base import computed_var, figure_out_type
+from reflex_base.utils.imports import ImportVar
+from reflex_base.vars.base import (
+    Var,
+    VarData,
+    _global_vars,
+    computed_var,
+    figure_out_type,
+    var_operation,
+    var_operation_return,
+)
 
 from reflex.state import State
 
@@ -64,6 +73,64 @@ def test_var_subclass_registration_invalidates_lookup_caches() -> None:
     assert isinstance(
         Var(_js_expr="a", _var_type=FancyTestStr).guess_type(), FancyTestStrVar
     )
+
+
+def test_var_operation_does_not_register_global_vars() -> None:
+    """Internal var operations bypass the f-string tag round-trip.
+
+    Regression: each operand interpolation hashed the var and permanently
+    registered it in the module-global ``_global_vars`` (a memory leak,
+    worst under hot-reload), then the return expression regex-decoded the
+    tag back out. Operand VarData already flows through
+    ``CustomVarOperation._args``.
+    """
+    lhs = Var(
+        _js_expr="tag_bypass_lhs",
+        _var_data=VarData(imports={"op-lib": [ImportVar(tag="thing")]}),
+    ).to(int)
+
+    before = len(_global_vars)
+    result = lhs + 1
+    assert len(_global_vars) == before
+
+    # The suppression flag does not persist on the operand after the op.
+    assert "_format_without_tagging" not in lhs.__dict__
+
+    # Operand VarData still reaches the merged operation VarData via _args.
+    var_data = result._get_all_var_data()
+    assert var_data is not None
+    assert dict(var_data.imports)["op-lib"] == (ImportVar(tag="thing"),)
+    assert str(result) == "(tag_bypass_lhs + 1)"
+
+    # Formatting outside an operation still registers (and tags) as before.
+    formatted = f"{lhs}"
+    assert len(_global_vars) == before + 1
+    assert formatted != str(lhs)
+
+
+def test_var_operation_body_created_vars_keep_var_data() -> None:
+    """Vars created inside an operation body still contribute their VarData.
+
+    Only the operands bypass tagging; a var constructed inside the body is
+    not carried by ``_args``, so it must keep flowing through the tagged
+    return expression.
+    """
+    from reflex_base.vars.number import NumberVar
+
+    @var_operation
+    def op_with_derived(value: NumberVar):
+        derived = Var(
+            _js_expr="derivedHelper",
+            _var_data=VarData(imports={"derived-lib": [ImportVar(tag="helper")]}),
+        )
+        return var_operation_return(f"({value} + {derived})", var_type=int)
+
+    result = op_with_derived(Var(_js_expr="a").to(int))
+
+    var_data = result._get_all_var_data()
+    assert var_data is not None
+    assert dict(var_data.imports)["derived-lib"] == (ImportVar(tag="helper"),)
+    assert str(result) == "(a + derivedHelper)"
 
 
 def test_computed_var_replace() -> None:

--- a/tests/units/vars/test_base.py
+++ b/tests/units/vars/test_base.py
@@ -1,10 +1,13 @@
+import threading
 from collections.abc import Mapping, Sequence
 
 import pytest
+from reflex_base import constants
 from reflex_base.utils.imports import ImportVar
 from reflex_base.vars.base import (
     Var,
     VarData,
+    _format_without_tagging,
     _global_vars,
     computed_var,
     figure_out_type,
@@ -93,8 +96,10 @@ def test_var_operation_does_not_register_global_vars() -> None:
     result = lhs + 1
     assert len(_global_vars) == before
 
-    # The suppression flag does not persist on the operand after the op.
+    # The suppression does not persist after the op, and never mutates the
+    # (shared, otherwise immutable) operand.
     assert "_format_without_tagging" not in lhs.__dict__
+    assert not _format_without_tagging.get()
 
     # Operand VarData still reaches the merged operation VarData via _args.
     var_data = result._get_all_var_data()
@@ -106,6 +111,51 @@ def test_var_operation_does_not_register_global_vars() -> None:
     formatted = f"{lhs}"
     assert len(_global_vars) == before + 1
     assert formatted != str(lhs)
+
+
+def test_var_operation_tag_suppression_is_context_local() -> None:
+    """Suppression never leaks to another thread formatting the same var.
+
+    The operands of a running operation are shared, otherwise immutable
+    objects; suppressing their tag process-wide would make a concurrent
+    ``f"{var}"`` return an untagged expression and silently drop the
+    imports/hooks that the tag carries.
+    """
+    shared = Var(
+        _js_expr="ctx_local_operand",
+        _var_data=VarData(imports={"op-lib": [ImportVar(tag="thing")]}),
+    ).to(int)
+
+    other_thread_result: list[str] = []
+    other_thread_ran = threading.Event()
+    release_body = threading.Event()
+
+    def format_in_other_thread():
+        other_thread_ran.wait(timeout=5)
+        other_thread_result.append(f"{shared}")
+        release_body.set()
+
+    worker = threading.Thread(target=format_in_other_thread)
+    worker.start()
+
+    @var_operation
+    def op_with_concurrent_format(value: Var[int]):
+        # While this body runs, `value` is suppressed in *this* context only.
+        assert id(value) in _format_without_tagging.get()
+        other_thread_ran.set()
+        release_body.wait(timeout=5)
+        return var_operation_return(js_expression=f"({value} + 1)", var_type=int)
+
+    try:
+        op_with_concurrent_format(shared)
+    finally:
+        worker.join(timeout=5)
+
+    assert other_thread_result, "concurrent formatting thread did not run"
+    # The other thread got a real tag, not the raw expression.
+    assert other_thread_result[0] != str(shared)
+    assert constants.REFLEX_VAR_OPENING_TAG in other_thread_result[0]
+    assert not _format_without_tagging.get()
 
 
 def test_var_operation_body_created_vars_keep_var_data() -> None:


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

- [x] Memory-leak fix + micro-level performance improvement (non-breaking change, identical rendered output)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?

## What this does

Interpolating a `Var` into an f-string (`Var.__format__`) hashes the var, **permanently registers it in the module-global `_global_vars` dict** (which never evicts — a real memory leak, worst under dev hot-reload since entries and their `GLOBAL_CACHE` values survive GC), and emits a `<reflex-var>` tag that the constructed expression's `__post_init__` then regex-decodes back out. Every `@var_operation` (all arithmetic, comparisons, string/array/object ops) pays this round-trip for each operand — and for operands it is pure overhead, because their `VarData` already reaches the operation through `CustomVarOperation._args`.

### Fix

`var_operation` suppresses tagging for its operand vars while the body runs, and `Var.__format__` returns the raw JS expression for a suppressed var:

- the suppression is a **context-local** set of operand `id()`s (a `ContextVar[frozenset[int]]`), never state on the shared, otherwise immutable operand, so a concurrent thread or task formatting the same var still gets its tag;
- the wrapper sets the union of the outer set and its own operands and restores the previous set in a `finally`, so a nested operation cannot clear an outer one's suppression;
- the operand list stays referenced for the whole body, so no unrelated var can reuse a suppressed `id()` while the suppression is active;
- vars created *inside* an operation body are not operands and still tag normally, so their `VarData` keeps flowing through the return expression (covered by a dedicated test);
- formatting outside an operation is unchanged.

## Measured results

**Memory leak (the primary win).** Constructing 1000 operations with distinct operands grows `_global_vars` by **1001 entries before this change, 0 after**. This growth is unbounded over the life of the process and invisible to CodSpeed (no memory instrument on these benchmarks).

**Micro-level CPU.** Local A/B against the base commit (same machine, `timeit`, best of 5): constructing `a + b` drops from **18.17 µs/op to 13.52 µs/op (~25% faster)** for plain vars; state-var operands drop from 37.7 µs to 11.3 µs because their `VarData` hash was the dominant cost of the tag.

**Compiled output.** Compiling the same app on the base commit and on this branch produces byte-identical component bodies. Only the memoized component hash names change, because merged `VarData` now holds fewer duplicate `ImportVar` entries.

**CodSpeed benchmark suite: no measurable change.** Head vs base shows +0.1% total impact with all 27 benchmarks "Unchanged" (e.g. `test_console_log` 371.7 µs → 372.2 µs, `test_evaluate_page[_complicated_page]` 27.3 ms → 27.3 ms). The base run's flamegraph explains why: evaluate/compile time is dominated by `Component._post_init` (~61% of total), `LiteralVar._create_literal_var` (~17%), and `_isinstance` checks — var-operation construction is too thin a slice for a ~25% cut of it to move the suite. The benchmark-visible motivation for this PR is the leak fix; the CPU reduction is real but only at the micro level.

## Verification

- New unit tests: `_global_vars` does not grow when constructing an operation while operand `VarData` still reaches the merged result; the suppression does not persist after the op; suppression is context-local (a concurrent thread formatting the same var gets a tag); body-created vars keep contributing `VarData`; formatting outside an operation still registers/tags as before.

Part of a compiler-performance series; tracked in Linear as ENG-10104.
