### PR TITLE
fix: serve JavaScript assets with a stable MIME type

### DIFF
--- a/news/6831.bugfix.md
+++ b/news/6831.bugfix.md
@@ -1,0 +1,1 @@
+Fix production frontend hydration on Windows when the system MIME registry maps JavaScript files to `text/plain`.

--- a/reflex/utils/precompressed_staticfiles.py
+++ b/reflex/utils/precompressed_staticfiles.py
@@ -143,7 +143,11 @@ class PrecompressedStaticFiles(StaticFiles):
         response_path: str | PathLike[str] = full_path
         response_stat = stat_result
         response_headers: dict[str, str] = {}
-        media_type: str | None = None
+        media_type = (
+            "text/javascript"
+            if Path(full_path).suffix.lower() in {".js", ".mjs"}
+            else guess_type(os.fspath(full_path))[0]
+        )
 
         if self._encodings:
             response_headers["Vary"] = "Accept-Encoding"
@@ -151,7 +155,6 @@ class PrecompressedStaticFiles(StaticFiles):
             if sidecar is not None:
                 content_encoding, response_path, response_stat = sidecar
                 response_headers["Content-Encoding"] = content_encoding
-                media_type = guess_type(os.fspath(full_path))[0] or "text/plain"
 
         response = FileResponse(
             response_path,

--- a/tests/units/utils/test_precompressed_staticfiles.py
+++ b/tests/units/utils/test_precompressed_staticfiles.py
@@ -122,6 +122,35 @@ async def test_precompressed_static_files_prefers_best_accept_encoding(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("accept_encoding", "response_name"),
+    [("identity", "app.js"), ("gzip", "app.js.gz")],
+)
+async def test_precompressed_static_files_use_javascript_mime_independent_of_system_mapping(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    accept_encoding: str,
+    response_name: str,
+):
+    """Serve JavaScript with its standard MIME type despite a host override."""
+    (tmp_path / "app.js").write_text("console.log('hello');")
+    (tmp_path / "app.js.gz").write_bytes(b"compressed-gzip")
+    monkeypatch.setattr(
+        "reflex.utils.precompressed_staticfiles.guess_type",
+        lambda _path: ("text/plain", None),
+    )
+
+    static_files = PrecompressedStaticFiles(directory=tmp_path, encodings=["gzip"])
+    response = await static_files.get_response(
+        "app.js", _scope("/app.js", accept_encoding)
+    )
+
+    assert isinstance(response, FileResponse)
+    assert str(response.path).endswith(response_name)
+    assert response.media_type == "text/javascript"
+
+
+@pytest.mark.asyncio
 async def test_precompressed_static_files_fall_back_to_identity(tmp_path: Path):
     """Keep serving the original file when no accepted sidecar is available."""
     (tmp_path / "app.js").write_text("console.log('hello');")


### PR DESCRIPTION
## Summary
- serve `.js` and `.mjs` static assets as `text/javascript` rather than relying on host MIME mappings
- cover identity and precompressed responses when the system reports `.js` as `text/plain`

## Problem
On Windows, Python reads the `.js` content type from the registry. If it is registered as `text/plain`, production Reflex serves ES-module assets with that type, and browsers reject them before the frontend can hydrate.

## Testing
- `uv run ruff check reflex/utils/precompressed_staticfiles.py tests/units/utils/test_precompressed_staticfiles.py`
- `uv run pytest tests/units/utils/test_precompressed_staticfiles.py`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/6831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

