### PR TITLE
Add managed GCP provider, deployment rollback, and descriptions

### DIFF
--- a/docs/app/reflex_docs/pages/docs/cloud_cliref.py
+++ b/docs/app/reflex_docs/pages/docs/cloud_cliref.py
@@ -297,7 +297,13 @@ categories = {
             "history",
             "build-logs",
             "list",
+            "rollback",
+            "describe",
         ],
+    ),
+    "providers": prefix(
+        REFLEX_CLOUD_PREFIX + " providers",
+        ["status", "list"],
     ),
     "projects": prefix(
         REFLEX_CLOUD_PREFIX + " project",

--- a/docs/app/reflex_docs/templates/docpage/sidebar/sidebar_items/learn.py
+++ b/docs/app/reflex_docs/templates/docpage/sidebar/sidebar_items/learn.py
@@ -250,6 +250,7 @@ def get_sidebar_items_hosting():
             children=[
                 hosting.self_hosting,
                 hosting.databricks,
+                hosting.cloud_providers,
                 hosting.bring_your_own_cloud,
                 hosting.deploy_to_gcp,
             ],

--- a/docs/hosting/app-management.md
+++ b/docs/hosting/app-management.md
@@ -61,3 +61,49 @@ Here there is a `Delete app` button. Pressing this button will delete the app an
 Clicking on the `Settings` tab in the Cloud UI on the app page also allows a user to change the `app name`, change the `app description` and check the `app id`.
 
 The other app settings also allows users to edit and add secrets (environment variables) to the app. For more information on secrets, see the [Secrets (Environment Variables)](/docs/hosting/secrets-environment-vars/) page.
+
+## Deployment history
+
+Every `reflex deploy` creates a new deployment. List an app's deployment history — each deployment's status, Python/Reflex versions, VM type, optional description, and whether it can be rolled back to — with:
+
+```bash
+reflex cloud apps history [APP_ID]
+```
+
+If you omit `APP_ID`, the app is resolved from the `appid` in your `cloud.yml`/`pyproject.toml`, or you can pass `--app-name`. Add `--json` for machine-readable output.
+
+## Deployment descriptions
+
+You can attach a short changelog note to a deployment so your history is easy to scan (for example, `"bump pricing page copy"`). Set it at deploy time:
+
+```bash
+reflex deploy --description "bump pricing page copy"
+```
+
+You can also set or replace the note on an existing deployment. Find the deployment id with `reflex cloud apps history`, then:
+
+```bash
+reflex cloud apps describe <DEPLOYMENT_ID> --app-id <APP_ID> --description "hotfix: revert checkout change"
+```
+
+Pass `--description ""` to clear the note. Descriptions show up in `reflex cloud apps history` and in the Cloud dashboard.
+
+```md alert info
+# CLI command to set a deployment description
+`reflex cloud apps describe [OPTIONS] DEPLOYMENT_ID --description "<note>"`
+```
+
+## Rolling back a deployment
+
+If a deploy introduces a regression, you can roll back to any previous deployment that still has a built image. A rollback redeploys that deployment's existing image — no rebuild from source — and makes it current again, demoting the currently running deployment to history.
+
+```bash
+reflex cloud apps rollback <DEPLOYMENT_ID> --app-id <APP_ID>
+```
+
+Use `reflex cloud apps history` to find rollback-eligible deployments: their `can rollback` value is `True`. A deployment can only be rolled back to on the provider whose registry holds its image, so after [switching an app's provider](/docs/hosting/cloud-providers/) the deployments built on the previous provider are no longer offered as rollback targets.
+
+```md alert info
+# CLI command to roll back
+`reflex cloud apps rollback [OPTIONS] DEPLOYMENT_ID`
+```

--- a/docs/hosting/cloud-providers.md
+++ b/docs/hosting/cloud-providers.md
@@ -1,0 +1,75 @@
+```python exec
+import reflex as rx
+```
+
+# Cloud Providers
+
+By default, `reflex deploy` runs your app on Reflex Cloud's managed infrastructure. If your organization has connected its own cloud account, you can instead deploy the same app — with the same `reflex deploy` command and the same managed lifecycle (logs, scaling, history, rollbacks) — into **your own cloud account**. Today this is supported for **Google Cloud (GCP)**, where your app runs on [Cloud Run](https://cloud.google.com/run) in your GCP project.
+
+```md alert info
+# Enterprise tier only.
+
+Deploying to a connected cloud provider is part of the **Enterprise tier** of Reflex Cloud. Contact [sales@reflex.dev](mailto:sales@reflex.dev) to upgrade.
+```
+
+```md alert warning
+# Managed vs. self-service GCP deploys
+
+This page covers the **managed** flow: an admin connects a GCP account to your organization once, and Reflex Cloud deploys into it for you using the normal `reflex deploy` command, giving you the full managed lifecycle (history, rollback, scaling, logs). This is different from the self-service [`reflex cloud deploy --gcp`](/docs/hosting/deploy-to-gcp/) command, which builds and deploys from your own machine using your local `gcloud`.
+```
+
+## Connecting Google Cloud
+
+An organization admin connects the GCP account once, from the Reflex Cloud dashboard under **Organization → Cloud Providers**. You provide a service-account key, your GCP project number, and a region; Reflex validates that the service account has the permissions needed to deploy Cloud Run services and push images to Artifact Registry before storing the (encrypted) credentials.
+
+Once connected, check availability from the CLI:
+
+```bash
+reflex cloud providers status
+```
+
+This reports whether GCP is connected, whether your plan allows GCP deploys, and the connected project and region. List all connected provider accounts with:
+
+```bash
+reflex cloud providers list
+```
+
+## Choosing a provider at deploy time
+
+When your org has GCP connected, `reflex deploy` asks where you want to deploy:
+
+```console
+$ reflex deploy
+This organization has Google Cloud connected (region us-central1).
+Where would you like to deploy? [reflex-cloud/gcp] (reflex-cloud):
+```
+
+Choose `reflex-cloud` for Reflex's managed infrastructure or `gcp` for your connected Google Cloud account. To skip the prompt (for example in CI), pass `--provider`:
+
+```bash
+reflex deploy --provider gcp
+reflex deploy --provider reflex-cloud
+```
+
+You can also pin the provider in your `cloud.yml` / `pyproject.toml` so every deploy targets the same place:
+
+```yaml
+provider: gcp
+```
+
+When you deploy to GCP, the region and machine sizing come from the connected GCP account, so `--region` and `--vmtype` are ignored.
+
+## Switching providers
+
+An app remembers its provider between deploys. You can switch it at any time by choosing a different provider on your next `reflex deploy` (or with `--provider`). Switching a **deployed** app tears down its resources on the previous provider and requires a redeploy to come back up on the new one — `reflex deploy` performs that redeploy as part of the switch. In interactive mode the CLI warns and asks for confirmation before switching a deployed app.
+
+## What runs where
+
+| | Reflex Cloud | Google Cloud (managed) |
+| --- | --- | --- |
+| Runtime | Reflex-managed | Cloud Run in your GCP project |
+| Compute billing | Reflex Cloud | Your GCP account |
+| Region / sizing | `--region` / `--vmtype` | From the connected GCP account |
+| Logs, history, rollback, scaling | ✅ | ✅ |
+
+Deployment descriptions and rollbacks work the same way on both providers — see [App management](/docs/hosting/app-management/).

--- a/docs/hosting/deploy-to-gcp.md
+++ b/docs/hosting/deploy-to-gcp.md
@@ -12,6 +12,12 @@ The `reflex cloud deploy --gcp` command deploys a Reflex app to your own [Google
 Self-deploying to GCP Cloud Run is part of the **Enterprise tier** of Reflex Cloud. The control plane will return `403` to non-Enterprise tokens, and the CLI surfaces a clear error pointing at this. Contact [sales@reflex.dev](mailto:sales@reflex.dev) to upgrade.
 ```
 
+```md alert warning
+# Self-service vs. managed GCP deploys
+
+This page covers the **self-service** `reflex cloud deploy --gcp` command, which builds and deploys from your own machine using your local `gcloud`. If you'd rather connect a GCP account to your organization once and deploy with the normal `reflex deploy` command — keeping the managed lifecycle (history, rollback, scaling, logs) — see [Cloud Providers](/docs/hosting/cloud-providers/).
+```
+
 ## Prerequisites
 
 Before running the command, install and authenticate the local tools the deploy script invokes:

--- a/news/+reflex-deploy-provider.feature.md
+++ b/news/+reflex-deploy-provider.feature.md
@@ -1,0 +1,1 @@
+`reflex deploy` now accepts `--provider` (deploy to Reflex Cloud or a GCP account connected to your organization) and `--description` (record an optional changelog note on the deployment, shown in `reflex cloud apps history`).

--- a/packages/reflex-hosting-cli/news/+deployment-descriptions.feature.md
+++ b/packages/reflex-hosting-cli/news/+deployment-descriptions.feature.md
@@ -1,0 +1,1 @@
+Added optional per-deployment descriptions (changelog notes): set one at deploy time with `reflex deploy --description "..."`, set or clear it later with `reflex cloud apps describe`, and view it in `reflex cloud apps history`.

--- a/packages/reflex-hosting-cli/news/+deployment-rollback.feature.md
+++ b/packages/reflex-hosting-cli/news/+deployment-rollback.feature.md
@@ -1,0 +1,1 @@
+Added `reflex cloud apps rollback DEPLOYMENT_ID`, which rolls an app back to a previous deployment by redeploying its already-built image without rebuilding from source. `reflex cloud apps history` now reports whether each deployment can be rolled back to.

--- a/packages/reflex-hosting-cli/news/+gcp-managed-provider.feature.md
+++ b/packages/reflex-hosting-cli/news/+gcp-managed-provider.feature.md
@@ -1,0 +1,1 @@
+Added Google Cloud (GCP) as a managed deploy target for `reflex deploy`. When your organization has a GCP account connected (Enterprise tier), `reflex deploy` asks whether to deploy to Reflex Cloud or your GCP account (or pass `--provider gcp` / set `provider: gcp` in your config to skip the prompt), and `reflex cloud providers status` / `list` report the connection state.

--- a/packages/reflex-hosting-cli/src/reflex_cli/core/config.py
+++ b/packages/reflex-hosting-cli/src/reflex_cli/core/config.py
@@ -131,6 +131,7 @@ class Config:
     packages: list[str] = dataclasses.field(default_factory=list)
     appid: str | None = dataclasses.field(default=None)
     strategy: str | None = dataclasses.field(default=None)
+    provider: str | None = dataclasses.field(default=None)
     include_db: bool = dataclasses.field(default=False)
 
     _cloud_config_path: Path | None = dataclasses.field(default=None)

--- a/packages/reflex-hosting-cli/src/reflex_cli/utils/hosting.py
+++ b/packages/reflex-hosting-cli/src/reflex_cli/utils/hosting.py
@@ -780,6 +780,7 @@ def create_app(
     client: AuthenticatedClient,
     description: str,
     project_id: str | None,
+    provider: str | None = None,
 ):
     """Create a new application.
 
@@ -788,6 +789,8 @@ def create_app(
         description: The description of the application.
         project_id: The ID of the project to associate the application with.
         client: The authenticated client
+        provider: The hosting provider to pin the app to (e.g. "gcp"). ``None``
+            keeps the Reflex Cloud default.
 
     Returns:
         dict: The created application details as a dictionary.
@@ -803,9 +806,16 @@ def create_app(
         raise ValueError("app_name should be a string")
     if not isinstance(client, AuthenticatedClient):
         raise NotAuthenticatedError("not authenticated")
+    payload: dict[str, Any] = {
+        "name": app_name,
+        "description": description,
+        "project": project_id,
+    }
+    if provider is not None:
+        payload["provider"] = provider
     response = httpx.post(
         urljoin(constants.Hosting.HOSTING_SERVICE, "/api/v1/apps/"),
-        json={"name": app_name, "description": description, "project": project_id},
+        json=payload,
         headers=authorization_header(client.token),
         timeout=constants.Hosting.TIMEOUT,
     )
@@ -815,6 +825,299 @@ def create_app(
     response.raise_for_status()
     response_json = response.json()
     return response_json
+
+
+# Hosting provider identifiers understood by the backend. "Reflex Cloud" is the
+# managed (Fly-backed) platform; "gcp" is a customer-connected GCP Cloud Run
+# target (bring-your-own-cloud, Enterprise tier).
+PROVIDER_REFLEX_CLOUD = "fly"
+PROVIDER_GCP = "gcp"
+
+# User-facing provider names accepted on the CLI, mapped to backend values.
+PROVIDER_ALIASES = {
+    "reflex-cloud": PROVIDER_REFLEX_CLOUD,
+    "reflex": PROVIDER_REFLEX_CLOUD,
+    "cloud": PROVIDER_REFLEX_CLOUD,
+    "fly": PROVIDER_REFLEX_CLOUD,
+    "gcp": PROVIDER_GCP,
+    "google": PROVIDER_GCP,
+    "google-cloud": PROVIDER_GCP,
+}
+
+
+def normalize_provider(provider: str) -> str | None:
+    """Map a user-facing provider name to the backend provider value.
+
+    Args:
+        provider: A provider name from the CLI (e.g. "reflex-cloud", "gcp").
+
+    Returns:
+        The backend provider value ("fly" or "gcp"), or None if unrecognized.
+
+    """
+    return PROVIDER_ALIASES.get(provider.strip().lower())
+
+
+def provider_display_name(provider: str | None) -> str:
+    """Return a human-facing label for a backend provider value.
+
+    Args:
+        provider: The backend provider value ("fly"/"gcp") or None.
+
+    Returns:
+        A display label, defaulting to "Reflex Cloud".
+
+    """
+    return "Google Cloud (GCP)" if provider == PROVIDER_GCP else "Reflex Cloud"
+
+
+def get_token_org_id(client: AuthenticatedClient) -> str | None:
+    """Return the organization id the caller's token is scoped to.
+
+    Args:
+        client: The authenticated client.
+
+    Returns:
+        The org id string, or None if unavailable.
+
+    """
+    org_id = client.validated_data.get("org_id")
+    return org_id if isinstance(org_id, str) and org_id else None
+
+
+def get_token_tier(client: AuthenticatedClient) -> str | None:
+    """Return the subscription tier of the caller's token org.
+
+    Args:
+        client: The authenticated client.
+
+    Returns:
+        The tier name (e.g. "Enterprise"), or None if unavailable.
+
+    """
+    tier = client.validated_data.get("tier")
+    return tier if isinstance(tier, str) and tier else None
+
+
+def get_gcp_provider_status(org_id: str, client: AuthenticatedClient) -> dict:
+    """Fetch the org's GCP deploy availability.
+
+    Args:
+        org_id: The organization id to query.
+        client: The authenticated client.
+
+    Returns:
+        A dict ``{configured, allowed, project_id, region}``: ``configured`` is
+        whether a GCP account is connected, ``allowed`` whether the org's tier
+        permits GCP deploys.
+
+    Raises:
+        NotAuthenticatedError: If the token is not valid.
+
+    """
+    import httpx
+
+    if not isinstance(client, AuthenticatedClient):
+        raise NotAuthenticatedError("not authenticated")
+    response = httpx.get(
+        urljoin(
+            constants.Hosting.HOSTING_SERVICE,
+            f"/api/v1/orgs/{org_id}/provider-accounts/gcp/status",
+        ),
+        headers=authorization_header(client.token),
+        timeout=constants.Hosting.TIMEOUT,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def gcp_deploy_available(client: AuthenticatedClient) -> dict | None:
+    """Best-effort check of whether GCP is a usable deploy target for the caller.
+
+    Never raises: it decides whether to *offer* GCP in ``reflex deploy``, so a
+    lookup failure (older backend, permissions, network) simply falls back to
+    the Reflex Cloud default rather than aborting the deploy.
+
+    Args:
+        client: The authenticated client.
+
+    Returns:
+        The GCP status dict when GCP is both configured and allowed for the
+        caller's org, otherwise None.
+
+    """
+    org_id = get_token_org_id(client)
+    if not org_id:
+        return None
+    try:
+        status = get_gcp_provider_status(org_id, client)
+    except Exception as ex:
+        console.debug(f"Unable to determine GCP availability: {ex}")
+        return None
+    if status.get("configured") and status.get("allowed"):
+        return status
+    return None
+
+
+def list_provider_accounts(org_id: str, client: AuthenticatedClient) -> list[dict]:
+    """List the cloud provider accounts connected to an organization.
+
+    Args:
+        org_id: The organization id to query.
+        client: The authenticated client.
+
+    Returns:
+        A list of ``{provider, config, created_by, created_at, updated_at}``
+        dicts (no secret material).
+
+    Raises:
+        NotAuthenticatedError: If the token is not valid.
+
+    """
+    import httpx
+
+    if not isinstance(client, AuthenticatedClient):
+        raise NotAuthenticatedError("not authenticated")
+    response = httpx.get(
+        urljoin(
+            constants.Hosting.HOSTING_SERVICE,
+            f"/api/v1/orgs/{org_id}/provider-accounts",
+        ),
+        headers=authorization_header(client.token),
+        timeout=constants.Hosting.TIMEOUT,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def set_app_provider(app_id: str, provider: str, client: AuthenticatedClient) -> str:
+    """Choose which hosting platform an app deploys to.
+
+    Switching providers on a deployed app tears down its resources on the
+    previous provider and demotes its deployments; the app must be redeployed to
+    come back up on the new provider.
+
+    Args:
+        app_id: The id of the application.
+        provider: The backend provider value ("fly" or "gcp").
+        client: The authenticated client.
+
+    Returns:
+        The provider now set on the app, or a ``"... failed: ..."`` string on
+        error.
+
+    Raises:
+        NotAuthenticatedError: If the token is not valid.
+
+    """
+    import httpx
+
+    if not isinstance(client, AuthenticatedClient):
+        raise NotAuthenticatedError("not authenticated")
+    response = httpx.post(
+        urljoin(constants.Hosting.HOSTING_SERVICE, f"/api/v1/apps/{app_id}/provider"),
+        json={"provider": provider},
+        headers=authorization_header(client.token),
+        timeout=constants.Hosting.TIMEOUT,
+    )
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as ex:
+        try:
+            ex_details = ex.response.json().get("detail")
+        except (ValueError, AttributeError):
+            ex_details = ex.response.text
+        return f"set provider failed: {ex_details}"
+    return response.json().get("provider", provider)
+
+
+def rollback_deployment(
+    app_id: str, deployment_id: str, client: AuthenticatedClient
+) -> str | None:
+    """Roll an app back to one of its previous deployments.
+
+    Redeploys the target deployment's already-built image and makes it the
+    current deployment again, without rebuilding from source.
+
+    Args:
+        app_id: The id of the application.
+        deployment_id: The id of the deployment to roll back to.
+        client: The authenticated client.
+
+    Returns:
+        None on success, or a ``"rollback failed: ..."`` string on error.
+
+    Raises:
+        NotAuthenticatedError: If the token is not valid.
+
+    """
+    import httpx
+
+    if not isinstance(client, AuthenticatedClient):
+        raise NotAuthenticatedError("not authenticated")
+    response = httpx.post(
+        urljoin(
+            constants.Hosting.HOSTING_SERVICE,
+            f"/api/v1/apps/{app_id}/deployments/{deployment_id}/rollback",
+        ),
+        headers=authorization_header(client.token),
+        timeout=constants.Hosting.TIMEOUT,
+    )
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as ex:
+        try:
+            ex_details = ex.response.json().get("detail")
+        except (ValueError, AttributeError):
+            ex_details = ex.response.text
+        return f"rollback failed: {ex_details}"
+    return None
+
+
+def update_deployment_description(
+    app_id: str,
+    deployment_id: str,
+    description: str,
+    client: AuthenticatedClient,
+) -> str | None:
+    """Set or clear the changelog note on a single deployment.
+
+    Args:
+        app_id: The id of the application.
+        deployment_id: The id of the deployment to annotate.
+        description: The note to store (empty string clears it).
+        client: The authenticated client.
+
+    Returns:
+        None on success, or a ``"update description failed: ..."`` string on
+        error.
+
+    Raises:
+        NotAuthenticatedError: If the token is not valid.
+
+    """
+    import httpx
+
+    if not isinstance(client, AuthenticatedClient):
+        raise NotAuthenticatedError("not authenticated")
+    response = httpx.post(
+        urljoin(
+            constants.Hosting.HOSTING_SERVICE,
+            f"/api/v1/apps/{app_id}/deployments/{deployment_id}/description",
+        ),
+        json={"description": description},
+        headers=authorization_header(client.token),
+        timeout=constants.Hosting.TIMEOUT,
+    )
+    try:
+        response.raise_for_status()
+    except httpx.HTTPStatusError as ex:
+        try:
+            ex_details = ex.response.json().get("detail")
+        except (ValueError, AttributeError):
+            ex_details = ex.response.text
+        return f"update description failed: {ex_details}"
+    return None
 
 
 def get_hostname(
@@ -1364,6 +1667,7 @@ def create_deployment(
     packages: list | None,
     strategy: str | None,
     app_id: str | None,
+    description: str | None = None,
 ) -> str:
     """Create a new deployment for an application.
 
@@ -1379,9 +1683,11 @@ def create_deployment(
         packages: The list of packages to install on the VM.
         strategy: The deployment strategy to use.
         app_id: The ID of the application.
+        description: An optional changelog note recorded on this deployment and
+            shown in ``reflex cloud apps history``.
 
     Returns:
-        The deployment id.git c
+        The deployment id.
 
     Raises:
         NotAuthenticatedError: If the token is not valid.
@@ -1430,6 +1736,8 @@ def create_deployment(
         payload["packages"] = json.dumps(packages)
     if strategy:
         payload["deployment_strategy"] = strategy
+    if description:
+        payload["description"] = description
 
     response = httpx.post(
         urljoin(constants.Hosting.HOSTING_SERVICE, "/api/v1/deployments"),
@@ -1824,6 +2132,8 @@ def get_app_history(app_id: str, client: AuthenticatedClient) -> list:
             "reflex version": deployment["reflex_version"],
             "vm type": deployment["vm_type"],
             "timestamp": deployment["timestamp"],
+            "description": deployment.get("description") or "",
+            "can rollback": deployment.get("can_rollback", False),
         }
         for deployment in response_json
     ]

--- a/packages/reflex-hosting-cli/src/reflex_cli/utils/hosting.py
+++ b/packages/reflex-hosting-cli/src/reflex_cli/utils/hosting.py
@@ -827,18 +827,20 @@ def create_app(
     return response_json
 
 
-# Hosting provider identifiers understood by the backend. "Reflex Cloud" is the
-# managed (Fly-backed) platform; "gcp" is a customer-connected GCP Cloud Run
-# target (bring-your-own-cloud, Enterprise tier).
+# Hosting provider identifiers understood by the backend. Reflex Cloud is the
+# managed platform (its backend wire value happens to be "fly", an
+# implementation detail kept out of user-facing names); "gcp" is a
+# customer-connected GCP Cloud Run target (bring-your-own-cloud, Enterprise tier).
 PROVIDER_REFLEX_CLOUD = "fly"
 PROVIDER_GCP = "gcp"
 
-# User-facing provider names accepted on the CLI, mapped to backend values.
+# User-facing provider names accepted on the CLI, mapped to backend values. Only
+# provider-agnostic names are exposed — the "fly" wire value is deliberately not
+# an alias so deploy scripts don't couple to how Reflex Cloud is hosted.
 PROVIDER_ALIASES = {
     "reflex-cloud": PROVIDER_REFLEX_CLOUD,
     "reflex": PROVIDER_REFLEX_CLOUD,
     "cloud": PROVIDER_REFLEX_CLOUD,
-    "fly": PROVIDER_REFLEX_CLOUD,
     "gcp": PROVIDER_GCP,
     "google": PROVIDER_GCP,
     "google-cloud": PROVIDER_GCP,
@@ -852,7 +854,8 @@ def normalize_provider(provider: str) -> str | None:
         provider: A provider name from the CLI (e.g. "reflex-cloud", "gcp").
 
     Returns:
-        The backend provider value ("fly" or "gcp"), or None if unrecognized.
+        The backend provider value (``PROVIDER_REFLEX_CLOUD`` or
+        ``PROVIDER_GCP``), or None if unrecognized.
 
     """
     return PROVIDER_ALIASES.get(provider.strip().lower())
@@ -862,7 +865,8 @@ def provider_display_name(provider: str | None) -> str:
     """Return a human-facing label for a backend provider value.
 
     Args:
-        provider: The backend provider value ("fly"/"gcp") or None.
+        provider: The backend provider value (``PROVIDER_GCP`` for GCP; anything
+            else, including None, is treated as Reflex Cloud).
 
     Returns:
         A display label, defaulting to "Reflex Cloud".
@@ -999,7 +1003,8 @@ def set_app_provider(app_id: str, provider: str, client: AuthenticatedClient) ->
 
     Args:
         app_id: The id of the application.
-        provider: The backend provider value ("fly" or "gcp").
+        provider: The backend provider value (``PROVIDER_REFLEX_CLOUD`` or
+            ``PROVIDER_GCP``).
         client: The authenticated client.
 
     Returns:

--- a/packages/reflex-hosting-cli/src/reflex_cli/v2/apps.py
+++ b/packages/reflex-hosting-cli/src/reflex_cli/v2/apps.py
@@ -204,7 +204,7 @@ def app_rollback(
                 f"Roll back to deployment {deployment_id}? The current deployment "
                 "will be replaced.",
                 choices=["y", "n"],
-                default="y",
+                default="n",
             )
             != "y"
         ):

--- a/packages/reflex-hosting-cli/src/reflex_cli/v2/apps.py
+++ b/packages/reflex-hosting-cli/src/reflex_cli/v2/apps.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import click
 
@@ -23,6 +24,54 @@ from reflex_cli.utils.exceptions import (
 @click.group()
 def apps_cli():
     """Commands for managing apps."""
+
+
+def _resolve_app_id(
+    app_id: str | None,
+    app_name: str | None,
+    client: Any,
+    interactive: bool,
+) -> str:
+    """Resolve an app id from --app-id, --app-name, or the cloud config.
+
+    Args:
+        app_id: The explicit app id, if given.
+        app_name: The app name to look up, if given.
+        client: The authenticated client.
+        interactive: Whether to interactively resolve name conflicts.
+
+    Returns:
+        The resolved app id.
+
+    Raises:
+        Exit: If no app id can be resolved.
+
+    """
+    from reflex_cli.utils import hosting
+
+    if not app_id:
+        config = hosting.read_config()
+        if config:
+            app_id = config.appid
+            if not isinstance(app_id, (str, type(None))):
+                console.error(
+                    "app_id must be a string or None. Please check your config file."
+                )
+                raise click.exceptions.Exit(1)
+
+    if app_name is not None and app_id is None:
+        result = hosting.search_app(
+            app_name=app_name,
+            project_id=None,
+            client=client,
+            interactive=interactive,
+        )
+        app_id = result.get("id") if result else None
+
+    if not app_id:
+        console.error("No valid app_id or app_name provided.")
+        raise click.exceptions.Exit(1)
+    return app_id
 
 
 @apps_cli.command(name="history")
@@ -102,6 +151,141 @@ def app_history(
             console.print_table(table, headers=headers)
         else:
             console.print(str(history))
+    except NotAuthenticatedError as err:
+        console.error("You are not authenticated. Run `reflex login` to authenticate.")
+        raise click.exceptions.Exit(1) from err
+
+
+@apps_cli.command(name="rollback")
+@click.argument("deployment_id", required=True)
+@click.option("--app-id", help="The ID of the application.")
+@click.option("--app-name", help="The name of the application.")
+@click.option("--token", help="The authentication token.")
+@click.option(
+    "--loglevel",
+    type=click.Choice([level.value for level in constants.LogLevel]),
+    default=constants.LogLevel.INFO.value,
+    help="The log level to use.",
+)
+@click.option(
+    "--interactive/--no-interactive",
+    "-i",
+    is_flag=True,
+    default=True,
+    help="Whether to use interactive mode.",
+)
+def app_rollback(
+    deployment_id: str,
+    app_id: str | None,
+    app_name: str | None,
+    token: str | None,
+    loglevel: str,
+    interactive: bool,
+):
+    """Roll an app back to a previous deployment.
+
+    Redeploys the target deployment's already-built image and makes it current
+    again, without rebuilding from source. DEPLOYMENT_ID is a past deployment
+    from `reflex cloud apps history` whose "can rollback" is True. Identify the
+    app with --app-id/--app-name or a cloud.yml/pyproject.toml appid.
+    """
+    from reflex_cli.utils import hosting
+
+    console.set_log_level(loglevel)
+    try:
+        authenticated_client = hosting.get_authenticated_client(
+            token=token, interactive=interactive
+        )
+        app_id = _resolve_app_id(app_id, app_name, authenticated_client, interactive)
+
+        if (
+            interactive
+            and console.ask(
+                f"Roll back to deployment {deployment_id}? The current deployment "
+                "will be replaced.",
+                choices=["y", "n"],
+                default="y",
+            )
+            != "y"
+        ):
+            console.info("Rollback cancelled.")
+            return
+
+        result = hosting.rollback_deployment(
+            app_id=app_id, deployment_id=deployment_id, client=authenticated_client
+        )
+        if result:
+            console.error(result)
+            raise click.exceptions.Exit(1)
+        console.success(f"Rollback to deployment {deployment_id} started.")
+        console.print(
+            "Track progress with `reflex cloud apps status` or the Reflex Cloud "
+            "dashboard."
+        )
+    except NotAuthenticatedError as err:
+        console.error("You are not authenticated. Run `reflex login` to authenticate.")
+        raise click.exceptions.Exit(1) from err
+
+
+@apps_cli.command(name="describe")
+@click.argument("deployment_id", required=True)
+@click.option(
+    "--description",
+    required=True,
+    help='The changelog note to set. Pass --description "" to clear it.',
+)
+@click.option("--app-id", help="The ID of the application.")
+@click.option("--app-name", help="The name of the application.")
+@click.option("--token", help="The authentication token.")
+@click.option(
+    "--loglevel",
+    type=click.Choice([level.value for level in constants.LogLevel]),
+    default=constants.LogLevel.INFO.value,
+    help="The log level to use.",
+)
+@click.option(
+    "--interactive/--no-interactive",
+    "-i",
+    is_flag=True,
+    default=True,
+    help="Whether to use interactive mode.",
+)
+def app_describe(
+    deployment_id: str,
+    description: str,
+    app_id: str | None,
+    app_name: str | None,
+    token: str | None,
+    loglevel: str,
+    interactive: bool,
+):
+    """Set or clear the changelog note on a past deployment.
+
+    The note is shown in `reflex cloud apps history`. Identify the app with
+    --app-id/--app-name or a cloud.yml/pyproject.toml appid.
+    """
+    from reflex_cli.utils import hosting
+
+    console.set_log_level(loglevel)
+    try:
+        authenticated_client = hosting.get_authenticated_client(
+            token=token, interactive=interactive
+        )
+        app_id = _resolve_app_id(app_id, app_name, authenticated_client, interactive)
+
+        result = hosting.update_deployment_description(
+            app_id=app_id,
+            deployment_id=deployment_id,
+            description=description,
+            client=authenticated_client,
+        )
+        if result:
+            console.error(result)
+            raise click.exceptions.Exit(1)
+        if description.strip():
+            console.success(f"Updated description for deployment {deployment_id}.")
+        else:
+            console.success(f"Cleared description for deployment {deployment_id}.")
     except NotAuthenticatedError as err:
         console.error("You are not authenticated. Run `reflex login` to authenticate.")
         raise click.exceptions.Exit(1) from err

--- a/packages/reflex-hosting-cli/src/reflex_cli/v2/apps.py
+++ b/packages/reflex-hosting-cli/src/reflex_cli/v2/apps.py
@@ -49,7 +49,19 @@ def _resolve_app_id(
     """
     from reflex_cli.utils import hosting
 
-    if not app_id:
+    # Explicit --app-id wins, then an explicit --app-name lookup, and only then
+    # the cloud.yml/pyproject appid — so passing --app-name always overrides a
+    # configured appid rather than being silently ignored.
+    if not app_id and app_name is not None:
+        result = hosting.search_app(
+            app_name=app_name,
+            project_id=None,
+            client=client,
+            interactive=interactive,
+        )
+        app_id = result.get("id") if result else None
+
+    if not app_id and app_name is None:
         config = hosting.read_config()
         if config:
             app_id = config.appid
@@ -58,15 +70,6 @@ def _resolve_app_id(
                     "app_id must be a string or None. Please check your config file."
                 )
                 raise click.exceptions.Exit(1)
-
-    if app_name is not None and app_id is None:
-        result = hosting.search_app(
-            app_name=app_name,
-            project_id=None,
-            client=client,
-            interactive=interactive,
-        )
-        app_id = result.get("id") if result else None
 
     if not app_id:
         console.error("No valid app_id or app_name provided.")
@@ -219,8 +222,8 @@ def app_rollback(
             raise click.exceptions.Exit(1)
         console.success(f"Rollback to deployment {deployment_id} started.")
         console.print(
-            "Track progress with `reflex cloud apps status` or the Reflex Cloud "
-            "dashboard."
+            f"Track progress with `reflex cloud apps status {deployment_id} "
+            "--watch` or the Reflex Cloud dashboard."
         )
     except NotAuthenticatedError as err:
         console.error("You are not authenticated. Run `reflex login` to authenticate.")

--- a/packages/reflex-hosting-cli/src/reflex_cli/v2/cli.py
+++ b/packages/reflex-hosting-cli/src/reflex_cli/v2/cli.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import contextlib
 import dataclasses
 import json
 import os
 import shutil
 import tempfile
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
 
@@ -155,6 +156,51 @@ def _resolve_deploy_provider(
         raise click.exceptions.Exit(1)
     console.info(f"Deploying to {hosting.provider_display_name(target)}.")
     return target
+
+
+@contextlib.contextmanager
+def _restore_provider_on_failure(
+    app: dict[str, Any], switched_from: str | None, client: Any
+) -> Iterator[None]:
+    """Re-pin the previous provider if the deploy fails after a switch.
+
+    Switching a deployed app to a new provider tears down its old resources up
+    front, so a failure in a later step (hostname, export, deploy creation)
+    would strand the app on the new provider. On failure, best-effort restore
+    the previous provider so its last deployment stays a valid
+    ``reflex cloud apps rollback`` target for recovery.
+
+    Args:
+        app: The resolved app dict (must contain "id" and "name").
+        switched_from: The provider to restore to, or None if no destructive
+            switch happened (nothing to undo).
+        client: The authenticated client.
+
+    Yields:
+        None.
+
+    """
+    from reflex_cli.utils import hosting
+
+    try:
+        yield
+    except BaseException:
+        if switched_from is not None:
+            label = hosting.provider_display_name(switched_from)
+            restore = hosting.set_app_provider(app["id"], switched_from, client=client)
+            if isinstance(restore, str) and restore.startswith("set provider failed"):
+                console.warn(
+                    f"Deploy failed after switching '{app['name']}' provider, and "
+                    f"restoring {label} also failed: {restore}. Check the app in "
+                    "the Reflex Cloud dashboard."
+                )
+            else:
+                console.warn(
+                    f"Deploy failed after switching provider; restored "
+                    f"'{app['name']}' to {label}. Recover its previous deployment "
+                    "with `reflex cloud apps rollback`."
+                )
+        raise
 
 
 def deploy(
@@ -434,12 +480,22 @@ def deploy(
     # Choose/confirm the hosting provider before reserving the hostname: the
     # reserved URL is baked into the exported frontend, and a GCP app resolves
     # to a *.run.app backend URL, so the provider must be pinned first.
+    previous_provider = app.get("provider")
     effective_provider = _resolve_deploy_provider(
         app=app,
         provider_arg=provider,
         interactive=interactive,
         app_was_created=app_was_created,
         client=authenticated_client,
+    )
+    # A destructive provider switch on an already-deployed app tears its old
+    # resources down; remember what to restore to if a later step fails.
+    switched_from = (
+        previous_provider
+        if not app_was_created
+        and previous_provider is not None
+        and effective_provider != previous_provider
+        else None
     )
     if effective_provider == hosting.PROVIDER_GCP:
         # GCP Cloud Run ignores Reflex Cloud regions/VM types — the region and
@@ -453,133 +509,142 @@ def deploy(
         regions = None
         vmtype = None
 
-    urls = hosting.get_hostname(
-        app_id=app["id"],
-        app_name=app["name"],
-        hostname=hostname,
-        client=authenticated_client,
-    )
-    if "error" in urls:
-        console.error(urls["error"])
-        raise click.exceptions.Exit(1)
-    server_url = os.getenv("REFLEX_OVERRIDE_BACKEND_URL") or urls["server"]  # backend
-    host_url = os.getenv("REFLEX_OVERRIDE_FRONTEND_URL") or urls["hostname"]  # frontend
-    processed_envs = hosting.process_envs(envs) if envs else None
-
-    if not app_name:
-        console.error("Please set an app name.")
-        raise click.exceptions.Exit(1)
-
-    # at this point, if project_id is None, the App should have the correct project_id and
-    # we should use that going forward to pass validation checks.
-    project_id = project_id or app.get("project_id")
-
-    validation_message = hosting.validate_deployment_args(
-        app_name=app_name,
-        app_id=app.get("id"),
-        project_id=project_id,
-        regions=regions,
-        vmtype=vmtype,
-        hostname=hostname,
-        client=authenticated_client,
-    )
-
-    if validation_message != "success":
-        console.error(validation_message)
-        raise click.exceptions.Exit(1)
-
-    if envfile:
-        try:
-            from dotenv import dotenv_values  # pyright: ignore[reportMissingImports]
-
-            processed_envs = dotenv_values(envfile)
-        except ImportError:
-            console.error(
-                """The `python-dotenv` package is required to load environment variables from a file. Run `pip install "python-dotenv>=1.0.1"`."""
-            )
-            raise click.exceptions.Exit(1) from None
-
-    # Compile the app in production mode: backend first then frontend.
-    temporary_dir = tempfile.TemporaryDirectory()
-    temporary_dir_path = Path(temporary_dir.name)
-
-    import importlib.metadata
-
-    rx_version = version.parse(importlib.metadata.version("reflex"))
-    breaking_version = version.parse("0.7.6")
-    # Try zipping backend first
-    try:
-        # Check if the reflex version is >= 0.7.6
-        if rx_version <= breaking_version:
-            export_fn(
-                str(temporary_dir_path),
-                server_url,
-                host_url,
-                False,
-                True,
-                True,
-            )  # pyright: ignore[reportCallIssue]
-        else:
-            export_fn(
-                str(temporary_dir_path),
-                server_url,
-                host_url,
-                False,
-                True,
-                include_db,
-                True,  # pyright: ignore[reportCallIssue]
-            )
-    except Exception as ex:
-        console.error(f"Unable to export due to: {ex}")
-        if temporary_dir_path.exists():
-            shutil.rmtree(temporary_dir_path)
-        raise click.exceptions.Exit(1) from ex
-
-    # Zip frontend
-    try:
-        # Check if the reflex version is >= 0.7.6
-        if rx_version <= breaking_version:
-            export_fn(str(temporary_dir_path), server_url, host_url, True, False, True)  # pyright: ignore[reportCallIssue]
-        else:
-            export_fn(
-                str(temporary_dir_path),
-                server_url,
-                host_url,
-                True,
-                False,
-                include_db,
-                True,  # pyright: ignore[reportCallIssue]
-            )
-    except ImportError as ie:
-        console.error(
-            f"Encountered ImportError, did you install all the dependencies? {ie}"
+    with _restore_provider_on_failure(app, switched_from, authenticated_client):
+        urls = hosting.get_hostname(
+            app_id=app["id"],
+            app_name=app["name"],
+            hostname=hostname,
+            client=authenticated_client,
         )
-        if temporary_dir_path.exists():
-            shutil.rmtree(temporary_dir_path)
-        raise click.exceptions.Exit(1) from ie
-    except Exception as ex:
-        console.error(f"Unable to export due to: {ex}")
-        if temporary_dir_path.exists():
-            shutil.rmtree(temporary_dir_path)
-        raise click.exceptions.Exit(1) from ex
+        if "error" in urls:
+            console.error(urls["error"])
+            raise click.exceptions.Exit(1)
+        server_url = (
+            os.getenv("REFLEX_OVERRIDE_BACKEND_URL") or urls["server"]
+        )  # backend
+        host_url = (
+            os.getenv("REFLEX_OVERRIDE_FRONTEND_URL") or urls["hostname"]
+        )  # frontend
+        processed_envs = hosting.process_envs(envs) if envs else None
 
-    result = hosting.create_deployment(
-        app_id=app.get("id"),
-        app_name=app_name,
-        project_id=project_id,
-        regions=regions,
-        zip_dir=Path(temporary_dir_path),
-        hostname=extract_domain(host_url) if hostname else None,
-        vmtype=vmtype,
-        secrets=processed_envs,
-        client=authenticated_client,
-        packages=packages,
-        strategy=strategy,
-        description=deployment_description,
-    )
-    if "failed" in result:
-        console.error(result)
-        raise click.exceptions.Exit(1)
+        if not app_name:
+            console.error("Please set an app name.")
+            raise click.exceptions.Exit(1)
+
+        # at this point, if project_id is None, the App should have the correct project_id and
+        # we should use that going forward to pass validation checks.
+        project_id = project_id or app.get("project_id")
+
+        validation_message = hosting.validate_deployment_args(
+            app_name=app_name,
+            app_id=app.get("id"),
+            project_id=project_id,
+            regions=regions,
+            vmtype=vmtype,
+            hostname=hostname,
+            client=authenticated_client,
+        )
+
+        if validation_message != "success":
+            console.error(validation_message)
+            raise click.exceptions.Exit(1)
+
+        if envfile:
+            try:
+                from dotenv import (
+                    dotenv_values,  # pyright: ignore[reportMissingImports]
+                )
+
+                processed_envs = dotenv_values(envfile)
+            except ImportError:
+                console.error(
+                    """The `python-dotenv` package is required to load environment variables from a file. Run `pip install "python-dotenv>=1.0.1"`."""
+                )
+                raise click.exceptions.Exit(1) from None
+
+        # Compile the app in production mode: backend first then frontend.
+        temporary_dir = tempfile.TemporaryDirectory()
+        temporary_dir_path = Path(temporary_dir.name)
+
+        import importlib.metadata
+
+        rx_version = version.parse(importlib.metadata.version("reflex"))
+        breaking_version = version.parse("0.7.6")
+        # Try zipping backend first
+        try:
+            # Check if the reflex version is >= 0.7.6
+            if rx_version <= breaking_version:
+                export_fn(
+                    str(temporary_dir_path),
+                    server_url,
+                    host_url,
+                    False,
+                    True,
+                    True,
+                )  # pyright: ignore[reportCallIssue]
+            else:
+                export_fn(
+                    str(temporary_dir_path),
+                    server_url,
+                    host_url,
+                    False,
+                    True,
+                    include_db,
+                    True,  # pyright: ignore[reportCallIssue]
+                )
+        except Exception as ex:
+            console.error(f"Unable to export due to: {ex}")
+            if temporary_dir_path.exists():
+                shutil.rmtree(temporary_dir_path)
+            raise click.exceptions.Exit(1) from ex
+
+        # Zip frontend
+        try:
+            # Check if the reflex version is >= 0.7.6
+            if rx_version <= breaking_version:
+                export_fn(
+                    str(temporary_dir_path), server_url, host_url, True, False, True
+                )  # pyright: ignore[reportCallIssue]
+            else:
+                export_fn(
+                    str(temporary_dir_path),
+                    server_url,
+                    host_url,
+                    True,
+                    False,
+                    include_db,
+                    True,  # pyright: ignore[reportCallIssue]
+                )
+        except ImportError as ie:
+            console.error(
+                f"Encountered ImportError, did you install all the dependencies? {ie}"
+            )
+            if temporary_dir_path.exists():
+                shutil.rmtree(temporary_dir_path)
+            raise click.exceptions.Exit(1) from ie
+        except Exception as ex:
+            console.error(f"Unable to export due to: {ex}")
+            if temporary_dir_path.exists():
+                shutil.rmtree(temporary_dir_path)
+            raise click.exceptions.Exit(1) from ex
+
+        result = hosting.create_deployment(
+            app_id=app.get("id"),
+            app_name=app_name,
+            project_id=project_id,
+            regions=regions,
+            zip_dir=Path(temporary_dir_path),
+            hostname=extract_domain(host_url) if hostname else None,
+            vmtype=vmtype,
+            secrets=processed_envs,
+            client=authenticated_client,
+            packages=packages,
+            strategy=strategy,
+            description=deployment_description,
+        )
+        if "failed" in result:
+            console.error(result)
+            raise click.exceptions.Exit(1)
     hosting_ui_url = f"{constants.Hosting.HOSTING_SERVICE_UI}/project/{app['project_id']}/app/{app['id']}/"
     console.print(
         f"deployment progress can now be viewed on the website: {hosting_ui_url}"

--- a/packages/reflex-hosting-cli/src/reflex_cli/v2/cli.py
+++ b/packages/reflex-hosting-cli/src/reflex_cli/v2/cli.py
@@ -97,8 +97,8 @@ def _resolve_deploy_provider(
         client: The authenticated client.
 
     Returns:
-        The backend provider value in effect ("fly"/"gcp"), or None if left at
-        the app's existing default.
+        The backend provider value in effect (Reflex Cloud's default or GCP), or
+        None if left at the app's existing default.
 
     Raises:
         Exit: If ``--provider`` is invalid or a required switch fails.

--- a/packages/reflex-hosting-cli/src/reflex_cli/v2/cli.py
+++ b/packages/reflex-hosting-cli/src/reflex_cli/v2/cli.py
@@ -144,7 +144,7 @@ def _resolve_deploy_provider(
         )
         if (
             interactive
-            and console.ask("Continue?", choices=["y", "n"], default="y") != "y"
+            and console.ask("Continue?", choices=["y", "n"], default="n") != "y"
         ):
             console.info("Deployment cancelled.")
             raise click.exceptions.Exit(0)

--- a/packages/reflex-hosting-cli/src/reflex_cli/v2/cli.py
+++ b/packages/reflex-hosting-cli/src/reflex_cli/v2/cli.py
@@ -74,6 +74,89 @@ def logout(
     console.success("Successfully logged out.")
 
 
+def _resolve_deploy_provider(
+    app: dict[str, Any],
+    provider_arg: str | None,
+    interactive: bool,
+    app_was_created: bool,
+    client: Any,
+) -> str | None:
+    """Resolve and pin the hosting provider for this deploy.
+
+    Decides whether the deploy targets Reflex Cloud or a connected GCP account,
+    prompting interactively when GCP is available and no ``--provider`` was
+    given, then pins the app to the chosen provider (switching, with a teardown
+    warning, when it differs from the app's current provider).
+
+    Args:
+        app: The resolved app dict (must contain "id" and "name").
+        provider_arg: The ``--provider`` value, if the user passed one.
+        interactive: Whether to prompt.
+        app_was_created: Whether the app was just created in this deploy (a
+            switch then has nothing to tear down).
+        client: The authenticated client.
+
+    Returns:
+        The backend provider value in effect ("fly"/"gcp"), or None if left at
+        the app's existing default.
+
+    Raises:
+        Exit: If ``--provider`` is invalid or a required switch fails.
+
+    """
+    from reflex_cli.utils import hosting
+
+    current = app.get("provider")
+
+    if provider_arg is not None:
+        # Explicit --provider always wins; validated by the caller already.
+        target = hosting.normalize_provider(provider_arg)
+    else:
+        gcp_status = hosting.gcp_deploy_available(client)
+        if not gcp_status or not interactive:
+            # No GCP connected, or non-interactive with no explicit choice: keep
+            # whatever the app already targets.
+            return current
+        region = gcp_status.get("region")
+        console.print(
+            "This organization has Google Cloud connected"
+            + (f" (region {region})" if region else "")
+            + "."
+        )
+        default_choice = "gcp" if current == hosting.PROVIDER_GCP else "reflex-cloud"
+        choice = console.ask(
+            "Where would you like to deploy?",
+            choices=["reflex-cloud", "gcp"],
+            default=default_choice,
+        )
+        target = hosting.normalize_provider(choice)
+
+    if target is None or target == (current or hosting.PROVIDER_REFLEX_CLOUD):
+        # Nothing to change; the app already targets this provider.
+        return target or current
+
+    if not app_was_created and current is not None:
+        console.warn(
+            f"Switching '{app['name']}' from {hosting.provider_display_name(current)} "
+            f"to {hosting.provider_display_name(target)} tears down its current "
+            "deployment on the old provider; this deploy brings it back up on the "
+            "new one."
+        )
+        if (
+            interactive
+            and console.ask("Continue?", choices=["y", "n"], default="y") != "y"
+        ):
+            console.info("Deployment cancelled.")
+            raise click.exceptions.Exit(0)
+
+    result = hosting.set_app_provider(app["id"], target, client=client)
+    if isinstance(result, str) and result.startswith("set provider failed"):
+        console.error(result)
+        raise click.exceptions.Exit(1)
+    console.info(f"Deploying to {hosting.provider_display_name(target)}.")
+    return target
+
+
 def deploy(
     export_fn: Callable[[str, str, str, bool, bool, bool, bool], None]
     | Callable[[str, str, str, bool, bool, bool], None],
@@ -92,6 +175,8 @@ def deploy(
     env: str | None = None,
     project_name: str | None = None,
     app_id: str | None = None,
+    provider: str | None = None,
+    deployment_description: str | None = None,
     **kwargs,
 ):
     """Deploy the app to the Reflex hosting service.
@@ -113,6 +198,11 @@ def deploy(
         env: The environment to use for deployment.
         project_name: The name of the project.
         app_id: The ID of the app.
+        provider: The hosting provider to deploy to ("reflex-cloud" or "gcp").
+            When omitted and the org has GCP connected, the CLI prompts in
+            interactive mode.
+        deployment_description: An optional changelog note recorded on this
+            deployment and shown in ``reflex cloud apps history``.
         **kwargs: Additional keyword arguments.
 
     Raises:
@@ -152,6 +242,8 @@ def deploy(
             project_id = config.get("project", None)
         if not project_name:
             project_name = config.get("projectname", None)
+        if not provider:
+            provider = config.get("provider", None)
         if not app_id:
             app_id = config.get("appid", None)
             if not isinstance(app_id, (str, type(None))):
@@ -207,11 +299,20 @@ def deploy(
 
     envs = envs or []
 
+    # Validate --provider up front so an obvious typo fails before any work.
+    if provider is not None and hosting.normalize_provider(provider) is None:
+        console.error(f"Unknown provider {provider!r}. Use 'reflex-cloud' or 'gcp'.")
+        raise click.exceptions.Exit(2)
+
     if not app_name and not app_id:
         console.error(
             "Please provide a valid app name or ID for the deployed instance."
         )
         raise click.exceptions.Exit(1)
+
+    # Tracks whether the app is created during this deploy: a provider switch on
+    # a brand-new app has nothing to tear down, so we skip the switch warning.
+    app_was_created = False
     try:
         if app_name and not app_id:
             search_project_id = project_id
@@ -315,6 +416,7 @@ def deploy(
                 project_id=project_id,
                 client=authenticated_client,
             )
+            app_was_created = True
             console.info(f"created app. \nName: {app['name']} \nId: {app['id']}")
         else:
             console.error("Please create an app to deploy.")
@@ -326,7 +428,30 @@ def deploy(
             project_id=project_id,
             client=authenticated_client,
         )
+        app_was_created = True
         console.info(f"created app. \nName: {app['name']} \nId: {app['id']}")
+
+    # Choose/confirm the hosting provider before reserving the hostname: the
+    # reserved URL is baked into the exported frontend, and a GCP app resolves
+    # to a *.run.app backend URL, so the provider must be pinned first.
+    effective_provider = _resolve_deploy_provider(
+        app=app,
+        provider_arg=provider,
+        interactive=interactive,
+        app_was_created=app_was_created,
+        client=authenticated_client,
+    )
+    if effective_provider == hosting.PROVIDER_GCP:
+        # GCP Cloud Run ignores Reflex Cloud regions/VM types — the region and
+        # sizing come from the org's connected GCP account. Drop them so
+        # validation and the deploy don't send incompatible values.
+        if regions or vmtype:
+            console.info(
+                "Ignoring --region/--vmtype for the Google Cloud target "
+                "(region and sizing come from the connected GCP account)."
+            )
+        regions = None
+        vmtype = None
 
     urls = hosting.get_hostname(
         app_id=app["id"],
@@ -450,6 +575,7 @@ def deploy(
         client=authenticated_client,
         packages=packages,
         strategy=strategy,
+        description=deployment_description,
     )
     if "failed" in result:
         console.error(result)

--- a/packages/reflex-hosting-cli/src/reflex_cli/v2/deployments.py
+++ b/packages/reflex-hosting-cli/src/reflex_cli/v2/deployments.py
@@ -14,6 +14,7 @@ from reflex_cli.utils import console
 from reflex_cli.v2.apps import apps_cli
 from reflex_cli.v2.gcp import deploy_command as gcp_deploy_command
 from reflex_cli.v2.project import project_cli
+from reflex_cli.v2.providers import providers_cli
 from reflex_cli.v2.scan import scan_command
 from reflex_cli.v2.secrets import secrets_cli
 from reflex_cli.v2.vmtypes_regions import vm_types_regions_cli
@@ -61,6 +62,10 @@ hosting_cli.add_command(
 hosting_cli.add_command(
     project_cli,
     name="project",
+)
+hosting_cli.add_command(
+    providers_cli,
+    name="providers",
 )
 hosting_cli.add_command(
     secrets_cli,

--- a/packages/reflex-hosting-cli/src/reflex_cli/v2/providers.py
+++ b/packages/reflex-hosting-cli/src/reflex_cli/v2/providers.py
@@ -1,0 +1,211 @@
+"""Cloud provider commands for the Reflex Cloud CLI.
+
+Read-only visibility into the cloud providers connected to your organization
+(currently GCP for bring-your-own-cloud deploys). Connecting or removing a
+provider account uploads and validates a service-account key and is done from
+the Reflex Cloud dashboard (Organization → Cloud Providers).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import click
+
+from reflex_cli import constants
+from reflex_cli.utils import console
+from reflex_cli.utils.exceptions import NotAuthenticatedError
+
+
+@click.group()
+def providers_cli():
+    """Commands for inspecting connected cloud providers."""
+
+
+def _resolve_org_id(org_id: str | None, client: Any) -> str:
+    """Resolve the organization id from --org-id or the caller's token.
+
+    Args:
+        org_id: The explicit org id, if given.
+        client: The authenticated client.
+
+    Returns:
+        The resolved organization id.
+
+    Raises:
+        Exit: If no org id can be resolved.
+
+    """
+    from reflex_cli.utils import hosting
+
+    resolved = org_id or hosting.get_token_org_id(client)
+    if not resolved:
+        console.error(
+            "Could not determine your organization. Pass --org-id explicitly."
+        )
+        raise click.exceptions.Exit(1)
+    return resolved
+
+
+@providers_cli.command(name="status")
+@click.option("--org-id", help="The organization ID (defaults to your token's org).")
+@click.option("--token", help="The authentication token.")
+@click.option(
+    "--loglevel",
+    type=click.Choice([level.value for level in constants.LogLevel]),
+    default=constants.LogLevel.INFO.value,
+    help="The log level to use.",
+)
+@click.option(
+    "--json/--no-json",
+    "-j",
+    "as_json",
+    is_flag=True,
+    help="Whether to output the result in json format.",
+)
+@click.option(
+    "--interactive/--no-interactive",
+    "-i",
+    is_flag=True,
+    default=True,
+    help="Whether to use interactive mode.",
+)
+def providers_status(
+    org_id: str | None,
+    token: str | None,
+    loglevel: str,
+    as_json: bool,
+    interactive: bool,
+):
+    """Show whether your organization can deploy to Google Cloud (GCP)."""
+    import httpx
+
+    from reflex_cli.utils import hosting
+
+    console.set_log_level(loglevel)
+    try:
+        authenticated_client = hosting.get_authenticated_client(
+            token=token, interactive=interactive
+        )
+        org_id = _resolve_org_id(org_id, authenticated_client)
+        try:
+            status = hosting.get_gcp_provider_status(
+                org_id, client=authenticated_client
+            )
+        except httpx.HTTPStatusError as ex:
+            try:
+                detail = ex.response.json().get("detail")
+            except (ValueError, AttributeError):
+                detail = ex.response.text
+            console.error(f"Failed to fetch GCP status: {detail}")
+            raise click.exceptions.Exit(1) from ex
+
+        if as_json:
+            console.print(json.dumps(status))
+            return
+
+        configured = status.get("configured")
+        allowed = status.get("allowed")
+        if configured and allowed:
+            console.success("Google Cloud is connected and ready for deploys.")
+        elif configured and not allowed:
+            console.warn(
+                "Google Cloud is connected, but your plan does not allow GCP "
+                "deploys. GCP deploys require the Enterprise tier."
+            )
+        elif not configured and allowed:
+            console.warn(
+                "Google Cloud is not connected yet. Connect it from the Reflex "
+                "Cloud dashboard: Organization -> Cloud Providers."
+            )
+        else:
+            console.warn(
+                "Google Cloud is not connected, and GCP deploys require the "
+                "Enterprise tier. Contact sales@reflex.dev to upgrade."
+            )
+        if status.get("project_id"):
+            console.print(f"  Project: {status['project_id']}")
+        if status.get("region"):
+            console.print(f"  Region:  {status['region']}")
+    except NotAuthenticatedError as err:
+        console.error("You are not authenticated. Run `reflex login` to authenticate.")
+        raise click.exceptions.Exit(1) from err
+
+
+@providers_cli.command(name="list")
+@click.option("--org-id", help="The organization ID (defaults to your token's org).")
+@click.option("--token", help="The authentication token.")
+@click.option(
+    "--loglevel",
+    type=click.Choice([level.value for level in constants.LogLevel]),
+    default=constants.LogLevel.INFO.value,
+    help="The log level to use.",
+)
+@click.option(
+    "--json/--no-json",
+    "-j",
+    "as_json",
+    is_flag=True,
+    help="Whether to output the result in json format.",
+)
+@click.option(
+    "--interactive/--no-interactive",
+    "-i",
+    is_flag=True,
+    default=True,
+    help="Whether to use interactive mode.",
+)
+def providers_list(
+    org_id: str | None,
+    token: str | None,
+    loglevel: str,
+    as_json: bool,
+    interactive: bool,
+):
+    """List the cloud provider accounts connected to your organization."""
+    import httpx
+
+    from reflex_cli.utils import hosting
+
+    console.set_log_level(loglevel)
+    try:
+        authenticated_client = hosting.get_authenticated_client(
+            token=token, interactive=interactive
+        )
+        org_id = _resolve_org_id(org_id, authenticated_client)
+        try:
+            accounts = hosting.list_provider_accounts(
+                org_id, client=authenticated_client
+            )
+        except httpx.HTTPStatusError as ex:
+            try:
+                detail = ex.response.json().get("detail")
+            except (ValueError, AttributeError):
+                detail = ex.response.text
+            console.error(f"Failed to list provider accounts: {detail}")
+            raise click.exceptions.Exit(1) from ex
+
+        if as_json:
+            console.print(json.dumps(accounts))
+            return
+        if not accounts:
+            console.print(
+                "No cloud providers connected. Connect one from the Reflex Cloud "
+                "dashboard: Organization -> Cloud Providers."
+            )
+            return
+        headers = ["Provider", "Project", "Region", "Connected"]
+        rows = [
+            [
+                account.get("provider", ""),
+                (account.get("config") or {}).get("project_id", ""),
+                (account.get("config") or {}).get("region", ""),
+                account.get("created_at", ""),
+            ]
+            for account in accounts
+        ]
+        console.print_table(rows, headers=headers)
+    except NotAuthenticatedError as err:
+        console.error("You are not authenticated. Run `reflex login` to authenticate.")
+        raise click.exceptions.Exit(1) from err

--- a/reflex/reflex.py
+++ b/reflex/reflex.py
@@ -790,6 +790,17 @@ def makemigrations(message: str | None):
     help="The hostname of the frontend.",
 )
 @click.option(
+    "--provider",
+    help="The hosting provider to deploy to: 'reflex-cloud' (default) or 'gcp' "
+    "(a GCP account connected to your org, Enterprise tier). When omitted and "
+    "GCP is connected, you'll be prompted in interactive mode.",
+)
+@click.option(
+    "--description",
+    help="An optional note recorded on this deployment and shown in "
+    "`reflex cloud apps history`.",
+)
+@click.option(
     "--interactive/--no-interactive",
     is_flag=True,
     default=True,
@@ -838,6 +849,8 @@ def deploy(
     env: tuple[str],
     vmtype: str | None,
     hostname: str | None,
+    provider: str | None,
+    description: str | None,
     interactive: bool,
     envfile: str | None,
     project: str | None,
@@ -909,6 +922,8 @@ def deploy(
         token=token,
         project=project,
         project_name=project_name,
+        provider=provider,
+        deployment_description=description,
         **({"config_path": config_path} if config_path is not None else {}),
     )
 

--- a/tests/units/reflex_cli/utils/test_hosting.py
+++ b/tests/units/reflex_cli/utils/test_hosting.py
@@ -358,6 +358,25 @@ def _client(**data: object) -> AuthenticatedClient:
     return AuthenticatedClient(token="fake-token", validated_data=data)
 
 
+def _ok_body(mocker: MockerFixture, body: object):
+    """Build a mock 2xx response whose ``.json()`` returns an arbitrary body.
+
+    ``_ok`` only accepts dict payloads; use this for list/str JSON responses.
+
+    Args:
+        mocker: The pytest-mock fixture.
+        body: The value ``response.json()`` should return.
+
+    Returns:
+        A mock response object.
+
+    """
+    response = mocker.Mock()
+    response.raise_for_status.return_value = None
+    response.json.return_value = body
+    return response
+
+
 def test_normalize_provider():
     """User-facing provider names map to backend values (or None if unknown)."""
     from reflex_cli.utils.hosting import PROVIDER_GCP, PROVIDER_REFLEX_CLOUD
@@ -440,7 +459,7 @@ def test_get_gcp_provider_status_hits_endpoint(mocker: MockerFixture):
 def test_list_provider_accounts_hits_endpoint(mocker: MockerFixture):
     """Listing connected providers targets the org provider-accounts endpoint."""
     mock_get = mocker.patch(
-        "httpx.get", return_value=_ok(mocker, [{"provider": "gcp"}])
+        "httpx.get", return_value=_ok_body(mocker, [{"provider": "gcp"}])
     )
     assert list_provider_accounts("org-1", _CLIENT) == [{"provider": "gcp"}]
     assert mock_get.call_args.args[0].endswith("/api/v1/orgs/org-1/provider-accounts")
@@ -477,6 +496,7 @@ def test_rollback_deployment_error(mocker: MockerFixture):
     """A rejected rollback surfaces the server detail as an error string."""
     mocker.patch("httpx.post", return_value=_error(mocker, 400, "no image"))
     result = rollback_deployment("app-1", "dep-1", _CLIENT)
+    assert result is not None
     assert result.startswith("rollback failed")
     assert "no image" in result
 
@@ -495,6 +515,7 @@ def test_update_deployment_description_error(mocker: MockerFixture):
     """A missing deployment surfaces the server detail as an error string."""
     mocker.patch("httpx.post", return_value=_error(mocker, 404, "no deployment"))
     result = update_deployment_description("app-1", "dep-1", "note", _CLIENT)
+    assert result is not None
     assert result.startswith("update description failed")
 
 
@@ -518,7 +539,7 @@ def test_create_app_omits_provider_when_none(mocker: MockerFixture):
 
 def test_create_deployment_forwards_description(mocker: MockerFixture):
     """A per-deployment note is sent as the multipart description field."""
-    mock_post = mocker.patch("httpx.post", return_value=_ok(mocker, "dep-1"))
+    mock_post = mocker.patch("httpx.post", return_value=_ok_body(mocker, "dep-1"))
     mocker.patch("importlib.metadata.version", return_value="0.1.99")
     mocker.patch("reflex_cli.utils.dependency.get_reflex_version", return_value="1.0")
     mocker.patch("pathlib.Path.open", mock_open(read_data=b"zip"))
@@ -565,7 +586,7 @@ def test_get_app_history_includes_description_and_can_rollback(mocker: MockerFix
             "timestamp": "t2",
         },
     ]
-    mocker.patch("httpx.get", return_value=_ok(mocker, payload))
+    mocker.patch("httpx.get", return_value=_ok_body(mocker, payload))
     history = get_app_history("app-1", _CLIENT)
     assert history[0]["description"] == "hotfix"
     assert history[0]["can rollback"] is True

--- a/tests/units/reflex_cli/utils/test_hosting.py
+++ b/tests/units/reflex_cli/utils/test_hosting.py
@@ -13,14 +13,27 @@ from reflex_cli.utils.hosting import (
     ScaleType,
     SecurityReviewError,
     authenticated_token,
+    create_app,
+    create_deployment,
     delete_token_from_config,
+    gcp_deploy_available,
+    get_app_history,
     get_authenticated_client,
     get_existing_access_token,
+    get_gcp_provider_status,
     get_security_review,
     get_selected_project,
+    get_token_org_id,
+    get_token_tier,
+    list_provider_accounts,
     normalize_project_id,
+    normalize_provider,
+    provider_display_name,
+    rollback_deployment,
     save_token_to_config,
+    set_app_provider,
     submit_security_review,
+    update_deployment_description,
 )
 
 _CLIENT = AuthenticatedClient(token="fake-token", validated_data={})
@@ -338,3 +351,219 @@ def test_get_security_review_returns_payload(mocker: MockerFixture):
     assert mock_get.call_args.args[0].endswith(
         "/api/v1/agents/security-review/jobs/job-1"
     )
+
+
+def _client(**data: object) -> AuthenticatedClient:
+    """Build an authenticated client with the given validated token data."""
+    return AuthenticatedClient(token="fake-token", validated_data=data)
+
+
+def test_normalize_provider():
+    """User-facing provider names map to backend values (or None if unknown)."""
+    assert normalize_provider("reflex-cloud") == "fly"
+    assert normalize_provider("Reflex") == "fly"
+    assert normalize_provider("GCP") == "gcp"
+    assert normalize_provider("google-cloud") == "gcp"
+    assert normalize_provider("aws") is None
+
+
+def test_provider_display_name():
+    """Backend provider values render human-facing labels, defaulting to Cloud."""
+    assert provider_display_name("gcp") == "Google Cloud (GCP)"
+    assert provider_display_name("fly") == "Reflex Cloud"
+    assert provider_display_name(None) == "Reflex Cloud"
+
+
+def test_get_token_org_and_tier():
+    """org_id/tier come from the validated token data, None when absent."""
+    client = _client(org_id="org-1", tier="Enterprise")
+    assert get_token_org_id(client) == "org-1"
+    assert get_token_tier(client) == "Enterprise"
+    assert get_token_org_id(_client()) is None
+    assert get_token_tier(_client()) is None
+
+
+def test_gcp_deploy_available_configured_and_allowed(mocker: MockerFixture):
+    """GCP is offered only when it's both connected and tier-allowed."""
+    mocker.patch(
+        "reflex_cli.utils.hosting.get_gcp_provider_status",
+        return_value={"configured": True, "allowed": True, "region": "us-central1"},
+    )
+    assert gcp_deploy_available(_client(org_id="o")) == {
+        "configured": True,
+        "allowed": True,
+        "region": "us-central1",
+    }
+
+
+def test_gcp_deploy_available_not_allowed(mocker: MockerFixture):
+    """A connected-but-not-allowed org does not get GCP offered."""
+    mocker.patch(
+        "reflex_cli.utils.hosting.get_gcp_provider_status",
+        return_value={"configured": True, "allowed": False},
+    )
+    assert gcp_deploy_available(_client(org_id="o")) is None
+
+
+def test_gcp_deploy_available_swallows_errors(mocker: MockerFixture):
+    """A lookup failure falls back to no GCP rather than aborting the deploy."""
+    mocker.patch(
+        "reflex_cli.utils.hosting.get_gcp_provider_status",
+        side_effect=Exception("boom"),
+    )
+    assert gcp_deploy_available(_client(org_id="o")) is None
+
+
+def test_gcp_deploy_available_without_org():
+    """No resolvable org id means GCP is not offered."""
+    assert gcp_deploy_available(_client()) is None
+
+
+def test_get_gcp_provider_status_hits_endpoint(mocker: MockerFixture):
+    """The status call targets the org-scoped GCP status endpoint."""
+    mock_get = mocker.patch(
+        "httpx.get", return_value=_ok(mocker, {"configured": True, "allowed": True})
+    )
+    assert get_gcp_provider_status("org-1", _CLIENT) == {
+        "configured": True,
+        "allowed": True,
+    }
+    assert mock_get.call_args.args[0].endswith(
+        "/api/v1/orgs/org-1/provider-accounts/gcp/status"
+    )
+
+
+def test_list_provider_accounts_hits_endpoint(mocker: MockerFixture):
+    """Listing connected providers targets the org provider-accounts endpoint."""
+    mock_get = mocker.patch(
+        "httpx.get", return_value=_ok(mocker, [{"provider": "gcp"}])
+    )
+    assert list_provider_accounts("org-1", _CLIENT) == [{"provider": "gcp"}]
+    assert mock_get.call_args.args[0].endswith("/api/v1/orgs/org-1/provider-accounts")
+
+
+def test_set_app_provider_success(mocker: MockerFixture):
+    """A successful switch posts the provider and returns the new value."""
+    mock_post = mocker.patch(
+        "httpx.post", return_value=_ok(mocker, {"provider": "gcp"})
+    )
+    assert set_app_provider("app-1", "gcp", _CLIENT) == "gcp"
+    assert mock_post.call_args.args[0].endswith("/api/v1/apps/app-1/provider")
+    assert mock_post.call_args.kwargs["json"] == {"provider": "gcp"}
+
+
+def test_set_app_provider_error(mocker: MockerFixture):
+    """A rejected switch surfaces the server detail as an error string."""
+    mocker.patch("httpx.post", return_value=_error(mocker, 403, "Enterprise required"))
+    result = set_app_provider("app-1", "gcp", _CLIENT)
+    assert result.startswith("set provider failed")
+    assert "Enterprise required" in result
+
+
+def test_rollback_deployment_success(mocker: MockerFixture):
+    """A successful rollback returns None and targets the rollback endpoint."""
+    mock_post = mocker.patch("httpx.post", return_value=_ok(mocker))
+    assert rollback_deployment("app-1", "dep-1", _CLIENT) is None
+    assert mock_post.call_args.args[0].endswith(
+        "/api/v1/apps/app-1/deployments/dep-1/rollback"
+    )
+
+
+def test_rollback_deployment_error(mocker: MockerFixture):
+    """A rejected rollback surfaces the server detail as an error string."""
+    mocker.patch("httpx.post", return_value=_error(mocker, 400, "no image"))
+    result = rollback_deployment("app-1", "dep-1", _CLIENT)
+    assert result.startswith("rollback failed")
+    assert "no image" in result
+
+
+def test_update_deployment_description_success(mocker: MockerFixture):
+    """Setting a note posts the description to the deployment description endpoint."""
+    mock_post = mocker.patch("httpx.post", return_value=_ok(mocker))
+    assert update_deployment_description("app-1", "dep-1", "note", _CLIENT) is None
+    assert mock_post.call_args.args[0].endswith(
+        "/api/v1/apps/app-1/deployments/dep-1/description"
+    )
+    assert mock_post.call_args.kwargs["json"] == {"description": "note"}
+
+
+def test_update_deployment_description_error(mocker: MockerFixture):
+    """A missing deployment surfaces the server detail as an error string."""
+    mocker.patch("httpx.post", return_value=_error(mocker, 404, "no deployment"))
+    result = update_deployment_description("app-1", "dep-1", "note", _CLIENT)
+    assert result.startswith("update description failed")
+
+
+def test_create_app_forwards_provider(mocker: MockerFixture):
+    """create_app forwards a provider when given one."""
+    response = _ok(mocker, {"id": "app-1", "name": "n"})
+    response.status_code = 200
+    mock_post = mocker.patch("httpx.post", return_value=response)
+    create_app("n", _CLIENT, "desc", "proj-1", provider="gcp")
+    assert mock_post.call_args.kwargs["json"]["provider"] == "gcp"
+
+
+def test_create_app_omits_provider_when_none(mocker: MockerFixture):
+    """create_app omits the provider field when none is requested."""
+    response = _ok(mocker, {"id": "app-1", "name": "n"})
+    response.status_code = 200
+    mock_post = mocker.patch("httpx.post", return_value=response)
+    create_app("n", _CLIENT, "desc", "proj-1")
+    assert "provider" not in mock_post.call_args.kwargs["json"]
+
+
+def test_create_deployment_forwards_description(mocker: MockerFixture):
+    """A per-deployment note is sent as the multipart description field."""
+    mock_post = mocker.patch("httpx.post", return_value=_ok(mocker, "dep-1"))
+    mocker.patch("importlib.metadata.version", return_value="0.1.99")
+    mocker.patch("reflex_cli.utils.dependency.get_reflex_version", return_value="1.0")
+    mocker.patch("pathlib.Path.open", mock_open(read_data=b"zip"))
+    from pathlib import Path
+
+    create_deployment(
+        zip_dir=Path("/tmp"),
+        client=_CLIENT,
+        app_name="n",
+        project_id=None,
+        regions=None,
+        hostname=None,
+        vmtype=None,
+        secrets=None,
+        packages=None,
+        strategy=None,
+        app_id="app-1",
+        description="my note",
+    )
+    assert mock_post.call_args.kwargs["data"]["description"] == "my note"
+
+
+def test_get_app_history_includes_description_and_can_rollback(mocker: MockerFixture):
+    """History rows carry the deployment note and rollback eligibility."""
+    payload = [
+        {
+            "id": "d1",
+            "status": "Running",
+            "hostname": "h",
+            "python_version": "3.11",
+            "reflex_version": "1.0",
+            "vm_type": "c1",
+            "timestamp": "t",
+            "description": "hotfix",
+            "can_rollback": True,
+        },
+        {
+            "id": "d2",
+            "status": "Historical",
+            "hostname": "h2",
+            "python_version": "3.11",
+            "reflex_version": "1.0",
+            "vm_type": "c1",
+            "timestamp": "t2",
+        },
+    ]
+    mocker.patch("httpx.get", return_value=_ok(mocker, payload))
+    history = get_app_history("app-1", _CLIENT)
+    assert history[0]["description"] == "hotfix"
+    assert history[0]["can rollback"] is True
+    assert history[1]["description"] == ""
+    assert history[1]["can rollback"] is False

--- a/tests/units/reflex_cli/utils/test_hosting.py
+++ b/tests/units/reflex_cli/utils/test_hosting.py
@@ -360,11 +360,15 @@ def _client(**data: object) -> AuthenticatedClient:
 
 def test_normalize_provider():
     """User-facing provider names map to backend values (or None if unknown)."""
-    assert normalize_provider("reflex-cloud") == "fly"
-    assert normalize_provider("Reflex") == "fly"
-    assert normalize_provider("GCP") == "gcp"
-    assert normalize_provider("google-cloud") == "gcp"
+    from reflex_cli.utils.hosting import PROVIDER_GCP, PROVIDER_REFLEX_CLOUD
+
+    assert normalize_provider("reflex-cloud") == PROVIDER_REFLEX_CLOUD
+    assert normalize_provider("Reflex") == PROVIDER_REFLEX_CLOUD
+    assert normalize_provider("GCP") == PROVIDER_GCP
+    assert normalize_provider("google-cloud") == PROVIDER_GCP
     assert normalize_provider("aws") is None
+    # The backend wire value is not exposed as a user-facing name.
+    assert normalize_provider("fly") is None
 
 
 def test_provider_display_name():

--- a/tests/units/reflex_cli/v2/test_apps.py
+++ b/tests/units/reflex_cli/v2/test_apps.py
@@ -10,7 +10,7 @@ from pytest_mock import MockerFixture, MockFixture
 from reflex_cli.core.config import Config
 from reflex_cli.utils import hosting
 from reflex_cli.utils.exceptions import GetAppError
-from reflex_cli.v2.apps import apps_cli
+from reflex_cli.v2.apps import _resolve_app_id, apps_cli
 from reflex_cli.v2.deployments import hosting_cli
 from typer.main import Typer, get_command
 
@@ -1644,3 +1644,44 @@ def test_app_describe_error_exits_nonzero(mocker: MockFixture):
     )
 
     assert result.exit_code == 1
+
+
+def test_resolve_app_id_prefers_app_name_over_config(mocker: MockFixture):
+    """An explicit --app-name overrides a configured appid rather than being ignored."""
+    client = hosting.AuthenticatedClient(token="t", validated_data={})
+    mocker.patch(
+        "reflex_cli.utils.hosting.read_config",
+        return_value=Config(appid="config-app-id"),
+    )
+    search = mocker.patch(
+        "reflex_cli.utils.hosting.search_app", return_value={"id": "named-app-id"}
+    )
+
+    assert _resolve_app_id(None, "myapp", client, interactive=False) == "named-app-id"
+    search.assert_called_once()
+
+
+def test_resolve_app_id_falls_back_to_config(mocker: MockFixture):
+    """With no explicit app id or name, the configured appid is used."""
+    client = hosting.AuthenticatedClient(token="t", validated_data={})
+    mocker.patch(
+        "reflex_cli.utils.hosting.read_config",
+        return_value=Config(appid="config-app-id"),
+    )
+    search = mocker.patch("reflex_cli.utils.hosting.search_app")
+
+    assert _resolve_app_id(None, None, client, interactive=False) == "config-app-id"
+    search.assert_not_called()
+
+
+def test_resolve_app_id_explicit_id_wins(mocker: MockFixture):
+    """An explicit app id short-circuits both name lookup and config."""
+    client = hosting.AuthenticatedClient(token="t", validated_data={})
+    read_config = mocker.patch("reflex_cli.utils.hosting.read_config")
+    search = mocker.patch("reflex_cli.utils.hosting.search_app")
+
+    assert _resolve_app_id("explicit-id", "myapp", client, interactive=False) == (
+        "explicit-id"
+    )
+    search.assert_not_called()
+    read_config.assert_not_called()

--- a/tests/units/reflex_cli/v2/test_apps.py
+++ b/tests/units/reflex_cli/v2/test_apps.py
@@ -10,6 +10,7 @@ from pytest_mock import MockerFixture, MockFixture
 from reflex_cli.core.config import Config
 from reflex_cli.utils import hosting
 from reflex_cli.utils.exceptions import GetAppError
+from reflex_cli.v2.apps import apps_cli
 from reflex_cli.v2.deployments import hosting_cli
 from typer.main import Typer, get_command
 
@@ -1518,3 +1519,110 @@ def test_scale_correct_post_request_config(
         scale_params=mock_scale_params.return_value,
         client=mock_authenticated_client,
     )
+
+
+# The rollback/describe tests invoke the `apps` group directly rather than
+# through `hosting_cli` so they don't depend on the reflex-version gate on the
+# top-level group callback.
+
+
+def test_app_rollback_success(mocker: MockFixture):
+    """A confirmed rollback calls the API with the resolved app + deployment."""
+    mock_client = hosting.AuthenticatedClient(token="t", validated_data={})
+    mocker.patch(
+        "reflex_cli.utils.hosting.get_authenticated_client", return_value=mock_client
+    )
+    mock_rollback = mocker.patch(
+        "reflex_cli.utils.hosting.rollback_deployment", return_value=None
+    )
+
+    result = runner.invoke(
+        apps_cli,
+        ["rollback", "dep-1", "--app-id", "app-1", "--no-interactive"],
+    )
+
+    assert result.exit_code == 0, result.output
+    mock_rollback.assert_called_once_with(
+        app_id="app-1", deployment_id="dep-1", client=mock_client
+    )
+
+
+def test_app_rollback_error_exits_nonzero(mocker: MockFixture):
+    """An API error string surfaces and the command exits non-zero."""
+    mock_client = hosting.AuthenticatedClient(token="t", validated_data={})
+    mocker.patch(
+        "reflex_cli.utils.hosting.get_authenticated_client", return_value=mock_client
+    )
+    mocker.patch(
+        "reflex_cli.utils.hosting.rollback_deployment",
+        return_value="rollback failed: no image",
+    )
+
+    result = runner.invoke(
+        apps_cli,
+        ["rollback", "dep-1", "--app-id", "app-1", "--no-interactive"],
+    )
+
+    assert result.exit_code == 1
+
+
+def test_app_rollback_resolves_app_name(mocker: MockFixture):
+    """--app-name is resolved to an app id before rolling back."""
+    mock_client = hosting.AuthenticatedClient(token="t", validated_data={})
+    mocker.patch(
+        "reflex_cli.utils.hosting.get_authenticated_client", return_value=mock_client
+    )
+    mocker.patch(
+        "reflex_cli.utils.hosting.search_app", return_value={"id": "resolved-id"}
+    )
+    mock_rollback = mocker.patch(
+        "reflex_cli.utils.hosting.rollback_deployment", return_value=None
+    )
+
+    result = runner.invoke(
+        apps_cli,
+        ["rollback", "dep-1", "--app-name", "myapp", "--no-interactive"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert mock_rollback.call_args.kwargs["app_id"] == "resolved-id"
+
+
+def test_app_describe_sets_note(mocker: MockFixture):
+    """Describe forwards the note to the description endpoint."""
+    mock_client = hosting.AuthenticatedClient(token="t", validated_data={})
+    mocker.patch(
+        "reflex_cli.utils.hosting.get_authenticated_client", return_value=mock_client
+    )
+    mock_desc = mocker.patch(
+        "reflex_cli.utils.hosting.update_deployment_description", return_value=None
+    )
+
+    result = runner.invoke(
+        apps_cli,
+        ["describe", "dep-1", "--description", "hotfix", "--app-id", "app-1"],
+    )
+
+    assert result.exit_code == 0, result.output
+    mock_desc.assert_called_once_with(
+        app_id="app-1", deployment_id="dep-1", description="hotfix", client=mock_client
+    )
+
+
+def test_app_describe_error_exits_nonzero(mocker: MockFixture):
+    """A failed description update exits non-zero."""
+    mock_client = hosting.AuthenticatedClient(token="t", validated_data={})
+    mocker.patch(
+        "reflex_cli.utils.hosting.get_authenticated_client", return_value=mock_client
+    )
+    mocker.patch(
+        "reflex_cli.utils.hosting.update_deployment_description",
+        return_value="update description failed: no deployment",
+    )
+
+    result = runner.invoke(
+        apps_cli,
+        ["describe", "dep-1", "--description", "x", "--app-id", "app-1"],
+    )
+
+    assert result.exit_code == 1

--- a/tests/units/reflex_cli/v2/test_apps.py
+++ b/tests/units/reflex_cli/v2/test_apps.py
@@ -1547,6 +1547,24 @@ def test_app_rollback_success(mocker: MockFixture):
     )
 
 
+def test_app_rollback_defaults_to_cancel(mocker: MockFixture):
+    """Pressing Enter at the confirm prompt cancels rather than rolling back."""
+    mock_client = hosting.AuthenticatedClient(token="t", validated_data={})
+    mocker.patch(
+        "reflex_cli.utils.hosting.get_authenticated_client", return_value=mock_client
+    )
+    mock_rollback = mocker.patch("reflex_cli.utils.hosting.rollback_deployment")
+
+    result = runner.invoke(
+        apps_cli,
+        ["rollback", "dep-1", "--app-id", "app-1"],
+        input="\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    mock_rollback.assert_not_called()
+
+
 def test_app_rollback_error_exits_nonzero(mocker: MockFixture):
     """An API error string surfaces and the command exits non-zero."""
     mock_client = hosting.AuthenticatedClient(token="t", validated_data={})

--- a/tests/units/reflex_cli/v2/test_cli.py
+++ b/tests/units/reflex_cli/v2/test_cli.py
@@ -1138,3 +1138,49 @@ def test_resolve_deploy_provider_interactive_prompt_selects_gcp(mocker: MockFixt
     )
     assert result == "gcp"
     mock_set.assert_called_once()
+
+
+def test_restore_provider_on_failure_restores_on_error(mocker: MockFixture):
+    """A failure after a switch re-pins the previous provider, then re-raises."""
+    client = hosting.AuthenticatedClient(token="t", validated_data={})
+    mock_set = mocker.patch(
+        "reflex_cli.utils.hosting.set_app_provider", return_value="fly"
+    )
+    app = {"id": "app-1", "name": "myapp"}
+    error = ValueError("boom")
+
+    with (
+        pytest.raises(ValueError),
+        cli._restore_provider_on_failure(app, "fly", client),
+    ):
+        raise error
+
+    mock_set.assert_called_once_with("app-1", "fly", client=client)
+
+
+def test_restore_provider_on_failure_noop_without_switch(mocker: MockFixture):
+    """With no prior switch, a failure leaves the provider untouched."""
+    client = hosting.AuthenticatedClient(token="t", validated_data={})
+    mock_set = mocker.patch("reflex_cli.utils.hosting.set_app_provider")
+    app = {"id": "app-1", "name": "myapp"}
+    error = ValueError("boom")
+
+    with (
+        pytest.raises(ValueError),
+        cli._restore_provider_on_failure(app, None, client),
+    ):
+        raise error
+
+    mock_set.assert_not_called()
+
+
+def test_restore_provider_on_failure_noop_on_success(mocker: MockFixture):
+    """On success the provider is left as the newly-switched one."""
+    client = hosting.AuthenticatedClient(token="t", validated_data={})
+    mock_set = mocker.patch("reflex_cli.utils.hosting.set_app_provider")
+    app = {"id": "app-1", "name": "myapp"}
+
+    with cli._restore_provider_on_failure(app, "fly", client):
+        pass
+
+    mock_set.assert_not_called()

--- a/tests/units/reflex_cli/v2/test_cli.py
+++ b/tests/units/reflex_cli/v2/test_cli.py
@@ -1102,6 +1102,25 @@ def test_resolve_deploy_provider_switch_failure_exits(mocker: MockFixture):
         )
 
 
+def test_resolve_deploy_provider_switch_confirm_defaults_to_cancel(
+    mocker: MockFixture,
+):
+    """Switching a deployed app's provider requires an explicit yes (default n)."""
+    client = hosting.AuthenticatedClient(token="t", validated_data={})
+    ask = mocker.patch("reflex_cli.utils.console.ask", return_value="n")
+    mock_set = mocker.patch("reflex_cli.utils.hosting.set_app_provider")
+    app = {"id": "app-1", "name": "myapp", "provider": "fly"}
+
+    with pytest.raises(click.exceptions.Exit):
+        cli._resolve_deploy_provider(
+            app, "gcp", interactive=True, app_was_created=False, client=client
+        )
+
+    mock_set.assert_not_called()
+    # The teardown confirmation must default to "n" so Enter alone cancels.
+    assert ask.call_args.kwargs.get("default") == "n"
+
+
 def test_resolve_deploy_provider_interactive_prompt_selects_gcp(mocker: MockFixture):
     """When GCP is available and the user picks it, the app switches to GCP."""
     client = hosting.AuthenticatedClient(token="t", validated_data={})

--- a/tests/units/reflex_cli/v2/test_cli.py
+++ b/tests/units/reflex_cli/v2/test_cli.py
@@ -1044,3 +1044,78 @@ def test_deploy_empty_project_in_config_is_not_forwarded_to_create_app(
     get_project.assert_not_called()
     create_app.assert_called_once()
     assert create_app.call_args.kwargs.get("project_id") is None
+
+
+def test_resolve_deploy_provider_explicit_gcp_switches(mocker: MockFixture):
+    """--provider gcp on a fly app switches it and returns the new provider."""
+    client = hosting.AuthenticatedClient(token="t", validated_data={})
+    mock_set = mocker.patch(
+        "reflex_cli.utils.hosting.set_app_provider", return_value="gcp"
+    )
+    app = {"id": "app-1", "name": "myapp", "provider": "fly"}
+    result = cli._resolve_deploy_provider(
+        app, "gcp", interactive=False, app_was_created=True, client=client
+    )
+    assert result == "gcp"
+    mock_set.assert_called_once_with("app-1", "gcp", client=client)
+
+
+def test_resolve_deploy_provider_reflex_cloud_no_switch(mocker: MockFixture):
+    """--provider reflex-cloud on a fly app is a no-op (already Reflex Cloud)."""
+    client = hosting.AuthenticatedClient(token="t", validated_data={})
+    mock_set = mocker.patch("reflex_cli.utils.hosting.set_app_provider")
+    app = {"id": "app-1", "name": "myapp", "provider": "fly"}
+    result = cli._resolve_deploy_provider(
+        app, "reflex-cloud", interactive=False, app_was_created=False, client=client
+    )
+    assert result == "fly"
+    mock_set.assert_not_called()
+
+
+def test_resolve_deploy_provider_non_interactive_keeps_current(mocker: MockFixture):
+    """Non-interactive with no --provider keeps the app's provider, no prompt."""
+    client = hosting.AuthenticatedClient(token="t", validated_data={})
+    mocker.patch(
+        "reflex_cli.utils.hosting.gcp_deploy_available",
+        return_value={"configured": True, "allowed": True},
+    )
+    mock_set = mocker.patch("reflex_cli.utils.hosting.set_app_provider")
+    app = {"id": "app-1", "name": "myapp", "provider": "fly"}
+    result = cli._resolve_deploy_provider(
+        app, None, interactive=False, app_was_created=False, client=client
+    )
+    assert result == "fly"
+    mock_set.assert_not_called()
+
+
+def test_resolve_deploy_provider_switch_failure_exits(mocker: MockFixture):
+    """A rejected provider switch aborts the deploy."""
+    client = hosting.AuthenticatedClient(token="t", validated_data={})
+    mocker.patch(
+        "reflex_cli.utils.hosting.set_app_provider",
+        return_value="set provider failed: Enterprise required",
+    )
+    app = {"id": "app-1", "name": "myapp", "provider": "fly"}
+    with pytest.raises(click.exceptions.Exit):
+        cli._resolve_deploy_provider(
+            app, "gcp", interactive=False, app_was_created=True, client=client
+        )
+
+
+def test_resolve_deploy_provider_interactive_prompt_selects_gcp(mocker: MockFixture):
+    """When GCP is available and the user picks it, the app switches to GCP."""
+    client = hosting.AuthenticatedClient(token="t", validated_data={})
+    mocker.patch(
+        "reflex_cli.utils.hosting.gcp_deploy_available",
+        return_value={"configured": True, "allowed": True, "region": "us-central1"},
+    )
+    mocker.patch("reflex_cli.utils.console.ask", return_value="gcp")
+    mock_set = mocker.patch(
+        "reflex_cli.utils.hosting.set_app_provider", return_value="gcp"
+    )
+    app = {"id": "app-1", "name": "myapp", "provider": "fly"}
+    result = cli._resolve_deploy_provider(
+        app, None, interactive=True, app_was_created=True, client=client
+    )
+    assert result == "gcp"
+    mock_set.assert_called_once()

--- a/tests/units/reflex_cli/v2/test_providers.py
+++ b/tests/units/reflex_cli/v2/test_providers.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+
+import httpx
+from click.testing import CliRunner
+from pytest_mock import MockFixture
+from reflex_cli.utils import hosting
+from reflex_cli.v2.providers import providers_cli
+
+runner = CliRunner()
+
+_CLIENT = hosting.AuthenticatedClient(
+    token="fake-token", validated_data={"org_id": "org-1", "tier": "Enterprise"}
+)
+
+
+def test_providers_status_ready(mocker: MockFixture):
+    """A connected + allowed org reports GCP as ready with project/region."""
+    mocker.patch(
+        "reflex_cli.utils.hosting.get_authenticated_client", return_value=_CLIENT
+    )
+    mock_status = mocker.patch(
+        "reflex_cli.utils.hosting.get_gcp_provider_status",
+        return_value={
+            "configured": True,
+            "allowed": True,
+            "project_id": "my-proj",
+            "region": "us-central1",
+        },
+    )
+
+    result = runner.invoke(providers_cli, ["status"])
+
+    assert result.exit_code == 0, result.output
+    assert "ready" in result.output.lower()
+    assert "us-central1" in result.output
+    # Defaults to the token's org when --org-id is omitted.
+    assert mock_status.call_args.args[0] == "org-1"
+
+
+def test_providers_status_not_configured(mocker: MockFixture):
+    """An allowed-but-unconnected org is told to connect from the dashboard."""
+    mocker.patch(
+        "reflex_cli.utils.hosting.get_authenticated_client", return_value=_CLIENT
+    )
+    mocker.patch(
+        "reflex_cli.utils.hosting.get_gcp_provider_status",
+        return_value={"configured": False, "allowed": True},
+    )
+
+    result = runner.invoke(providers_cli, ["status"])
+
+    assert result.exit_code == 0, result.output
+    assert "not connected" in result.output.lower()
+
+
+def test_providers_status_json(mocker: MockFixture):
+    """--json emits the raw status payload."""
+    mocker.patch(
+        "reflex_cli.utils.hosting.get_authenticated_client", return_value=_CLIENT
+    )
+    payload = {
+        "configured": True,
+        "allowed": True,
+        "project_id": "my-proj",
+        "region": "us-central1",
+    }
+    mocker.patch(
+        "reflex_cli.utils.hosting.get_gcp_provider_status", return_value=payload
+    )
+
+    result = runner.invoke(providers_cli, ["status", "--json"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == payload
+
+
+def test_providers_status_error_exits_nonzero(mocker: MockFixture):
+    """A 403 (not a member) surfaces the detail and exits non-zero."""
+    mocker.patch(
+        "reflex_cli.utils.hosting.get_authenticated_client", return_value=_CLIENT
+    )
+    response = httpx.Response(
+        403, json={"detail": "Not a member"}, request=httpx.Request("GET", "https://x")
+    )
+    mocker.patch(
+        "reflex_cli.utils.hosting.get_gcp_provider_status",
+        side_effect=httpx.HTTPStatusError(
+            "e", request=response.request, response=response
+        ),
+    )
+
+    result = runner.invoke(providers_cli, ["status"])
+
+    assert result.exit_code == 1
+
+
+def test_providers_list(mocker: MockFixture):
+    """Listing renders a row per connected provider account."""
+    mocker.patch(
+        "reflex_cli.utils.hosting.get_authenticated_client", return_value=_CLIENT
+    )
+    mocker.patch(
+        "reflex_cli.utils.hosting.list_provider_accounts",
+        return_value=[
+            {
+                "provider": "gcp",
+                "config": {"project_id": "my-proj", "region": "us-central1"},
+                "created_at": "2026-07-01T00:00:00Z",
+            }
+        ],
+    )
+
+    result = runner.invoke(providers_cli, ["list"])
+
+    assert result.exit_code == 0, result.output
+    assert "gcp" in result.output
+    assert "my-proj" in result.output
+
+
+def test_providers_list_empty(mocker: MockFixture):
+    """An org with no providers gets a connect hint, not a table."""
+    mocker.patch(
+        "reflex_cli.utils.hosting.get_authenticated_client", return_value=_CLIENT
+    )
+    mocker.patch("reflex_cli.utils.hosting.list_provider_accounts", return_value=[])
+
+    result = runner.invoke(providers_cli, ["list"])
+
+    assert result.exit_code == 0, result.output
+    assert "No cloud providers connected" in result.output
+
+
+def test_providers_status_requires_org(mocker: MockFixture):
+    """With no token org and no --org-id, the command errors out."""
+    client = hosting.AuthenticatedClient(token="fake-token", validated_data={})
+    mocker.patch(
+        "reflex_cli.utils.hosting.get_authenticated_client", return_value=client
+    )
+
+    result = runner.invoke(providers_cli, ["status"])
+
+    assert result.exit_code == 1


### PR DESCRIPTION
### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

### Description

This PR adds three major features to Reflex Cloud's deployment management:

1. **Managed GCP provider support**: Organizations with Enterprise tier can now deploy to their own Google Cloud (GCP) account connected via the Reflex Cloud dashboard. The `reflex deploy` command prompts interactively when GCP is available, and `--provider` allows explicit selection. New CLI commands `reflex cloud providers status` and `reflex cloud providers list` provide visibility into connected cloud accounts.

2. **Deployment rollback**: Added `reflex cloud apps rollback DEPLOYMENT_ID` to roll an app back to a previous deployment by redeploying its already-built image without rebuilding from source. This is useful for quick recovery from bad deployments.

3. **Deployment descriptions**: Deployments can now have optional changelog notes. Set one at deploy time with `reflex deploy --description "..."`, or set/clear it later with `reflex cloud apps describe DEPLOYMENT_ID --description "..."`. Descriptions appear in `reflex cloud apps history` output.

### Changes

**Core hosting utilities** (`packages/reflex-hosting-cli/src/reflex_cli/utils/hosting.py`):
- Added `provider` parameter to `create_app()` to pin apps to a specific hosting provider
- New provider management functions: `normalize_provider()`, `provider_display_name()`, `get_token_org_id()`, `get_token_tier()`, `get_gcp_provider_status()`, `gcp_deploy_available()`, `list_provider_accounts()`, `set_app_provider()`
- New deployment management functions: `rollback_deployment()`, `update_deployment_description()`
- Provider constants and aliases mapping user-facing names to backend values

**CLI commands**:
- New `reflex cloud providers` group with `status` and `list` subcommands (`packages/reflex-hosting-cli/src/reflex_cli/v2/providers.py`)
- New `reflex cloud apps rollback` and `reflex cloud apps describe` subcommands (`packages/reflex-hosting-cli/src/reflex_cli/v2/apps.py`)
- Updated `reflex deploy` to accept `--provider` and `--description` options, with interactive provider selection when GCP is available (`reflex/reflex.py` and `packages/reflex-hosting-cli/src/reflex_cli/v2/cli.py`)
- Added `_resolve_deploy_provider()` helper to handle provider selection logic with warnings for provider switches

**Documentation**:
- New `docs/hosting/cloud-providers.md` explaining managed GCP deploys, provider selection, and the distinction from self-service GCP deploys
- Updated `docs/hosting/app-management.md` with deployment history, rollback, and description sections
- Updated CLI reference docs to include new commands

**Tests**:
- Comprehensive unit tests for all new hosting utilities and CLI commands
- Tests cover provider normalization, GCP availability checks, provider switching, rollback, and description updates
- Tests verify error handling and interactive mode behavior

### Test Plan

All new functionality is covered by unit tests:
- `tests/units/reflex_cli/utils/test_hosting.py`: Provider utilities, GCP status, provider account listing, rollback, and description updates
- `tests/units/reflex_cli/v2/test_providers.py`: `providers status` and `providers list` CLI commands
- `tests/units/reflex_cli/v2/test_apps.py`: `apps rollback` and `apps describe` CLI commands
- `tests/units/reflex_cli/v2/test_cli.py`: `_resolve_deploy_provider()` logic and provider switching

Run with: `uv run pytest tests/units/reflex_cli --cov`

https://claude.ai/code/session_01K1YRndqwXapfwj5Rtx9Mzz