### PR TITLE
Fix client state setter event var args

### DIFF
--- a/reflex/experimental/client_state.py
+++ b/reflex/experimental/client_state.py
@@ -22,6 +22,12 @@ _refs_import = {
 }
 
 
+def _event_arg_name(value_str: str) -> tuple[str, ...]:
+    """Return the event argument name for an event-derived expression."""
+    match = re.match(r"^([A-Za-z_$][0-9A-Za-z_$]*)", value_str)
+    return (match.group(1),) if match else ()
+
+
 def _client_state_ref(var_name: str) -> Var:
     """Get the ref accessor Var for a ClientStateVar.
 
@@ -194,7 +200,7 @@ class ClientStateVar(Var):
 
     @property
     def value(self) -> Var:
-        """Get a placeholder for the Var.
+        """A placeholder for the Var.
 
         This property can only be rendered on the frontend.
 
@@ -235,8 +241,7 @@ class ClientStateVar(Var):
             value_str = str(value_var)
 
             setter = ArgsFunctionOperationBuilder.create(
-                # remove patterns of ["*"] from the value_str using regex
-                args_names=(re.sub(r"(\?\.)?\[\".*\"\]", "", value_str),)
+                args_names=_event_arg_name(value_str)
                 if value_str.startswith("_")
                 else (),
                 return_expr=setter.call(value_var),

--- a/reflex/experimental/client_state.py
+++ b/reflex/experimental/client_state.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import dataclasses
-import re
+import unicodedata
 from collections.abc import Callable
 from typing import Any
 
@@ -24,8 +24,46 @@ _refs_import = {
 
 def _event_arg_name(value_str: str) -> tuple[str, ...]:
     """Return the event argument name for an event-derived expression."""
-    match = re.match(r"^([A-Za-z_$][0-9A-Za-z_$]*)", value_str)
-    return (match.group(1),) if match else ()
+    if not value_str:
+        return ()
+
+    arg_name = value_str[0]
+    if not _is_js_identifier_start(arg_name):
+        return ()
+
+    for char in value_str[1:]:
+        if not _is_js_identifier_part(char):
+            break
+        arg_name += char
+
+    return (arg_name,)
+
+
+def _is_js_identifier_start(char: str) -> bool:
+    """Return whether a character can start a JavaScript identifier."""
+    return char in {"$", "_"} or unicodedata.category(char) in {
+        "Lu",
+        "Ll",
+        "Lt",
+        "Lm",
+        "Lo",
+        "Nl",
+    }
+
+
+def _is_js_identifier_part(char: str) -> bool:
+    """Return whether a character can continue a JavaScript identifier."""
+    return (
+        _is_js_identifier_start(char)
+        or unicodedata.category(char)
+        in {
+            "Mn",
+            "Mc",
+            "Nd",
+            "Pc",
+        }
+        or char in {"\u200c", "\u200d"}
+    )
 
 
 def _client_state_ref(var_name: str) -> Var:

--- a/tests/units/test_event.py
+++ b/tests/units/test_event.py
@@ -361,6 +361,20 @@ def test_event_window_alert():
     )
 
 
+def test_call_function_client_state_setter_accepts_optional_chain_var():
+    """Client state setters should use the event object as the function arg."""
+    from reflex.experimental.client_state import ClientStateVar
+
+    last_x = ClientStateVar.create("last_x", default=0)
+    spec = rx.call_function(last_x.set_value(Var("_event?.clientX")))
+
+    assert (
+        format.format_event(spec)
+        == 'ReflexEvent("_call_function", {function:((_event) => '
+        "(refs['_client_state_setLast_x'](_event?.clientX))),callback:null})"
+    )
+
+
 @pytest.mark.parametrize(
     ("func", "qualname"), [("set_focus", "_set_focus"), ("blur_focus", "_blur_focus")]
 )

--- a/tests/units/test_event.py
+++ b/tests/units/test_event.py
@@ -375,6 +375,20 @@ def test_call_function_client_state_setter_accepts_optional_chain_var():
     )
 
 
+def test_call_function_client_state_setter_accepts_unicode_event_var():
+    """Client state setters should preserve unicode event argument names."""
+    from reflex.experimental.client_state import ClientStateVar
+
+    last_x = ClientStateVar.create("last_x", default=0)
+    spec = rx.call_function(last_x.set_value(Var("_événement?.clientX")))
+
+    assert (
+        format.format_event(spec)
+        == 'ReflexEvent("_call_function", {function:((_événement) => '
+        "(refs['_client_state_setLast_x'](_événement?.clientX))),callback:null})"
+    )
+
+
 @pytest.mark.parametrize(
     ("func", "qualname"), [("set_focus", "_set_focus"), ("blur_focus", "_blur_focus")]
 )


### PR DESCRIPTION
Fixes #5741.

`ClientStateVar.set_value()` was using the rendered value expression to build the wrapper function argument. That works for plain event vars, but breaks for optional-chain expressions like `_event?.clientX` because the generated handler ends up with `_event?.clientX` as the argument name:

```js
((_event?.clientX) => ...)
```

This patch keeps the setter call value as-is, but derives the wrapper argument from the leading event identifier instead, so the generated function is valid:

```js
((_event) => ...(_event?.clientX))
```

Added a regression test for the optional-chain client-state setter case.

Tested with:

```text
python -m pytest tests\units\test_event.py -q
python -m pytest tests\units\test_event.py::test_call_function_client_state_setter_accepts_optional_chain_var tests\units\compiler\test_memoize_plugin.py::test_client_state_setter_in_call_function_event_imports_refs -q
python -m ruff check reflex\experimental\client_state.py tests\units\test_event.py
```

Pytest warned that it could not write `.pytest_cache` in my Windows workspace, but the tests passed.