### PR TITLE
ENG-10919: Unify documentation demos with connected View, Code, and D…

### DIFF
--- a/docs/enterprise/drag-and-drop.md
+++ b/docs/enterprise/drag-and-drop.md
@@ -471,7 +471,7 @@ Provides information about the drop target state:
 
 The `item` parameter allows you to pass data from draggable components to drop handlers:
 
-```python demo exec toggle
+```python demo exec
 import reflex as rx
 import reflex_enterprise as rxe
 
@@ -513,7 +513,7 @@ def item_data_example():
 
 The `collect` parameter allows you to access drag and drop state information in real-time:
 
-```python demo exec toggle
+```python demo exec
 import reflex as rx
 import reflex_enterprise as rxe
 

--- a/docs/recipes/auth/login_form.md
+++ b/docs/recipes/auth/login_form.md
@@ -8,7 +8,7 @@ The login form is a common component in web applications. It allows users to aut
 
 ## Default
 
-```python demo exec toggle
+```python demo exec
 def login_default() -> rx.Component:
     return rx.card(
         rx.vstack(
@@ -81,7 +81,7 @@ def login_default() -> rx.Component:
 
 ## Icons
 
-```python demo exec toggle
+```python demo exec
 def login_default_icons() -> rx.Component:
     return rx.card(
         rx.vstack(
@@ -159,7 +159,7 @@ def login_default_icons() -> rx.Component:
 
 ## Third-party auth
 
-```python demo exec toggle
+```python demo exec
 def login_single_thirdparty() -> rx.Component:
     return rx.card(
         rx.vstack(
@@ -252,7 +252,7 @@ def login_single_thirdparty() -> rx.Component:
 
 ## Multiple third-party auth
 
-```python demo exec toggle
+```python demo exec
 def login_multiple_thirdparty() -> rx.Component:
     return rx.card(
         rx.vstack(

--- a/docs/recipes/auth/signup_form.md
+++ b/docs/recipes/auth/signup_form.md
@@ -8,7 +8,7 @@ The sign up form is a common component in web applications. It allows users to c
 
 ## Default
 
-```python demo exec toggle
+```python demo exec
 def signup_default() -> rx.Component:
     return rx.card(
         rx.vstack(
@@ -89,7 +89,7 @@ def signup_default() -> rx.Component:
 
 ## Icons
 
-```python demo exec toggle
+```python demo exec
 def signup_default_icons() -> rx.Component:
     return rx.card(
         rx.vstack(
@@ -176,7 +176,7 @@ def signup_default_icons() -> rx.Component:
 
 ## Third-party auth
 
-```python demo exec toggle
+```python demo exec
 def signup_single_thirdparty() -> rx.Component:
     return rx.card(
         rx.vstack(
@@ -277,7 +277,7 @@ def signup_single_thirdparty() -> rx.Component:
 
 ## Multiple third-party auth
 
-```python demo exec toggle
+```python demo exec
 def signup_multiple_thirdparty() -> rx.Component:
     return rx.card(
         rx.vstack(

--- a/docs/recipes/content/forms.md
+++ b/docs/recipes/content/forms.md
@@ -10,7 +10,7 @@ For more details, see the [form docs page](/docs/library/forms/form).
 
 ## Event creation
 
-```python demo exec toggle
+```python demo exec
 def form_field(label: str, placeholder: str, type: str, name: str) -> rx.Component:
     return rx.form.field(
         rx.flex(
@@ -80,7 +80,7 @@ def event_form() -> rx.Component:
 
 ## Contact
 
-```python demo exec toggle
+```python demo exec
 def form_field(label: str, placeholder: str, type: str, name: str) -> rx.Component:
     return rx.form.field(
         rx.flex(

--- a/docs/recipes/content/stats.md
+++ b/docs/recipes/content/stats.md
@@ -8,7 +8,7 @@ Stats cards are used to display key metrics or data points. They are typically u
 
 ## Variant 1
 
-```python demo exec toggle
+```python demo exec
 from reflex.components.radix.themes.base import LiteralAccentColor
 
 
@@ -79,7 +79,7 @@ def stats(
 
 ## Variant 2
 
-```python demo exec toggle
+```python demo exec
 from reflex.components.radix.themes.base import LiteralAccentColor
 
 

--- a/docs/recipes/content/top_banner.md
+++ b/docs/recipes/content/top_banner.md
@@ -8,7 +8,7 @@ Top banners are used to highlight important information or features at the top o
 
 ## Basic
 
-```python demo exec toggle
+```python demo exec
 class TopBannerBasic(rx.ComponentState):
     hide: bool = False
 
@@ -75,7 +75,7 @@ top_banner_basic = TopBannerBasic.create
 
 ## Sign up
 
-```python demo exec toggle
+```python demo exec
 class TopBannerSignup(rx.ComponentState):
     hide: bool = False
 
@@ -143,7 +143,7 @@ top_banner_signup = TopBannerSignup.create
 
 ## Gradient
 
-```python demo exec toggle
+```python demo exec
 class TopBannerGradient(rx.ComponentState):
     hide: bool = False
 
@@ -203,7 +203,7 @@ top_banner_gradient = TopBannerGradient.create
 
 ## Newsletter
 
-```python demo exec toggle
+```python demo exec
 class TopBannerNewsletter(rx.ComponentState):
     hide: bool = False
 

--- a/docs/recipes/layout/footer.md
+++ b/docs/recipes/layout/footer.md
@@ -8,7 +8,7 @@ A footer bar is a common UI element located at the bottom of a webpage. It typic
 
 ## Basic
 
-```python demo exec toggle
+```python demo exec
 def footer_item(text: str, href: str) -> rx.Component:
     return rx.link(rx.text(text, size="3"), href=href)
 
@@ -111,7 +111,7 @@ def footer() -> rx.Component:
 
 ## Newsletter form
 
-```python demo exec toggle
+```python demo exec
 def footer_item(text: str, href: str) -> rx.Component:
     return rx.link(rx.text(text, size="3"), href=href)
 
@@ -223,7 +223,7 @@ def footer_newsletter() -> rx.Component:
 
 ## Three columns
 
-```python demo exec toggle
+```python demo exec
 def footer_item(text: str, href: str) -> rx.Component:
     return rx.link(rx.text(text, size="3"), href=href)
 

--- a/docs/recipes/layout/navbar.md
+++ b/docs/recipes/layout/navbar.md
@@ -16,7 +16,7 @@ Having a clear and consistent navigation structure can greatly improve the user 
 
 ## Basic
 
-```python demo exec toggle
+```python demo exec
 def navbar_link(text: str, url: str) -> rx.Component:
     return rx.link(rx.text(text, size="4", weight="medium"), href=url)
 
@@ -86,7 +86,7 @@ def navbar() -> rx.Component:
 
 ## Dropdown
 
-```python demo exec toggle
+```python demo exec
 def navbar_link(text: str, url: str) -> rx.Component:
     return rx.link(rx.text(text, size="4", weight="medium"), href=url)
 
@@ -179,7 +179,7 @@ def navbar_dropdown() -> rx.Component:
 
 ## Search bar
 
-```python demo exec toggle
+```python demo exec
 def navbar_searchbar() -> rx.Component:
     return rx.box(
         rx.desktop_only(
@@ -241,7 +241,7 @@ def navbar_searchbar() -> rx.Component:
 
 ## Icons
 
-```python demo exec toggle
+```python demo exec
 def navbar_icons_item(text: str, icon: str, url: str) -> rx.Component:
     return rx.link(
         rx.hstack(rx.icon(icon), rx.text(text, size="4", weight="medium")), href=url
@@ -319,7 +319,7 @@ def navbar_icons() -> rx.Component:
 
 ## Buttons
 
-```python demo exec toggle
+```python demo exec
 def navbar_link(text: str, url: str) -> rx.Component:
     return rx.link(rx.text(text, size="4", weight="medium"), href=url)
 
@@ -397,7 +397,7 @@ def navbar_buttons() -> rx.Component:
 
 ## User profile
 
-```python demo exec toggle
+```python demo exec
 def navbar_link(text: str, url: str) -> rx.Component:
     return rx.link(rx.text(text, size="4", weight="medium"), href=url)
 

--- a/docs/recipes/layout/sidebar.md
+++ b/docs/recipes/layout/sidebar.md
@@ -43,7 +43,7 @@ Similar to a navigation bar, a sidebar is a common UI element found on the side 
 
 ## Basic
 
-```python demo exec toggle
+```python demo exec
 def sidebar_item(text: str, icon: str, href: str) -> rx.Component:
     return rx.link(
         rx.hstack(
@@ -145,7 +145,7 @@ def sidebar() -> rx.Component:
 
 ## Bottom user profile
 
-```python demo exec toggle
+```python demo exec
 def sidebar_item(text: str, icon: str, href: str) -> rx.Component:
     return rx.link(
         rx.hstack(
@@ -314,7 +314,7 @@ def sidebar_bottom_profile() -> rx.Component:
 
 ## Top user profile
 
-```python demo exec toggle
+```python demo exec
 def sidebar_item(text: str, icon: str, href: str) -> rx.Component:
     return rx.link(
         rx.hstack(

--- a/docs/recipes/others/chips.md
+++ b/docs/recipes/others/chips.md
@@ -8,7 +8,7 @@ Chips are compact elements that represent small pieces of information, such as t
 
 ## Status
 
-```python demo exec toggle
+```python demo exec
 from reflex.components.radix.themes.base import LiteralAccentColor
 
 status_chip_props = {
@@ -40,7 +40,7 @@ def status_chips_group() -> rx.Component:
 
 ## Single selection
 
-```python demo exec toggle
+```python demo exec
 chip_props = {
     "radius": "full",
     "variant": "soft",
@@ -111,7 +111,7 @@ def item_selector() -> rx.Component:
 
 This example demonstrates selecting multiple skills from a list. It includes buttons to add all skills, clear selected skills, and select a random number of skills.
 
-```python demo exec toggle
+```python demo exec
 import random
 from reflex.components.radix.themes.base import LiteralAccentColor
 

--- a/docs/recipes/others/dark_mode_toggle.md
+++ b/docs/recipes/others/dark_mode_toggle.md
@@ -7,7 +7,7 @@ from reflex.style import set_color_mode, color_mode
 
 The Dark Mode Toggle component lets users switch between light and dark themes.
 
-```python demo exec toggle
+```python demo exec
 import reflex as rx
 from reflex.style import set_color_mode, color_mode
 

--- a/docs/recipes/others/pricing_cards.md
+++ b/docs/recipes/others/pricing_cards.md
@@ -8,7 +8,7 @@ A pricing card shows the price of a product or service. It typically includes a 
 
 ## Basic
 
-```python demo exec toggle
+```python demo exec
 def feature_item(text: str) -> rx.Component:
     return rx.hstack(
         rx.icon("check", color=rx.color("grass", 9)), rx.text(text, size="4")
@@ -65,7 +65,7 @@ def pricing_card_beginner() -> rx.Component:
 
 ## Comparison cards
 
-```python demo exec toggle
+```python demo exec
 def feature_item(feature: str) -> rx.Component:
     return rx.hstack(
         rx.icon("check", color=rx.color("blue", 9), size=21),

--- a/docs/recipes/others/speed_dial.md
+++ b/docs/recipes/others/speed_dial.md
@@ -8,7 +8,7 @@ A speed dial is a component that allows users to quickly access frequently used 
 
 ## Vertical
 
-```python demo exec toggle
+```python demo exec
 class SpeedDialVertical(rx.ComponentState):
     is_open: bool = False
 
@@ -95,7 +95,7 @@ def render_vertical():
 
 ## Horizontal
 
-```python demo exec toggle
+```python demo exec
 class SpeedDialHorizontal(rx.ComponentState):
     is_open: bool = False
 
@@ -183,7 +183,7 @@ def render_horizontal():
 
 ## Vertical with text
 
-```python demo exec toggle
+```python demo exec
 class SpeedDialVerticalText(rx.ComponentState):
     is_open: bool = False
 
@@ -277,7 +277,7 @@ def render_vertical_text():
 
 ## Reveal animation
 
-```python demo exec toggle
+```python demo exec
 class SpeedDialReveal(rx.ComponentState):
     is_open: bool = False
 
@@ -380,7 +380,7 @@ def render_reveal():
 
 ## Menu
 
-```python demo exec toggle
+```python demo exec
 class SpeedDialMenu(rx.ComponentState):
     is_open: bool = False
 

--- a/docs/wrapping-react/local-packages.md
+++ b/docs/wrapping-react/local-packages.md
@@ -127,7 +127,7 @@ code.
 
 These package specifiers can be used for `library` or `lib_dependencies`.
 
-```python demo exec toggle
+```python demo exec
 class GithubComponent(rx.Component):
     library = "@masenf/hello-react@github:masenf/hello-react"
     tag = "Counter"

--- a/packages/reflex-site-shared/src/reflex_site_shared/components/blocks/__init__.py
+++ b/packages/reflex-site-shared/src/reflex_site_shared/components/blocks/__init__.py
@@ -3,4 +3,5 @@
 from .code import *
 from .demo import *
 from .headings import *
+from .tabs import *
 from .typography import *

--- a/packages/reflex-site-shared/src/reflex_site_shared/components/blocks/demo.py
+++ b/packages/reflex-site-shared/src/reflex_site_shared/components/blocks/demo.py
@@ -8,6 +8,7 @@ import ruff_format
 import reflex as rx
 
 from .code import code_block, code_block_dark
+from .tabs import doc_tab_card, doc_tab_list, doc_tab_trigger
 
 
 def docdemobox(*children, **props) -> rx.Component:
@@ -62,6 +63,60 @@ def doccode(
     )
 
 
+def _doc_view_panel(
+    comp: rx.Component,
+    demobox_props: dict[str, Any] | None = None,
+) -> rx.Component:
+    """Create a preview panel on the tab card's shared surface.
+
+    Args:
+        comp: Rendered demo component.
+        demobox_props: Props to apply to the demo content wrapper.
+
+    Returns:
+        The styled preview panel.
+    """
+    return rx.tabs.content(
+        rx.box(
+            docdemobox(comp, **(demobox_props or {})),
+            class_name=(
+                "[&>div]:!rounded-none [&>div]:!border-0 [&>div]:!bg-transparent"
+            ),
+        ),
+        value="view",
+        class_name="w-full outline-none",
+    )
+
+
+def _doc_code_panel(
+    source: str,
+    value: str,
+    theme: str = "light",
+) -> rx.Component:
+    """Create a code panel that uses the tab card's shared surface.
+
+    Args:
+        source: Source code to display.
+        value: Value of the corresponding tab trigger.
+        theme: Theme for the code snippet.
+
+    Returns:
+        The styled tab panel.
+    """
+    return rx.tabs.content(
+        doccode(source, theme=theme),
+        value=value,
+        class_name=(
+            "w-full p-4 outline-none sm:p-6 [&>div]:!m-0 "
+            "[&>div]:!rounded-none [&>div]:!border-0 [&>div]:!bg-transparent "
+            "[&_div]:!bg-transparent [&_pre]:!bg-transparent "
+            "[&_.code-block]:!rounded-none [&_.code-block]:!border-0 "
+            "[&_.code-block]:!bg-transparent [&_.code-block]:!shadow-none "
+            "[&_summary]:!from-[var(--secondary-2)]"
+        ),
+    )
+
+
 def docdemo(
     code: str,
     state: str | None = None,
@@ -100,40 +155,21 @@ def docdemo(
     if state is not None:
         code = state + code
 
-    if demobox_props.pop("toggle", False):
-        return rx.tabs.root(
-            rx.tabs.list(
-                rx.tabs.trigger(
-                    rx.box(
-                        "UI",
-                    ),
-                    value="tab1",
-                    class_name="tab-style",
-                ),
-                rx.tabs.trigger(
-                    rx.box(
-                        "Code",
-                    ),
-                    value="tab2",
-                    class_name="tab-style",
-                ),
-                class_name="justify-end",
-            ),
-            rx.tabs.content(
-                rx.box(docdemobox(comp, **(demobox_props or {})), class_name="my-4"),
-                value="tab1",
-            ),
-            rx.tabs.content(
-                rx.box(doccode(code, theme=theme or "light"), class_name="my-4"),
-                value="tab2",
-            ),
-            default_value="tab1",
-        )
-    # Create the demo.
+    demobox_props.pop("toggle", None)
     return rx.box(
-        docdemobox(comp, **(demobox_props or {})),
-        doccode(code, theme=theme or "light"),
-        class_name="py-4 gap-4 flex flex-col w-full",
+        rx.tabs.root(
+            doc_tab_list(
+                doc_tab_trigger("View", value="view", icon="eye"),
+                doc_tab_trigger("Code", value="code", icon="code-xml"),
+            ),
+            doc_tab_card(
+                _doc_view_panel(comp, demobox_props),
+                _doc_code_panel(code, "code", theme or "light"),
+            ),
+            default_value="view",
+            class_name="w-full",
+        ),
+        class_name="w-full py-4",
         **props,
     )
 
@@ -142,32 +178,39 @@ def docgraphing(
     code: str,
     comp: rx.Component | None = None,
     data: str | None = None,
-):
-    """Docgraphing.
+) -> rx.Component:
+    """Create a graph demo with connected code and data tabs.
+
+    Args:
+        code: Chart source code to display.
+        comp: Rendered chart preview.
+        data: Optional extracted chart data source.
 
     Returns:
-        The component.
+        The styled graph demo.
     """
-    return rx.box(
-        rx.flex(
-            comp,
-            class_name="w-full flex flex-col p-6 rounded-xl overflow-x-auto border border-secondary-4 bg-secondary-2 items-center justify-center",
+    tabs = [
+        (
+            doc_tab_trigger("View", value="view", icon="eye"),
+            _doc_view_panel(comp),
         ),
+        (
+            doc_tab_trigger("Code", value="code", icon="code-xml"),
+            _doc_code_panel(code, "code"),
+        ),
+    ]
+    if data:
+        tabs.append((
+            doc_tab_trigger("Data", value="data", icon="database"),
+            _doc_code_panel(data, "data"),
+        ))
+
+    return rx.box(
         rx.tabs.root(
-            rx.tabs.list(
-                rx.tabs.trigger("Code", value="code", class_name="tab-style"),
-                rx.tabs.trigger("Data", value="data", class_name="tab-style"),
-                justify_content="end",
-            ),
-            rx.box(
-                rx.tabs.content(doccode(code), value="code", class_name="w-full px-0"),
-                rx.tabs.content(
-                    doccode(data or ""), value="data", class_name="w-full px-0"
-                ),
-                class_name="w-full my-4",
-            ),
-            default_value="code",
-            class_name="w-full mt-6 justify-end",
+            doc_tab_list(*(trigger for trigger, _ in tabs)),
+            doc_tab_card(*(panel for _, panel in tabs)),
+            default_value="view",
+            class_name="w-full",
         ),
         class_name="w-full py-4 flex flex-col",
     )

--- a/packages/reflex-site-shared/src/reflex_site_shared/components/blocks/demo.py
+++ b/packages/reflex-site-shared/src/reflex_site_shared/components/blocks/demo.py
@@ -10,6 +10,10 @@ import reflex as rx
 from .code import code_block, code_block_dark
 from .tabs import doc_tab_card, doc_tab_list, doc_tab_trigger
 
+_VIEW_TAB_VALUE = "view"
+_CODE_TAB_VALUE = "code"
+_DATA_TAB_VALUE = "data"
+
 
 def docdemobox(*children, **props) -> rx.Component:
     """Create a documentation demo box with the output of the code.
@@ -83,7 +87,7 @@ def _doc_view_panel(
                 "[&>div]:!rounded-none [&>div]:!border-0 [&>div]:!bg-transparent"
             ),
         ),
-        value="view",
+        value=_VIEW_TAB_VALUE,
         class_name="w-full outline-none",
     )
 
@@ -155,18 +159,17 @@ def docdemo(
     if state is not None:
         code = state + code
 
-    demobox_props.pop("toggle", None)
     return rx.box(
         rx.tabs.root(
             doc_tab_list(
-                doc_tab_trigger("View", value="view", icon="eye"),
-                doc_tab_trigger("Code", value="code", icon="code-xml"),
+                doc_tab_trigger("View", value=_VIEW_TAB_VALUE, icon="eye"),
+                doc_tab_trigger("Code", value=_CODE_TAB_VALUE, icon="code-xml"),
             ),
             doc_tab_card(
                 _doc_view_panel(comp, demobox_props),
-                _doc_code_panel(code, "code", theme or "light"),
+                _doc_code_panel(code, _CODE_TAB_VALUE, theme or "light"),
             ),
-            default_value="view",
+            default_value=_VIEW_TAB_VALUE,
             class_name="w-full",
         ),
         class_name="w-full py-4",
@@ -191,25 +194,25 @@ def docgraphing(
     """
     tabs = [
         (
-            doc_tab_trigger("View", value="view", icon="eye"),
+            doc_tab_trigger("View", value=_VIEW_TAB_VALUE, icon="eye"),
             _doc_view_panel(comp),
         ),
         (
-            doc_tab_trigger("Code", value="code", icon="code-xml"),
-            _doc_code_panel(code, "code"),
+            doc_tab_trigger("Code", value=_CODE_TAB_VALUE, icon="code-xml"),
+            _doc_code_panel(code, _CODE_TAB_VALUE),
         ),
     ]
     if data:
         tabs.append((
-            doc_tab_trigger("Data", value="data", icon="database"),
-            _doc_code_panel(data, "data"),
+            doc_tab_trigger("Data", value=_DATA_TAB_VALUE, icon="database"),
+            _doc_code_panel(data, _DATA_TAB_VALUE),
         ))
 
     return rx.box(
         rx.tabs.root(
             doc_tab_list(*(trigger for trigger, _ in tabs)),
             doc_tab_card(*(panel for _, panel in tabs)),
-            default_value="view",
+            default_value=_VIEW_TAB_VALUE,
             class_name="w-full",
         ),
         class_name="w-full py-4 flex flex-col",

--- a/packages/reflex-site-shared/src/reflex_site_shared/components/blocks/tabs.py
+++ b/packages/reflex-site-shared/src/reflex_site_shared/components/blocks/tabs.py
@@ -17,8 +17,13 @@ _DOC_TAB_CLASS = (
     "!bg-secondary-3 !px-4 !py-2.5 !text-sm !font-medium "
     "!text-secondary-11 !shadow-none transition-colors duration-150 "
     "before:!hidden after:!hidden hover:!text-secondary-12 "
+    "dark:!bg-secondary-4 dark:!text-secondary-10 "
+    "dark:data-[state=inactive]:hover:!bg-secondary-5 "
+    "dark:data-[state=inactive]:hover:!text-secondary-11 "
     "data-[state=active]:!z-10 data-[state=active]:!border-b-transparent "
     "data-[state=active]:!bg-secondary-2 data-[state=active]:!text-secondary-12 "
+    "dark:data-[state=active]:!bg-secondary-2 "
+    "dark:data-[state=active]:!text-secondary-12 "
     "[&_.rt-BaseTabListTriggerInner]:!bg-transparent"
 )
 

--- a/packages/reflex-site-shared/src/reflex_site_shared/components/blocks/tabs.py
+++ b/packages/reflex-site-shared/src/reflex_site_shared/components/blocks/tabs.py
@@ -1,0 +1,74 @@
+"""Shared tab primitives for documentation cards."""
+
+import reflex as rx
+
+__all__ = ["doc_tab_card", "doc_tab_list", "doc_tab_trigger"]
+
+_DOC_TAB_LIST_CLASS = (
+    "doc-demo-tab-list relative z-10 -mb-px flex w-full items-end justify-end "
+    "!gap-0 !border-b-0 !bg-transparent !p-0 !shadow-none "
+    "before:!hidden after:!hidden"
+)
+
+_DOC_TAB_CLASS = (
+    "doc-demo-tab cursor-pointer appearance-none !rounded-none "
+    "first:!rounded-tl-xl last:!rounded-tr-xl "
+    "!border !border-secondary-4 -ml-px first:!ml-0 "
+    "!bg-secondary-3 !px-4 !py-2.5 !text-sm !font-medium "
+    "!text-secondary-11 !shadow-none transition-colors duration-150 "
+    "before:!hidden after:!hidden hover:!text-secondary-12 "
+    "data-[state=active]:!z-10 data-[state=active]:!border-b-transparent "
+    "data-[state=active]:!bg-secondary-2 data-[state=active]:!text-secondary-12 "
+    "[&_.rt-BaseTabListTriggerInner]:!bg-transparent"
+)
+
+_DOC_TAB_CARD_CLASS = (
+    "doc-demo-tab-card relative w-full overflow-hidden rounded-xl rounded-tr-none "
+    "border border-secondary-4 bg-secondary-2"
+)
+
+
+def doc_tab_list(*children: rx.Component) -> rx.Component:
+    """Create a connected tab strip for a documentation card.
+
+    Args:
+        children: Tab triggers to render.
+
+    Returns:
+        The styled tab list.
+    """
+    return rx.tabs.list(*children, class_name=_DOC_TAB_LIST_CLASS)
+
+
+def doc_tab_trigger(label: str, *, value: str, icon: str) -> rx.Component:
+    """Create a folder-style trigger for a documentation card.
+
+    Args:
+        label: Visible trigger label.
+        value: Value of the corresponding tab panel.
+        icon: Lucide icon name to render before the label.
+
+    Returns:
+        The styled tab trigger.
+    """
+    return rx.tabs.trigger(
+        rx.el.span(
+            rx.icon(icon, size=15, aria_hidden="true"),
+            rx.el.span(label),
+            class_name="inline-flex items-center gap-2",
+        ),
+        value=value,
+        class_name=_DOC_TAB_CLASS,
+    )
+
+
+def doc_tab_card(*children: rx.Component) -> rx.Component:
+    """Create the shared surface beneath a documentation tab strip.
+
+    Args:
+        children: Tab panels to render.
+
+    Returns:
+        The styled tab card.
+    """
+    return rx.box(*children, class_name=_DOC_TAB_CARD_CLASS)

--- a/packages/reflex-site-shared/src/reflex_site_shared/docs/markdown.py
+++ b/packages/reflex-site-shared/src/reflex_site_shared/docs/markdown.py
@@ -463,9 +463,6 @@ class ReflexDocTransformer(DocumentTransformer[rx.Component]):
             k, sep, v = flag.partition("=")
             if sep:
                 demobox_props[k] = v
-        if "toggle" in flags:
-            demobox_props["toggle"] = True
-
         return docdemo(content, comp=comp, demobox_props=demobox_props, id=comp_id)
 
     def _render_demo_only(self, content: str, flags: set[str]) -> rx.Component:

--- a/packages/reflex-site-shared/src/reflex_site_shared/styles/assets/tailwind-theme.css
+++ b/packages/reflex-site-shared/src/reflex_site_shared/styles/assets/tailwind-theme.css
@@ -1858,17 +1858,6 @@
         background-color: var(--secondary-3) !important;
     }
 
-
-    .tab-style {
-        color: var(--secondary-9);
-        cursor: pointer;
-        padding: 0.25em 0.5em;
-        font-size: 0.9rem;
-        font-weight: 500;
-        line-height: 1.25rem;
-        letter-spacing: -0.01094rem;
-    }
-
     .pill-tab-list {
         display: inline-flex !important;
         gap: 2px !important;
@@ -1947,15 +1936,6 @@
         box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4) !important;
     }
 
-    .tab-style:hover:not([data-state='active'])::before {
-        background: transparent !important;
-        background-color: transparent !important;
-    }
-
-    .tab-style:hover {
-        color: var(--secondary-11);
-    }
-
     .hover-card-shadow:hover {
         background: var(0 3px 6px 0 rgba(0, 0, 0, 0.03),
                 0 1px 0 0 #FFF inset,
@@ -1975,14 +1955,6 @@
 
     :where(.dark, .dark *) .navbar-shadow {
         box-shadow: 0 0 0 1px var(--secondary-4);
-    }
-
-    .tab-style[data-state='active'] {
-        color: var(--c-violet-9);
-    }
-
-    .tab-style:not([data-state='active']) {
-        color: var(--secondary-12);
     }
 
     .demo-code-block {


### PR DESCRIPTION
…ata tabs

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/6851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

