### PR TITLE
fix(recharts): stop routing component props to wrapperStyle

### DIFF
--- a/news/6575.bugfix.md
+++ b/news/6575.bugfix.md
@@ -1,0 +1,1 @@
+Fix Recharts component props (e.g. `stroke_dasharray` on `reference_line`, `tick_formatter` on `x_axis`/`y_axis`) being misclassified as CSS and routed to `wrapperStyle` instead of reaching the underlying Recharts component.

--- a/packages/reflex-components-recharts/src/reflex_components_recharts/cartesian.py
+++ b/packages/reflex-components-recharts/src/reflex_components_recharts/cartesian.py
@@ -10,7 +10,7 @@ from reflex_base.constants import EventTriggers
 from reflex_base.constants.colors import Color
 from reflex_base.event import EventHandler, no_args_event_spec
 from reflex_base.vars.base import LiteralVar, Var
-from reflex_base.vars.function import FunctionStringVar
+from reflex_base.vars.function import FunctionStringVar, FunctionVar
 
 from .recharts import (
     ACTIVE_DOT_TYPE,
@@ -136,11 +136,28 @@ class Axis(Recharts):
         Returns:
             The Axis component.
         """
-        if isinstance(tick_formatter := props.get("tick_formatter"), str):
-            props["tick_formatter"] = FunctionStringVar.create(
-                tick_formatter,
-                _var_type=Callable[..., Any],  # pyright: ignore [reportArgumentType]
-            )
+        if (tick_formatter := props.get("tick_formatter")) is not None:
+            if isinstance(tick_formatter, str):
+                props["tick_formatter"] = FunctionStringVar.create(
+                    tick_formatter,
+                    _var_type=Callable[..., Any],  # pyright: ignore [reportArgumentType]
+                )
+            elif isinstance(tick_formatter, FunctionVar):
+                # Normalize to a consistent _var_type regardless of how the
+                # caller constructed the FunctionVar, so it satisfies the
+                # declared field type below.
+                props["tick_formatter"] = tick_formatter._replace(
+                    _var_type=Callable[..., Any]  # pyright: ignore [reportArgumentType]
+                )
+            elif not isinstance(tick_formatter, Var):
+                msg = (
+                    "tick_formatter must be a raw JS function expression string "
+                    f'(e.g. "(value) => value.toFixed(2)") or a Var, got a Python '
+                    f"{type(tick_formatter).__name__}. Python values (including "
+                    "plain callables like lambdas) cannot be sent to the client "
+                    "as-is and are not supported."
+                )
+                raise TypeError(msg)
         return super().create(*children, **props)
 
     stroke: Var[str | Color] = field(

--- a/packages/reflex-components-recharts/src/reflex_components_recharts/cartesian.py
+++ b/packages/reflex-components-recharts/src/reflex_components_recharts/cartesian.py
@@ -10,6 +10,7 @@ from reflex_base.constants import EventTriggers
 from reflex_base.constants.colors import Color
 from reflex_base.event import EventHandler, no_args_event_spec
 from reflex_base.vars.base import LiteralVar, Var
+from reflex_base.vars.function import FunctionStringVar
 
 from .recharts import (
     ACTIVE_DOT_TYPE,
@@ -114,13 +115,30 @@ class Axis(Recharts):
 
     tick_size: Var[int] = field(doc="The length of tick line. Default: 6")
 
-    tick_formatter: Var[str] = field(
-        doc="A function to format the tick value shown in the axis."
+    tick_formatter: Var[Any] = field(
+        doc="A function to format the tick value shown in the axis. Pass a "
+        "raw JS function body as a string, e.g. tick_formatter="
+        '"(value) => value.toFixed(2)".'
     )
 
     min_tick_gap: Var[int] = field(
         doc="The minimum gap between two adjacent labels. Default: 5"
     )
+
+    @classmethod
+    def create(cls, *children, **props):
+        """Create an Axis component.
+
+        Args:
+            *children: The children of the component.
+            **props: The properties of the component.
+
+        Returns:
+            The Axis component.
+        """
+        if isinstance(tick_formatter := props.get("tick_formatter"), str):
+            props["tick_formatter"] = FunctionStringVar.create(tick_formatter)
+        return super().create(*children, **props)
 
     stroke: Var[str | Color] = field(
         default=LiteralVar.create(Color("gray", 9)),

--- a/packages/reflex-components-recharts/src/reflex_components_recharts/cartesian.py
+++ b/packages/reflex-components-recharts/src/reflex_components_recharts/cartesian.py
@@ -114,6 +114,10 @@ class Axis(Recharts):
 
     tick_size: Var[int] = field(doc="The length of tick line. Default: 6")
 
+    tick_formatter: Var[str] = field(
+        doc="A function to format the tick value shown in the axis."
+    )
+
     min_tick_gap: Var[int] = field(
         doc="The minimum gap between two adjacent labels. Default: 5"
     )
@@ -814,6 +818,10 @@ class ReferenceLine(Reference):
 
     stroke_width: Var[str | int | float] = field(
         doc="The width of the stroke. Default: 1"
+    )
+
+    stroke_dasharray: Var[str] = field(
+        doc="The pattern of dashes and gaps used to paint the reference line."
     )
 
     # Valid children components

--- a/packages/reflex-components-recharts/src/reflex_components_recharts/cartesian.py
+++ b/packages/reflex-components-recharts/src/reflex_components_recharts/cartesian.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from typing import Any, ClassVar, TypedDict
 
 from reflex_base.components.component import field
@@ -115,9 +115,9 @@ class Axis(Recharts):
 
     tick_size: Var[int] = field(doc="The length of tick line. Default: 6")
 
-    tick_formatter: Var[Any] = field(
+    tick_formatter: Var[str | Callable[..., Any]] = field(
         doc="A function to format the tick value shown in the axis. Pass a "
-        "raw JS function body as a string, e.g. tick_formatter="
+        "raw JS function expression as a string, e.g. tick_formatter="
         '"(value) => value.toFixed(2)".'
     )
 
@@ -137,7 +137,10 @@ class Axis(Recharts):
             The Axis component.
         """
         if isinstance(tick_formatter := props.get("tick_formatter"), str):
-            props["tick_formatter"] = FunctionStringVar.create(tick_formatter)
+            props["tick_formatter"] = FunctionStringVar.create(
+                tick_formatter,
+                _var_type=Callable[..., Any],  # pyright: ignore [reportArgumentType]
+            )
         return super().create(*children, **props)
 
     stroke: Var[str | Color] = field(

--- a/pyi_hashes.json
+++ b/pyi_hashes.json
@@ -112,7 +112,7 @@
   "packages/reflex-components-react-player/src/reflex_components_react_player/react_player.pyi": "86fc106181638c6a0a2a199332be817f",
   "packages/reflex-components-react-player/src/reflex_components_react_player/video.pyi": "2682dc6e825d25307d8390d01e2bd653",
   "packages/reflex-components-recharts/src/reflex_components_recharts/__init__.pyi": "359e123d9a046557ce05a96ce10313f5",
-  "packages/reflex-components-recharts/src/reflex_components_recharts/cartesian.pyi": "541710a9f3f7a3ad3f5539f1f7f856dc",
+  "packages/reflex-components-recharts/src/reflex_components_recharts/cartesian.pyi": "de962ad6968036849f605e473acd42b0",
   "packages/reflex-components-recharts/src/reflex_components_recharts/charts.pyi": "280a7cd51298ee676f3d076104133f44",
   "packages/reflex-components-recharts/src/reflex_components_recharts/general.pyi": "f5e3491c4e1f69ba89085682888888a9",
   "packages/reflex-components-recharts/src/reflex_components_recharts/polar.pyi": "99ebcfc07868061bdc3c2010d85a153f",

--- a/pyi_hashes.json
+++ b/pyi_hashes.json
@@ -112,7 +112,7 @@
   "packages/reflex-components-react-player/src/reflex_components_react_player/react_player.pyi": "86fc106181638c6a0a2a199332be817f",
   "packages/reflex-components-react-player/src/reflex_components_react_player/video.pyi": "2682dc6e825d25307d8390d01e2bd653",
   "packages/reflex-components-recharts/src/reflex_components_recharts/__init__.pyi": "359e123d9a046557ce05a96ce10313f5",
-  "packages/reflex-components-recharts/src/reflex_components_recharts/cartesian.pyi": "3485aaabbfd3ca89908ae19425c7297e",
+  "packages/reflex-components-recharts/src/reflex_components_recharts/cartesian.pyi": "541710a9f3f7a3ad3f5539f1f7f856dc",
   "packages/reflex-components-recharts/src/reflex_components_recharts/charts.pyi": "280a7cd51298ee676f3d076104133f44",
   "packages/reflex-components-recharts/src/reflex_components_recharts/general.pyi": "f5e3491c4e1f69ba89085682888888a9",
   "packages/reflex-components-recharts/src/reflex_components_recharts/polar.pyi": "99ebcfc07868061bdc3c2010d85a153f",

--- a/pyi_hashes.json
+++ b/pyi_hashes.json
@@ -112,7 +112,7 @@
   "packages/reflex-components-react-player/src/reflex_components_react_player/react_player.pyi": "86fc106181638c6a0a2a199332be817f",
   "packages/reflex-components-react-player/src/reflex_components_react_player/video.pyi": "2682dc6e825d25307d8390d01e2bd653",
   "packages/reflex-components-recharts/src/reflex_components_recharts/__init__.pyi": "359e123d9a046557ce05a96ce10313f5",
-  "packages/reflex-components-recharts/src/reflex_components_recharts/cartesian.pyi": "de962ad6968036849f605e473acd42b0",
+  "packages/reflex-components-recharts/src/reflex_components_recharts/cartesian.pyi": "1eedb94040e51bd722030b6e57815ce1",
   "packages/reflex-components-recharts/src/reflex_components_recharts/charts.pyi": "280a7cd51298ee676f3d076104133f44",
   "packages/reflex-components-recharts/src/reflex_components_recharts/general.pyi": "f5e3491c4e1f69ba89085682888888a9",
   "packages/reflex-components-recharts/src/reflex_components_recharts/polar.pyi": "99ebcfc07868061bdc3c2010d85a153f",

--- a/tests/units/components/recharts/test_cartesian.py
+++ b/tests/units/components/recharts/test_cartesian.py
@@ -50,15 +50,23 @@ def test_reference_line_stroke_dasharray():
     reference_line = ReferenceLine.create(stroke_dasharray="8 8")
     assert "strokeDasharray" not in reference_line.style
     props = reference_line.render()["props"]
-    assert any("strokeDasharray" in prop for prop in props)
+    assert 'strokeDasharray:"8 8"' in props
     assert not any("wrapperStyle" in prop for prop in props)
 
 
 def test_xaxis_tick_formatter():
-    x_axis = XAxis.create(tick_formatter="(value) => value")
+    x_axis = XAxis.create(tick_formatter="(value) => value.toFixed(2)")
     assert "tickFormatter" not in x_axis.style
     props = x_axis.render()["props"]
-    assert any("tickFormatter" in prop for prop in props)
+    assert "tickFormatter:(value) => value.toFixed(2)" in props
+    assert not any("wrapperStyle" in prop for prop in props)
+
+
+def test_yaxis_tick_formatter():
+    y_axis = YAxis.create(tick_formatter="(value) => value.toFixed(2)")
+    assert "tickFormatter" not in y_axis.style
+    props = y_axis.render()["props"]
+    assert "tickFormatter:(value) => value.toFixed(2)" in props
     assert not any("wrapperStyle" in prop for prop in props)
 
 

--- a/tests/units/components/recharts/test_cartesian.py
+++ b/tests/units/components/recharts/test_cartesian.py
@@ -1,3 +1,4 @@
+import pytest
 from reflex_components_recharts import (
     Area,
     Bar,
@@ -68,6 +69,11 @@ def test_yaxis_tick_formatter():
     props = y_axis.render()["props"]
     assert "tickFormatter:(value) => value.toFixed(2)" in props
     assert not any("wrapperStyle" in prop for prop in props)
+
+
+def test_xaxis_tick_formatter_rejects_non_callable():
+    with pytest.raises(TypeError):
+        XAxis.create(tick_formatter=123)  # pyright: ignore [reportArgumentType]
 
 
 def test_scatter():

--- a/tests/units/components/recharts/test_cartesian.py
+++ b/tests/units/components/recharts/test_cartesian.py
@@ -1,4 +1,5 @@
 import pytest
+from reflex_base.vars.function import FunctionStringVar
 from reflex_components_recharts import (
     Area,
     Bar,
@@ -74,6 +75,19 @@ def test_yaxis_tick_formatter():
 def test_xaxis_tick_formatter_rejects_non_callable():
     with pytest.raises(TypeError):
         XAxis.create(tick_formatter=123)  # pyright: ignore [reportArgumentType]
+
+
+def test_xaxis_tick_formatter_rejects_python_callable():
+    with pytest.raises(TypeError, match="Python"):
+        XAxis.create(
+            tick_formatter=lambda value: value  # pyright: ignore [reportArgumentType]
+        )
+
+
+def test_xaxis_tick_formatter_accepts_prebuilt_function_var():
+    x_axis = XAxis.create(tick_formatter=FunctionStringVar.create("myGlobalFormatter"))
+    props = x_axis.render()["props"]
+    assert "tickFormatter:myGlobalFormatter" in props
 
 
 def test_scatter():

--- a/tests/units/components/recharts/test_cartesian.py
+++ b/tests/units/components/recharts/test_cartesian.py
@@ -3,6 +3,7 @@ from reflex_components_recharts import (
     Bar,
     Brush,
     Line,
+    ReferenceLine,
     Scatter,
     XAxis,
     YAxis,
@@ -43,6 +44,22 @@ def test_bar():
 def test_line():
     line = Line.create().render()
     assert line["name"] == "RechartsLine"
+
+
+def test_reference_line_stroke_dasharray():
+    reference_line = ReferenceLine.create(stroke_dasharray="8 8")
+    assert "strokeDasharray" not in reference_line.style
+    props = reference_line.render()["props"]
+    assert any("strokeDasharray" in prop for prop in props)
+    assert not any("wrapperStyle" in prop for prop in props)
+
+
+def test_xaxis_tick_formatter():
+    x_axis = XAxis.create(tick_formatter="(value) => value")
+    assert "tickFormatter" not in x_axis.style
+    props = x_axis.render()["props"]
+    assert any("tickFormatter" in prop for prop in props)
+    assert not any("wrapperStyle" in prop for prop in props)
 
 
 def test_scatter():


### PR DESCRIPTION
Declare stroke_dasharray on ReferenceLine and tick_formatter on Axis (shared by XAxis/YAxis) as explicit fields. Previously undeclared kwargs fell through Component.create()'s default classification into style, which _get_style() (added in #4447) then dumps into wrapperStyle, so the props never reached the underlying Recharts component.

Fixes #6575

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

## What changed

`Component.create()` treats any kwarg not declared as an explicit field on the class as a style prop. `_get_style()` (added in #4447) then dumps `style` into `wrapperStyle`. `stroke_dasharray` on `ReferenceLine` and `tick_formatter` on `XAxis`/`YAxis` weren't declared as real fields, so they were misclassified as CSS and never reached the underlying Recharts component — dashed reference lines rendered solid, `tick_formatter` was ignored.

Fix: declared both as explicit `Var` fields on `ReferenceLine` and the shared `Axis` base class.

## Test plan

- Added regression tests asserting these props render as component props, not swallowed into `style`/`wrapperStyle` (`tests/units/components/recharts/test_cartesian.py`)
- `uv run pytest tests/units/components/recharts` — 10 passed
- `uv run ruff check .` / `ruff format --check .` / `uv run pyright` — clean
- `.pyi` stubs regenerated via `scripts/make_pyi.py`
- `pre-commit run --files ...` — all hooks passed

closes #6575


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/6833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

