### PR TITLE
fix(vars): carry custom Field attrs by reference, not deepcopy

### DIFF
--- a/packages/reflex-base/news/6809.bugfix.md
+++ b/packages/reflex-base/news/6809.bugfix.md
@@ -1,0 +1,1 @@
+Custom attributes on a `Field` are now carried onto the rebuilt field by reference instead of deep copy, so stateful callable markers keep their identity and markers holding non-copyable values (locks, clients) no longer crash state class creation.

--- a/packages/reflex-base/src/reflex_base/vars/base.py
+++ b/packages/reflex-base/src/reflex_base/vars/base.py
@@ -3500,8 +3500,9 @@ class Field(Generic[FIELD_TYPE]):
             default_factory: The default factory for the field.
             is_var: Whether the field is a Var.
             annotated_type: The annotated type for the field.
-            source_field: If given, deep-copy custom (non-reserved) attributes
-                from this field that the new field did not compute itself.
+            source_field: If given, carry custom (non-reserved) attributes
+                from this field that the new field did not compute itself,
+                by reference.
         """
         self.default = default
         self.default_factory = default_factory
@@ -3533,9 +3534,14 @@ class Field(Generic[FIELD_TYPE]):
         else:
             self.outer_type_ = self.annotated_type = self.type_ = self.type_origin = Any
         if source_field is not None:
+            # Carry custom attrs by reference: the source field is a throwaway
+            # namespace value replaced during class creation, and tag consumers
+            # rely on identity (deep-copying cloned stateful callable markers
+            # and crashed outright on non-copyable values like locks). This
+            # matches how _copy_fn carries a function's __dict__.
             for key, value in source_field.__dict__.items():
                 if key not in self.__dict__ and key not in _RESERVED_FIELD_ATTRS:
-                    self.__dict__[key] = copy.deepcopy(value)
+                    self.__dict__[key] = value
 
     def default_value(self) -> FIELD_TYPE:
         """Get the default value for the field.

--- a/tests/units/reflex_base/vars/test_base.py
+++ b/tests/units/reflex_base/vars/test_base.py
@@ -66,33 +66,17 @@ def test_reserved_annotation_attr_not_copied():
 
 
 def test_custom_attr_is_carried_by_reference():
-    """Custom attrs are carried onto the rebuilt Field as the same objects.
+    """Custom attrs land on the rebuilt Field as the same objects.
 
-    The source Field is a throwaway namespace value replaced during class
-    creation, so sharing is safe — and identity is what tag consumers rely on
-    (matching how ``_copy_fn`` carries a function's ``__dict__``).
-    """
-    f = field("x")
-    opts = {"a": [1]}
-    f._opts = opts  # pyright: ignore[reportAttributeAccessIssue]
-
-    class MyState(EvenMoreBasicBaseState):
-        name: str = f  # pyright: ignore[reportAssignmentType]
-
-    rebuilt = MyState.get_fields()["name"]
-    assert rebuilt._opts is opts  # pyright: ignore[reportAttributeAccessIssue]
-
-
-def test_custom_callable_attr_survives_by_identity():
-    """A callable-object custom attr is not cloned by the rebuild.
-
-    Downstream markers (e.g. auth check objects) may be stateful; the rebuilt
-    field must expose the original instance, not a copy.
+    Identity is what tag consumers rely on (e.g. stateful callable markers
+    must not run as clones), and any copy scheme would break it. The lock
+    also guards the old failure mode directly: deep-copying carried attrs
+    raised ``TypeError: cannot pickle '_thread.lock' object``.
     """
 
     class Check:
-        def __call__(self) -> bool:
-            return True
+        def __init__(self) -> None:
+            self.lock = threading.Lock()
 
     check = Check()
     f = field("x")
@@ -103,25 +87,3 @@ def test_custom_callable_attr_survives_by_identity():
 
     rebuilt = MyState.get_fields()["name"]
     assert rebuilt._check is check  # pyright: ignore[reportAttributeAccessIssue]
-
-
-def test_non_copyable_custom_attr_does_not_break_class_creation():
-    """A custom attr holding non-copyable state must not crash class creation.
-
-    Regression: deep-copying carried attrs raised ``TypeError: cannot pickle
-    '_thread.lock' object`` for markers holding locks, clients, or similar.
-    """
-
-    class Guard:
-        def __init__(self) -> None:
-            self.lock = threading.Lock()
-
-    guard = Guard()
-    f = field("x")
-    f._guard = guard  # pyright: ignore[reportAttributeAccessIssue]
-
-    class MyState(EvenMoreBasicBaseState):
-        name: str = f  # pyright: ignore[reportAssignmentType]
-
-    rebuilt = MyState.get_fields()["name"]
-    assert rebuilt._guard is guard  # pyright: ignore[reportAttributeAccessIssue]

--- a/tests/units/reflex_base/vars/test_base.py
+++ b/tests/units/reflex_base/vars/test_base.py
@@ -1,5 +1,6 @@
 """Tests for reflex_base.vars.base state metaclass field handling."""
 
+import threading
 from typing import Any
 
 from reflex_base.utils.types import get_field_type
@@ -64,8 +65,13 @@ def test_reserved_annotation_attr_not_copied():
     assert get_field_type(MyState, "name") is str
 
 
-def test_custom_mutable_attr_is_deepcopied():
-    """Mutable custom attrs are deep-copied, not shared by reference."""
+def test_custom_attr_is_carried_by_reference():
+    """Custom attrs are carried onto the rebuilt Field as the same objects.
+
+    The source Field is a throwaway namespace value replaced during class
+    creation, so sharing is safe — and identity is what tag consumers rely on
+    (matching how ``_copy_fn`` carries a function's ``__dict__``).
+    """
     f = field("x")
     opts = {"a": [1]}
     f._opts = opts  # pyright: ignore[reportAttributeAccessIssue]
@@ -74,7 +80,48 @@ def test_custom_mutable_attr_is_deepcopied():
         name: str = f  # pyright: ignore[reportAssignmentType]
 
     rebuilt = MyState.get_fields()["name"]
-    assert rebuilt._opts == {"a": [1]}  # pyright: ignore[reportAttributeAccessIssue]
-    assert rebuilt._opts is not opts  # pyright: ignore[reportAttributeAccessIssue]
-    opts["a"].append(2)
-    assert rebuilt._opts == {"a": [1]}  # pyright: ignore[reportAttributeAccessIssue]
+    assert rebuilt._opts is opts  # pyright: ignore[reportAttributeAccessIssue]
+
+
+def test_custom_callable_attr_survives_by_identity():
+    """A callable-object custom attr is not cloned by the rebuild.
+
+    Downstream markers (e.g. auth check objects) may be stateful; the rebuilt
+    field must expose the original instance, not a copy.
+    """
+
+    class Check:
+        def __call__(self) -> bool:
+            return True
+
+    check = Check()
+    f = field("x")
+    f._check = check  # pyright: ignore[reportAttributeAccessIssue]
+
+    class MyState(EvenMoreBasicBaseState):
+        name: str = f  # pyright: ignore[reportAssignmentType]
+
+    rebuilt = MyState.get_fields()["name"]
+    assert rebuilt._check is check  # pyright: ignore[reportAttributeAccessIssue]
+
+
+def test_non_copyable_custom_attr_does_not_break_class_creation():
+    """A custom attr holding non-copyable state must not crash class creation.
+
+    Regression: deep-copying carried attrs raised ``TypeError: cannot pickle
+    '_thread.lock' object`` for markers holding locks, clients, or similar.
+    """
+
+    class Guard:
+        def __init__(self) -> None:
+            self.lock = threading.Lock()
+
+    guard = Guard()
+    f = field("x")
+    f._guard = guard  # pyright: ignore[reportAttributeAccessIssue]
+
+    class MyState(EvenMoreBasicBaseState):
+        name: str = f  # pyright: ignore[reportAssignmentType]
+
+    rebuilt = MyState.get_fields()["name"]
+    assert rebuilt._guard is guard  # pyright: ignore[reportAttributeAccessIssue]


### PR DESCRIPTION
## Summary

#6726 made the state metaclass preserve custom `Field` attributes through the field rebuild, but carried them via `copy.deepcopy`. For tag consumers that regressed two supported cases:

- a stateful callable marker (e.g. an auth check object) survives the rebuild as a deep-copied **clone**, so the original instance never runs
- a marker holding non-copyable state (a lock, an HTTP client) crashes state class creation outright with `TypeError: cannot pickle '_thread.lock' object`

This carries the attrs **by reference** instead. The source `Field` is a throwaway namespace value replaced during class creation, so sharing is safe — nobody is left holding the original to mutate. It also aligns the semantics with the sister fix #6725, where `_copy_fn` carries a function's `__dict__` by reference (`newfn.__dict__.update(fn.__dict__)`): as of 0.9.7 a tag on a function survives as the same object while a tag on a `Field` survives as a clone, and this closes that inconsistency.

Concretely hit by reflex-enterprise's `rxe.field(auth=<callable check>)` (reflex-enterprise#193), which currently has to hide the check behind a holder function to dodge the deepcopy.

## Changes

- `Field.__init__` `source_field` carry-over: `copy.deepcopy(value)` → `value`
- Replaced `test_custom_mutable_attr_is_deepcopied` (which asserted the isolation semantics this PR deliberately removes) with `test_custom_attr_is_carried_by_reference`: one identity assert on a lock-holding marker object — any copy scheme breaks identity, and the lock also guards the old deepcopy crash directly

## Behavior note

A mutable custom attr is now shared between the original and rebuilt field. This only matters if one `Field` literal is reused across two state classes *and* its tag is mutated afterward — a scenario deepcopy 'protected' at the cost of the crashes above.
