### PR TITLE
fix: properly annotate EventCallback.fn for tests

### DIFF
--- a/packages/reflex-base/src/reflex_base/event/__init__.py
+++ b/packages/reflex-base/src/reflex_base/event/__init__.py
@@ -2700,8 +2700,10 @@ class EventCallback(Generic[Unpack[P]], EventActionsMixin):
     """A descriptor that wraps a function to be used as an event."""
 
     if TYPE_CHECKING:
-        # Accessing an event handler on the state class returns an EventHandler
-        # at runtime, whose `fn` is the undecorated function.
+        # EventCallback is never instantiated: `event()` returns the undecorated
+        # function, which the state metaclass turns into an EventHandler. This
+        # class is only the static stand-in for it, so declare the EventHandler
+        # attribute that `SomeState.handler` actually exposes at runtime.
         fn: Callable[[Any, Unpack[P]], Any]
 
     def __init__(self, func: Callable[[Any, Unpack[P]], Any]):

--- a/packages/reflex-base/src/reflex_base/event/__init__.py
+++ b/packages/reflex-base/src/reflex_base/event/__init__.py
@@ -2699,6 +2699,11 @@ V5 = TypeVar("V5")
 class EventCallback(Generic[Unpack[P]], EventActionsMixin):
     """A descriptor that wraps a function to be used as an event."""
 
+    if TYPE_CHECKING:
+        # Accessing an event handler on the state class returns an EventHandler
+        # at runtime, whose `fn` is the undecorated function.
+        fn: Callable[[Any, Unpack[P]], Any]
+
     def __init__(self, func: Callable[[Any, Unpack[P]], Any]):
         """Initialize the descriptor with the function to be wrapped.
 

--- a/tests/units/test_event.py
+++ b/tests/units/test_event.py
@@ -734,7 +734,7 @@ def test_event_decorator_with_event_actions():
     # Test background + event actions work together
     bg_temporal_handler = MyTestState.handle_background_temporal
     assert bg_temporal_handler.event_actions == {"temporal": True}
-    assert hasattr(bg_temporal_handler.fn, BACKGROUND_TASK_MARKER)  # pyright: ignore [reportAttributeAccessIssue]
+    assert hasattr(bg_temporal_handler.fn, BACKGROUND_TASK_MARKER)
 
     # Test no event actions (existing behavior preserved)
     no_actions_handler = MyTestState.handle_no_actions
@@ -809,12 +809,12 @@ def test_event_decorator_backward_compatibility():
     old_handler = MyTestState.handle_old_style
     assert isinstance(old_handler, EventHandler)
     assert old_handler.event_actions == {}
-    assert not hasattr(old_handler.fn, BACKGROUND_TASK_MARKER)  # pyright: ignore [reportAttributeAccessIssue]
+    assert not hasattr(old_handler.fn, BACKGROUND_TASK_MARKER)
 
     # Old background parameter should work unchanged
     bg_handler = MyTestState.handle_old_background
     assert bg_handler.event_actions == {}
-    assert hasattr(bg_handler.fn, BACKGROUND_TASK_MARKER)  # pyright: ignore [reportAttributeAccessIssue]
+    assert hasattr(bg_handler.fn, BACKGROUND_TASK_MARKER)
 
 
 def test_event_var_in_rx_cond():


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/6894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

