### PR TITLE
Apply package.json overrides after frozen install

### DIFF
--- a/news/6792.bugfix.md
+++ b/news/6792.bugfix.md
@@ -1,1 +1,0 @@
-Apply framework `package.json` overrides after the frozen install instead of while restoring `reflex.lock/package.json`, so upgrading to a Reflex version that adds an override no longer fails with `lockfile had changes, but lockfile is frozen`.

--- a/news/6792.bugfix.md
+++ b/news/6792.bugfix.md
@@ -1,0 +1,1 @@
+Apply framework `package.json` overrides after the frozen install instead of while restoring `reflex.lock/package.json`, so upgrading to a Reflex version that adds an override no longer fails with `lockfile had changes, but lockfile is frozen`.

--- a/news/6844.bugfix.md
+++ b/news/6844.bugfix.md
@@ -1,0 +1,1 @@
+Fixed `reflex run` failing with `error: lockfile had changes, but lockfile is frozen` after upgrading to a Reflex version that adds a `package.json` override. Overrides are now applied after the lockfile saved in `reflex.lock/` has been installed, so it is no longer treated as out of date.

--- a/reflex/utils/frontend_skeleton.py
+++ b/reflex/utils/frontend_skeleton.py
@@ -407,6 +407,32 @@ def sync_web_lockfiles_to_root():
         sync_web_lockfile_to_root(name)
 
 
+def _read_package_json_object(package_json_path: Path) -> dict:
+    """Read a package.json file as a JSON object.
+
+    Args:
+        package_json_path: The package.json file to read.
+
+    Returns:
+        The parsed JSON object, or an empty dict if the file is missing,
+        cannot be parsed, or is not a JSON object.
+    """
+    if not package_json_path.exists():
+        return {}
+    try:
+        parsed = json.loads(package_json_path.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        console.warn(f"Failed to read {package_json_path}: {e}; treating it as empty.")
+        return {}
+    if not isinstance(parsed, dict):
+        console.warn(
+            f"Expected {package_json_path} to contain a JSON object, "
+            f"got {type(parsed).__name__}; treating it as empty."
+        )
+        return {}
+    return parsed
+
+
 def _read_persisted_package_json() -> dict:
     """Read the persisted package.json from the app root.
 
@@ -414,23 +440,7 @@ def _read_persisted_package_json() -> dict:
         The parsed JSON object, or an empty dict if the file is missing,
         cannot be parsed, or is not a JSON object.
     """
-    root_package_json_path = get_root_lockfile_path(constants.PackageJson.PATH)
-    if not root_package_json_path.exists():
-        return {}
-    try:
-        parsed = json.loads(root_package_json_path.read_text())
-    except (json.JSONDecodeError, OSError) as e:
-        console.warn(
-            f"Failed to read {root_package_json_path}: {e}; starting with empty dependency lists."
-        )
-        return {}
-    if not isinstance(parsed, dict):
-        console.warn(
-            f"Expected {root_package_json_path} to contain a JSON object, "
-            f"got {type(parsed).__name__}; starting with empty dependency lists."
-        )
-        return {}
-    return parsed
+    return _read_package_json_object(get_root_lockfile_path(constants.PackageJson.PATH))
 
 
 def initialize_web_directory():
@@ -522,12 +532,16 @@ def _compile_package_json():
     ``reflex.lock/package.json`` (when present) so resolved version pins
     survive a fresh ``reflex init``. User-added ``scripts`` are preserved;
     only the framework-owned ``dev`` and ``export`` entries are refreshed
-    from constants. User-added ``overrides`` are kept, with the
-    framework-owned entries refreshed on top. Any other persisted fields
-    (e.g. ``packageManager``, ``engines``) are passed through unchanged.
-    The framework-managed entries in ``constants.PackageJson.DEPENDENCIES``
-    / ``DEV_DEPENDENCIES`` are added later at install time via ``bun add``
-    so they pick up strict pins.
+    from constants. Any other persisted fields (e.g. ``packageManager``,
+    ``engines``) are passed through unchanged.
+
+    Everything a lockfile resolves against is reproduced verbatim, so the
+    rendered file still pairs with the persisted lockfile: the framework
+    entries in ``constants.PackageJson.DEPENDENCIES`` / ``DEV_DEPENDENCIES``
+    are added later at install time via ``bun add`` (picking up strict pins),
+    and ``overrides`` are carried over as persisted, with
+    ``constants.PackageJson.OVERRIDES`` merged in by
+    :func:`update_package_json_overrides` after the frozen install.
 
     Returns:
         Rendered package.json content as string.
@@ -542,12 +556,45 @@ def _compile_package_json():
         scripts=scripts,
         dependencies=persisted.pop("dependencies", None) or {},
         dev_dependencies=persisted.pop("devDependencies", None) or {},
-        overrides={
-            **(persisted.pop("overrides", None) or {}),
-            **constants.PackageJson.OVERRIDES,
-        },
+        overrides=persisted.pop("overrides", None) or {},
         **persisted,
     )
+
+
+def update_package_json_overrides() -> bool:
+    """Merge the framework-owned overrides into ``.web/package.json``.
+
+    ``overrides`` participate in dependency resolution, so injecting them
+    while restoring the persisted ``package.json`` would desync it from the
+    persisted lockfile and make ``--frozen-lockfile`` fail outright on any
+    Reflex upgrade that introduces a new override. Applying them here instead
+    keeps the restored pair intact for the frozen install; the caller
+    refreshes the lockfile afterwards.
+
+    User-added and previously resolved overrides are kept, with the
+    framework-owned entries taking precedence on conflict.
+
+    Returns:
+        Whether ``.web/package.json`` was changed.
+    """
+    package_json_path = get_web_lockfile_path(constants.PackageJson.PATH)
+    package_json = _read_package_json_object(package_json_path)
+    if not package_json:
+        # Nothing usable to merge into. initialize_package_json() renders a
+        # full file upstream, so this only happens for a hand-damaged .web.
+        return False
+
+    overrides = package_json.get("overrides") or {}
+    if all(
+        overrides.get(name) == version
+        for name, version in constants.PackageJson.OVERRIDES.items()
+    ):
+        return False
+
+    package_json["overrides"] = {**overrides, **constants.PackageJson.OVERRIDES}
+    console.debug(f"Applying framework overrides to {package_json_path}")
+    package_json_path.write_text(json.dumps(package_json))
+    return True
 
 
 def initialize_package_json():

--- a/reflex/utils/js_runtimes.py
+++ b/reflex/utils/js_runtimes.py
@@ -589,7 +589,8 @@ def _frontend_packages_cache_payload(
     return (
         f"{sorted(packages)!r},{config.json()},{list(install_package_managers)!r},"
         f"{sorted(constants.PackageJson.DEPENDENCIES.items())!r},"
-        f"{sorted(constants.PackageJson.DEV_DEPENDENCIES.items())!r}"
+        f"{sorted(constants.PackageJson.DEV_DEPENDENCIES.items())!r},"
+        f"{sorted(constants.PackageJson.OVERRIDES.items())!r}"
     )
 
 
@@ -706,6 +707,11 @@ def _install_frontend_packages(
     ):
         _run_initial_install(primary_package_manager, env, config.frozen_lockfile)
 
+    # Framework overrides are withheld while the persisted package.json is
+    # restored so the frozen install above sees exactly the file that produced
+    # the persisted lockfile. Merge them now, before any resolution happens.
+    overrides_changed = frontend_skeleton.update_package_json_overrides()
+
     pinned_packages, unpinned_packages = _split_by_version_specifier(packages)
     pinned_dev_deps, unpinned_dev_deps = _split_by_version_specifier(development_deps)
 
@@ -752,6 +758,14 @@ def _install_frontend_packages(
         run_package_manager(
             [primary_package_manager, "add", "--legacy-peer-deps", *deps_to_add],
             show_status_message="Installing frontend packages",
+        )
+
+    if overrides_changed and not (dev_deps_to_add or deps_to_add):
+        # Newly merged overrides with no add to carry them into the lockfile:
+        # resolve them now so the persisted pair stays frozen-install ready.
+        run_package_manager(
+            [primary_package_manager, "install", "--legacy-peer-deps"],
+            show_status_message="Applying frontend package overrides",
         )
 
 

--- a/tests/units/test_prerequisites.py
+++ b/tests/units/test_prerequisites.py
@@ -81,9 +81,10 @@ class InstallPackagesEnv:
 
 
 def _stub_framework_packages(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Empty out framework deps so install call counts are predictable."""
+    """Empty out framework deps and overrides so install call counts are predictable."""
     monkeypatch.setattr(constants.PackageJson, "DEPENDENCIES", {})
     monkeypatch.setattr(constants.PackageJson, "DEV_DEPENDENCIES", {})
+    monkeypatch.setattr(constants.PackageJson, "OVERRIDES", {})
 
 
 @pytest.fixture
@@ -910,6 +911,136 @@ def test_install_frontend_packages_bun_skips_frozen_lockfile_when_disabled(
         assert "--frozen-lockfile" not in call
 
 
+def _write_restored_package_json(env: InstallPackagesEnv, overrides: dict[str, str]):
+    """Persist a package.json as a completed previous run would have left it.
+
+    Dependencies are left empty so no stale-removal call muddies the counts.
+
+    Args:
+        env: The install_packages_env fixture instance.
+        overrides: The overrides the persisted lockfile was resolved against.
+    """
+    env.root_package_json.write_text(
+        json.dumps({
+            "name": "reflex",
+            "type": "module",
+            "scripts": {
+                "dev": constants.PackageJson.Commands.DEV,
+                "export": constants.PackageJson.Commands.EXPORT,
+            },
+            "dependencies": {},
+            "devDependencies": {},
+            "overrides": overrides,
+        })
+    )
+
+
+def test_install_frontend_packages_applies_overrides_after_frozen_install(
+    install_packages_env: InstallPackagesEnv,
+    monkeypatch,
+):
+    """A newly introduced framework override lands only after the frozen install.
+
+    Upgrading Reflex can add an override that the persisted lockfile knows
+    nothing about. Merging it before the frozen install would desync the pair
+    and abort with "lockfile had changes, but lockfile is frozen".
+    """
+    env = install_packages_env
+    monkeypatch.setattr(constants.PackageJson, "OVERRIDES", {"postcss": "8.5.23"})
+    env.root_lock.write_text("root-lock")
+    _write_restored_package_json(env, {"user-pkg": "2.0.0"})
+
+    seen: list[tuple[list[str], dict]] = []
+
+    def run_package_manager(args, **kwargs):
+        seen.append((
+            list(args),
+            json.loads(env.web_package_json.read_text())["overrides"],
+        ))
+
+    env.patch_pm(["bun"], run_package_manager)
+    env.install({"some-pkg@1.0.0"})
+
+    # The frozen install must see the persisted overrides untouched.
+    frozen_installs = [
+        (args, overrides) for args, overrides in seen if "install" in args
+    ]
+    assert len(frozen_installs) == 1
+    assert "--frozen-lockfile" in frozen_installs[0][0]
+    assert frozen_installs[0][1] == {"user-pkg": "2.0.0"}
+
+    # Every subsequent add resolves against the merged overrides.
+    merged = {"user-pkg": "2.0.0", "postcss": "8.5.23"}
+    add_calls = [(args, overrides) for args, overrides in seen if "add" in args]
+    assert add_calls
+    assert all(overrides == merged for _, overrides in add_calls)
+
+    assert json.loads(env.web_package_json.read_text())["overrides"] == merged
+    assert json.loads(env.root_package_json.read_text())["overrides"] == merged
+
+
+def test_install_frontend_packages_reconciles_lockfile_for_overrides_only_change(
+    install_packages_env: InstallPackagesEnv,
+    monkeypatch,
+):
+    """New overrides with nothing to add still refresh the lockfile."""
+    env = install_packages_env
+    monkeypatch.setattr(constants.PackageJson, "OVERRIDES", {"postcss": "8.5.23"})
+    env.root_lock.write_text("root-lock")
+    _write_restored_package_json(env, {})
+    calls = _record_calls(env)
+
+    env.install()
+
+    assert [c for c in calls if "add" in c] == []
+    install_calls = [c for c in calls if "install" in c]
+    assert len(install_calls) == 2
+    # Frozen first (against the restored pair), then non-frozen to resolve the
+    # merged overrides into the lockfile.
+    assert "--frozen-lockfile" in install_calls[0]
+    assert "--frozen-lockfile" not in install_calls[1]
+
+
+def test_install_frontend_packages_skips_reconcile_when_overrides_unchanged(
+    install_packages_env: InstallPackagesEnv,
+    monkeypatch,
+):
+    """Already-applied overrides do not trigger an extra install."""
+    env = install_packages_env
+    monkeypatch.setattr(constants.PackageJson, "OVERRIDES", {"postcss": "8.5.23"})
+    env.root_lock.write_text("root-lock")
+    _write_restored_package_json(env, {"postcss": "8.5.23"})
+    calls = _record_calls(env)
+
+    env.install()
+
+    assert len([c for c in calls if "install" in c]) == 1
+
+
+def test_install_frontend_packages_cache_invalidated_by_new_override(
+    install_packages_env: InstallPackagesEnv,
+    monkeypatch,
+):
+    """A changed framework override busts the install cache so it gets applied."""
+    env = install_packages_env
+    monkeypatch.setattr(constants.PackageJson, "OVERRIDES", {})
+    env.root_lock.write_text("root-lock")
+    _write_restored_package_json(env, {})
+    calls = _record_calls(env)
+
+    env.install()
+    env.install()
+    assert len(calls) == 1
+
+    monkeypatch.setattr(constants.PackageJson, "OVERRIDES", {"postcss": "8.5.23"})
+    env.install()
+
+    assert len(calls) == 3
+    assert json.loads(env.web_package_json.read_text())["overrides"] == {
+        "postcss": "8.5.23"
+    }
+
+
 def test_install_frontend_packages_persists_package_json_to_root(
     install_packages_env: InstallPackagesEnv,
 ):
@@ -967,14 +1098,15 @@ def test_compile_package_json_recovers_dependencies(tmp_path, monkeypatch):
 
     assert rendered["dependencies"] == {"react": "19.2.5"}
     assert rendered["devDependencies"] == {"vite": "8.0.9"}
-    assert rendered["overrides"] == {"old-override": "1.0", "cookie": "1.1.1"}
+    # Framework overrides are merged after the frozen install, not here.
+    assert rendered["overrides"] == {"old-override": "1.0"}
     assert rendered["scripts"]["dev"] == constants.PackageJson.Commands.DEV
     assert rendered["scripts"]["export"] == constants.PackageJson.Commands.EXPORT
     assert rendered["scripts"]["old"] == "x"
 
 
 def test_compile_package_json_no_persisted_starts_empty(tmp_path, monkeypatch):
-    """Without a persisted file, deps/devDeps are empty."""
+    """Without a persisted file, deps/devDeps/overrides are empty."""
     monkeypatch.setattr(
         constants.PackageJson,
         "OVERRIDES",
@@ -986,7 +1118,7 @@ def test_compile_package_json_no_persisted_starts_empty(tmp_path, monkeypatch):
 
     assert rendered["dependencies"] == {}
     assert rendered["devDependencies"] == {}
-    assert rendered["overrides"] == {"cookie": "1.1.1"}
+    assert rendered["overrides"] == {}
 
 
 def test_compile_package_json_preserves_user_scripts(tmp_path):
@@ -1015,8 +1147,10 @@ def test_compile_package_json_preserves_user_scripts(tmp_path):
     assert rendered["scripts"]["export"] == constants.PackageJson.Commands.EXPORT
 
 
-def test_compile_package_json_preserves_user_overrides(tmp_path, monkeypatch):
-    """User-added overrides survive init; framework overrides win conflicts."""
+def test_compile_package_json_preserves_persisted_overrides_verbatim(
+    tmp_path, monkeypatch
+):
+    """Persisted overrides round-trip untouched so they still pair with the lockfile."""
     root_pkg = tmp_path / constants.Bun.ROOT_LOCKFILE_DIR / constants.PackageJson.PATH
     root_pkg.parent.mkdir(parents=True, exist_ok=True)
     root_pkg.write_text(
@@ -1036,7 +1170,88 @@ def test_compile_package_json_preserves_user_overrides(tmp_path, monkeypatch):
     with chdir(tmp_path):
         rendered = json.loads(frontend_skeleton._compile_package_json())
 
-    assert rendered["overrides"] == {"user-pkg": "2.0.0", "cookie": "1.1.1"}
+    assert rendered["overrides"] == {"user-pkg": "2.0.0", "cookie": "0.0.1"}
+
+
+def test_update_package_json_overrides_merges_framework_entries(tmp_path, monkeypatch):
+    """User-added overrides survive the merge; framework overrides win conflicts."""
+    web_dir = tmp_path / constants.Dirs.WEB
+    web_dir.mkdir()
+    _patch_web_dir(monkeypatch, web_dir)
+    web_pkg = web_dir / constants.PackageJson.PATH
+    web_pkg.write_text(
+        json.dumps({
+            "name": "reflex",
+            "dependencies": {"react": "19.2.5"},
+            "overrides": {"user-pkg": "2.0.0", "cookie": "0.0.1"},
+        })
+    )
+    monkeypatch.setattr(constants.PackageJson, "OVERRIDES", {"cookie": "1.1.1"})
+
+    with chdir(tmp_path):
+        assert frontend_skeleton.update_package_json_overrides() is True
+
+    updated = json.loads(web_pkg.read_text())
+    assert updated["overrides"] == {"user-pkg": "2.0.0", "cookie": "1.1.1"}
+    # Untouched fields are preserved as-is.
+    assert updated["name"] == "reflex"
+    assert updated["dependencies"] == {"react": "19.2.5"}
+
+
+def test_update_package_json_overrides_adds_missing_section(tmp_path, monkeypatch):
+    """A package.json without an overrides section gets one."""
+    web_dir = tmp_path / constants.Dirs.WEB
+    web_dir.mkdir()
+    _patch_web_dir(monkeypatch, web_dir)
+    web_pkg = web_dir / constants.PackageJson.PATH
+    web_pkg.write_text(json.dumps({"name": "reflex"}))
+    monkeypatch.setattr(constants.PackageJson, "OVERRIDES", {"cookie": "1.1.1"})
+
+    with chdir(tmp_path):
+        assert frontend_skeleton.update_package_json_overrides() is True
+
+    assert json.loads(web_pkg.read_text())["overrides"] == {"cookie": "1.1.1"}
+
+
+def test_update_package_json_overrides_noop_when_already_applied(tmp_path, monkeypatch):
+    """An up-to-date package.json is left byte-identical so no reinstall is triggered."""
+    web_dir = tmp_path / constants.Dirs.WEB
+    web_dir.mkdir()
+    _patch_web_dir(monkeypatch, web_dir)
+    web_pkg = web_dir / constants.PackageJson.PATH
+    original = json.dumps({
+        "name": "reflex",
+        "overrides": {"user-pkg": "2.0.0", "cookie": "1.1.1"},
+    })
+    web_pkg.write_text(original)
+    monkeypatch.setattr(constants.PackageJson, "OVERRIDES", {"cookie": "1.1.1"})
+
+    with chdir(tmp_path):
+        assert frontend_skeleton.update_package_json_overrides() is False
+
+    assert web_pkg.read_text() == original
+
+
+@pytest.mark.parametrize("content", [None, "{not json", "[]"])
+def test_update_package_json_overrides_skips_unusable_file(
+    tmp_path, monkeypatch, content
+):
+    """A missing or malformed .web/package.json is left for the dependency adds."""
+    web_dir = tmp_path / constants.Dirs.WEB
+    web_dir.mkdir()
+    _patch_web_dir(monkeypatch, web_dir)
+    web_pkg = web_dir / constants.PackageJson.PATH
+    if content is not None:
+        web_pkg.write_text(content)
+    monkeypatch.setattr(constants.PackageJson, "OVERRIDES", {"cookie": "1.1.1"})
+
+    with chdir(tmp_path):
+        assert frontend_skeleton.update_package_json_overrides() is False
+
+    if content is None:
+        assert not web_pkg.exists()
+    else:
+        assert web_pkg.read_text() == content
 
 
 def test_compile_package_json_preserves_additional_fields(tmp_path):
@@ -1082,7 +1297,7 @@ def test_compile_package_json_null_fields(tmp_path):
 
     assert rendered["dependencies"] == {}
     assert rendered["devDependencies"] == {}
-    assert rendered["overrides"] == constants.PackageJson.OVERRIDES
+    assert rendered["overrides"] == {}
     assert rendered["scripts"]["dev"] == constants.PackageJson.Commands.DEV
 
 
@@ -1098,7 +1313,7 @@ def test_compile_package_json_non_object_root(tmp_path, content):
 
     assert rendered["dependencies"] == {}
     assert rendered["devDependencies"] == {}
-    assert rendered["overrides"] == constants.PackageJson.OVERRIDES
+    assert rendered["overrides"] == {}
 
 
 def test_install_frontend_packages_removes_stale_dependencies(


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

Fixes the issue where upgrading Reflex to a version that introduces a new `package.json` override fails with `lockfile had changes, but lockfile is frozen`.

**Root cause:** Framework overrides were being merged into `package.json` while restoring the persisted file from `reflex.lock/`, which would desync it from the persisted lockfile and cause `--frozen-lockfile` to fail.

**Solution:** Defer merging framework overrides until after the frozen install completes. This keeps the restored `package.json`/lockfile pair intact for the frozen install, then applies overrides via a new `update_package_json_overrides()` function before any dependency resolution happens.

### Changes

**Core logic (`reflex/utils/frontend_skeleton.py`):**
- Refactored `_read_persisted_package_json()` into a generic `_read_package_json_object()` helper
- Modified `_compile_package_json()` to preserve persisted overrides verbatim (no framework merging)
- Added `update_package_json_overrides()` to merge framework overrides into `.web/package.json` after the frozen install
- Updated docstrings to clarify the new override handling strategy

**Install flow (`reflex/utils/js_runtimes.py`):**
- Call `update_package_json_overrides()` after the frozen install
- If overrides changed but no packages are being added, run a non-frozen install to resolve the new overrides into the lockfile
- Updated cache payload to include overrides so changes bust the install cache

**Tests (`tests/units/test_prerequisites.py`):**
- Added `_stub_framework_packages()` to also stub `OVERRIDES` for predictable test counts
- Added 4 new integration tests covering:
  - Applying new overrides after frozen install while preserving user overrides
  - Reconciling lockfile when only overrides change
  - Skipping reconcile when overrides are already applied
  - Cache invalidation when overrides change
- Added 5 new unit tests for `update_package_json_overrides()` covering merging, missing sections, no-ops, and malformed files
- Updated existing tests to reflect that framework overrides are no longer merged during compilation

### Test Plan

All new tests pass and cover the override handling logic:
- `test_install_frontend_packages_applies_overrides_after_frozen_install` validates the core fix
- `test_install_frontend_packages_reconciles_lockfile_for_overrides_only_change` ensures lockfile is refreshed when needed
- `test_install_frontend_packages_skips_reconcile_when_overrides_unchanged` prevents unnecessary work
- `test_install_frontend_packages_cache_invalidated_by_new_override` ensures cache busting works
- Unit tests for `update_package_json_overrides()` cover all edge cases

Existing tests updated to match new behavior where framework overrides are applied post-frozen-install rather than during compilation.

closes #6792

https://claude.ai/code/session_018WXodmwe6tFZ6DkweqArij

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/6844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

