### PR TITLE
Update search breadcrumbs

### DIFF
--- a/packages/reflex-site-shared/src/reflex_site_shared/styles/assets/components/AlgoliaSearch.tsx
+++ b/packages/reflex-site-shared/src/reflex_site_shared/styles/assets/components/AlgoliaSearch.tsx
@@ -120,7 +120,7 @@ function isEditableTarget(target: EventTarget | null): boolean {
   );
 }
 
-function normalizeResultUrl(hit: AlgoliaHit): string | null {
+function normalizeResultUrl(hit: AlgoliaHit): URL | null {
   const candidate = hit.url ?? hit.objectID;
   try {
     const url = new URL(candidate, "https://reflex.dev");
@@ -129,27 +129,26 @@ function normalizeResultUrl(hit: AlgoliaHit): string | null {
     if (!isReflexHost || !["http:", "https:"].includes(url.protocol)) {
       return null;
     }
-    return url.toString();
+    return url;
   } catch {
     return null;
   }
 }
 
-function resultSection(url: string): ResultSection {
-  const path = new URL(url).pathname;
-  if (path.startsWith("/docs/xy/")) {
+function resultSection(pathname: string): ResultSection {
+  if (pathname.startsWith("/docs/xy/")) {
     return "XY";
   }
-  if (path.startsWith("/docs/library/")) {
+  if (pathname.startsWith("/docs/library/")) {
     return "Components";
   }
-  if (path.startsWith("/docs/api-reference/")) {
+  if (pathname.startsWith("/docs/api-reference/")) {
     return "API Reference";
   }
-  if (path.startsWith("/docs/")) {
+  if (pathname.startsWith("/docs/")) {
     return "Docs";
   }
-  if (path.startsWith("/blog/")) {
+  if (pathname.startsWith("/blog/")) {
     return "Blog";
   }
   return "Reflex";
@@ -174,13 +173,16 @@ function resultPathLabel(pathSegment: string): string {
     .join(" ");
 }
 
-function resultPathBreadcrumbs(url: string, section: ResultSection): string[] {
+function resultPathBreadcrumbs(
+  pathname: string,
+  section: ResultSection,
+): string[] {
   const prefix = RESULT_PATH_PREFIXES[section];
   if (!prefix) {
     return [];
   }
 
-  const pathSegments = new URL(url).pathname.split("/").filter(Boolean);
+  const pathSegments = pathname.split("/").filter(Boolean);
   if (!prefix.every((segment, index) => pathSegments[index] === segment)) {
     return [];
   }
@@ -188,19 +190,27 @@ function resultPathBreadcrumbs(url: string, section: ResultSection): string[] {
   return pathSegments.slice(prefix.length, -1).slice(0, 2).map(resultPathLabel);
 }
 
-function resultBreadcrumbs(url: string, section: ResultSection): string[] {
+function resultBreadcrumbs(pathname: string, section: ResultSection): string[] {
   const root = section === "Blog" ? "Blogs" : section;
-  return [root, ...resultPathBreadcrumbs(url, section)];
+  const normalizedRoot = root.toLowerCase();
+  return [
+    root,
+    ...resultPathBreadcrumbs(pathname, section).filter(
+      (breadcrumb) => breadcrumb.toLowerCase() !== normalizedRoot,
+    ),
+  ];
 }
 
 function normalizeHits(hits: AlgoliaHit[]): SearchHit[] {
   return hits.flatMap((hit) => {
-    const url = normalizeResultUrl(hit);
-    if (!url) {
+    const normalizedUrl = normalizeResultUrl(hit);
+    if (!normalizedUrl) {
       return [];
     }
 
-    const section = resultSection(url);
+    const url = normalizedUrl.toString();
+    const pathname = normalizedUrl.pathname;
+    const section = resultSection(pathname);
     const displayTitle = resultTitle(hit);
     return [
       {
@@ -208,7 +218,7 @@ function normalizeHits(hits: AlgoliaHit[]): SearchHit[] {
         url,
         section,
         displayTitle,
-        breadcrumbs: resultBreadcrumbs(url, section),
+        breadcrumbs: resultBreadcrumbs(pathname, section),
       },
     ];
   });

--- a/packages/reflex-site-shared/src/reflex_site_shared/styles/assets/components/AlgoliaSearch.tsx
+++ b/packages/reflex-site-shared/src/reflex_site_shared/styles/assets/components/AlgoliaSearch.tsx
@@ -55,6 +55,33 @@ const RESULT_ICONS: Record<ResultSection, IconSvgElement> = {
   Reflex: ReflexIcon,
 };
 
+const RESULT_PATH_PREFIXES: Partial<Record<ResultSection, string[]>> = {
+  Docs: ["docs"],
+  Components: ["docs", "library"],
+  XY: ["docs", "xy"],
+  "API Reference": ["docs", "api-reference"],
+};
+
+const RESULT_PATH_LABELS: Record<string, string> = {
+  ai: "AI",
+  api: "API",
+  cli: "CLI",
+  css: "CSS",
+  html: "HTML",
+  http: "HTTP",
+  https: "HTTPS",
+  js: "JS",
+  json: "JSON",
+  llm: "LLM",
+  mcp: "MCP",
+  sql: "SQL",
+  ui: "UI",
+  url: "URL",
+  ux: "UX",
+  xml: "XML",
+  xy: "XY",
+};
+
 interface AlgoliaHit {
   objectID: string;
   url?: string;
@@ -136,34 +163,34 @@ function resultTitle(hit: AlgoliaHit): string {
   return cleanResultLabel(hit.title || hit.headers?.at(-1) || "Reflex");
 }
 
-function resultBreadcrumbs(
-  hit: AlgoliaHit,
-  section: ResultSection,
-  displayTitle: string,
-): string[] {
-  const root = section === "Blog" ? "Blogs" : section;
-  if (
-    section === "API Reference" ||
-    section === "Blog" ||
-    section === "Reflex"
-  ) {
-    return [root];
+function resultPathLabel(pathSegment: string): string {
+  return pathSegment
+    .split("-")
+    .map(
+      (word) =>
+        RESULT_PATH_LABELS[word] ??
+        `${word.charAt(0).toUpperCase()}${word.slice(1)}`,
+    )
+    .join(" ");
+}
+
+function resultPathBreadcrumbs(url: string, section: ResultSection): string[] {
+  const prefix = RESULT_PATH_PREFIXES[section];
+  if (!prefix) {
+    return [];
   }
 
-  const breadcrumbs = [root];
-  const seen = new Set([
-    root.toLocaleLowerCase(),
-    displayTitle.toLocaleLowerCase(),
-  ]);
-  for (const header of (hit.headers ?? []).slice(0, 2)) {
-    const label = cleanResultLabel(header);
-    const normalizedLabel = label.toLocaleLowerCase();
-    if (label && !seen.has(normalizedLabel)) {
-      breadcrumbs.push(label);
-      seen.add(normalizedLabel);
-    }
+  const pathSegments = new URL(url).pathname.split("/").filter(Boolean);
+  if (!prefix.every((segment, index) => pathSegments[index] === segment)) {
+    return [];
   }
-  return breadcrumbs;
+
+  return pathSegments.slice(prefix.length, -1).slice(0, 2).map(resultPathLabel);
+}
+
+function resultBreadcrumbs(url: string, section: ResultSection): string[] {
+  const root = section === "Blog" ? "Blogs" : section;
+  return [root, ...resultPathBreadcrumbs(url, section)];
 }
 
 function normalizeHits(hits: AlgoliaHit[]): SearchHit[] {
@@ -181,7 +208,7 @@ function normalizeHits(hits: AlgoliaHit[]): SearchHit[] {
         url,
         section,
         displayTitle,
-        breadcrumbs: resultBreadcrumbs(hit, section, displayTitle),
+        breadcrumbs: resultBreadcrumbs(url, section),
       },
     ];
   });

--- a/tests/units/reflex_site_shared/test_algolia.py
+++ b/tests/units/reflex_site_shared/test_algolia.py
@@ -425,21 +425,29 @@ def test_algolia_search_input_row_contains_safari_search_input() -> None:
 
 
 def test_algolia_search_builds_result_breadcrumbs() -> None:
-    """Render result hierarchy from its section and indexed headers."""
+    """Render docs hierarchy from canonical URLs instead of indexed headings."""
     assets = dict(SharedSiteStylesPlugin().get_static_assets())
     source = assets[Path("public/components/AlgoliaSearch.tsx")]
 
     assert "breadcrumbs: string[];" in source
     assert "function resultBreadcrumbs(" in source
     assert 'section === "Blog" ? "Blogs" : section' in source
-    assert 'section === "API Reference" ||' in source
-    assert 'section === "Blog" ||' in source
-    assert 'section === "Reflex"' in source
-    assert "breadcrumbs: resultBreadcrumbs(hit, section, displayTitle)" in source
+    assert "RESULT_PATH_PREFIXES" in source
+    assert 'Docs: ["docs"]' in source
+    assert 'Components: ["docs", "library"]' in source
+    assert 'XY: ["docs", "xy"]' in source
+    assert '"API Reference": ["docs", "api-reference"]' in source
+    assert "RESULT_PATH_LABELS" in source
+    assert 'ai: "AI"' in source
+    assert "function resultPathBreadcrumbs(" in source
+    assert ".slice(prefix.length, -1)" in source
+    assert ".map(resultPathLabel)" in source
+    assert "return [root, ...resultPathBreadcrumbs(url, section)];" in source
+    assert "breadcrumbs: resultBreadcrumbs(url, section)" in source
     assert 'className="ReflexSearch-hitBreadcrumbs"' in source
     assert "hit.breadcrumbs.map((breadcrumb, index)" in source
     assert "icon={ArrowRight01Icon}" in source
-    assert "(hit.headers ?? []).slice(0, 2)" in source
+    assert "(hit.headers ?? []).slice(0, 2)" not in source
     assert "<mark" not in source
     assert "font-size: 1.125rem;" in source
 

--- a/tests/units/reflex_site_shared/test_algolia.py
+++ b/tests/units/reflex_site_shared/test_algolia.py
@@ -47,7 +47,7 @@ def test_algolia_search_asset_is_published_and_non_ai() -> None:
         ("/docs/", "Docs"),
         ("/blog/", "Blog"),
     ):
-        assert f'path.startsWith("{route}")' in source
+        assert f'pathname.startsWith("{route}")' in source
         assert f'return "{section}"' in source
     assert 'return "Reflex"' in source
 
@@ -439,11 +439,16 @@ def test_algolia_search_builds_result_breadcrumbs() -> None:
     assert '"API Reference": ["docs", "api-reference"]' in source
     assert "RESULT_PATH_LABELS" in source
     assert 'ai: "AI"' in source
+    assert "function normalizeResultUrl(hit: AlgoliaHit): URL | null" in source
+    assert "function resultSection(pathname: string)" in source
     assert "function resultPathBreadcrumbs(" in source
+    assert 'pathname.split("/").filter(Boolean)' in source
     assert ".slice(prefix.length, -1)" in source
     assert ".map(resultPathLabel)" in source
-    assert "return [root, ...resultPathBreadcrumbs(url, section)];" in source
-    assert "breadcrumbs: resultBreadcrumbs(url, section)" in source
+    assert "breadcrumb.toLowerCase() !== normalizedRoot" in source
+    assert "const url = normalizedUrl.toString();" in source
+    assert "const pathname = normalizedUrl.pathname;" in source
+    assert "breadcrumbs: resultBreadcrumbs(pathname, section)" in source
     assert 'className="ReflexSearch-hitBreadcrumbs"' in source
     assert "hit.breadcrumbs.map((breadcrumb, index)" in source
     assert "icon={ArrowRight01Icon}" in source
@@ -574,7 +579,8 @@ def test_algolia_search_precomputes_result_metadata() -> None:
         "</ul>", 1
     )[0]
 
-    assert "const section = resultSection(url)" in normalize_hits
+    assert "const section = resultSection(pathname)" in normalize_hits
+    assert normalize_hits.count("new URL(") == 0
     assert "const displayTitle = resultTitle(hit)" in normalize_hits
     assert "section," in normalize_hits
     assert "displayTitle," in normalize_hits


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/6883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

