### PR TITLE
fix: replace queued write with latest state in StateManagerDisk

### DIFF
--- a/reflex/istate/manager/disk.py
+++ b/reflex/istate/manager/disk.py
@@ -340,6 +340,15 @@ class StateManagerDisk(StateManager):
                     state=state,
                     timestamp=time.time(),
                 )
+            else:
+                # A write for this token is already queued; replace the queued
+                # state with the latest value so a stale snapshot is not
+                # flushed to disk. Preserve the original timestamp so the
+                # item still flushes at its originally scheduled time.
+                self._write_queue[token] = dataclasses.replace(
+                    self._write_queue[token],
+                    state=state,
+                )
         else:
             # Immediate write to disk.
             await self.set_state_for_substate(token, state)

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -4441,7 +4441,7 @@ async def test_state_manager_disk_set_state_updates_queued_write(tmp_path, token
         token: A token.
     """
     state_manager = StateManagerDisk()
-    state_manager.__dict__["states_directory"] = tmp_path
+    object.__setattr__(state_manager, "states_directory", tmp_path)
     state_manager._write_debounce_seconds = 60
 
     state_token = StateToken(ident=token, cls=int)
@@ -4454,7 +4454,7 @@ async def test_state_manager_disk_set_state_updates_queued_write(tmp_path, token
     await state_manager.close()
 
     reloaded_state_manager = StateManagerDisk()
-    reloaded_state_manager.__dict__["states_directory"] = tmp_path
+    object.__setattr__(reloaded_state_manager, "states_directory", tmp_path)
     assert await reloaded_state_manager.load_state(state_token) == 2
     await reloaded_state_manager.close()
 

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -46,7 +46,7 @@ from reflex.istate.manager import StateManager
 from reflex.istate.manager.disk import StateManagerDisk
 from reflex.istate.manager.memory import StateManagerMemory
 from reflex.istate.manager.redis import StateManagerRedis
-from reflex.istate.manager.token import BaseStateToken
+from reflex.istate.manager.token import BaseStateToken, StateToken
 from reflex.istate.proxy import StateProxy
 from reflex.state import (
     BaseState,
@@ -4429,6 +4429,34 @@ async def test_state_manager_disk_close_resets_write_queue_task():
     await state_manager.close()
 
     assert state_manager._write_queue_task is None
+
+
+@pytest.mark.asyncio
+async def test_state_manager_disk_set_state_updates_queued_write(tmp_path, token):
+    """Test that a second set_state call for an already-queued token replaces
+    the queued state, so the latest value is what gets flushed to disk.
+
+    Args:
+        tmp_path: A temporary directory (pytest fixture).
+        token: A token.
+    """
+    state_manager = StateManagerDisk()
+    state_manager.__dict__["states_directory"] = tmp_path
+    state_manager._write_debounce_seconds = 60
+
+    state_token = StateToken(ident=token, cls=int)
+
+    await state_manager.set_state(state_token, 1)
+    await state_manager.set_state(state_token, 2)
+
+    assert state_manager._write_queue[state_token].state == 2
+
+    await state_manager.close()
+
+    reloaded_state_manager = StateManagerDisk()
+    reloaded_state_manager.__dict__["states_directory"] = tmp_path
+    assert await reloaded_state_manager.load_state(state_token) == 2
+    await reloaded_state_manager.close()
 
 
 class Obj(Base):


### PR DESCRIPTION
### All Submissions:
- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

## What does this PR do and why?

`StateManagerDisk.set_state` only enqueued a token for a debounced write if that token wasn't already in `_write_queue`:

```python
if token not in self._write_queue:
    self._write_queue[token] = QueueItem(...)
```

If `set_state` was called again for the same token before the queued item flushed, the existing `QueueItem` was left untouched, so `_flush_write_queue` / `_process_write_queue` would later write the **first** queued value to disk instead of the **latest** one. Direct `set_state` calls with a replacement state object (as opposed to `modify_state`, which mutates the object in place) could silently lose data during the debounce window.

This PR changes `set_state` so that when a token is already queued, the queued `QueueItem` is replaced with one carrying the latest state via `dataclasses.replace` (since `QueueItem` is a frozen dataclass), while preserving the original `timestamp` so the flush still happens at its originally scheduled time — only the value that gets written changes.

A regression test (`test_state_manager_disk_set_state_updates_queued_write`) was added that mirrors the reproduction from the linked issue: it calls `set_state` twice for the same token with debouncing enabled, asserts the queued state reflects the latest call, then verifies the value persisted to disk after `close()` also reflects the latest call. Verified this test fails on the pre-fix code (`1 == 2`) and passes with the fix.

Also added a towncrier news fragment (`news/+disk-state-manager-stale-write-queue.bugfix.md`) per repo convention.

closes #6839

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/6840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

