### PR TITLE
fix(testing): enable the development condition for the AppHarness

### DIFF
--- a/news/+harness-dev-condition.bugfix.md
+++ b/news/+harness-dev-condition.bugfix.md
@@ -1,0 +1,1 @@
+`AppHarness` starts the frontend dev server with the `development` export condition enabled, fixing "Frontend did not start" on node-less (bun-only) installs where react-router's dev CLI restart guard trips.

--- a/reflex/testing.py
+++ b/reflex/testing.py
@@ -43,6 +43,7 @@ import reflex.utils.processes
 from reflex.istate.shared import SharedState as SharedState  # To register it.
 from reflex.state import reload_state_module
 from reflex.utils import js_runtimes
+from reflex.utils.exec import _with_development_condition
 from reflex.utils.export import export
 from reflex.utils.token_manager import TokenManager
 
@@ -384,7 +385,14 @@ class AppHarness:
                 "dev",
             ],
             cwd=self.app_path / reflex.utils.prerequisites.get_web_dir(),
-            env={"PORT": "0", "NO_COLOR": "1"},
+            # The development condition keeps react-router's dev CLI from
+            # re-executing itself, which trips its restart guard on node-less
+            # (bun-only) installs.
+            env=_with_development_condition({
+                **os.environ,
+                "PORT": "0",
+                "NO_COLOR": "1",
+            }),
             **FRONTEND_POPEN_ARGS,
         )
 

--- a/tests/units/test_testing.py
+++ b/tests/units/test_testing.py
@@ -190,7 +190,7 @@ def test_app_harness_initialize_reloads_existing_imported_app(
 
 
 def test_app_harness_frontend_env_has_development_condition(
-    tmp_path, monkeypatch: pytest.MonkeyPatch
+    tmp_path, monkeypatch: pytest.MonkeyPatch, harness_mocks
 ) -> None:
     """The frontend dev server env enables the `development` export condition."""
     harness = AppHarness(

--- a/tests/units/test_testing.py
+++ b/tests/units/test_testing.py
@@ -187,3 +187,39 @@ def test_app_harness_initialize_reloads_existing_imported_app(
     harness._initialize_app()
 
     harness_mocks.get_and_validate_app.assert_called_once_with(reload=True)
+
+
+def test_app_harness_frontend_env_has_development_condition(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The frontend dev server env enables the `development` export condition."""
+    harness = AppHarness(
+        app_name="testapp",
+        app_source=None,
+        app_path=tmp_path,
+        app_module_path=tmp_path / "testapp.py",
+    )
+    monkeypatch.setattr(
+        reflex_testing.js_runtimes,
+        "get_js_package_executor",
+        lambda raise_on_none: [["bun"]],
+    )
+    fake_socket = mock.Mock(getsockname=lambda: ("127.0.0.1", 8000))
+    monkeypatch.setattr(
+        AppHarness, "_poll_for_servers", lambda self, timeout: fake_socket
+    )
+    monkeypatch.setattr(
+        reflex_testing.reflex.utils.build, "setup_frontend", lambda path: None
+    )
+    captured: dict = {}
+
+    def fake_new_process(args, **kwargs):
+        captured.update(kwargs)
+        return mock.Mock()
+
+    monkeypatch.setattr(
+        reflex_testing.reflex.utils.processes, "new_process", fake_new_process
+    )
+    harness._start_frontend()
+    for options_var in ("NODE_OPTIONS", "BUN_OPTIONS"):
+        assert "--conditions=development" in captured["env"][options_var]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/6931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

