### PR TITLE
ENG-10963 feat(log): deprecate the legacy console logging helpers (5/5)

### DIFF
--- a/packages/reflex-base/news/+eng-10963-console-deprecate.deprecation.md
+++ b/packages/reflex-base/news/+eng-10963-console-deprecate.deprecation.md
@@ -1,0 +1,1 @@
+The `console.debug/info/success/log/warn/error/timing` helpers are deprecated (removal in 1.0) but keep working as shims; use `logging.getLogger(__name__)` and the pipeline in `reflex_base.utils.log` instead. The interactive Rich features (`print`/`rule`/`status`/`ask`/`progress`) remain first-class.

--- a/packages/reflex-base/src/reflex_base/utils/console.py
+++ b/packages/reflex-base/src/reflex_base/utils/console.py
@@ -1,4 +1,11 @@
-"""Functions to communicate to the user via console."""
+"""Functions to communicate to the user via console.
+
+The logging-shaped helpers (``debug``/``info``/``success``/``log``/``warn``/
+``error``/``timing``) are deprecated and kept with their legacy behavior until
+removal; new code should use ``logging.getLogger(__name__)`` and the pipeline
+in :mod:`reflex_base.utils.log`. The interactive Rich features
+(``print``/``rule``/``status``/``ask``/``progress``) remain first-class.
+"""
 
 from __future__ import annotations
 
@@ -12,7 +19,7 @@ import time
 from collections.abc import Sequence
 from pathlib import Path
 from types import FrameType, ModuleType
-from typing import overload
+from typing import TYPE_CHECKING, overload
 
 from rich.console import Console, OverflowMethod
 from rich.progress import MofNCompleteColumn, Progress, TaskID, TimeElapsedColumn
@@ -50,6 +57,21 @@ _EMITTED_LOGS = set()
 
 # Prints which have been printed.
 _EMITTED_PRINTS = set()
+
+
+def _shim_deprecation(name: str, replacement: str):
+    """Warn that a deprecated console logging helper was called.
+
+    Args:
+        name: The console function name.
+        replacement: The logging-API replacement to suggest.
+    """
+    deprecate(
+        feature_name=f"console.{name}",
+        reason=f"use {replacement} on logging.getLogger(__name__) instead",
+        deprecation_version="0.9.9",
+        removal_version="1.0",
+    )
 
 
 def set_log_level(log_level: LogLevel | None):
@@ -144,14 +166,8 @@ def print_to_log_file(msg: str, *, dedupe: bool = False, **kwargs):
     log_file_console().print(f"[{datetime.datetime.now()}] {msg}", **kwargs)
 
 
-def debug(msg: str, *, dedupe: bool = False, **kwargs):
-    """Print a debug message.
-
-    Args:
-        msg: The debug message.
-        dedupe: If True, suppress multiple console logs of debug message.
-        kwargs: Keyword arguments to pass to the print function.
-    """
+def _debug(msg: str, *, dedupe: bool = False, **kwargs):
+    """Render a debug message with the legacy behavior."""
     if is_debug():
         msg_ = f"[purple]Debug: {msg}[/purple]"
         if dedupe:
@@ -166,6 +182,18 @@ def debug(msg: str, *, dedupe: bool = False, **kwargs):
         print_to_log_file(f"[purple]Debug: {msg}[/purple]", **kwargs)
 
 
+def debug(msg: str, *, dedupe: bool = False, **kwargs):
+    """Print a debug message.
+
+    Args:
+        msg: The debug message.
+        dedupe: If True, suppress multiple console logs of debug message.
+        kwargs: Keyword arguments to pass to the print function.
+    """
+    _shim_deprecation("debug", "logger.debug(msg)")
+    _debug(msg, dedupe=dedupe, **kwargs)
+
+
 def info(msg: str, *, dedupe: bool = False, **kwargs):
     """Print an info message.
 
@@ -174,6 +202,7 @@ def info(msg: str, *, dedupe: bool = False, **kwargs):
         dedupe: If True, suppress multiple console logs of info message.
         kwargs: Keyword arguments to pass to the print function.
     """
+    _shim_deprecation("info", "logger.info(msg)")
     if _log.get_log_level() <= LogLevel.INFO:
         if dedupe:
             if msg in _EMITTED_INFO:
@@ -192,6 +221,7 @@ def success(msg: str, *, dedupe: bool = False, **kwargs):
         dedupe: If True, suppress multiple console logs of success message.
         kwargs: Keyword arguments to pass to the print function.
     """
+    _shim_deprecation("success", "logger.log(log.SUCCESS, msg)")
     if _log.get_log_level() <= LogLevel.INFO:
         if dedupe:
             if msg in _EMITTED_SUCCESS:
@@ -210,6 +240,7 @@ def log(msg: str, *, dedupe: bool = False, **kwargs):
         dedupe: If True, suppress multiple console logs of log message.
         kwargs: Keyword arguments to pass to the print function.
     """
+    _shim_deprecation("log", "logger.info(msg)")
     if _log.get_log_level() <= LogLevel.INFO:
         if dedupe:
             if msg in _EMITTED_LOGS:
@@ -243,6 +274,7 @@ def warn(msg: str, *, dedupe: bool = False, **kwargs):
         dedupe: If True, suppress multiple console logs of warning message.
         kwargs: Keyword arguments to pass to the print function.
     """
+    _shim_deprecation("warn", "logger.warning(msg)")
     if _log.get_log_level() <= LogLevel.WARNING:
         if dedupe:
             if msg in _EMITTED_WARNINGS:
@@ -379,6 +411,7 @@ def error(msg: str, *, dedupe: bool = False, **kwargs):
         dedupe: If True, suppress multiple console logs of error message.
         kwargs: Keyword arguments to pass to the print function.
     """
+    _shim_deprecation("error", "logger.error(msg)")
     if _log.get_log_level() <= LogLevel.ERROR:
         if dedupe:
             if msg in _EMITTED_ERRORS:
@@ -502,11 +535,12 @@ def timing(msg: str):
     Yields:
         None.
     """
+    _shim_deprecation("timing", "log.timing(logger, msg)")
     start = time.time()
     try:
         yield
     finally:
-        debug(f"[white]\\[timing] {msg}: {time.time() - start:.2f}s[/white]")
+        _debug(f"[white]\\[timing] {msg}: {time.time() - start:.2f}s[/white]")
 
 
 class PoorProgress:
@@ -565,3 +599,17 @@ class PoorProgress:
 
     def stop(self):
         """Stop the progress bar."""
+
+
+if TYPE_CHECKING:
+    from typing_extensions import deprecated
+
+    debug = deprecated("Use logging.getLogger(__name__).debug(msg) instead")(debug)
+    info = deprecated("Use logging.getLogger(__name__).info(msg) instead")(info)
+    success = deprecated(
+        "Use logging.getLogger(__name__).log(log.SUCCESS, msg) instead"
+    )(success)
+    log = deprecated("Use logging.getLogger(__name__).info(msg) instead")(log)
+    warn = deprecated("Use logging.getLogger(__name__).warning(msg) instead")(warn)
+    error = deprecated("Use logging.getLogger(__name__).error(msg) instead")(error)
+    timing = deprecated("Use reflex_base.utils.log.timing(logger, msg) instead")(timing)

--- a/tests/units/reflex_base/utils/test_log.py
+++ b/tests/units/reflex_base/utils/test_log.py
@@ -294,6 +294,64 @@ def test_timing_logs_at_debug(capsys):
     assert out.startswith("Debug: [timing] block: ")
 
 
+def test_console_shims_delegate(capsys):
+    """Legacy console helpers route through the pipeline and warn once."""
+    console.info("legacy info")
+    console.warn("legacy warn")
+    console.error("legacy error")
+    out, err = capsys.readouterr()
+    out_lines = out.splitlines()
+    assert "Info: legacy info" in out_lines
+    assert "Warning: legacy warn" in out_lines
+    assert "legacy error" in err.splitlines()
+    assert "console.info has been deprecated" in out.replace("\n", " ")
+
+
+def test_console_info_preserves_rich_print_kwargs(monkeypatch):
+    """The deprecated info helper retains its Rich print contract."""
+    rich_console = mock.Mock()
+    monkeypatch.setattr(console, "_console", rich_console)
+    monkeypatch.setattr(console, "_shim_deprecation", mock.Mock())
+
+    console.info("[bold]message[/bold]", markup=False, soft_wrap=True)
+
+    rich_console.print.assert_called_once_with(
+        "[cyan]Info: [bold]message[/bold][/cyan]",
+        markup=False,
+        soft_wrap=True,
+    )
+
+
+def test_console_log_preserves_rich_log_rendering(monkeypatch):
+    """The deprecated log helper still delegates to Rich Console.log."""
+    rich_console = mock.Mock()
+    monkeypatch.setattr(console, "_console", rich_console)
+    monkeypatch.setattr(console, "_shim_deprecation", mock.Mock())
+
+    console.log("message", justify="left")
+
+    rich_console.log.assert_called_once_with("message", justify="left")
+
+
+def test_console_debug_progress_preserves_file_log(monkeypatch):
+    """Progress-bound debug output retains its legacy file-log behavior."""
+    progress = mock.Mock()
+    print_to_log_file = mock.Mock()
+    monkeypatch.setattr(console, "_shim_deprecation", mock.Mock())
+    monkeypatch.setattr(console, "is_debug", lambda: True)
+    monkeypatch.setattr(console, "should_use_log_file_console", lambda: True)
+    monkeypatch.setattr(console, "print_to_log_file", print_to_log_file)
+
+    console.debug("message", progress=progress, markup=False)
+
+    progress.console.print.assert_called_once_with(
+        "[purple]Debug: message[/purple]", markup=False
+    )
+    print_to_log_file.assert_called_once_with(
+        "[purple]Debug: message[/purple]", markup=False
+    )
+
+
 def test_console_deprecate_preserves_rich_print_kwargs(monkeypatch):
     """The legacy deprecation helper retains its Rich print contract."""
     rich_print = mock.Mock()


### PR DESCRIPTION
With every call site migrated, `console.debug/info/success/log/warn/error/timing` now emit a runtime deprecation warning (removal in 1.0) and are marked with `typing_extensions.deprecated` for type-level warnings. Behavior is otherwise unchanged; the interactive Rich features (`print`/`rule`/`status`/`ask`/`progress`) remain first-class.

This must land last: the deprecation markers only pass CI once no in-repo call site uses the helpers.

## Stack (ENG-10963)
#6863 → #6864 → #6865 → #6866 → this.
Merge in order; each PR is based on the previous branch.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/6867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

