### PR TITLE
perf: elide unchanged connection-scoped router fields from deltas

### DIFF
--- a/news/6906.performance.md
+++ b/news/6906.performance.md
@@ -1,0 +1,1 @@
+State deltas no longer re-ship the session block and request headers on every navigation; only the router fields that changed (page, url, route_id) are sent, cutting the per-navigation delta by ~72%.

--- a/packages/reflex-base/news/6906.performance.md
+++ b/packages/reflex-base/news/6906.performance.md
@@ -1,0 +1,1 @@
+State deltas no longer re-ship the session block and request headers on every navigation; only the router fields that changed (page, url, route_id) are sent, cutting the per-navigation delta by ~72%.

--- a/packages/reflex-base/src/reflex_base/.templates/web/utils/state.js
+++ b/packages/reflex-base/src/reflex_base/.templates/web/utils/state.js
@@ -156,6 +156,10 @@ export const isStateful = () => {
   return event_queue.some((event) => event.name.startsWith("reflex___state"));
 };
 
+// Root-state field carrying RouterData; must match `constants.ROUTER +
+// FIELD_MARKER` on the backend (see reflex.istate.data).
+const ROUTER_FIELD = "router_rx_state_";
+
 /**
  * Apply a delta to the state.
  * @param state The state to apply the delta to.
@@ -166,16 +170,17 @@ export const applyDelta = (state, delta) => {
   // Once the connection-scoped router fields (session, headers) have been
   // sent, the backend elides them from subsequent deltas; merge partial
   // router payloads over the previously received value so they carry
-  // forward.
-  const router = delta["router_rx_state_"];
-  const prev_router = state["router_rx_state_"];
+  // forward. The merge is field-agnostic, so adding RouterData fields on the
+  // backend needs no change here.
+  const router = delta[ROUTER_FIELD];
+  const prev_router = state[ROUTER_FIELD];
   if (
     router !== null &&
     prev_router !== null &&
     typeof router === "object" &&
     typeof prev_router === "object"
   ) {
-    new_state["router_rx_state_"] = { ...prev_router, ...router };
+    new_state[ROUTER_FIELD] = { ...prev_router, ...router };
   }
   return new_state;
 };

--- a/packages/reflex-base/src/reflex_base/.templates/web/utils/state.js
+++ b/packages/reflex-base/src/reflex_base/.templates/web/utils/state.js
@@ -162,7 +162,22 @@ export const isStateful = () => {
  * @param delta The delta to apply.
  */
 export const applyDelta = (state, delta) => {
-  return { ...state, ...delta };
+  const new_state = { ...state, ...delta };
+  // Once the connection-scoped router fields (session, headers) have been
+  // sent, the backend elides them from subsequent deltas; merge partial
+  // router payloads over the previously received value so they carry
+  // forward.
+  const router = delta["router_rx_state_"];
+  const prev_router = state["router_rx_state_"];
+  if (
+    router !== null &&
+    prev_router !== null &&
+    typeof router === "object" &&
+    typeof prev_router === "object"
+  ) {
+    new_state["router_rx_state_"] = { ...prev_router, ...router };
+  }
+  return new_state;
 };
 
 /**

--- a/packages/reflex-base/src/reflex_base/event/processor/base_state_processor.py
+++ b/packages/reflex-base/src/reflex_base/event/processor/base_state_processor.py
@@ -368,12 +368,9 @@ class BaseStateEventProcessor(EventProcessor):
                     # can elide the connection-scoped fields the client
                     # already holds. Direct router writes elsewhere reset
                     # this flag (see BaseState.__setattr__).
-                    object.__setattr__(
-                        state,
-                        "_router_static_unchanged",
-                        router_connection_scope(previous_router)
-                        == router_connection_scope(router),
-                    )
+                    state._router_static_unchanged = router_connection_scope(
+                        previous_router
+                    ) == router_connection_scope(router)
 
             # Preprocess the event.
             if (

--- a/packages/reflex-base/src/reflex_base/event/processor/base_state_processor.py
+++ b/packages/reflex-base/src/reflex_base/event/processor/base_state_processor.py
@@ -12,7 +12,7 @@ from enum import Enum
 from importlib.util import find_spec
 from typing import TYPE_CHECKING, Any
 
-from reflex.istate.data import RouterData
+from reflex.istate.data import RouterData, router_connection_scope
 from reflex.istate.manager.token import BaseStateToken
 from reflex.istate.proxy import StateProxy
 from reflex.utils import types
@@ -365,14 +365,14 @@ class BaseStateEventProcessor(EventProcessor):
                 if state.router != (router := RouterData.from_router_data(router_data)):
                     state.router = router
                     # When only the per-navigation fields changed, the delta
-                    # can elide the connection-scoped fields (session,
-                    # headers) the client already holds. Direct router writes
-                    # elsewhere reset this flag (see BaseState.__setattr__).
+                    # can elide the connection-scoped fields the client
+                    # already holds. Direct router writes elsewhere reset
+                    # this flag (see BaseState.__setattr__).
                     object.__setattr__(
                         state,
                         "_router_static_unchanged",
-                        previous_router.session == router.session
-                        and previous_router.headers == router.headers,
+                        router_connection_scope(previous_router)
+                        == router_connection_scope(router),
                     )
 
             # Preprocess the event.

--- a/packages/reflex-base/src/reflex_base/event/processor/base_state_processor.py
+++ b/packages/reflex-base/src/reflex_base/event/processor/base_state_processor.py
@@ -358,11 +358,22 @@ class BaseStateEventProcessor(EventProcessor):
 
             # re-assign only when the value is set and different
             if router_data and state.router_data != router_data:
+                previous_router = state.router
                 # assignment will recurse into substates and force recalculation of
                 # dependent ComputedVar (dynamic route variables)
                 state.router_data = router_data
                 if state.router != (router := RouterData.from_router_data(router_data)):
                     state.router = router
+                    # When only the per-navigation fields changed, the delta
+                    # can elide the connection-scoped fields (session,
+                    # headers) the client already holds. Direct router writes
+                    # elsewhere reset this flag (see BaseState.__setattr__).
+                    object.__setattr__(
+                        state,
+                        "_router_static_unchanged",
+                        previous_router.session == router.session
+                        and previous_router.headers == router.headers,
+                    )
 
             # Preprocess the event.
             if (

--- a/packages/reflex-base/src/reflex_base/utils/exceptions.py
+++ b/packages/reflex-base/src/reflex_base/utils/exceptions.py
@@ -72,6 +72,10 @@ class VarNameError(ReflexError, NameError):
     """Custom NameError for when a state var has been shadowed by a substate var."""
 
 
+class ReservedStateFieldError(ReflexError, NameError):
+    """Raised when a state class declares a field name reserved for internal use."""
+
+
 class VarTypeError(ReflexError, TypeError):
     """Custom TypeError for var related errors."""
 

--- a/packages/reflex-base/src/reflex_base/utils/types.py
+++ b/packages/reflex-base/src/reflex_base/utils/types.py
@@ -163,7 +163,14 @@ PrimitiveToAnnotation = {
     dict: Dict,  # noqa: UP006
 }
 
-RESERVED_BACKEND_VAR_NAMES = {"_abc_impl", "_backend_vars", "_was_touched", "_mixin"}
+RESERVED_BACKEND_VAR_NAMES = {
+    "_abc_impl",
+    "_backend_vars",
+    "_partial_router_capable",
+    "_router_static_unchanged",
+    "_was_touched",
+    "_mixin",
+}
 
 
 class Unset:

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -1990,16 +1990,24 @@ class EventNamespace(AsyncNamespace):
             self._token_manager.ensure_lost_and_found_task(self.emit_update)
         query_params = urllib.parse.parse_qs(environ.get("QUERY_STRING", ""))
         token_list = query_params.get("token", [])
-        if token_list:
-            await self.link_token_to_sid(sid, token_list[0])
-        else:
-            logger.warning(f"No token provided in connection for session {sid}")
-
         subprotocol = environ.get("HTTP_SEC_WEBSOCKET_PROTOCOL")
         if subprotocol and subprotocol != constants.Reflex.VERSION:
             logger.warning(
                 f"Frontend version {subprotocol} for session {sid} does not match the backend version {constants.Reflex.VERSION}."
             )
+
+        if token_list:
+            await self.link_token_to_sid(
+                sid,
+                token_list[0],
+                # Only a frontend compiled by this exact backend version is
+                # known to merge partial router deltas; anything else (e.g. a
+                # cached bundle from before a rolling deployment) gets the
+                # full router in every delta.
+                partial_router_capable=subprotocol == constants.Reflex.VERSION,
+            )
+        else:
+            logger.warning(f"No token provided in connection for session {sid}")
 
     def on_disconnect(self, sid: str) -> asyncio.Task | None:
         """Event for when the websocket disconnects.
@@ -2232,12 +2240,17 @@ class EventNamespace(AsyncNamespace):
         # handlers (e.g. error trackers) receive client errors too.
         self.app.frontend_exception_handler(Exception(report))
 
-    async def link_token_to_sid(self, sid: str, token: str):
+    async def link_token_to_sid(
+        self, sid: str, token: str, partial_router_capable: bool = False
+    ):
         """Link a token to a session id.
 
         Args:
             sid: The Socket.IO session id.
             token: The client token.
+            partial_router_capable: Whether the connected frontend advertised
+                (via exact version match on the websocket subprotocol) that it
+                merges partial router deltas.
         """
         # Use TokenManager for duplicate detection and Redis support
         new_token = await self._token_manager.link_token_to_sid(token, sid)
@@ -2253,3 +2266,4 @@ class EventNamespace(AsyncNamespace):
             ) as state:
                 state.router_data[constants.RouteVar.SESSION_ID] = sid
                 state.router = RouterData.from_router_data(state.router_data)
+                state._partial_router_capable = partial_router_capable

--- a/reflex/istate/data.py
+++ b/reflex/istate/data.py
@@ -474,6 +474,24 @@ def serialize_router_data(obj: RouterData) -> dict:
     return {
         "session": obj.session,
         "headers": obj.headers,
+        **serialize_partial_router_data(obj),
+    }
+
+
+def serialize_partial_router_data(obj: RouterData) -> dict:
+    """Serialize only the per-navigation fields of a RouterData object.
+
+    Used for state deltas once the connection-scoped fields (session and
+    headers) have already been sent to the client; the frontend merges this
+    partial payload over its previously received router value.
+
+    Args:
+        obj: the RouterData object.
+
+    Returns:
+        A dict with the per-navigation fields of the RouterData object.
+    """
+    return {
         "page": obj._page,
         # ReflexURL is a str subclass, so json.dumps handles it natively and
         # never invokes the `default=serialize` hook. Call the URL serializer

--- a/reflex/istate/data.py
+++ b/reflex/istate/data.py
@@ -461,6 +461,26 @@ class RouterData:
         )
 
 
+# RouterData fields that are fixed for the lifetime of a client connection.
+# State deltas may omit these once the client has them (see
+# serialize_partial_router_data); the event processor decides that by
+# comparing exactly these fields, so adding one here is all that is needed to
+# keep the two in step.
+CONNECTION_SCOPED_ROUTER_FIELDS = ("session", "headers")
+
+
+def router_connection_scope(obj: RouterData) -> tuple:
+    """Get the connection-scoped router values used to detect client-visible changes.
+
+    Args:
+        obj: the RouterData object.
+
+    Returns:
+        A tuple of the connection-scoped field values, in declaration order.
+    """
+    return tuple(getattr(obj, name) for name in CONNECTION_SCOPED_ROUTER_FIELDS)
+
+
 @serializer(to=dict)
 def serialize_router_data(obj: RouterData) -> dict:
     """Serialize a RouterData object to a dict.
@@ -472,8 +492,13 @@ def serialize_router_data(obj: RouterData) -> dict:
         A dict representation of the RouterData object.
     """
     return {
-        "session": obj.session,
-        "headers": obj.headers,
+        **dict(
+            zip(
+                CONNECTION_SCOPED_ROUTER_FIELDS,
+                router_connection_scope(obj),
+                strict=True,
+            )
+        ),
         **serialize_partial_router_data(obj),
     }
 

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -2094,6 +2094,10 @@ class BaseState(EvenMoreBasicBaseState):
         state.pop("parent_state", None)
         state.pop("substates", None)
         state.pop("_was_touched", None)
+        # Transient, request-scoped: recomputed by the event processor on every
+        # router reassignment. Persisting it could arm a partial router delta
+        # for a client that never received the connection-scoped fields.
+        state.pop("_router_static_unchanged", None)
         # Remove all inherited vars.
         for inherited_var_name in self.inherited_vars:
             state.pop(inherited_var_name, None)

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -46,6 +46,7 @@ from reflex_base.utils.exceptions import (
     DynamicRouteArgShadowsStateVarError,
     EventHandlerShadowsBuiltInStateMethodError,
     ReflexRuntimeError,
+    ReservedStateFieldError,
     SetUndefinedStateVarError,
     StateMismatchError,
     StateSchemaMismatchError,
@@ -441,6 +442,19 @@ class BaseState(EvenMoreBasicBaseState):
     # Whether the state has ever been touched since instantiation.
     _was_touched: bool = field(default=False, is_var=False)
 
+    # Whether the event processor's last router reassignment left the
+    # connection-scoped fields (session, headers) unchanged. Transient:
+    # recomputed on every reassignment, cleared by any direct router write,
+    # and never pickled.
+    _router_static_unchanged: bool = field(default=False, is_var=False)
+
+    # Whether the connected client advertised, via an exact version match on
+    # the websocket subprotocol, that its applyDelta merges partial router
+    # payloads. Set on connect; False for older frontends (e.g. cached
+    # bundles during a rolling deployment), which then receive the full
+    # router in every delta.
+    _partial_router_capable: bool = field(default=False, is_var=False)
+
     # A special event handler for setting base vars.
     setvar: ClassVar[EventHandler]
 
@@ -559,6 +573,11 @@ class BaseState(EvenMoreBasicBaseState):
 
         # Event handlers should not shadow builtin state methods.
         cls._check_overridden_methods()
+
+        # Internal router bookkeeping fields must not be redefined by user
+        # states: a shadowing value would silently control whether router
+        # deltas are sent partially.
+        cls._check_reserved_internal_fields()
 
         # Computed vars should not shadow builtin state props.
         cls._check_overridden_basevars()
@@ -961,6 +980,29 @@ class BaseState(EvenMoreBasicBaseState):
         for method_name in overridden_methods:
             msg = f"The event handler name `{method_name}` shadows a builtin State method; use a different name instead"
             raise EventHandlerShadowsBuiltInStateMethodError(msg)
+
+    _RESERVED_INTERNAL_FIELD_NAMES = frozenset({
+        "_partial_router_capable",
+        "_router_static_unchanged",
+    })
+
+    @classmethod
+    def _check_reserved_internal_fields(cls):
+        """Check that internal bookkeeping fields are not redefined.
+
+        Raises:
+            ReservedStateFieldError: When a state class declares a field
+                reserved for internal use.
+        """
+        declared = set(inspect.get_annotations(cls)) | {
+            name for name in cls._RESERVED_INTERNAL_FIELD_NAMES if name in cls.__dict__
+        }
+        for name in cls._RESERVED_INTERNAL_FIELD_NAMES & declared:
+            msg = (
+                f"The field name `{name}` in {cls.__module__}.{cls.__name__} is "
+                "reserved for internal use; use a different name instead"
+            )
+            raise ReservedStateFieldError(msg)
 
     @classmethod
     def _check_overridden_basevars(cls):
@@ -1894,7 +1936,8 @@ class BaseState(EvenMoreBasicBaseState):
         if (
             self.parent_state is None
             and (router_field := constants.ROUTER + FIELD_MARKER) in subdelta
-            and getattr(self, "_router_static_unchanged", False)
+            and self._router_static_unchanged
+            and self._partial_router_capable
         ):
             # The connection-scoped router fields (session, headers) this
             # client already received are unchanged, so ship only the

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -73,7 +73,7 @@ from typing_extensions import Self
 import reflex.istate.dynamic
 from reflex import event
 from reflex.istate import HANDLED_PICKLE_ERRORS, debug_failed_pickles
-from reflex.istate.data import RouterData
+from reflex.istate.data import RouterData, serialize_partial_router_data
 from reflex.istate.proxy import ImmutableMutableProxy as ImmutableMutableProxy
 from reflex.istate.proxy import MutableProxy, is_mutable_type
 from reflex.istate.storage import ClientStorageBase
@@ -1560,6 +1560,12 @@ class BaseState(EvenMoreBasicBaseState):
             self.dirty_vars.add(name)
             self._mark_dirty()
 
+        # Any direct router write invalidates the partial-router-delta
+        # optimization; the event processor re-arms it after comparing the
+        # connection-scoped fields (see BaseStateEventProcessor).
+        if name == constants.ROUTER:
+            object.__setattr__(self, "_router_static_unchanged", False)
+
     def reset(self):
         """Reset all the base vars to their default values."""
         # Reset the base vars.
@@ -1884,6 +1890,19 @@ class BaseState(EvenMoreBasicBaseState):
             for prop in delta_vars
             if not types.is_backend_base_variable(prop, type(self))
         }
+
+        if (
+            self.parent_state is None
+            and (router_field := constants.ROUTER + FIELD_MARKER) in subdelta
+            and getattr(self, "_router_static_unchanged", False)
+        ):
+            # The connection-scoped router fields (session, headers) this
+            # client already received are unchanged, so ship only the
+            # per-navigation fields; the frontend merges the partial payload
+            # over its previously received router value.
+            subdelta[router_field] = serialize_partial_router_data(
+                subdelta[router_field]
+            )
 
         if len(subdelta) > 0:
             delta[self.get_full_name()] = subdelta

--- a/reflex/state.py
+++ b/reflex/state.py
@@ -561,6 +561,12 @@ class BaseState(EvenMoreBasicBaseState):
 
         super().__init_subclass__(**kwargs)
 
+        # Internal router bookkeeping fields must not be redefined by user
+        # states: a shadowing value would silently control whether router
+        # deltas are sent partially. Checked before the mixin early-return so
+        # a mixin cannot smuggle the field into concrete states.
+        cls._check_reserved_internal_fields()
+
         if cls._mixin:
             return
 
@@ -573,11 +579,6 @@ class BaseState(EvenMoreBasicBaseState):
 
         # Event handlers should not shadow builtin state methods.
         cls._check_overridden_methods()
-
-        # Internal router bookkeeping fields must not be redefined by user
-        # states: a shadowing value would silently control whether router
-        # deltas are sent partially.
-        cls._check_reserved_internal_fields()
 
         # Computed vars should not shadow builtin state props.
         cls._check_overridden_basevars()

--- a/tests/units/test_app.py
+++ b/tests/units/test_app.py
@@ -682,12 +682,14 @@ async def test_router_delta_partial_only_when_connection_scope_unchanged(
 
     # Changed headers with the same session id must also fall back to the
     # full payload — headers are the other half of the connection scope.
+    original_headers = router_data[RouteVar.HEADERS]
+    assert isinstance(original_headers, dict)
     new_headers = await _router_delta({
         **router_data,
         RouteVar.PATH: "/fourth",
         RouteVar.SESSION_ID: "a-different-session-id",
         RouteVar.HEADERS: {
-            **router_data[RouteVar.HEADERS],
+            **original_headers,
             "user-agent": "A Different Agent",
         },
     })

--- a/tests/units/test_app.py
+++ b/tests/units/test_app.py
@@ -21,6 +21,7 @@ import pytest
 import reflex_base
 from pytest_mock import MockerFixture
 from reflex_base.components.component import Component
+from reflex_base.constants import RouteVar
 from reflex_base.constants.state import FIELD_MARKER
 from reflex_base.event import Event
 from reflex_base.event.context import EventContext
@@ -584,6 +585,82 @@ async def test_dynamic_var_event(
     assert emitted_deltas == [
         (token, {test_state.get_name(): {"int_val" + FIELD_MARKER: 50}})
     ]
+
+
+@pytest.mark.asyncio
+async def test_router_delta_partial_only_when_connection_scope_unchanged(
+    test_state: type[ATestState],
+    mock_base_state_event_processor: BaseStateEventProcessor,
+    emitted_deltas: list[tuple[str, dict[str, dict[str, Any]]]],
+    token: str,
+    clean_registration_context: RegistrationContext,
+    router_data: dict[str, str | dict],
+):
+    """The processor must elide session/headers only while they are unchanged.
+
+    Drives the real comparison in the event processor rather than setting the
+    internal flag directly, so arming a partial payload after the session
+    actually changed would fail here.
+
+    Args:
+        test_state: State Fixture.
+        mock_base_state_event_processor: BaseStateEventProcessor Fixture.
+        emitted_deltas: List to store emitted deltas.
+        token: a Token.
+        clean_registration_context: The registration context fixture.
+        router_data: The router data fixture.
+    """
+    clean_registration_context.register_base_state(test_state)
+    router_field = constants.ROUTER + FIELD_MARKER
+
+    state = test_state()  # pyright: ignore [reportCallIssue]
+    state.add_var("nav_val", int, 0)
+
+    def set_nav_val(self, value: int):
+        self.nav_val = value
+
+    state._add_event_handler("set_nav_val", set_nav_val)
+
+    def _event(rd: dict) -> Event:
+        return Event(
+            name=f"{test_state.get_name()}.set_nav_val",
+            payload={"value": 1},
+            router_data=rd,
+        )
+
+    async def _router_delta(rd: dict):
+        emitted_deltas.clear()
+        async with mock_base_state_event_processor as processor:
+            await processor.enqueue(token, _event(rd))
+            await processor.join()
+        for _tok, delta in emitted_deltas:
+            for substate in delta.values():
+                if router_field in substate:
+                    return substate[router_field]
+        return None
+
+    # First event on this connection: the client has no router yet, so the
+    # full payload (session + headers) must be sent.
+    first = await _router_delta(router_data)
+    assert isinstance(first, RouterData)
+
+    # Same session and headers, different page: connection-scoped fields are
+    # elided.
+    same_connection = await _router_delta({**router_data, RouteVar.PATH: "/second"})
+    assert same_connection is not None
+    assert not isinstance(same_connection, RouterData)
+    assert set(same_connection) == {"page", "url", "route_id"}
+
+    # A new session id must fall back to the full payload, otherwise the
+    # client would keep serving the old token forever.
+    new_session = await _router_delta({
+        **router_data,
+        RouteVar.PATH: "/third",
+        RouteVar.SESSION_ID: "a-different-session-id",
+    })
+    assert isinstance(new_session, RouterData), (
+        "session changed but the delta omitted it; the client would keep the stale value"
+    )
 
 
 @pytest.fixture

--- a/tests/units/test_app.py
+++ b/tests/units/test_app.py
@@ -53,7 +53,7 @@ from reflex.compiler.compiler import (
 )
 from reflex.compiler.plugins import default_page_plugins
 from reflex.environment import environment
-from reflex.istate.data import RouterData, serialize_partial_router_data
+from reflex.istate.data import RouterData
 from reflex.istate.manager.disk import StateManagerDisk
 from reflex.istate.manager.memory import StateManagerMemory
 from reflex.istate.manager.redis import StateManagerRedis
@@ -591,6 +591,7 @@ async def test_dynamic_var_event(
 async def test_router_delta_partial_only_when_connection_scope_unchanged(
     test_state: type[ATestState],
     mock_base_state_event_processor: BaseStateEventProcessor,
+    mock_root_event_context: EventContext,
     emitted_deltas: list[tuple[str, dict[str, dict[str, Any]]]],
     token: str,
     clean_registration_context: RegistrationContext,
@@ -605,6 +606,7 @@ async def test_router_delta_partial_only_when_connection_scope_unchanged(
     Args:
         test_state: State Fixture.
         mock_base_state_event_processor: BaseStateEventProcessor Fixture.
+        mock_root_event_context: The mock event context (for direct state access).
         emitted_deltas: List to store emitted deltas.
         token: a Token.
         clean_registration_context: The registration context fixture.
@@ -639,10 +641,26 @@ async def test_router_delta_partial_only_when_connection_scope_unchanged(
                     return substate[router_field]
         return None
 
-    # First event on this connection: the client has no router yet, so the
-    # full payload (session + headers) must be sent.
-    first = await _router_delta(router_data)
-    assert isinstance(first, RouterData)
+    # Before the connect handler has verified the client version, deltas are
+    # always full — even across repeated navigations with an unchanged
+    # session. This is what a cached pre-upgrade frontend receives during a
+    # rolling deployment.
+    legacy_first = await _router_delta(router_data)
+    assert isinstance(legacy_first, RouterData)
+    legacy_second = await _router_delta({**router_data, RouteVar.PATH: "/legacy"})
+    assert isinstance(legacy_second, RouterData)
+
+    # The connect handler verified an exact version match: partial deltas
+    # allowed from here on.
+    root = await mock_root_event_context.state_manager.get_state(
+        BaseStateToken(ident=token, cls=test_state)
+    )
+    root._partial_router_capable = True
+
+    # First navigation after capability: session/headers changed relative to
+    # nothing? No — they were already sent above; unchanged, so partial.
+    first = await _router_delta({**router_data, RouteVar.PATH: "/armed"})
+    assert not isinstance(first, RouterData)
 
     # Same session and headers, different page: connection-scoped fields are
     # elided.
@@ -1996,11 +2014,9 @@ async def test_dynamic_route_var_route_change_completed_on_load(
             name=f"{OnLoadInternalState.get_full_name()}.{constants.CompileVars.ON_LOAD_INTERNAL.rpartition('.')[2]}",
             val=exp_val,
         )
-        # The connection-scoped router fields (session, headers) are unchanged
-        # across these navigations, so deltas carry the partial router payload.
-        exp_router = serialize_partial_router_data(
-            RouterData.from_router_data(on_load_internal.router_data)
-        )
+        # This client never advertises partial-router capability (no connect
+        # handshake in this flow), so deltas always carry the full router.
+        exp_router = RouterData.from_router_data(on_load_internal.router_data)
         async with mock_base_state_event_processor as processor:
             await processor.enqueue(
                 token,

--- a/tests/units/test_app.py
+++ b/tests/units/test_app.py
@@ -680,6 +680,21 @@ async def test_router_delta_partial_only_when_connection_scope_unchanged(
         "session changed but the delta omitted it; the client would keep the stale value"
     )
 
+    # Changed headers with the same session id must also fall back to the
+    # full payload — headers are the other half of the connection scope.
+    new_headers = await _router_delta({
+        **router_data,
+        RouteVar.PATH: "/fourth",
+        RouteVar.SESSION_ID: "a-different-session-id",
+        RouteVar.HEADERS: {
+            **router_data[RouteVar.HEADERS],
+            "user-agent": "A Different Agent",
+        },
+    })
+    assert isinstance(new_headers, RouterData), (
+        "headers changed but the delta omitted them; the client would keep stale headers"
+    )
+
 
 @pytest.fixture
 def list_mutation_state():

--- a/tests/units/test_app.py
+++ b/tests/units/test_app.py
@@ -671,23 +671,28 @@ async def test_router_delta_partial_only_when_connection_scope_unchanged(
 
     # A new session id must fall back to the full payload, otherwise the
     # client would keep serving the old token forever.
+    reconnected_sid = "a-different-session-id"
     new_session = await _router_delta({
         **router_data,
         RouteVar.PATH: "/third",
-        RouteVar.SESSION_ID: "a-different-session-id",
+        RouteVar.SESSION_ID: reconnected_sid,
     })
     assert isinstance(new_session, RouterData), (
         "session changed but the delta omitted it; the client would keep the stale value"
     )
 
-    # Changed headers with the same session id must also fall back to the
-    # full payload — headers are the other half of the connection scope.
+    # Changed headers with an unchanged session must also fall back to the
+    # full payload — headers are the other half of the connection scope. The
+    # state now holds `reconnected_sid` (assigned by the previous event), so
+    # reusing it here means the session compares equal and ONLY the headers
+    # differ; the mutation check for this leg is dropping "headers" from
+    # CONNECTION_SCOPED_ROUTER_FIELDS, which makes this assertion fail.
     original_headers = router_data[RouteVar.HEADERS]
     assert isinstance(original_headers, dict)
     new_headers = await _router_delta({
         **router_data,
         RouteVar.PATH: "/fourth",
-        RouteVar.SESSION_ID: "a-different-session-id",
+        RouteVar.SESSION_ID: reconnected_sid,
         RouteVar.HEADERS: {
             **original_headers,
             "user-agent": "A Different Agent",

--- a/tests/units/test_app.py
+++ b/tests/units/test_app.py
@@ -52,7 +52,7 @@ from reflex.compiler.compiler import (
 )
 from reflex.compiler.plugins import default_page_plugins
 from reflex.environment import environment
-from reflex.istate.data import RouterData
+from reflex.istate.data import RouterData, serialize_partial_router_data
 from reflex.istate.manager.disk import StateManagerDisk
 from reflex.istate.manager.memory import StateManagerMemory
 from reflex.istate.manager.redis import StateManagerRedis
@@ -1919,7 +1919,11 @@ async def test_dynamic_route_var_route_change_completed_on_load(
             name=f"{OnLoadInternalState.get_full_name()}.{constants.CompileVars.ON_LOAD_INTERNAL.rpartition('.')[2]}",
             val=exp_val,
         )
-        exp_router = RouterData.from_router_data(on_load_internal.router_data)
+        # The connection-scoped router fields (session, headers) are unchanged
+        # across these navigations, so deltas carry the partial router payload.
+        exp_router = serialize_partial_router_data(
+            RouterData.from_router_data(on_load_internal.router_data)
+        )
         async with mock_base_state_event_processor as processor:
             await processor.enqueue(
                 token,

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -1095,58 +1095,56 @@ def test_get_client_ip(test_state, router_data):
 
 
 def test_partial_router_delta(test_state, router_data):
-    """Navigation deltas elide unchanged connection-scoped router fields.
+    """get_delta ships a partial router payload only when flag and capability agree.
+
+    The comparison that arms `_router_static_unchanged` is driven end to end
+    through the event processor in
+    ``test_router_delta_partial_only_when_connection_scope_unchanged``; this
+    test treats the flag and the client capability as givens and pins down
+    ``get_delta``'s serialization for each combination.
 
     Args:
         test_state: A state.
         router_data: The router data fixture.
     """
     router_field = constants.ROUTER + FIELD_MARKER
-    # Simulate the connect handler having verified the client's version.
+
+    def router_delta_value(*, unchanged: bool, capable: bool, path: str):
+        test_state.router = RouterData.from_router_data({
+            **router_data,
+            RouteVar.PATH: path,
+        })
+        # The direct write above cleared the flag; apply the scenario.
+        test_state._router_static_unchanged = unchanged
+        test_state._partial_router_capable = capable
+        value = test_state.get_delta()[test_state.get_full_name()][router_field]
+        test_state._clean()
+        return value
+
+    # Unchanged connection scope + capable client: partial payload.
+    value = router_delta_value(unchanged=True, capable=True, path="/partial")
+    assert set(value) == {"page", "url", "route_id"}
+    assert value["route_id"] == "/partial"
+
+    # Capable client, but the connection scope changed: full payload.
+    value = router_delta_value(unchanged=False, capable=True, path="/changed")
+    assert isinstance(value, RouterData)
+
+    # Unchanged scope, but the client never advertised support (e.g. a cached
+    # pre-upgrade bundle during a rolling deployment): full payload.
+    value = router_delta_value(unchanged=True, capable=False, path="/legacy")
+    assert isinstance(value, RouterData)
+
+    # Any direct router write clears the flag, so a write after arming falls
+    # back to the full payload without help from the processor.
+    test_state._router_static_unchanged = True
     test_state._partial_router_capable = True
-
-    # First router assignment (hydrate): the full router is in the delta.
-    test_state.router = RouterData.from_router_data(router_data)
-    delta_value = test_state.get_delta()[test_state.get_full_name()][router_field]
-    assert isinstance(delta_value, RouterData)
-    test_state._clean()
-
-    # Same connection navigates to a new page: the event processor detects
-    # unchanged session/headers and arms the partial-delta flag.
-    previous_router = test_state.router
-    new_router = RouterData.from_router_data({**router_data, RouteVar.PATH: "/other"})
-    test_state.router = new_router
-    object.__setattr__(
-        test_state,
-        "_router_static_unchanged",
-        previous_router.session == new_router.session
-        and previous_router.headers == new_router.headers,
-    )
-    delta_value = test_state.get_delta()[test_state.get_full_name()][router_field]
-    assert set(delta_value) == {"page", "url", "route_id"}
-    assert delta_value["route_id"] == "/other"
-    test_state._clean()
-
-    # Any direct router write invalidates the flag: full router again.
     test_state.router = RouterData.from_router_data({
         **router_data,
         RouteVar.PATH: "/direct",
     })
-    delta_value = test_state.get_delta()[test_state.get_full_name()][router_field]
-    assert isinstance(delta_value, RouterData)
-    test_state._clean()
-
-    # A client that did not advertise support (e.g. a cached pre-upgrade
-    # bundle during a rolling deployment) always gets the full router, even
-    # when the connection-scoped fields are unchanged.
-    test_state._partial_router_capable = False
-    test_state.router = RouterData.from_router_data({
-        **router_data,
-        RouteVar.PATH: "/legacy",
-    })
-    test_state._router_static_unchanged = True
-    delta_value = test_state.get_delta()[test_state.get_full_name()][router_field]
-    assert isinstance(delta_value, RouterData)
+    value = test_state.get_delta()[test_state.get_full_name()][router_field]
+    assert isinstance(value, RouterData)
     test_state._clean()
 
 
@@ -1167,6 +1165,20 @@ def test_reserved_internal_router_fields_cannot_be_redefined():
                     "__annotations__": {name: bool},
                     name: True,
                 },
+            )
+        # Mixins are checked at definition too, so the field cannot be
+        # smuggled into concrete states through a mixin base.
+        with pytest.raises(ReservedStateFieldError):
+            type(
+                "ShadowingMixin",
+                (BaseState,),
+                {
+                    "__module__": __name__,
+                    "__qualname__": "ShadowingMixin",
+                    "__annotations__": {name: bool},
+                    name: True,
+                },
+                mixin=True,
             )
 
 

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -42,7 +42,14 @@ from reflex_base.vars.base import Field, Var, computed_var, field
 import reflex as rx
 from reflex.app import App
 from reflex.environment import environment
-from reflex.istate.data import HeaderData, RouterData, _FrozenDictStrStr
+from reflex.istate.data import (
+    HeaderData,
+    RouterData,
+    _FrozenDictStrStr,
+    router_connection_scope,
+    serialize_partial_router_data,
+    serialize_router_data,
+)
 from reflex.istate.manager import StateManager
 from reflex.istate.manager.disk import StateManagerDisk
 from reflex.istate.manager.memory import StateManagerMemory
@@ -1125,6 +1132,30 @@ def test_partial_router_delta(test_state, router_data):
     delta_value = test_state.get_delta()[test_state.get_full_name()][router_field]
     assert isinstance(delta_value, RouterData)
     test_state._clean()
+
+
+def test_partial_router_delta_covers_every_elided_field(router_data):
+    """Every field a navigation delta omits must be one that is compared.
+
+    A field that is elided but not compared would leave a stale value on the
+    client forever, so changing any omitted field must be visible to the
+    processor's comparison.
+
+    Args:
+        router_data: The router data fixture.
+    """
+    router = RouterData.from_router_data(router_data)
+    omitted = set(serialize_router_data(router)) - set(
+        serialize_partial_router_data(router)
+    )
+    assert omitted, "partial payload must omit something, else there is no saving"
+
+    for omitted_field in omitted:
+        changed = dataclasses.replace(router, **{omitted_field: None})
+        assert router_connection_scope(changed) != router_connection_scope(router), (
+            f"router field {omitted_field!r} is omitted from navigation deltas but is"
+            " not compared, so a change to it would never reach the client"
+        )
 
 
 def test_get_current_page(test_state):

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -1086,6 +1086,47 @@ def test_get_client_ip(test_state, router_data):
     assert test_state.router.session.client_ip == "127.0.0.1"
 
 
+def test_partial_router_delta(test_state, router_data):
+    """Navigation deltas elide unchanged connection-scoped router fields.
+
+    Args:
+        test_state: A state.
+        router_data: The router data fixture.
+    """
+    router_field = constants.ROUTER + FIELD_MARKER
+
+    # First router assignment (hydrate): the full router is in the delta.
+    test_state.router = RouterData.from_router_data(router_data)
+    delta_value = test_state.get_delta()[test_state.get_full_name()][router_field]
+    assert isinstance(delta_value, RouterData)
+    test_state._clean()
+
+    # Same connection navigates to a new page: the event processor detects
+    # unchanged session/headers and arms the partial-delta flag.
+    previous_router = test_state.router
+    new_router = RouterData.from_router_data({**router_data, RouteVar.PATH: "/other"})
+    test_state.router = new_router
+    object.__setattr__(
+        test_state,
+        "_router_static_unchanged",
+        previous_router.session == new_router.session
+        and previous_router.headers == new_router.headers,
+    )
+    delta_value = test_state.get_delta()[test_state.get_full_name()][router_field]
+    assert set(delta_value) == {"page", "url", "route_id"}
+    assert delta_value["route_id"] == "/other"
+    test_state._clean()
+
+    # Any direct router write invalidates the flag: full router again.
+    test_state.router = RouterData.from_router_data({
+        **router_data,
+        RouteVar.PATH: "/direct",
+    })
+    delta_value = test_state.get_delta()[test_state.get_full_name()][router_field]
+    assert isinstance(delta_value, RouterData)
+    test_state._clean()
+
+
 def test_get_current_page(test_state):
     assert test_state.router._page.path == ""
 

--- a/tests/units/test_state.py
+++ b/tests/units/test_state.py
@@ -32,6 +32,7 @@ from reflex_base.utils.exceptions import (
     InvalidLockWarningThresholdError,
     LockExpiredError,
     ReflexRuntimeError,
+    ReservedStateFieldError,
     SetUndefinedStateVarError,
     StateSerializationError,
     UnretrievableVarValueError,
@@ -1101,6 +1102,8 @@ def test_partial_router_delta(test_state, router_data):
         router_data: The router data fixture.
     """
     router_field = constants.ROUTER + FIELD_MARKER
+    # Simulate the connect handler having verified the client's version.
+    test_state._partial_router_capable = True
 
     # First router assignment (hydrate): the full router is in the delta.
     test_state.router = RouterData.from_router_data(router_data)
@@ -1132,6 +1135,39 @@ def test_partial_router_delta(test_state, router_data):
     delta_value = test_state.get_delta()[test_state.get_full_name()][router_field]
     assert isinstance(delta_value, RouterData)
     test_state._clean()
+
+    # A client that did not advertise support (e.g. a cached pre-upgrade
+    # bundle during a rolling deployment) always gets the full router, even
+    # when the connection-scoped fields are unchanged.
+    test_state._partial_router_capable = False
+    test_state.router = RouterData.from_router_data({
+        **router_data,
+        RouteVar.PATH: "/legacy",
+    })
+    test_state._router_static_unchanged = True
+    delta_value = test_state.get_delta()[test_state.get_full_name()][router_field]
+    assert isinstance(delta_value, RouterData)
+    test_state._clean()
+
+
+def test_reserved_internal_router_fields_cannot_be_redefined():
+    """User states must not shadow the internal router bookkeeping fields.
+
+    A shadowing value would silently control whether router deltas are sent
+    partially, so redefinition raises instead.
+    """
+    for name in ("_router_static_unchanged", "_partial_router_capable"):
+        with pytest.raises(ReservedStateFieldError):
+            type(
+                "ShadowingState",
+                (BaseState,),
+                {
+                    "__module__": __name__,
+                    "__qualname__": "ShadowingState",
+                    "__annotations__": {name: bool},
+                    name: True,
+                },
+            )
 
 
 def test_partial_router_delta_covers_every_elided_field(router_data):


### PR DESCRIPTION
## What

Every client-side navigation fires `on_load_internal`, which reassigns `state.router` and marks the whole var dirty — so every navigation delta re-ships the complete `RouterData`, including the session block and every request header (twice, via `raw_headers`). Measured on a minimal app with no cookies:

- navigation delta: **1,870 bytes**, of which **1,323 bytes (71%) are session + headers** that cannot change for the life of the websocket
- apps with real auth cookies re-ship those on every page change too

This lands on the client on every nav (and every event that carries a changed `router_data`), gets JSON-parsed, and replaces the router value in the root state context.

## How

Ship `session`/`headers` only when they actually changed:

- `BaseStateEventProcessor` compares the previous router when reassigning; if session and headers are unchanged it arms a transient `_router_static_unchanged` flag on the root state (never pickled meaningfully — recomputed on every reassignment).
- `get_delta` then serializes only the per-navigation fields (`page`, `url`, `route_id`) for the router var via `serialize_partial_router_data` (extracted from the existing serializer, so the two can't drift).
- `applyDelta` on the frontend merges partial router payloads over the previously received value, so session/headers carry forward on the client.
- **Fail-safe:** any direct `router` write clears the flag in `__setattr__` — covering the connect handler's sid update and the linked-token `client_token` rewrite — falling back to the full payload.

Reconnects and cross-worker moves are safe by construction: a new socket has a new `session_id`, so the comparison fails and the full router is sent; a state restored on another worker has empty `router_data` (excluded from pickle), which also fails the comparison.

## Compatibility

**Rolling deployments / cached frontends.** A pre-upgrade frontend replaces the router value instead of merging, so it must never receive a partial payload. The frontend already advertises the exact version it was compiled by as the websocket subprotocol, and the backend already compares it; this PR turns that existing handshake into the capability gate. `on_connect` records `subprotocol == backend version` on the root state (`_partial_router_capable`), and `get_delta` sends the partial payload only when it is set. Older bundles, proxies that strip the subprotocol, and polling transports all fall back to the full router in every delta. The capability survives pickling and worker moves, and reconnects re-evaluate it — a tab that reconnects with a stale cached bundle after a redeploy is downgraded to full payloads. Verified live by forcing a mismatched subprotocol from a real browser client: every navigation delta carried the full session/headers.

**Internal fields are reserved.** `_router_static_unchanged` (transient, never pickled) and `_partial_router_capable` are declared `is_var=False` fields on `BaseState`, added to `RESERVED_BACKEND_VAR_NAMES`, and `__init_subclass__` raises `ReservedStateFieldError` if a user state declares either name — a collision surfaces as an error instead of silently steering delta serialization.

## Measured result

- Navigation delta drops **1,870 → 516 bytes (−72%)** on the minimal app.
- Rendered router vars (`State.router.session.client_token`, `State.router.headers.user_agent`) verified intact on the client after slim deltas, across navigations and events, on a fresh boot.
- New unit test `test_partial_router_delta` covers full-on-first-send, partial-when-unchanged, and full-again-after-direct-write. `test_dynamic_route_var_route_change_completed_on_load` updated: its `router_data` carries no sid/headers, so the partial payload correctly applies from the first on_load. Full unit suite: 7,460 passed.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/6906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


