### PR TITLE
correct Base UI submenu tag casing

### DIFF
--- a/packages/reflex-components-internal/src/reflex_components_internal/components/base/menu.py
+++ b/packages/reflex-components-internal/src/reflex_components_internal/components/base/menu.py
@@ -333,7 +333,7 @@ class MenuLinkItem(MenuBaseComponent):
 class MenuSubMenuRoot(MenuBaseComponent):
     """Groups all parts of a submenu. Doesn't render its own HTML element."""
 
-    tag = "Menu.SubMenuRoot"
+    tag = "Menu.SubmenuRoot"
 
     # Whether the menu is initially open. To render a controlled menu, use the open prop instead. Defaults to False.
     default_open: Var[bool]
@@ -377,7 +377,7 @@ class MenuSubMenuRoot(MenuBaseComponent):
 class MenuSubMenuTrigger(MenuBaseComponent):
     """A menu item that opens a submenu."""
 
-    tag = "Menu.SubMenuTrigger"
+    tag = "Menu.SubmenuTrigger"
 
     # Overrides the text label to use when the item is matched during keyboard text navigation.
     label: Var[str]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/6887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

