### PR TITLE
fix(format): recognize quote and backtick wrapping in is_wrapped

### DIFF
--- a/news/6813.bugfix.md
+++ b/news/6813.bugfix.md
@@ -1,0 +1,1 @@
+Fixed `is_wrapped` to recognize quote- and backtick-wrapped text so `wrap` no longer double-wraps it.

--- a/packages/reflex-base/src/reflex_base/utils/format.py
+++ b/packages/reflex-base/src/reflex_base/utils/format.py
@@ -95,8 +95,13 @@ def is_wrapped(text: str, open: str, close: str | None = None) -> bool:
         Whether the text is wrapped.
     """
     close = get_close_char(open, close)
-    if not (text.startswith(open) and text.endswith(close)):
+    if len(text) < 2 or not (text.startswith(open) and text.endswith(close)):
         return False
+
+    # Identical delimiters (e.g. quotes or backticks) cannot nest, so the text
+    # is wrapped only when the delimiter does not reappear inside the content.
+    if open == close:
+        return open not in text[1:-1]
 
     depth = 0
     for ch in text[:-1]:

--- a/tests/units/utils/test_format.py
+++ b/tests/units/utils/test_format.py
@@ -171,6 +171,11 @@ def test_get_close_char(input: str, output: str):
         ("{wrap", "{", False),
         ("{wrap}", "(", False),
         ("(wrap)", "(", True),
+        # Identical delimiters (quotes/backticks) that cannot nest.
+        ("`wrap`", "`", True),
+        ('"wrap"', '"', True),
+        ("`a`b`", "`", False),
+        ("`", "`", False),
     ],
 )
 def test_is_wrapped(text: str, open: str, expected: bool):


### PR DESCRIPTION
`is_wrapped()` never recognizes quote- or backtick-wrapped text, so `wrap()` with the default `check_first=True` double-wraps it:

```python
from reflex.utils.format import wrap
wrap("`x`", "`")   # "``x``"  (expected "`x`")
wrap('"x"', '"')    # '""x""' (expected '"x"')
```

When `open == close` (the quote and backtick entries in `WRAP_MAP`), the opening delimiter matched both `if ch == open` and `if ch == close` on the same character, so `depth` dropped straight back to 0 and the function returned `False` for any such string. `wrap(text, open)` then never noticed the input was already wrapped and wrapped it again.

Identical delimiters can't nest, so this handles them directly: the text counts as wrapped when the delimiter doesn't reappear inside the content. Distinct-delimiter behavior is unchanged.

`test_is_wrapped` only exercised `{` and `(`, so the quote/backtick cases are added (including `` `a`b` `` which should stay `False`).

I couldn't run the full unit suite locally: its conftest imports `reflex_components_core`, and pydantic v1 doesn't load on my Python 3.14. I verified instead by importing `reflex_base.utils.format` directly and running the parametrized cases plus the distinct-delimiter regressions, which all pass, and confirming `wrap("`x`", "`")` is now idempotent.
