### PR TITLE
[fix] Only check the redis session lock once per set_state fan-out

### DIFF
--- a/reflex/istate/manager/redis.py
+++ b/reflex/istate/manager/redis.py
@@ -380,6 +380,7 @@ class StateManagerRedis(StateManager):
         state: TOKEN_TYPE,
         *,
         lock_id: bytes | None = None,
+        lock_checked: bool = False,
         **context: Unpack[StateModificationContext],
     ):
         """Set the state for a token.
@@ -388,6 +389,9 @@ class StateManagerRedis(StateManager):
             token: The token to set the state for.
             state: The state to set.
             lock_id: If provided, the lock must be held with this value to set the state.
+            lock_checked: If true, skip Redis lock revalidation for this fan-out. Parent
+                calls validate once, then recurse with this set so each substate does not
+                repeat GET/PTTL on the same session lock key.
             context: The event context.
 
         Raises:
@@ -395,24 +399,26 @@ class StateManagerRedis(StateManager):
             RuntimeError: If the state instance doesn't match the state name in the token.
         """
         token = self._coerce_token(token)
-        # Check that we're holding the lock.
-        if (
-            lock_id is not None
-            and (existing_lock_id := await self.redis.get(self._lock_key(token)))
-            != lock_id
-        ):
-            msg = (
-                f"Lock expired for token {token} while processing. Consider increasing "
-                f"`app.state_manager.lock_expiration` (currently {self.lock_expiration}) "
-                "or use `@rx.event(background=True)` decorator for long-running tasks. "
-                f"Current lock id: {existing_lock_id!r}, expected lock id: {lock_id!r}."
-                + (
-                    f" Happened in event: {event.name}"
-                    if (event := context.get("event")) is not None
-                    else ""
+        # Validate the session lock once per fan-out (not once per substate).
+        did_lock_check = False
+        if lock_id is not None and not lock_checked:
+            if (
+                existing_lock_id := await self.redis.get(self._lock_key(token))
+            ) != lock_id:
+                msg = (
+                    f"Lock expired for token {token} while processing. Consider increasing "
+                    f"`app.state_manager.lock_expiration` (currently {self.lock_expiration}) "
+                    "or use `@rx.event(background=True)` decorator for long-running tasks. "
+                    f"Current lock id: {existing_lock_id!r}, expected lock id: {lock_id!r}."
+                    + (
+                        f" Happened in event: {event.name}"
+                        if (event := context.get("event")) is not None
+                        else ""
+                    )
                 )
-            )
-            raise LockExpiredError(msg)
+                raise LockExpiredError(msg)
+            did_lock_check = True
+            lock_checked = True
 
         if not isinstance(token, BaseStateToken):
             # Non-BaseState token: simple single-key write.
@@ -425,7 +431,7 @@ class StateManagerRedis(StateManager):
 
         lock_key = token.lock_key
 
-        if lock_id is not None and lock_key not in self._local_leases:
+        if did_lock_check and lock_key not in self._local_leases:
             time_taken = (
                 self.lock_expiration - (await self.redis.pttl(self._lock_key(token)))
             ) / 1000
@@ -448,6 +454,7 @@ class StateManagerRedis(StateManager):
                     token,
                     substate,
                     lock_id=lock_id,
+                    lock_checked=lock_checked,
                     **context,
                 ),
                 name=f"reflex_set_state|{lock_key}|{substate.get_full_name()}",

--- a/tests/units/istate/manager/test_redis.py
+++ b/tests/units/istate/manager/test_redis.py
@@ -115,6 +115,80 @@ async def test_basic_get_set(
     )
 
 
+def _redis_key_bytes(key: Any) -> bytes:
+    """Normalize a redis key to bytes for comparisons.
+
+    Args:
+        key: The redis key.
+
+    Returns:
+        The key as bytes.
+    """
+    if isinstance(key, bytes):
+        return key
+    if isinstance(key, str):
+        return key.encode()
+    if isinstance(key, memoryview):
+        return key.tobytes()
+    return bytes(key)
+
+
+@pytest.mark.asyncio
+async def test_set_state_validates_lock_once_per_fanout(
+    state_manager_redis: StateManagerRedis,
+    root_state: type[RedisTestState],
+):
+    """Lock GET/PTTL should run once per set_state fan-out, not per substate.
+
+    Args:
+        state_manager_redis: The StateManagerRedis to test.
+        root_state: The root state class.
+    """
+    state_manager_redis._oplock_enabled = False
+    # Ensure the PTTL warning path is eligible (no local lease).
+    state_manager_redis._local_leases.clear()
+
+    ident = str(uuid.uuid4())
+    token = BaseStateToken(ident=ident, cls=root_state)
+    lock_key = state_manager_redis._lock_key(token)
+    lock_id = b"test-lock-id"
+
+    await state_manager_redis.redis.set(
+        lock_key, lock_id, px=state_manager_redis.lock_expiration
+    )
+
+    state = await state_manager_redis.get_state(token)
+    assert len(state.substates) >= 2
+
+    lock_gets = 0
+    lock_pttls = 0
+    original_get = state_manager_redis.redis.get
+    original_pttl = state_manager_redis.redis.pttl
+
+    async def tracked_get(key: Any, *args: Any, **kwargs: Any):
+        nonlocal lock_gets
+        if _redis_key_bytes(key) == lock_key:
+            lock_gets += 1
+        return await original_get(key, *args, **kwargs)
+
+    async def tracked_pttl(key: Any, *args: Any, **kwargs: Any):
+        nonlocal lock_pttls
+        if _redis_key_bytes(key) == lock_key:
+            lock_pttls += 1
+        return await original_pttl(key, *args, **kwargs)
+
+    state_manager_redis.redis.get = tracked_get  # pyright: ignore[reportAttributeAccessIssue]
+    state_manager_redis.redis.pttl = tracked_pttl  # pyright: ignore[reportAttributeAccessIssue]
+    try:
+        await state_manager_redis.set_state(token, state, lock_id=lock_id)
+    finally:
+        state_manager_redis.redis.get = original_get  # pyright: ignore[reportAttributeAccessIssue]
+        state_manager_redis.redis.pttl = original_pttl  # pyright: ignore[reportAttributeAccessIssue]
+
+    assert lock_gets == 1
+    assert lock_pttls == 1
+
+
 async def test_modify(
     state_manager_redis: StateManagerRedis,
     root_state: type[RedisTestState],

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -2175,7 +2175,8 @@ async def test_state_manager_lock_warning_threshold_contend(
         console_warn.assert_not_called()
     else:
         console_warn.assert_called()
-        assert console_warn.call_count == 7
+        # One warning per set_state fan-out (not once per substate).
+        assert console_warn.call_count == 1
 
 
 class CopyingAsyncMock(AsyncMock):


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

closes #6848

## Summary

`StateManagerRedis.set_state` was rechecking the session lock (`GET` + `PTTL`) once per substate while walking the in memory tree. That's the same lock key every time, so for a large state tree it was a lot of useless Redis round-trips, even when nothing was dirty.

This validates the lock once at the root of the fan-out and passes `lock_checked=True` into the recursive calls. Dirty substates still get written the same way as before.

## Test plan

- [x] Added `test_set_state_validates_lock_once_per_fanout`
- [x] Updated `test_state_manager_lock_warning_threshold_contend` (one warning per fan-out, not one per substate)
- [x] `uv run pytest tests/units --cov --no-cov-on-fail --cov-report=`
- [x] `uv run ruff check .`
- [x] `uv run ruff format .`
- [x] `uv run pyright reflex tests`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/6853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

