### PR TITLE
test: fix flaky memo test by waiting for hydration before interacting

### DIFF
--- a/tests/integration/tests_playwright/test_memo.py
+++ b/tests/integration/tests_playwright/test_memo.py
@@ -89,6 +89,11 @@ def MemoApp():
 
     def index() -> rx.Component:
         return rx.vstack(
+            rx.input(
+                value=MemoState.router.session.client_token,
+                read_only=True,
+                id="token",
+            ),
             rx.text(MemoState.last_value, id="memo-last-value"),
             my_memoed_component(
                 some_value="memod_some_value", event=MemoState.set_last_value
@@ -132,6 +137,21 @@ def memo_app(
         yield harness
 
 
+def _load_page(page: Page, memo_app: AppHarness) -> None:
+    """Navigate to the app and wait until it is hydrated and connected.
+
+    Waits for the client token to appear so that event handlers are attached
+    before the test interacts with the page.
+
+    Args:
+        page: Playwright page.
+        memo_app: Running app harness.
+    """
+    assert memo_app.frontend_url is not None
+    page.goto(memo_app.frontend_url)
+    expect(page.locator("#token")).not_to_have_value("")
+
+
 def test_memo_event_handler_partial_application(
     memo_app: AppHarness, page: Page
 ) -> None:
@@ -141,8 +161,7 @@ def test_memo_event_handler_partial_application(
         memo_app: Running app harness.
         page: Playwright page.
     """
-    assert memo_app.frontend_url is not None
-    page.goto(memo_app.frontend_url)
+    _load_page(page, memo_app)
 
     expect(page.locator("#memo-last-value")).to_have_text("")
     page.click("#memo-button")
@@ -156,8 +175,7 @@ def test_memo_event_handler_raw_pass_through(memo_app: AppHarness, page: Page) -
         memo_app: Running app harness.
         page: Playwright page.
     """
-    assert memo_app.frontend_url is not None
-    page.goto(memo_app.frontend_url)
+    _load_page(page, memo_app)
 
     page.locator("#memo-input").fill("typed_value")
     expect(page.locator("#memo-last-value")).to_have_text("typed_value")
@@ -170,8 +188,7 @@ def test_memo_recursive_tree_render(memo_app: AppHarness, page: Page) -> None:
         memo_app: Running app harness.
         page: Playwright page.
     """
-    assert memo_app.frontend_url is not None
-    page.goto(memo_app.frontend_url)
+    _load_page(page, memo_app)
 
     tree_root = page.locator("#tree-root")
     node_names = tree_root.locator(".tree-node-name")
@@ -186,8 +203,7 @@ def test_memo_recursive_tree_reacts_to_state(memo_app: AppHarness, page: Page) -
         memo_app: Running app harness.
         page: Playwright page.
     """
-    assert memo_app.frontend_url is not None
-    page.goto(memo_app.frontend_url)
+    _load_page(page, memo_app)
 
     node_names = page.locator("#tree-root .tree-node-name")
     expect(node_names).to_have_count(4)
@@ -213,8 +229,7 @@ def test_memo_key_preserves_identity_across_reorder(
         memo_app: Running app harness.
         page: Playwright page.
     """
-    assert memo_app.frontend_url is not None
-    page.goto(memo_app.frontend_url)
+    _load_page(page, memo_app)
 
     rows = page.locator("#keyed-rows input")
     expect(rows).to_have_count(3)
@@ -243,8 +258,7 @@ def test_memo_wrapper_none_renders_and_updates(
         memo_app: Running app harness.
         page: Playwright page.
     """
-    assert memo_app.frontend_url is not None
-    page.goto(memo_app.frontend_url)
+    _load_page(page, memo_app)
 
     expect(page.locator("#unwrapped-label")).to_have_text("")
     page.locator("#memo-input").fill("unwrapped_update")


### PR DESCRIPTION
## Summary

`test_memo_event_handler_raw_pass_through` failed intermittently in CI:

```
AssertionError: Locator expected to have text 'typed_value'
Actual value:
```

The test filled `#memo-input` immediately after `page.goto()`, racing React hydration: if the `fill()` fired before the `on_change` handler was attached (and before the websocket connected), the input event was silently lost, so `#memo-last-value` stayed empty until the 5s expect timed out.

## Fix

Use the same pattern as `test_debounce_input.py`:
- Render `MemoState.router.session.client_token` in a read-only `#token` input — it only becomes non-empty once the client is hydrated and connected to the backend.
- Add a `_load_page()` helper (`goto` + wait for `#token` to be non-empty) and use it in all six tests of the module, since they all interact right after navigation and share the same latent race.

## Testing

- `uv run pytest tests/integration/tests_playwright/test_memo.py` — 6 passed
- ruff check/format clean

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/6835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

