### PR TITLE
ENG-11083: document the auto-provisioning flow end to end (SCIM + service account + team grants)

### DIFF
--- a/docs/ai_builder/organization/automated_provisioning.md
+++ b/docs/ai_builder/organization/automated_provisioning.md
@@ -1,0 +1,302 @@
+---
+tags: Organization
+description: Wire an identity provider and a provisioning system to Reflex end to end, from service account credential through SCIM to project access and namespace placement.
+---
+
+# Automated Provisioning
+
+This page is the end-to-end runbook for provisioning Reflex from an external system: an identity provider, a Terraform run, or a script that reconciles desired state on a schedule. Each individual piece has its own page. This one puts them in order and names the places where wiring half of them looks like a broken feature.
+
+The shape of the flow is one idea: **a directory group is a team, and a team holds a role on a project.** The grant is made once per team, not once per person. After that, onboarding somebody is a directory add and nothing else. There is no separate "default permissions" mechanism to configure, because the team grant is it.
+
+```md alert info
+# Plan availability
+Everything on this page is Enterprise. SCIM, service accounts, and granting a team a project role are all refused on lower plans. If a step returns a plan error, [contact sales](https://reflex.dev/pricing/).
+```
+
+## The four steps
+
+| Step | What it establishes | Who can do it | Surface |
+| --- | --- | --- | --- |
+| Credential | The identity your provisioner acts as | Organization admin | Organization settings, then the token API |
+| Identity | Who exists, and which groups they are in | The SCIM token | `/api/scim/v2` |
+| Permissions | What a group can do on a project | The service account | `/api/v1/project/{id}/teams` |
+| Placement | Which Kubernetes namespace a project's sandboxes run in | Instance admin | `/api/v1/admin/namespace` |
+
+The base URL is your instance origin. On Reflex-hosted that is `https://build.reflex.dev`; on a self-hosted or on-premise install it is whatever origin your users reach the product at. All examples below use `$REFLEX_URL` for it.
+
+Placement applies only to Kubernetes installs, which in practice means on-premise. Skip step 4 on Reflex-hosted.
+
+## Step 1: the credential
+
+### Create the service account
+
+A provisioner should run as a [service account](/docs/ai/organization/service-accounts/), not as a person. A person's credentials die with their membership, and a provisioning system that stops working because somebody changed jobs is an outage nobody predicted.
+
+Creating one is a one-time setup action in the product, not an API call. Open **Service Accounts** in the organization sidebar, select **New service account**, and give it the **Member** organization role. Service accounts cannot be organization admins.
+
+### Grant it project access, and read this before you test anything
+
+In **Manage service account**, grant the account a role on every project it will provision. Grant **Admin**, because managing a project's members is an admin-tier capability and no lesser role carries it.
+
+This is the step that gets skipped, and skipping it fails in a confusing way:
+
+```md alert warning
+# The token carries the service account's permissions, not yours
+A token bound to a service account authenticates as that account. Nothing about the person who minted it is carried along. If you develop your provisioning scripts with your own token, everything works, because you are an organization admin. The moment you switch the same script to the service account's token, every call returns 403 until the account itself holds a role on those projects.
+```
+
+The same applies in reverse: revoking the service account's project role stops the provisioner, whatever the operator who created it can still do by hand.
+
+A service account's project access is managed only from organization settings. The project members API refuses to change it, and returns `a service account's project access is managed from organization settings.` if you try.
+
+### Mint a token bound to it
+
+With the account in place, mint its credential. This call is made by an organization admin, once:
+
+```bash
+curl -X POST "$REFLEX_URL/api/v1/user/token" \
+  -H "X-API-Token: $ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "idp-provisioner",
+    "expiration": 365,
+    "service_account_id": "<service-account-uuid>",
+    "access": {
+      "permissions": {"project": "write"},
+      "projects": "all"
+    }
+  }'
+```
+
+The response is the token id, which is itself the credential you send in `X-API-Token`. Store it in the provisioning system's secret manager. Reflex does not show it again.
+
+Notes on the fields:
+
+- **`service_account_id`** is what makes the credential organization-owned from the start. Omit it and you get a personal token that dies with your membership.
+- **`access`** is optional. Omitting it produces an unrestricted token. The scope shown above is the minimum for step 3: `project: write` covers reading, granting, and revoking team roles. Narrow `projects` from `"all"` to a list of project ids if the provisioner only manages some of them. Step 2 uses its own SCIM credential and step 4 cannot use this token at all, so neither needs anything added here.
+- **`expiration`** is in days. Plan the rotation; there is no renewal, only a new token.
+
+If you already have a working personal token and want to convert it in place rather than reissue, `POST /api/v1/user/token/{token_name}/service-account` with `{"service_account_id": "..."}` re-homes it. The secret value does not change, so a pipeline already using it keeps working, and from then on it is managed under the service account instead of in your own token list.
+
+```md alert warning
+# A scoped token cannot mint tokens
+A token restricted with `access` is refused by the token endpoints themselves, as is any service-account credential. Token management stays with a human admin on purpose, so a compromised provisioning credential cannot widen itself.
+```
+
+## Step 2: identity, over SCIM
+
+[Directory sync](/docs/ai/organization/provisioning/) is what creates people and groups. Open **Provisioning** in the organization sidebar, create a token, and copy the SCIM base URL, which is your instance origin followed by `/api/scim/v2`.
+
+The SCIM token is separate from the service account token. SCIM authenticates with `Authorization: Bearer`, the rest of the API with `X-API-Token`. They are not interchangeable.
+
+The service advertises PATCH and filtering, and does not support bulk operations, sorting, or ETags. `GET /api/scim/v2/ServiceProviderConfig` is unauthenticated and returns the current answer if your identity provider wants to discover it.
+
+### `/Users`
+
+A User is an organization membership.
+
+- **Create** adds the person to the organization with the **Member** organization role. An email that is already a member added by an admin is adopted into directory management rather than rejected, so turning SCIM on for an existing organization does not require emptying it first.
+- **A create for a user who is inactive in your directory is refused.** There is no "member but disabled" state to put them in. Activate them in the directory, and the next sync provisions them.
+- **Deactivating a user (`active: false`) or deleting them removes the membership outright** and revokes their tokens and sessions. It is not a suspension you can reverse by flipping a flag: re-enabling them in the directory provisions a fresh membership.
+- **SCIM only deprovisions what SCIM provisioned.** A break-glass admin added by hand is invisible to the directory and cannot be swept out by it.
+
+### `/Groups`
+
+A Group is a [team](/docs/ai/organization/teams/), and **the group's SCIM resource id is the team id you use in step 3.** Save it when you create the group; you do not have to look it up separately.
+
+- **Only teams the directory created are visible here.** A team an admin made in the product cannot be seen, renamed, or deleted through SCIM, and the reverse also holds: a member an admin adds to a synced team is not echoed in the group's `members` array. That is deliberate. It keeps your identity provider from repeatedly trying, and failing, to remove somebody it did not put there.
+- **Emptying a group leaves its project grants alone.** The access goes dormant, because nobody is left to inherit it, and comes back when the group refills. Which role a group holds is an administrator's decision made in the product, and a transient directory blip must not discard it.
+- **Deleting a group deletes the team and its grants.** SCIM DELETE is permanent removal, not suspension, and Groups have no `active` attribute to suspend with. It means exactly what deleting the team in the product means.
+- A PUT that omits `members` leaves membership alone; an explicit `[]` empties the group. A rename is a `displayName` change.
+
+## Step 3: permissions, granted to the team
+
+This is the step that turns a synced group into access. Three endpoints, all authenticated with the service account's token.
+
+Role names are per-project. List them first:
+
+```bash
+curl "$REFLEX_URL/api/v1/project/$PROJECT_ID/roles" \
+  -H "X-API-Token: $PROVISIONER_TOKEN"
+```
+
+Grant the role. The team id is the SCIM group id from step 2:
+
+```bash
+curl -X PUT "$REFLEX_URL/api/v1/project/$PROJECT_ID/teams/$TEAM_ID" \
+  -H "X-API-Token: $PROVISIONER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"role": "editor"}'
+```
+
+```json
+{"status": "granted", "team_id": "...", "role": "editor"}
+```
+
+Read the current state, which a reconciling provisioner should do rather than blind-writing:
+
+```bash
+curl "$REFLEX_URL/api/v1/project/$PROJECT_ID/teams" \
+  -H "X-API-Token: $PROVISIONER_TOKEN"
+```
+
+```json
+{
+  "grants": [
+    {"team_id": "...", "team_name": "Platform", "role": "editor",
+     "base_tier": "editor", "permissions": [], "member_count": 12}
+  ],
+  "pending": []
+}
+```
+
+`DELETE` on the same path revokes.
+
+### Read `status`, not the HTTP code
+
+Both writes are idempotent, because a provisioner asserts desired state instead of diffing first. Re-granting a role a team already holds succeeds, and revoking from a team that holds nothing answers `not_granted`.
+
+The one thing you cannot infer from a 200 is that the access exists:
+
+```md alert warning
+# `pending_approval` is a 200
+If the project requires approval for member changes, a grant parks as an approval request instead of applying. The response is `{"status": "pending_approval", ...}` with HTTP 200, and nobody has the access yet. A provisioner that treats 200 as success will record access that does not exist. Branch on `status`.
+```
+
+The gate is the project's [approval policy](/docs/ai/organization/deployment-approvals/) for member additions and role changes, and an organization can turn it on by default for every new project, so a project you have never configured can behave this way. The parked request also appears in the `pending` array of the listing, which is why the listing reports it: without it a parked grant reads as absent, your next pass re-asserts it, and every pass re-notifies the approver about a change they are already looking at. Re-asserting an identical request that is still pending is recognized and left alone.
+
+Revocations park the same way, and the team keeps its access until an approver accepts.
+
+### Constraints worth knowing before you hit them
+
+- **A team cannot hold an admin-tier role.** Managing members and roles derives from project admin, and handing that to every current and future member of a directory group is not something a group grant should be able to do. Grant admin per person.
+- **Everyone in a team must be an organization member first.** SCIM `/Users` before `/Groups`; most identity providers sequence this correctly on their own.
+- **The team and the project must belong to the same organization.**
+- Granting a team is collaboration, so it is refused on non-Enterprise plans the same way adding a person is.
+
+## Step 4: placement, for Kubernetes installs
+
+A project's Kubernetes namespace decides which cluster tenant its sandboxes run in. That is an infrastructure decision, so both endpoints below are **instance-admin only** and are not part of the organization admin's surface.
+
+```md alert warning
+# A service account can never be an instance admin
+The provisioning token from step 1 will not work here, whoever created it. Instance admin is a property of a user account, and a service account can never hold it. Drive these two endpoints with an unrestricted token belonging to an operator who is an instance admin. On-premise, that is your own platform team, so this costs nothing beyond using a different credential for this step. A token restricted with `access` is also refused, even when its owner is an instance admin.
+```
+
+### The organization default, for projects that do not exist yet
+
+```bash
+curl -X POST "$REFLEX_URL/api/v1/admin/org/orgs/update-default-namespace" \
+  -H "X-API-Token: $OPERATOR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"org_id": "<org-uuid>", "namespace": "platform-sandboxes"}'
+```
+
+New projects in the organization inherit this at creation. Inheritance happens once, at that moment; it is not a standing link. Changing the default later leaves existing projects where they are, and a blank namespace clears the default.
+
+### Retargeting a project that already exists
+
+```bash
+curl -X PUT "$REFLEX_URL/api/v1/admin/namespace/projects/$PROJECT_ID" \
+  -H "X-API-Token: $OPERATOR_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"namespace": "research-sandboxes"}'
+```
+
+```json
+{
+  "project_id": "...", "project_name": "Research", "org_id": "...",
+  "namespace": "research-sandboxes",
+  "effective_namespace": "research-sandboxes",
+  "status": "assigned",
+  "previous_namespace": "platform-sandboxes",
+  "applies_to": "sandboxes_created_after_this_change"
+}
+```
+
+`DELETE` on the same path clears the pin, as does a `PUT` with a blank namespace, so a provisioner asserting "no pin" does not have to know which verb this API prefers. `GET` on the path reads it back, and `GET /api/v1/admin/namespace/projects?namespace=&org_id=&limit=&offset=` lists projects for reconciliation.
+
+Three behaviours to build against:
+
+- **`applies_to` is not decoration.** Retargeting moves the *next* sandbox. Sandboxes that are already running keep the namespace they were created in and are still cleaned up there. A live migration of running work is not what this does, and would drop a user's running app mid-session.
+- **`status` distinguishes `assigned` and `cleared` from `unchanged`.** A re-assert answers `unchanged` and writes no audit row, so a loop reconciling every few minutes does not fill the audit trail with its own passes.
+- **The listing filters on the effective namespace**, which is the override if there is one and the deployment default otherwise. Asking for the default namespace therefore returns projects that carry no override, because their sandboxes really do run there.
+
+## What does not work, and why
+
+These are the wrong turns worth naming, because each one looks plausible.
+
+**`POST /api/v1/project/users/invite` is not the provisioning path.** It is a per-user role write that takes a Reflex user id, works only for somebody who is already an organization member, and has to be repeated for every person on every project. That is precisely the work the team grant exists to remove. Reaching for it means you have rebuilt per-user provisioning on top of a directory that was already telling you the group.
+
+**Organization invitations are not provisioning either.** An invitation is a promise that materializes when the invited person signs in and not before. Nothing you can poll turns it into access. SCIM `/Users` creates the membership directly, which is what a provisioner wants.
+
+**Namespace is not a directory attribute.** There is no SCIM extension for it. Namespace is an infrastructure placement decision that belongs to an instance admin, and a directory that could set it would let whoever administers your identity provider choose which cluster tenant workloads run in.
+
+**Do not sync service accounts through SCIM.** They are organization-owned machine identities, created in organization settings, and they hold a synthetic address under the reserved `.invalid` domain that no identity provider can ever assert. They are not directory users and there is nothing for the directory to manage.
+
+**Do not add people to a synced team in the product.** The membership works, but it is invisible to the identity provider, so your directory is no longer a complete description of who has access. Add them to the group in the directory instead. Manual membership is for teams the directory does not manage.
+
+## A worked example
+
+An identity provider with a `reflex-platform-engineers` group, which should hold `editor` on one project.
+
+**One-time setup, by an organization admin.**
+
+1. Create the service account `idp-provisioner` with the Member organization role.
+2. In **Manage service account**, grant it **Admin** on each project it will provision.
+3. Mint its token with `POST /api/v1/user/token` and `service_account_id` set, as in step 1. Store it as `$PROVISIONER_TOKEN`.
+4. On **Provisioning**, create a SCIM token and copy the base URL.
+
+**One-time setup, in the identity provider.**
+
+In Okta, add the SCIM application, set the base URL to `$REFLEX_URL/api/scim/v2`, set **Authentication Mode** to HTTP Header with the SCIM token as the bearer value, and enable **Create Users**, **Update User Attributes**, and **Deactivate Users**. Turn on **Push Groups** and push `reflex-platform-engineers`. In Microsoft Entra ID, the equivalents are the tenant URL, the secret token, and the default user and group mappings; leave the group mapping enabled.
+
+Push a small group first and confirm it appears under **Teams** before rolling the rest of the directory out.
+
+**Wiring the group to the project.**
+
+Take the group's SCIM id, which is the team id, and grant it:
+
+```bash
+curl -X PUT "$REFLEX_URL/api/v1/project/$PROJECT_ID/teams/$TEAM_ID" \
+  -H "X-API-Token: $PROVISIONER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"role": "editor"}'
+```
+
+Check `status`. If it says `pending_approval`, the grant is parked and an approver has to accept it before anybody has access.
+
+**Steady state.**
+
+Adding a person to `reflex-platform-engineers` in the directory now gives them editor on that project, with no call against Reflex beyond the ones the identity provider already makes. Removing them takes it away. Nothing per-user runs on your side ever again.
+
+A reconciliation loop, if you run one, should:
+
+- `GET /api/v1/project/{id}/teams` and compare both `grants` and `pending` against desired state.
+- Treat `pending_approval` as "not yet", and leave it alone rather than re-asserting.
+- Re-assert grants freely otherwise. They are idempotent and write no audit row when nothing moves.
+
+## Troubleshooting
+
+| Symptom | Cause |
+| --- | --- |
+| Every call 403s after switching to the service account token | The service account does not hold a role on the project. Grant it Admin from organization settings. |
+| 403 on the team grant with a mention of the plan | Granting a team project access is Enterprise. |
+| A grant returns 200 but nobody has access | `status` is `pending_approval`. The project gates member changes, and an approver has to accept. |
+| 400: teams cannot hold an admin-tier role | Grant admin per person; a group grant cannot carry it. |
+| 400 on a SCIM create saying inactive users are not provisioned | The user is deactivated in your directory. Activate them there and let the next sync provision them. |
+| A team an admin created is invisible over SCIM | Correct. Only directory-created teams appear on `/Groups`. |
+| A group emptied in the directory still shows a project role | Correct. The grant stays and the access is dormant until the group refills. |
+| 403 on the namespace endpoints with a service account token | Instance-admin only, and a service account can never be an instance admin. Use an operator's unrestricted token. |
+| A retargeted project's running sandbox is still in the old namespace | Correct. Retargeting applies to the next sandbox, per `applies_to`. |
+| 401 on SCIM with a working API token | SCIM uses `Authorization: Bearer`; the rest of the API uses `X-API-Token`. The two credentials are separate. |
+
+## Related
+
+- [Service accounts](/docs/ai/organization/service-accounts/) — create and manage machine identities.
+- [Provisioning](/docs/ai/organization/provisioning/) — the SCIM connection itself.
+- [Teams](/docs/ai/organization/teams/) — what a team is in the product.
+- [Managing project access](/docs/ai/organization/project-access/) — roles, and inspecting effective permissions.
+- [Project approvals](/docs/ai/organization/deployment-approvals/) — the gate behind `pending_approval`.
+- [Audit logs](/docs/ai/organization/audit-logs/) — the record every step above writes.

--- a/docs/ai_builder/organization/automated_provisioning.md
+++ b/docs/ai_builder/organization/automated_provisioning.md
@@ -1,17 +1,17 @@
 ---
 tags: Organization
-description: Wire an identity provider and a provisioning system to Reflex end to end, from service account credential through SCIM to project access and namespace placement.
+description: How to provision Reflex from an identity provider or a script, covering the service account credential, SCIM directory sync, team project roles, and namespace placement.
 ---
 
 # Automated Provisioning
 
-This page is the end-to-end runbook for provisioning Reflex from an external system: an identity provider, a Terraform run, or a script that reconciles desired state on a schedule. Each individual piece has its own page. This one puts them in order and names the places where wiring half of them looks like a broken feature.
+This page is the runbook for provisioning Reflex from an external system such as an identity provider, a Terraform run, or a scheduled reconcile script. Each piece has its own page. This one puts them in order and covers what happens when only part of the flow is wired.
 
-The shape of the flow is one idea: **a directory group is a team, and a team holds a role on a project.** The grant is made once per team, not once per person. After that, onboarding somebody is a directory add and nothing else. There is no separate "default permissions" mechanism to configure, because the team grant is it.
+A directory group is a team in Reflex, and a team holds a role on a project. You grant that role once per team. Onboarding a person is then a directory add, and there is no separate default-permissions setting to configure.
 
 ```md alert info
 # Plan availability
-Steps 1 to 3 are Enterprise: service accounts, SCIM, and granting a team a project role are all refused on lower plans. If one of them returns a plan error, [contact sales](https://reflex.dev/pricing/). Step 4 carries no plan gate at all, only the instance-admin requirement described there. On a self-hosted deployment that does not enforce plans, SCIM is governed by a deployment switch rather than by a tier.
+Steps 1 to 3 require the Enterprise plan. Service accounts, SCIM, and granting a team a project role are refused on lower plans; if one returns a plan error, [contact sales](https://reflex.dev/pricing/). Step 4 has no plan gate, only the instance-admin requirement described there. On a self-hosted deployment that does not enforce plans, SCIM is governed by a deployment switch instead of a tier.
 ```
 
 ## The four steps
@@ -23,36 +23,34 @@ Steps 1 to 3 are Enterprise: service accounts, SCIM, and granting a team a proje
 | Permissions | What a group can do on a project | The service account | `/api/v1/project/{id}/teams` |
 | Placement | Which Kubernetes namespace a project's sandboxes run in | Instance admin | `/api/v1/admin/namespace` |
 
-The base URL is your instance origin. On Reflex-hosted that is `https://build.reflex.dev`; on a self-hosted or on-premise install it is whatever origin your users reach the product at. All examples below use `$REFLEX_URL` for it.
+The base URL is your instance origin. On Reflex-hosted that is `https://build.reflex.dev`. On a self-hosted or on-premise install it is the origin your users reach the product at. The examples below use `$REFLEX_URL`.
 
-Placement applies only to Kubernetes installs, which in practice means on-premise. Skip step 4 on Reflex-hosted.
+Placement applies only to Kubernetes installs, so skip step 4 on Reflex-hosted.
 
-## Step 1: the credential
+## Step 1: the service account credential
 
 ### Create the service account
 
-A provisioner should run as a [service account](/docs/ai/organization/service-accounts/), not as a person. A person's credentials die with their membership, and a provisioning system that stops working because somebody changed jobs is an outage nobody predicted.
+Run the provisioner as a [service account](/docs/ai/organization/service-accounts/) rather than as a person. A personal token stops working when its owner leaves the organization, which takes the provisioning system down with it.
 
-Creating one is a one-time setup action in the product, not an API call. Open **Service Accounts** in the organization sidebar, select **New service account**, and give it the **Member** organization role. Service accounts cannot be organization admins.
+There is no API for creating one. Open **Service Accounts** in the organization sidebar, select **New service account**, and give it the **Member** organization role. Service accounts cannot be organization admins.
 
-### Grant it project access, and read this before you test anything
+### Grant it project access
 
-In **Manage service account**, grant the account a role on every project it will provision. Grant **Admin**, because managing a project's members is an admin-tier capability and no lesser role carries it.
-
-This is the step that gets skipped, and skipping it fails in a confusing way:
+In **Manage service account**, grant the account a role on every project it will provision. The role must be **Admin**, because managing a project's members is an admin-tier capability that no lesser role carries.
 
 ```md alert warning
 # The token carries the service account's permissions, not yours
-A token bound to a service account authenticates as that account. Nothing about the person who minted it is carried along. If you develop your provisioning scripts with your own token, everything works, because you are an organization admin. The moment you switch the same script to the service account's token, every call returns 403 until the account itself holds a role on those projects.
+A token bound to a service account authenticates as that account. Nothing about the person who minted it is carried along. Scripts developed with your own token work because you are an organization admin; the same scripts return 403 on every call once they use the service account's token, until the account itself holds a role on those projects.
 ```
 
-The same applies in reverse: revoking the service account's project role stops the provisioner, whatever the operator who created it can still do by hand.
+Revoking the account's project role stops the provisioner, regardless of what the operator who created it can still do by hand.
 
-A service account's project access is managed only from organization settings. The project members API will not do it either: a service account deliberately holds no organization membership row, so that call is refused with `user is not a member of this project's organization.` before it ever looks at the role you asked for. The message is about membership, but the fix is to grant the role in organization settings.
+A service account's project access is granted only from organization settings. The project members API cannot do it. Because a service account holds no organization membership row, that call is refused with `user is not a member of this project's organization.` The message names membership, but the fix is to grant the role in organization settings.
 
-### Mint a token bound to it
+### Mint its token
 
-With the account in place, mint its credential. This call is made by an organization admin, once:
+An organization admin makes this call once.
 
 ```bash
 curl -X POST "$REFLEX_URL/api/v1/user/token" \
@@ -69,50 +67,48 @@ curl -X POST "$REFLEX_URL/api/v1/user/token" \
   }'
 ```
 
-The response is the token id, which is itself the credential you send in `X-API-Token`. Store it in the provisioning system's secret manager. Reflex does not show it again.
+The response is the token id, and that id is the credential you send in `X-API-Token`. Store it in the provisioning system's secret manager. Reflex does not show it again.
 
-Notes on the fields:
+- `service_account_id` makes the credential organization-owned from the start. Without it you get a personal token tied to your own membership.
+- `access` is optional, and omitting it produces an unrestricted token. The scope above is the minimum for step 3, where `project: write` covers reading, granting, and revoking team roles. Narrow `projects` from `"all"` to a list of project ids if the provisioner manages only some of them. Step 2 uses its own SCIM credential and step 4 cannot use this token, so neither needs anything added here.
+- `expiration` is in days. There is no renewal, so plan a rotation.
 
-- **`service_account_id`** is what makes the credential organization-owned from the start. Omit it and you get a personal token that dies with your membership.
-- **`access`** is optional. Omitting it produces an unrestricted token. The scope shown above is the minimum for step 3: `project: write` covers reading, granting, and revoking team roles. Narrow `projects` from `"all"` to a list of project ids if the provisioner only manages some of them. Step 2 uses its own SCIM credential and step 4 cannot use this token at all, so neither needs anything added here.
-- **`expiration`** is in days. Plan the rotation; there is no renewal, only a new token.
-
-If you already have a working personal token and want to convert it in place rather than reissue, `POST /api/v1/user/token/{token_name}/service-account` with `{"service_account_id": "..."}` re-homes it. The secret value does not change, so a pipeline already using it keeps working, and from then on it is managed under the service account instead of in your own token list.
+To convert a personal token you already use instead of issuing a new one, `POST /api/v1/user/token/{token_name}/service-account` with `{"service_account_id": "..."}` re-homes it. The secret value does not change, so a pipeline using it keeps working, and the token moves from your own token list to the service account's.
 
 ```md alert warning
 # A scoped token cannot mint tokens
-A token restricted with `access` is refused by the token endpoints themselves, as is any service-account credential. Token management stays with a human admin on purpose, so a compromised provisioning credential cannot widen itself.
+A token restricted with `access` is refused by the token endpoints, as is any service-account credential. Token management stays with a human admin, so a compromised provisioning credential cannot widen itself.
 ```
 
-## Step 2: identity, over SCIM
+## Step 2: identity over SCIM
 
-[Directory sync](/docs/ai/organization/provisioning/) is what creates people and groups. Open **Provisioning** in the organization sidebar, create a token, and copy the SCIM base URL, which is your instance origin followed by `/api/scim/v2`.
+[Directory sync](/docs/ai/organization/provisioning/) creates the people and the groups. Open **Provisioning** in the organization sidebar, create a token, and copy the SCIM base URL, which is your instance origin followed by `/api/scim/v2`.
 
-The SCIM token is separate from the service account token. SCIM authenticates with `Authorization: Bearer`, the rest of the API with `X-API-Token`. They are not interchangeable.
+The SCIM token is separate from the service account token. SCIM authenticates with `Authorization: Bearer`, the rest of the API with `X-API-Token`.
 
-The service advertises PATCH and filtering, and does not support bulk operations, sorting, or ETags. `GET /api/scim/v2/ServiceProviderConfig` is unauthenticated and returns the current answer if your identity provider wants to discover it.
+The service supports PATCH and filtering. It does not support bulk operations, sorting, or ETags. `GET /api/scim/v2/ServiceProviderConfig` is unauthenticated, so an identity provider that discovers capabilities can read it.
 
 ### `/Users`
 
 A User is an organization membership.
 
-- **Create** adds the person to the organization with the **Member** organization role. An email that is already a member added by an admin is adopted into directory management rather than rejected, so turning SCIM on for an existing organization does not require emptying it first.
-- **A create for a user who is inactive in your directory is refused.** There is no "member but disabled" state to put them in. Activate them in the directory, and the next sync provisions them.
-- **Deactivating a user (`active: false`) or deleting them removes the membership outright** and revokes their tokens and sessions. It is not a suspension you can reverse by flipping a flag: re-enabling them in the directory provisions a fresh membership.
-- **SCIM only deprovisions what SCIM provisioned.** A break-glass admin added by hand is invisible to the directory and cannot be swept out by it.
+- A create adds the person to the organization with the **Member** organization role. An email an admin already added is adopted into directory management rather than rejected, so enabling SCIM on an existing organization does not require emptying it first.
+- A create for a user who is inactive in your directory is refused. There is no member-but-disabled state. Activate the user in the directory and the next sync provisions them.
+- Deactivating a user (`active: false`) or deleting them removes the membership and revokes their tokens and their session in that organization. Re-enabling them in the directory provisions a fresh membership rather than restoring the old one.
+- SCIM deprovisions only the memberships SCIM created. A break-glass admin added by hand is invisible to the directory.
 
 ### `/Groups`
 
-A Group is a [team](/docs/ai/organization/teams/), and **the group's SCIM resource id is the team id you use in step 3.** Save it when you create the group; you do not have to look it up separately.
+A Group is a [team](/docs/ai/organization/teams/). The group's SCIM resource id is the team id used in step 3, and it comes back in the create response, so there is nothing extra to look up.
 
-- **Only teams the directory created are visible here.** A team an admin made in the product cannot be seen, renamed, or deleted through SCIM, and the reverse also holds: a member an admin adds to a synced team is not echoed in the group's `members` array. That is deliberate. It keeps your identity provider from repeatedly trying, and failing, to remove somebody it did not put there.
-- **Emptying a group leaves its project grants alone.** The access goes dormant, because nobody is left to inherit it, and comes back when the group refills. Which role a group holds is an administrator's decision made in the product, and a transient directory blip must not discard it.
-- **Deleting a group deletes the team and its grants.** SCIM DELETE is permanent removal, not suspension, and Groups have no `active` attribute to suspend with. It means exactly what deleting the team in the product means.
-- A PUT that omits `members` leaves membership alone; an explicit `[]` empties the group. A rename is a `displayName` change.
+- Only teams the directory created are visible. A team an admin made in the product cannot be seen, renamed, or deleted through SCIM, and a member an admin adds to a synced team is not echoed in the group's `members` array, so your identity provider never tries to remove somebody it did not add.
+- Emptying a group leaves its project grants in place. The access is dormant while the group is empty and returns when the group refills, so a directory blip does not discard the role an admin gave the group.
+- Deleting a group deletes the team and the project grants it held. Groups have no `active` attribute, so DELETE is the only removal and it is permanent.
+- A PUT that omits `members` leaves membership alone. An explicit `[]` empties the group. A rename is a `displayName` change.
 
-## Step 3: permissions, granted to the team
+## Step 3: team roles on projects
 
-This is the step that turns a synced group into access. Three team endpoints, plus the project's role listing to find the role names they take, all authenticated with the service account's token.
+Three team endpoints, plus the project's role listing, all authenticated with the service account's token.
 
 Role names are per-project. List them first:
 
@@ -134,7 +130,7 @@ curl -X PUT "$REFLEX_URL/api/v1/project/$PROJECT_ID/teams/$TEAM_ID" \
 {"status": "granted", "team_id": "...", "role": "editor"}
 ```
 
-Read the current state, which a reconciling provisioner should do rather than blind-writing:
+Read the current grants, which a reconciling provisioner should do before writing:
 
 ```bash
 curl "$REFLEX_URL/api/v1/project/$PROJECT_ID/teams" \
@@ -153,40 +149,38 @@ curl "$REFLEX_URL/api/v1/project/$PROJECT_ID/teams" \
 
 `DELETE` on the same path revokes.
 
-### Read `status`, not the HTTP code
+### Idempotency and the `status` field
 
-Both writes are idempotent, because a provisioner asserts desired state instead of diffing first. Re-granting a role a team already holds succeeds, and revoking from a team that holds nothing answers `not_granted`.
-
-The one thing you cannot infer from a 200 is that the access exists:
+Both writes are idempotent. Re-granting a role a team already holds succeeds, and revoking from a team that holds nothing answers `not_granted`.
 
 ```md alert warning
 # `pending_approval` is a 200
-If the project requires approval for member changes, a grant parks as an approval request instead of applying. The response is `{"status": "pending_approval", ...}` with HTTP 200, and nobody has the access yet. A provisioner that treats 200 as success will record access that does not exist. Branch on `status`.
+If the project requires approval for member changes, a grant parks as an approval request instead of applying. The response is `{"status": "pending_approval", ...}` with HTTP 200, and nobody has the access yet. Branch on `status`, or you will record access that does not exist.
 ```
 
-The gate is the project's [approval policy](/docs/ai/organization/deployment-approvals/) for member additions and role changes, and an organization can turn it on by default for every new project, so a project you have never configured can behave this way. The parked request also appears in the `pending` array of the listing, which is why the listing reports it: without it a parked grant reads as absent, your next pass re-asserts it, and every pass re-notifies the approver about a change they are already looking at. Re-asserting an identical request that is still pending is recognized and left alone.
+The gate is the project's [approval policy](/docs/ai/organization/deployment-approvals/) for member additions and role changes, and an organization can enable it by default for every new project, so a project you never configured can behave this way. Parked requests appear in the `pending` array of the listing. Check that array before writing. An identical pending request is recognized and left alone, but a pass that ignores `pending` keeps replacing the request an approver is already reviewing and re-notifying them.
 
 Revocations park the same way, and the team keeps its access until an approver accepts.
 
-### Constraints worth knowing before you hit them
+### Constraints
 
-- **A team cannot hold an admin-tier role.** Managing members and roles derives from project admin, and handing that to every current and future member of a directory group is not something a group grant should be able to do. Grant admin per person.
-- **Everyone in a team must be an organization member first.** SCIM `/Users` before `/Groups`; most identity providers sequence this correctly on their own.
-- **The team and the project must belong to the same organization.**
-- Granting a team is collaboration, so it is refused on non-Enterprise plans the same way adding a person is.
+- A team cannot hold an admin-tier role. Grant admin per person.
+- Everyone in a team must be an organization member first. Sync `/Users` before `/Groups`; most identity providers already do.
+- The team and the project must belong to the same organization.
+- Granting a team a project role requires the Enterprise plan, as adding a person does.
 
-## Step 4: placement, for Kubernetes installs
+## Step 4: namespace placement
 
-A project's Kubernetes namespace decides which cluster tenant its sandboxes run in. That is an infrastructure decision, so both endpoints below are **instance-admin only** and are not part of the organization admin's surface.
+A project's Kubernetes namespace decides which cluster tenant its sandboxes run in. Both endpoints below are instance-admin only, not part of the organization admin's surface.
 
 ```md alert warning
 # A service account can never be an instance admin
-The provisioning token from step 1 will not work here, whoever created it. Instance admin is a property of a user account, and a service account can never hold it. Drive these two endpoints with an unrestricted token belonging to an operator who is an instance admin. On-premise, that is your own platform team, so this costs nothing beyond using a different credential for this step.
+The provisioning token from step 1 does not work here. Instance admin is a property of a user account and a service account can never hold it, so these two endpoints need a token belonging to an operator who is an instance admin. On-premise, that is your own platform team.
 ```
 
-Scoping that operator token does not buy much. A token carrying an `access` map reaches these endpoints only if it grants account-level write, which is already most of what an instance admin can do, so anything genuinely narrow is refused here even though its owner is an instance admin. Treat this credential as a privileged one and keep it out of the provisioning system.
+A token carrying an `access` map reaches these endpoints only if it grants account-level write, which is already most of an instance admin's power, so narrower scoping is refused here even when the owner is an instance admin. Treat this credential as privileged and keep it out of the provisioning system.
 
-### The organization default, for projects that do not exist yet
+### Set the organization default
 
 ```bash
 curl -X POST "$REFLEX_URL/api/v1/admin/org/orgs/update-default-namespace" \
@@ -195,9 +189,9 @@ curl -X POST "$REFLEX_URL/api/v1/admin/org/orgs/update-default-namespace" \
   -d '{"org_id": "<org-uuid>", "namespace": "platform-sandboxes"}'
 ```
 
-New projects in the organization inherit this at creation. Inheritance happens once, at that moment; it is not a standing link. Changing the default later leaves existing projects where they are, and a blank namespace clears the default.
+New projects inherit this value when they are created. Inheritance happens once, so changing the default later leaves existing projects where they are. A blank namespace clears the default.
 
-### Retargeting a project that already exists
+### Retarget an existing project
 
 ```bash
 curl -X PUT "$REFLEX_URL/api/v1/admin/namespace/projects/$PROJECT_ID" \
@@ -217,46 +211,44 @@ curl -X PUT "$REFLEX_URL/api/v1/admin/namespace/projects/$PROJECT_ID" \
 }
 ```
 
-`DELETE` on the same path clears the pin, as does a `PUT` with a blank namespace, so a provisioner asserting "no pin" does not have to know which verb this API prefers. `GET` on the path reads it back, and `GET /api/v1/admin/namespace/projects?namespace=&org_id=&limit=&offset=` lists projects for reconciliation.
+`DELETE` on the same path clears the pin, and so does a `PUT` with a blank namespace. `GET` on the path reads it back, and `GET /api/v1/admin/namespace/projects?namespace=&org_id=&limit=&offset=` lists projects for reconciliation.
 
-Three behaviours to build against:
+Three parts of the response affect how a reconciler should read it:
 
-- **`applies_to` is not decoration.** Retargeting moves the *next* sandbox. Sandboxes that are already running keep the namespace they were created in and are still cleaned up there. A live migration of running work is not what this does, and would drop a user's running app mid-session.
-- **`status` distinguishes `assigned` and `cleared` from `unchanged`.** A re-assert answers `unchanged` and writes no audit row, so a loop reconciling every few minutes does not fill the audit trail with its own passes.
-- **The listing filters on the effective namespace**, which is the override if there is one and the deployment default otherwise. Asking for the default namespace therefore returns projects that carry no override, because their sandboxes really do run there.
+- `applies_to` reports that the change is not retroactive. Retargeting moves the next sandbox. Sandboxes already running keep the namespace they were created in and are still cleaned up there. Migrating running work is out of scope, since a mid-session move would drop the user's app.
+- `status` is `assigned`, `cleared`, or `unchanged`. A re-assert answers `unchanged` and writes no audit row, so a reconcile loop does not fill the audit trail with its own passes.
+- The listing filters on the effective namespace, which is the override if there is one and the deployment default otherwise. Asking for the default namespace also returns projects that carry no override, because their sandboxes run there.
 
-## What does not work, and why
+## What does not work
 
-These are the wrong turns worth naming, because each one looks plausible.
+`POST /api/v1/project/users/invite` writes one user's role at a time. It takes a Reflex user id, works only for somebody who is already an organization member, and has to be repeated for every person on every project, which is the work a team grant removes.
 
-**`POST /api/v1/project/users/invite` is not the provisioning path.** It is a per-user role write that takes a Reflex user id, works only for somebody who is already an organization member, and has to be repeated for every person on every project. That is precisely the work the team grant exists to remove. Reaching for it means you have rebuilt per-user provisioning on top of a directory that was already telling you the group.
+Organization invitations wait for a sign-in. An invitation becomes a membership when the invited person signs in, and nothing a provisioner can poll turns it into access. SCIM `/Users` creates the membership directly.
 
-**Organization invitations are not provisioning either.** An invitation is a promise that materializes when the invited person signs in and not before. Nothing you can poll turns it into access. SCIM `/Users` creates the membership directly, which is what a provisioner wants.
+Namespace has no SCIM attribute. There is no extension for it, and a directory that could set it would let whoever administers your identity provider choose which cluster tenant workloads run in.
 
-**Namespace is not a directory attribute.** There is no SCIM extension for it. Namespace is an infrastructure placement decision that belongs to an instance admin, and a directory that could set it would let whoever administers your identity provider choose which cluster tenant workloads run in.
+Service accounts stay out of the directory. They are created in organization settings and hold a synthetic address under the reserved `.invalid` domain that no identity provider can assert, so there is nothing for the directory to manage.
 
-**Do not sync service accounts through SCIM.** They are organization-owned machine identities, created in organization settings, and they hold a synthetic address under the reserved `.invalid` domain that no identity provider can ever assert. They are not directory users and there is nothing for the directory to manage.
-
-**Do not add people to a synced team in the product.** The membership works, but it is invisible to the identity provider, so your directory is no longer a complete description of who has access. Add them to the group in the directory instead. Manual membership is for teams the directory does not manage.
+Adding people to a synced team in the product hides them from the identity provider. The membership works, but your directory stops being a complete description of who has access. Add them to the group in the directory instead.
 
 ## A worked example
 
-An identity provider with a `reflex-platform-engineers` group, which should hold `editor` on one project.
+A directory group called `reflex-platform-engineers` should hold `editor` on one project.
 
-**One-time setup, by an organization admin.**
+### One-time setup in Reflex
 
 1. Create the service account `idp-provisioner` with the Member organization role.
 2. In **Manage service account**, grant it **Admin** on each project it will provision.
 3. Mint its token with `POST /api/v1/user/token` and `service_account_id` set, as in step 1. Store it as `$PROVISIONER_TOKEN`.
 4. On **Provisioning**, create a SCIM token and copy the base URL.
 
-**One-time setup, in the identity provider.**
+### One-time setup in the identity provider
 
 In Okta, add the SCIM application, set the base URL to `$REFLEX_URL/api/scim/v2`, set **Authentication Mode** to HTTP Header with the SCIM token as the bearer value, and enable **Create Users**, **Update User Attributes**, and **Deactivate Users**. Turn on **Push Groups** and push `reflex-platform-engineers`. In Microsoft Entra ID, the equivalents are the tenant URL, the secret token, and the default user and group mappings; leave the group mapping enabled.
 
-Push a small group first and confirm it appears under **Teams** before rolling the rest of the directory out.
+Push a small group first and confirm it appears under **Teams** before rolling out the rest of the directory.
 
-**Wiring the group to the project.**
+### Wire the group to the project
 
 Take the group's SCIM id, which is the team id, and grant it:
 
@@ -269,9 +261,9 @@ curl -X PUT "$REFLEX_URL/api/v1/project/$PROJECT_ID/teams/$TEAM_ID" \
 
 Check `status`. If it says `pending_approval`, the grant is parked and an approver has to accept it before anybody has access.
 
-**Steady state.**
+### Steady state
 
-Adding a person to `reflex-platform-engineers` in the directory now gives them editor on that project, with no call against Reflex beyond the ones the identity provider already makes. Removing them takes it away. Nothing per-user runs on your side ever again.
+Adding a person to `reflex-platform-engineers` in the directory now gives them editor on that project, with no call against Reflex beyond the ones the identity provider already makes. Removing them from the group takes it away.
 
 A reconciliation loop, if you run one, should:
 
@@ -284,15 +276,15 @@ A reconciliation loop, if you run one, should:
 | Symptom | Cause |
 | --- | --- |
 | Every call 403s after switching to the service account token | The service account does not hold a role on the project. Grant it Admin from organization settings. |
-| 400 `user is not a member of this project's organization.` when adding the service account to a project | Expected. A service account holds no organization membership row, and its project access is granted from organization settings instead. |
-| 403 on the team grant with a mention of the plan | Granting a team project access is Enterprise. |
+| 400 `user is not a member of this project's organization.` when adding the service account to a project | A service account holds no organization membership row. Grant its project access from organization settings instead. |
+| 403 on the team grant with a mention of the plan | Granting a team project access requires the Enterprise plan. |
 | A grant returns 200 but nobody has access | `status` is `pending_approval`. The project gates member changes, and an approver has to accept. |
 | 400: teams cannot hold an admin-tier role | Grant admin per person; a group grant cannot carry it. |
 | 400 on a SCIM create saying inactive users are not provisioned | The user is deactivated in your directory. Activate them there and let the next sync provision them. |
-| A team an admin created is invisible over SCIM | Correct. Only directory-created teams appear on `/Groups`. |
-| A group emptied in the directory still shows a project role | Correct. The grant stays and the access is dormant until the group refills. |
-| 403 on the namespace endpoints with a service account token | Instance-admin only, and a service account can never be an instance admin. Use an operator's unrestricted token. |
-| A retargeted project's running sandbox is still in the old namespace | Correct. Retargeting applies to the next sandbox, per `applies_to`. |
+| A team an admin created is invisible over SCIM | `/Groups` lists only teams the directory created. Manage that team in the product. |
+| A group emptied in the directory still shows a project role | Emptying a group does not revoke its grant. The access is dormant until the group refills. |
+| 403 on the namespace endpoints with a service account token | These endpoints are instance-admin only, and a service account can never be an instance admin. Use an operator's unrestricted token. |
+| A retargeted project's running sandbox is still in the old namespace | Retargeting applies to sandboxes created after the change, as `applies_to` reports. |
 | 401 on SCIM with a working API token | SCIM uses `Authorization: Bearer`; the rest of the API uses `X-API-Token`. The two credentials are separate. |
 
 ## Related

--- a/docs/ai_builder/organization/automated_provisioning.md
+++ b/docs/ai_builder/organization/automated_provisioning.md
@@ -11,7 +11,7 @@ The shape of the flow is one idea: **a directory group is a team, and a team hol
 
 ```md alert info
 # Plan availability
-Everything on this page is Enterprise. SCIM, service accounts, and granting a team a project role are all refused on lower plans. If a step returns a plan error, [contact sales](https://reflex.dev/pricing/).
+Steps 1 to 3 are Enterprise: service accounts, SCIM, and granting a team a project role are all refused on lower plans. If one of them returns a plan error, [contact sales](https://reflex.dev/pricing/). Step 4 carries no plan gate at all, only the instance-admin requirement described there. On a self-hosted deployment that does not enforce plans, SCIM is governed by a deployment switch rather than by a tier.
 ```
 
 ## The four steps
@@ -48,7 +48,7 @@ A token bound to a service account authenticates as that account. Nothing about 
 
 The same applies in reverse: revoking the service account's project role stops the provisioner, whatever the operator who created it can still do by hand.
 
-A service account's project access is managed only from organization settings. The project members API refuses to change it, and returns `a service account's project access is managed from organization settings.` if you try.
+A service account's project access is managed only from organization settings. The project members API will not do it either: a service account deliberately holds no organization membership row, so that call is refused with `user is not a member of this project's organization.` before it ever looks at the role you asked for. The message is about membership, but the fix is to grant the role in organization settings.
 
 ### Mint a token bound to it
 
@@ -112,7 +112,7 @@ A Group is a [team](/docs/ai/organization/teams/), and **the group's SCIM resour
 
 ## Step 3: permissions, granted to the team
 
-This is the step that turns a synced group into access. Three endpoints, all authenticated with the service account's token.
+This is the step that turns a synced group into access. Three team endpoints, plus the project's role listing to find the role names they take, all authenticated with the service account's token.
 
 Role names are per-project. List them first:
 
@@ -181,8 +181,10 @@ A project's Kubernetes namespace decides which cluster tenant its sandboxes run 
 
 ```md alert warning
 # A service account can never be an instance admin
-The provisioning token from step 1 will not work here, whoever created it. Instance admin is a property of a user account, and a service account can never hold it. Drive these two endpoints with an unrestricted token belonging to an operator who is an instance admin. On-premise, that is your own platform team, so this costs nothing beyond using a different credential for this step. A token restricted with `access` is also refused, even when its owner is an instance admin.
+The provisioning token from step 1 will not work here, whoever created it. Instance admin is a property of a user account, and a service account can never hold it. Drive these two endpoints with an unrestricted token belonging to an operator who is an instance admin. On-premise, that is your own platform team, so this costs nothing beyond using a different credential for this step.
 ```
+
+Scoping that operator token does not buy much. A token carrying an `access` map reaches these endpoints only if it grants account-level write, which is already most of what an instance admin can do, so anything genuinely narrow is refused here even though its owner is an instance admin. Treat this credential as a privileged one and keep it out of the provisioning system.
 
 ### The organization default, for projects that do not exist yet
 
@@ -282,6 +284,7 @@ A reconciliation loop, if you run one, should:
 | Symptom | Cause |
 | --- | --- |
 | Every call 403s after switching to the service account token | The service account does not hold a role on the project. Grant it Admin from organization settings. |
+| 400 `user is not a member of this project's organization.` when adding the service account to a project | Expected. A service account holds no organization membership row, and its project access is granted from organization settings instead. |
 | 403 on the team grant with a mention of the plan | Granting a team project access is Enterprise. |
 | A grant returns 200 but nobody has access | `status` is `pending_approval`. The project gates member changes, and an approver has to accept. |
 | 400: teams cannot hold an admin-tier role | Grant admin per person; a group grant cannot carry it. |

--- a/docs/ai_builder/organization/automated_provisioning.md
+++ b/docs/ai_builder/organization/automated_provisioning.md
@@ -158,7 +158,11 @@ Both writes are idempotent. Re-granting a role a team already holds succeeds, an
 If the project requires approval for member changes, a grant parks as an approval request instead of applying. The response is `{"status": "pending_approval", ...}` with HTTP 200, and nobody has the access yet. Branch on `status`, or you will record access that does not exist.
 ```
 
-The gate is the project's [approval policy](/docs/ai/organization/deployment-approvals/) for member additions and role changes, and an organization can enable it by default for every new project, so a project you never configured can behave this way. Parked requests appear in the `pending` array of the listing. Check that array before writing. An identical pending request is recognized and left alone, but a pass that ignores `pending` keeps replacing the request an approver is already reviewing and re-notifying them.
+The gate is the project's [approval policy](/docs/ai/organization/deployment-approvals/) for member additions and role changes, and an organization can enable it by default for every new project, so a project you never configured can behave this way.
+
+A parked grant is absent from `grants` and present in `pending`. Read both before deciding what access exists.
+
+Re-asserting is safe. While the gate is on, asking again for the role a pending request already describes answers `pending_approval` without disturbing that request or notifying the approver a second time. Asking for a different role replaces the pending request and notifies again, which is correct, because the desired state changed. If the gate has since been turned off, the next call applies the grant and clears the stale request, so a loop recovers on its own.
 
 Revocations park the same way, and the team keeps its access until an approver accepts.
 
@@ -268,8 +272,8 @@ Adding a person to `reflex-platform-engineers` in the directory now gives them e
 A reconciliation loop, if you run one, should:
 
 - `GET /api/v1/project/{id}/teams` and compare both `grants` and `pending` against desired state.
-- Treat `pending_approval` as "not yet", and leave it alone rather than re-asserting.
-- Re-assert grants freely otherwise. They are idempotent and write no audit row when nothing moves.
+- Treat `pending_approval` as access that does not exist yet, and do not record it as granted.
+- Re-assert grants freely. They are idempotent, a pending request for the same role is left undisturbed, and nothing reaches the audit trail when nothing moves.
 
 ## Troubleshooting
 

--- a/docs/ai_builder/organization/provisioning.md
+++ b/docs/ai_builder/organization/provisioning.md
@@ -48,8 +48,11 @@ Open a project's **Members** page and assign a role to the synced team. Current 
 
 Teams created manually in Reflex are not managed by the identity provider. If the identity provider deletes a synced group, Reflex removes its team and project-role assignments.
 
+A synced team's project role can also be granted through the API, so that onboarding somebody is nothing more than a directory add. See [Automated provisioning](/docs/ai/organization/automated-provisioning/) for that flow end to end, including the credential a provisioning system should run as.
+
 ## Related
 
+- [Automated provisioning](/docs/ai/organization/automated-provisioning/) — wire directory sync, permissions, and placement together.
 - [Members & seats](/docs/ai/organization/members/) — understand membership and seats.
 - [Teams](/docs/ai/organization/teams/) — grant project access to groups.
 - [Single sign-on (SSO)](/docs/ai/organization/sso/) — authenticate through your identity provider.

--- a/docs/ai_builder/organization/service_accounts.md
+++ b/docs/ai_builder/organization/service_accounts.md
@@ -30,6 +30,11 @@ In **Manage service account**, choose a project and assign Viewer, Editor, or Ad
 
 You can review and revoke the account's project roles from the same dialog.
 
+```md alert warning
+# A credential carries the account's access, not yours
+A token bound to a service account acts as that account, and nothing about the person who issued it is carried along. Automation that worked while you tested it with your own credential will return 403 once it switches to the service account's, unless the account itself holds a role on the projects involved.
+```
+
 ## Issue a credential
 
 Under **Credentials**:
@@ -65,3 +70,4 @@ Deleting a service account permanently revokes its credentials and project roles
 
 - [Roles & permissions](/docs/ai/organization/roles-and-permissions/) — choose organization and project roles.
 - [Provisioning](/docs/ai/organization/provisioning/) — manage human membership through SCIM.
+- [Automated provisioning](/docs/ai/organization/automated-provisioning/) — use a service account to drive directory-based onboarding.

--- a/docs/app/reflex_docs/templates/docpage/sidebar/sidebar_items/ai.py
+++ b/docs/app/reflex_docs/templates/docpage/sidebar/sidebar_items/ai.py
@@ -62,6 +62,7 @@ def get_sidebar_items_ai_builder_overview():
                 ai_builder.organization.sso,
                 ai_builder.organization.provisioning,
                 ai_builder.organization.service_accounts,
+                ai_builder.organization.automated_provisioning,
                 ai_builder.organization.usage,
                 ai_builder.organization.deployment_approvals,
                 ai_builder.organization.audit_logs,


### PR DESCRIPTION
Every piece of automated provisioning exists now, but nothing tied them together. SCIM creates the people and the groups, [the team-grant API](https://github.com/reflex-dev/flexgen/pull/4705) attaches a group to a project, [the namespace API](https://github.com/reflex-dev/flexgen/pull/4710) places it, and a customer had to assemble that from four unrelated surfaces. The failure mode is wiring half of it and concluding the feature is broken.

One page, `docs/ai_builder/organization/automated_provisioning.md`, in the order a platform team actually does the work: credential, identity, permissions, placement. Then the wrong turns, a worked example against Okta and Entra, and a troubleshooting table.

The shape it leads with is that a directory group is a team and a team holds a role on a project, so the grant is made once per team rather than once per person. There is no separate "default permissions" mechanism to document because the team grant is it.

## The traps it names

Each of these produces a working-looking system that is not.

- **A token bound to a service account carries that account's principal, not the creator's.** Scripts developed with an admin's own token work, then 403 on every call the moment they switch, until the service account itself holds a project role. It has to be project Admin: `can_manage_members` is an admin-only meta in `schema.fga` that no custom role may delegate.
- **`pending_approval` is a 200.** A project gating member changes parks the grant instead of applying it, and an org can turn that gate on by default for every new project, so a project nobody configured behaves this way. A provisioner reading the status code records access nobody has.
- **A service account can never be an instance admin,** so the namespace endpoints take an operator's own unrestricted token rather than the provisioning credential. Worth saying plainly, since the natural assumption is that one credential drives all four steps. See the note below.
- **Emptying a directory group leaves its project grant in place and dormant;** deleting the group takes the team and the grants with it.
- **Namespace retargeting moves the next sandbox, not the running one,** which is what `applies_to` on every write response is for.

And what a provisioner should never touch: `POST /project/users/invite` is a per-user role write that takes a Reflex user id and only works for somebody who is already an org member, which is exactly the work a team grant removes. Org invitations materialize when the invited person signs in, so nothing you can poll turns one into access. Namespace is not a directory attribute.

## One correction to the record

ENG-11082's commit message says the namespace API is driven "with a service-account token whose owner is an instance admin." That cannot happen. A service account's backing `user` row is inserted with `superuser` false (`insert_service_account_user_query`), and admin user management excludes service accounts from the superuser flag deliberately, so `requires_super` never passes for one. The API is fine; the claim about how it is driven is not. The doc says step 4 takes an instance admin's own unrestricted token.

## Verification

- Page discovers, routes to `/docs/ai/organization/automated-provisioning/`, and renders through flexdown (alerts, tables and fences all parse).
- All six internal doc links resolve against the built route set.
- `uv run pre-commit run --all-files` passes.
- Every endpoint path, request shape, status value and refusal in the page was read out of current flexgen source rather than from the tickets.

**Not verified:** the Okta and Entra steps are written from what `ServiceProviderConfig` advertises and from the endpoint behaviour, not from an executed integration against a live tenant. The ticket asked for a worked example against a real IdP; validating it for real needs a tenant pointed at a running instance.

## Naming

The file is `automated_provisioning.md` rather than `auto_provisioning.md` because the sidebar label is the title-cased filename, not the H1, and the two disagreeing reads as a bug in the nav.

Linear: [ENG-11083](https://linear.app/reflex-dev/issue/ENG-11083/document-the-auto-provisioning-flow-end-to-end-scim-service "Document the auto-provisioning flow end to end (SCIM + service account + team grants)")

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/6872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

