### PR TITLE
Add start building link to docs demos

### DIFF
--- a/packages/reflex-site-shared/src/reflex_site_shared/components/blocks/demo.py
+++ b/packages/reflex-site-shared/src/reflex_site_shared/components/blocks/demo.py
@@ -3,9 +3,11 @@
 import textwrap
 from typing import Any
 
+import reflex_components_internal as ui
 import ruff_format
 
 import reflex as rx
+from reflex_site_shared.constants import REFLEX_BUILD_URL
 
 from .code import code_block, code_block_dark
 from .tabs import doc_tab_card, doc_tab_list, doc_tab_trigger
@@ -13,6 +15,77 @@ from .tabs import doc_tab_card, doc_tab_list, doc_tab_trigger
 _VIEW_TAB_VALUE = "view"
 _CODE_TAB_VALUE = "code"
 _DATA_TAB_VALUE = "data"
+
+
+def _reflex_build_icon() -> rx.Component:
+    """Create the Reflex Build mark for the demo action.
+
+    Returns:
+        The Reflex Build SVG icon.
+    """
+    return rx.el.svg(
+        rx.el.rect(
+            x="1",
+            y="1",
+            width="14",
+            height="14",
+            rx="3.5",
+            fill="currentColor",
+        ),
+        rx.el.path(
+            d="M9.75 9.16675V11.9376C9.75 12.0181 9.81529 12.0834 9.89583 12.0834H11.3542C11.4347 12.0834 11.5 12.0181 11.5 11.9376V9.31258C11.5 9.23204 11.4347 9.16675 11.3542 9.16675H9.75Z",
+            fill="white",
+        ),
+        rx.el.path(
+            d="M4.64583 3.91675C4.56529 3.91675 4.5 3.98204 4.5 4.06258V11.9376C4.5 12.0181 4.56529 12.0834 4.64583 12.0834H6.10417C6.18471 12.0834 6.25 12.0181 6.25 11.9376V9.31258C6.25 9.23204 6.31529 9.16675 6.39583 9.16675H9.75V7.41675H6.39583C6.31529 7.41675 6.25 7.35146 6.25 7.27091V5.81258C6.25 5.73204 6.31529 5.66675 6.39583 5.66675H9.60417C9.68471 5.66675 9.75 5.73204 9.75 5.81258V7.41675H11.3542C11.4347 7.41675 11.5 7.35146 11.5 7.27091V4.06258C11.5 3.98204 11.4347 3.91675 11.3542 3.91675H4.64583Z",
+            fill="white",
+        ),
+        width="16",
+        height="16",
+        view_box="0 0 16 16",
+        fill="none",
+        class_name="text-primary-9",
+        custom_attrs={"aria-hidden": "true"},
+    )
+
+
+def _reflex_build_action() -> rx.Component:
+    """Create the external Reflex Build action for a demo.
+
+    Returns:
+        A ghost-highlight link styled as a button.
+    """
+    return rx.el.a(
+        _reflex_build_icon(),
+        rx.el.span("Start Building Now!"),
+        ui.icon("ArrowUpRight01Icon", aria_hidden="true"),
+        href=REFLEX_BUILD_URL,
+        target="_blank",
+        rel="noopener noreferrer",
+        class_name=(
+            f"{ui.button.class_names.for_button('ghost-highlight', 'sm')} "
+            "mb-1.5 no-underline pl-0"
+        ),
+    )
+
+
+def _doc_demo_header(*triggers: rx.Component) -> rx.Component:
+    """Create the action and tab controls above a documentation demo.
+
+    Args:
+        triggers: Tab triggers associated with the demo.
+
+    Returns:
+        The demo header with the build action on the left.
+    """
+    return rx.el.div(
+        _reflex_build_action(),
+        doc_tab_list(*triggers),
+        class_name=(
+            "flex w-full flex-wrap items-end justify-between gap-x-2 gap-y-1 "
+            "sm:flex-nowrap"
+        ),
+    )
 
 
 def docdemobox(*children, **props) -> rx.Component:
@@ -161,7 +234,7 @@ def docdemo(
 
     return rx.box(
         rx.tabs.root(
-            doc_tab_list(
+            _doc_demo_header(
                 doc_tab_trigger("View", value=_VIEW_TAB_VALUE, icon="eye"),
                 doc_tab_trigger("Code", value=_CODE_TAB_VALUE, icon="code-xml"),
             ),
@@ -210,7 +283,7 @@ def docgraphing(
 
     return rx.box(
         rx.tabs.root(
-            doc_tab_list(*(trigger for trigger, _ in tabs)),
+            _doc_demo_header(*(trigger for trigger, _ in tabs)),
             doc_tab_card(*(panel for _, panel in tabs)),
             default_value=_VIEW_TAB_VALUE,
             class_name="w-full",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/6869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

