### PR TITLE
OPS-1673: Audit & update Integrations & Connections docs

### DIFF
--- a/docs/ai_builder/features/connect_to_git_providers.md
+++ b/docs/ai_builder/features/connect_to_git_providers.md
@@ -5,7 +5,7 @@ description: Connect Reflex Build to GitLab, Bitbucket, or any Git remote using 
 
 # Connecting to Git Providers
 
-Besides the [GitHub integration](/docs/ai/features/connect-to-github/), Reflex Build can sync to any Git remote, including GitLab, Bitbucket, a self-hosted server, or an existing GitHub repository. You connect it with a repository URL and a fine-grained access token, then push and pull the same way you would with GitHub.
+Besides the [GitHub integration](/docs/ai/features/connect-to-github/), Reflex Build can sync to any Git remote, including GitLab, Bitbucket, Azure DevOps, a self-hosted server, or an existing GitHub repository. You connect it with a repository URL and a fine-grained access token, then push and pull the same way you would with GitHub.
 
 ## What You Need
 

--- a/docs/ai_builder/features/connect_to_github.md
+++ b/docs/ai_builder/features/connect_to_github.md
@@ -50,7 +50,7 @@ When you connect a Build app to GitHub, Reflex Build creates a Git repository fo
 - If the `reflex-build` app is installed on a **GitHub organization**, the repository is created inside that organization.
 - Otherwise, the repository is created under your **personal GitHub account**.
 
-New repositories use the `main` branch and are private, unless you make them public when connecting.
+New repositories use the `main` branch. Repository visibility depends on your plan: on **Pro** you choose public or private when connecting; on the **Free** plan new repositories are public; on **Enterprise** they are always private.
 
 ## Pushing and Pulling Changes
 

--- a/packages/integrations-docs/src/integrations_docs/docs/database.md
+++ b/packages/integrations-docs/src/integrations_docs/docs/database.md
@@ -87,6 +87,15 @@ Database (mydatabase) - Target database name
    - Generates SQLAlchemy models
    - Makes schema available to the AI for queries
 
+## Connecting a Private or Remote Database
+
+Reflex Build connects to your database from its cloud sandbox, so the database must be reachable over the internet. A few tips for remote connections:
+
+- **Use an IPv4-reachable host or a connection pooler.** IPv6-only hosts may not be reachable from the sandbox; most managed providers offer a pooler endpoint that works.
+- **Allowlisting:** on **Enterprise** plans, database traffic can be routed through a static egress IP that you allowlist on your database's firewall.
+
+You provide a single connection string (or the individual fields), and Reflex Build derives the environment variables your app connects with — `REFLEX_DB_URL` and its async counterpart `REFLEX_ASYNC_DB_URL` — automatically.
+
 
 ```md alert
 # NoSQL Databases

--- a/packages/integrations-docs/src/integrations_docs/docs/snowflake.md
+++ b/packages/integrations-docs/src/integrations_docs/docs/snowflake.md
@@ -1,3 +1,7 @@
+---
+tags: Data Infrastructure
+description: Connect to Snowflake to query and analyze data in your Snowflake warehouse.
+---
 # Snowflake
 
 Snowflake is a cloud-based data warehousing platform that enables users to store, manage, and analyze large volumes of data. It provides a scalable and flexible architecture that separates storage and compute resources, allowing for efficient data processing and querying.


### PR DESCRIPTION
Audit of the AI Builder integration/connection docs against the current flexgen product. Verified flows in code before editing.

## Fixes in this PR (verified against code)
- **GitHub** (`connect_to_github.md`): repo visibility is **plan-dependent** — Free repos are public, Enterprise repos are always private, Pro chooses. The old "private unless you make them public" was only true for Pro.
- **Git providers** (`connect_to_git_providers.md`): added **Azure DevOps** to the supported list (it's supported via the generic git provider).
- **Database** (`database.md`): added a **"Connecting a Private or Remote Database"** section (must be internet-reachable; IPv4/connection-pooler tip; Enterprise static-egress allowlisting) and noted the app connects via `REFLEX_DB_URL` / `REFLEX_ASYNC_DB_URL` (derived automatically from the single connection input).
- **Snowflake** (`snowflake.md`): added the missing frontmatter (`tags` + `description`) — it had none, so its gallery card rendered without a category/subtitle.

## ⚠️ Needs a decision (not changed here)
- **Dead integration pages surfacing to users.** The integrations gallery lists every `.md` in `integrations-docs/docs/` (`integration_list.py` does an `os.listdir`), so **`airtable`, `hubspot`, and `langchain` show as integrations** — but none of them are registered in `flexgen/integrations/__init__.py`, so they don't exist in the product. Either remove these three pages (+ their sidebar entries) or re-register the integrations. Didn't delete unilaterally.

## Still open for the ticket's DoD
- **Screenshots**: couldn't refresh headless. `database.md` has none; the GitHub page's screenshots weren't re-verified against current UI.
- **UI navigation unverified**: `database.md` says "Settings drawer (gear icon) → Integrations tab" — I couldn't confirm this path against the current UI; worth a visual check.
- Minor: the package `overview.md` imports `from pcweb.pages...` while the docs app exposes `reflex_docs.pages...`; verify which site consumes it.

Linear: [OPS-1673](https://linear.app/reflex-dev/issue/OPS-1673/audit-and-update-integrations-and-connections-docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)