### PR TITLE
feat(reflex-hosting-cli): upload deploy archives straight to storage

### DIFF
--- a/packages/reflex-hosting-cli/news/+presigned-archive-upload.feature.md
+++ b/packages/reflex-hosting-cli/news/+presigned-archive-upload.feature.md
@@ -1,0 +1,1 @@
+`reflex deploy` uploads a build's two archives straight to storage, concurrently and with a progress bar for each, instead of relaying them through the control plane.

--- a/packages/reflex-hosting-cli/src/reflex_cli/utils/console.py
+++ b/packages/reflex-hosting-cli/src/reflex_cli/utils/console.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from reflex_base.constants.base import LogLevel
+from reflex_base.utils import log as _log
 from reflex_base.utils.console import PoorProgress as PoorProgress
 from reflex_base.utils.console import ask as ask
 from reflex_base.utils.console import debug as debug
@@ -31,3 +32,32 @@ def set_log_level(log_level: LogLevel | str):
     if isinstance(log_level, str):
         log_level = LogLevel.from_string(log_level) or LogLevel.INFO
     _set_log_level(log_level)
+
+
+def transfer_progress():
+    """Create a progress bar measured in bytes rather than in steps.
+
+    Lives here rather than beside ``progress`` in reflex-base because only the
+    deploy upload wants it: a new name over there would raise this package's
+    reflex-base floor, and the CLI is released on its own schedule.
+
+    Returns:
+        A new progress bar, sized and paced for a file transfer.
+    """
+    from rich.progress import (
+        BarColumn,
+        DownloadColumn,
+        Progress,
+        TextColumn,
+        TimeElapsedColumn,
+        TransferSpeedColumn,
+    )
+
+    return Progress(
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        DownloadColumn(),
+        TransferSpeedColumn(),
+        TimeElapsedColumn(),
+        disable=_log.is_json_mode(),
+    )

--- a/packages/reflex-hosting-cli/src/reflex_cli/utils/exceptions.py
+++ b/packages/reflex-hosting-cli/src/reflex_cli/utils/exceptions.py
@@ -43,6 +43,10 @@ class ResponseError(ReflexHostingCliError):
     """Raised when a response is not as expected."""
 
 
+class ArchiveUploadError(ReflexHostingCliError):
+    """Raised when a build's archives cannot be uploaded to storage."""
+
+
 class ConfigError(ReflexHostingCliError):
     """Raised when there is an error with the config."""
 

--- a/packages/reflex-hosting-cli/src/reflex_cli/utils/hosting.py
+++ b/packages/reflex-hosting-cli/src/reflex_cli/utils/hosting.py
@@ -53,8 +53,8 @@ ARCHIVES = {"backend": "backend.zip", "frontend": "frontend.zip"}
 UPLOAD_CHUNK_SIZE = 256 * 1024
 
 # Per socket operation, not per upload. A link that cannot move one chunk in
-# this long -- roughly 17 kbps -- cannot move a deploy archive inside the signed
-# window either, and hanging on it tells the user nothing.
+# this long -- roughly 17 kbps -- cannot finish an upload inside the window its
+# signature was issued for either, and hanging on it tells the user nothing.
 UPLOAD_CONNECT_TIMEOUT = 30.0
 UPLOAD_IO_TIMEOUT = 120.0
 
@@ -1985,6 +1985,41 @@ def _archive_chunks(
             advance(len(chunk))
 
 
+def presigned_put(target: dict[str, Any], content: Any, size: int) -> None:
+    """Upload a body to the presigned key it was signed for.
+
+    Content-Length is set here rather than left to httpx, and that is the whole
+    reason this is one function. The signature pins the exact byte count, so the
+    request has to carry it: for a bytes body httpx would derive the same value
+    anyway, but for a stream it cannot, and falls back to a chunked body that
+    the signature does not match. Getting that wrong is silent until storage
+    refuses the upload.
+
+    No authorization header goes with it. The signature is the credential, and
+    the destination is not ours to authenticate against.
+
+    Args:
+        target: The ``url`` and any required ``headers`` from the signing call.
+        content: The body, as bytes or as an iterator of byte chunks.
+        size: The body's exact byte count, as signed.
+
+    """
+    import httpx
+
+    response = httpx.put(
+        target["url"],
+        headers={**target.get("headers", {}), "Content-Length": str(size)},
+        content=content,
+        timeout=httpx.Timeout(
+            connect=UPLOAD_CONNECT_TIMEOUT,
+            read=UPLOAD_IO_TIMEOUT,
+            write=UPLOAD_IO_TIMEOUT,
+            pool=UPLOAD_CONNECT_TIMEOUT,
+        ),
+    )
+    response.raise_for_status()
+
+
 def _put_archive(
     path: Path,
     target: dict[str, Any],
@@ -1992,11 +2027,7 @@ def _put_archive(
     advance: Callable[[int], None],
     abandoned: threading.Event,
 ) -> None:
-    """Upload one archive to the key it was signed for.
-
-    Content-Length is set here rather than left to httpx: the exact byte count
-    is part of the signature, and an unsized body would go up chunked and fail
-    to match it.
+    """Stream one archive to the key it was signed for.
 
     Args:
         path: The archive to upload.
@@ -2006,20 +2037,7 @@ def _put_archive(
         abandoned: Set once the other archive's upload has failed.
 
     """
-    import httpx
-
-    response = httpx.put(
-        target["url"],
-        headers={**target["headers"], "Content-Length": str(size)},
-        content=_archive_chunks(path, advance, abandoned),
-        timeout=httpx.Timeout(
-            connect=UPLOAD_CONNECT_TIMEOUT,
-            read=UPLOAD_IO_TIMEOUT,
-            write=UPLOAD_IO_TIMEOUT,
-            pool=UPLOAD_CONNECT_TIMEOUT,
-        ),
-    )
-    response.raise_for_status()
+    presigned_put(target, _archive_chunks(path, advance, abandoned), size)
 
 
 def _put_reserved_archives(
@@ -2314,17 +2332,9 @@ def submit_security_review(zip_bytes: bytes, client: AuthenticatedClient) -> str
         raise SecurityReviewError(_security_review_detail(ex.response)) from ex
     upload = upload_url_response.json()
 
-    # 2. Upload the bytes to storage. The presigned URL pins the content length
-    #    and type, so send the returned headers verbatim and let httpx derive
-    #    Content-Length from the body — setting it manually breaks the signature.
-    put_response = httpx.put(
-        upload["url"],
-        content=zip_bytes,
-        headers=upload.get("headers", {}),
-        timeout=120,
-    )
+    # 2. Upload the bytes to storage, under the length and type the URL pins.
     try:
-        put_response.raise_for_status()
+        presigned_put(upload, zip_bytes, len(zip_bytes))
     except httpx.HTTPStatusError as ex:
         raise SecurityReviewError("failed to upload app source for review") from ex
 

--- a/packages/reflex-hosting-cli/src/reflex_cli/utils/hosting.py
+++ b/packages/reflex-hosting-cli/src/reflex_cli/utils/hosting.py
@@ -11,11 +11,14 @@ import platform
 import re
 import subprocess
 import sys
+import threading
 import time
 import uuid
 import webbrowser
-from collections.abc import Mapping
+from collections.abc import Callable, Iterator, Mapping
+from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
+from functools import partial
 from http import HTTPStatus
 from pathlib import Path
 from typing import Any, TypedDict
@@ -29,6 +32,7 @@ from reflex_cli.core.config import Config, RegionOption
 from reflex_cli.utils import console, dependency
 from reflex_cli.utils.dependency import is_valid_url
 from reflex_cli.utils.exceptions import (
+    ArchiveUploadError,
     GetAppError,
     NotAuthenticatedError,
     ResponseError,
@@ -39,6 +43,26 @@ from reflex_cli.utils.exceptions import (
 )
 
 logger = logging.getLogger(__name__)
+
+# The reserve endpoint's key for each of a build's archives, and the file it
+# signs a destination for.
+ARCHIVES = {"backend": "backend.zip", "frontend": "frontend.zip"}
+
+# Read size for a streamed archive PUT: small enough that the progress bar moves
+# on a slow uplink, large enough not to syscall per kilobyte.
+UPLOAD_CHUNK_SIZE = 256 * 1024
+
+# Per socket operation, not per upload. A link that cannot move one chunk in
+# this long -- roughly 17 kbps -- cannot move a deploy archive inside the signed
+# window either, and hanging on it tells the user nothing.
+UPLOAD_CONNECT_TIMEOUT = 30.0
+UPLOAD_IO_TIMEOUT = 120.0
+
+# A signature that lapsed mid-upload is recovered by reserving again, and a
+# fresh reservation mints a fresh deployment id -- so the retry re-uploads both
+# archives under the new prefix rather than resuming the one that expired. Past
+# two signed windows the link is the problem, and saying so beats looping.
+UPLOAD_ATTEMPTS = 2
 
 
 class ScaleType(str, Enum):
@@ -1870,6 +1894,250 @@ def validate_deployment_args(
     return "success"
 
 
+def _response_detail(response: Any, fallback: str) -> str:
+    """Read the server's explanation for a refusal out of its body.
+
+    Args:
+        response: The refused response.
+        fallback: What to say when the body does not carry an explanation.
+
+    Returns:
+        What the server said, or the fallback.
+
+    """
+    try:
+        detail = response.json()["detail"]
+    except (ValueError, KeyError, TypeError):
+        detail = None
+    # Every refusal this CLI can provoke carries a sentence. A body shaped some
+    # other way -- a validation report, an HTML error page from something in
+    # front of the service -- is not one, and pasting its repr at the user is
+    # worse than the fallback.
+    return detail if isinstance(detail, str) else fallback
+
+
+def reserve_archive_upload(
+    app_id: str, sizes: dict[str, int], client: AuthenticatedClient
+) -> dict[str, Any] | None:
+    """Ask the control plane where to put a build's archives.
+
+    Nothing this endpoint itself refuses with is a 404 -- an unknown app, a
+    missing permission and an out-of-range size are all 400 or 403 -- so a 404
+    means the route is not there, on a control plane older than it. The caller
+    relays the archives through it instead.
+
+    Args:
+        app_id: The app the build belongs to.
+        sizes: Each archive's exact byte count, keyed as in ``ARCHIVES``. The
+            count is signed into the URL, so a build that changes afterwards
+            needs a new reservation rather than a retry of the same upload.
+        client: The authenticated client.
+
+    Returns:
+        A deployment id with a signed target for each archive, or None if this
+        control plane cannot hand one out.
+
+    """
+    import httpx
+
+    response = httpx.post(
+        urljoin(constants.Hosting.HOSTING_SERVICE, "/api/v1/deployments/reserve"),
+        json={
+            "app_id": app_id,
+            "backend_size": sizes["backend"],
+            "frontend_size": sizes["frontend"],
+        },
+        headers=authorization_header(client.token),
+        timeout=constants.Hosting.TIMEOUT,
+    )
+    if response.status_code == HTTPStatus.NOT_FOUND:
+        return None
+    response.raise_for_status()
+    return response.json()
+
+
+class _UploadAbandonedError(Exception):
+    """The other archive's upload failed, so finishing this one buys nothing."""
+
+
+def _archive_chunks(
+    path: Path, advance: Callable[[int], None], abandoned: threading.Event
+) -> Iterator[bytes]:
+    """Read an archive in chunks, reporting each one once it is on the wire.
+
+    Args:
+        path: The archive to read.
+        advance: Called with a chunk's size after it has been written out.
+        abandoned: Set once the other archive's upload has failed.
+
+    Yields:
+        Successive chunks of the archive.
+
+    Raises:
+        _UploadAbandonedError: The other archive's upload failed partway through.
+
+    """
+    with path.open("rb") as archive:
+        while chunk := archive.read(UPLOAD_CHUNK_SIZE):
+            if abandoned.is_set():
+                raise _UploadAbandonedError
+            yield chunk
+            advance(len(chunk))
+
+
+def _put_archive(
+    path: Path,
+    target: dict[str, Any],
+    size: int,
+    advance: Callable[[int], None],
+    abandoned: threading.Event,
+) -> None:
+    """Upload one archive to the key it was signed for.
+
+    Content-Length is set here rather than left to httpx: the exact byte count
+    is part of the signature, and an unsized body would go up chunked and fail
+    to match it.
+
+    Args:
+        path: The archive to upload.
+        target: The ``url`` and required ``headers`` from the reservation.
+        size: The archive's byte count, as reserved.
+        advance: Called with a chunk's size after it has been written out.
+        abandoned: Set once the other archive's upload has failed.
+
+    """
+    import httpx
+
+    response = httpx.put(
+        target["url"],
+        headers={**target["headers"], "Content-Length": str(size)},
+        content=_archive_chunks(path, advance, abandoned),
+        timeout=httpx.Timeout(
+            connect=UPLOAD_CONNECT_TIMEOUT,
+            read=UPLOAD_IO_TIMEOUT,
+            write=UPLOAD_IO_TIMEOUT,
+            pool=UPLOAD_CONNECT_TIMEOUT,
+        ),
+    )
+    response.raise_for_status()
+
+
+def _put_reserved_archives(
+    zip_dir: Path, reservation: dict[str, Any], sizes: dict[str, int]
+) -> None:
+    """Upload both of a build's archives to their signed keys, concurrently.
+
+    They are independent objects under the same prefix, so nothing orders them.
+    But neither is worth finishing alone: this build submits under one id, and
+    if the other archive never lands there is nothing to submit. So the first
+    failure abandons its sibling mid-stream rather than leaving the user
+    watching a large upload complete into a deployment that cannot happen.
+
+    Whatever the first archive to genuinely fail raised comes back out of here.
+
+    Args:
+        zip_dir: The directory holding the archives.
+        reservation: The response from ``reserve_archive_upload``.
+        sizes: Each archive's byte count, keyed as in ``ARCHIVES``.
+
+    """
+    abandoned = threading.Event()
+
+    def upload(
+        filename: str,
+        target: dict[str, Any],
+        size: int,
+        advance: Callable[[int], None],
+    ) -> None:
+        try:
+            _put_archive(zip_dir / filename, target, size, advance, abandoned)
+        except _UploadAbandonedError:
+            # Stopping on purpose is not a failure of its own, and it never
+            # sets the flag: the archive that did fail is holding the reason,
+            # and its future is the one that should carry it out of here.
+            pass
+        except BaseException:
+            abandoned.set()
+            raise
+
+    with (
+        console.transfer_progress() as progress,
+        ThreadPoolExecutor(max_workers=len(ARCHIVES)) as pool,
+    ):
+        uploads = []
+        for key, filename in ARCHIVES.items():
+            task = progress.add_task(filename, total=sizes[key])
+            uploads.append(
+                pool.submit(
+                    upload,
+                    filename,
+                    reservation[key],
+                    sizes[key],
+                    partial(progress.advance, task),
+                )
+            )
+        for future in uploads:
+            future.result()
+
+
+def upload_archives(
+    zip_dir: Path, app_id: str, sizes: dict[str, int], client: AuthenticatedClient
+) -> str | None:
+    """Push a build's archives straight to storage, without relaying them.
+
+    A 403 on a PUT is a lapsed signature, and the recovery is a new reservation.
+    That mints a new deployment id naming a new prefix, so both archives go up
+    again under it -- the one that succeeded under the old id is not somewhere
+    the new deployment will look.
+
+    Args:
+        zip_dir: The directory holding the archives.
+        app_id: The app the build belongs to.
+        sizes: Each archive's byte count, keyed as in ``ARCHIVES``.
+        client: The authenticated client.
+
+    Returns:
+        The deployment id the archives now live under, or None if this control
+        plane has no reserve endpoint and they have to be relayed instead.
+
+    Raises:
+        ArchiveUploadError: The archives could not be put where they belong.
+
+    """
+    import httpx
+
+    for attempt in range(UPLOAD_ATTEMPTS):
+        try:
+            reservation = reserve_archive_upload(app_id, sizes, client)
+        except httpx.HTTPStatusError as ex:
+            raise ArchiveUploadError(
+                _response_detail(ex.response, f"HTTP {ex.response.status_code}")
+            ) from ex
+        except httpx.HTTPError as ex:
+            raise ArchiveUploadError(
+                f"could not reach the deployment service: {ex}"
+            ) from ex
+        if reservation is None:
+            return None
+        try:
+            _put_reserved_archives(zip_dir, reservation, sizes)
+        except httpx.HTTPStatusError as ex:
+            if ex.response.status_code != HTTPStatus.FORBIDDEN:
+                raise ArchiveUploadError(
+                    f"could not upload the build to storage: HTTP {ex.response.status_code}"
+                ) from ex
+            if attempt < UPLOAD_ATTEMPTS - 1:
+                console.warn("the upload window expired; reserving another one")
+        except httpx.HTTPError as ex:
+            raise ArchiveUploadError(f"could not upload the build: {ex}") from ex
+        else:
+            return reservation["deployment_id"]
+    raise ArchiveUploadError(
+        "the upload did not finish before its window closed; this usually means "
+        "the connection is too slow for the size of the build"
+    )
+
+
 def create_deployment(
     zip_dir: Path,
     client: AuthenticatedClient,
@@ -1913,22 +2181,6 @@ def create_deployment(
     if not isinstance(client, AuthenticatedClient):
         raise NotAuthenticatedError("not authenticated")
     cli_version = importlib.metadata.version("reflex-hosting-cli")
-    zips = [
-        (
-            "files",
-            (
-                "backend.zip",
-                (zip_dir / "backend.zip").open("rb"),
-            ),
-        ),
-        (
-            "files",
-            (
-                "frontend.zip",
-                (zip_dir / "frontend.zip").open("rb"),
-            ),
-        ),
-    ]
     payload: dict[str, Any] = {
         "app_id": app_id,
         "app_name": app_name,
@@ -1954,13 +2206,34 @@ def create_deployment(
     if description:
         payload["description"] = description
 
-    response = httpx.post(
-        urljoin(constants.Hosting.HOSTING_SERVICE, "/api/v1/deployments"),
-        data=payload,
-        files=zips,
-        headers=authorization_header(client.token),
-        timeout=55,
-    )
+    # The archives go straight to storage where the control plane can sign for
+    # them, and only their id is submitted here. Relaying them through it is the
+    # fallback for a control plane that cannot, and for a caller with no app id
+    # to reserve against.
+    stored_build_id = None
+    if app_id is not None:
+        sizes = {key: (zip_dir / name).stat().st_size for key, name in ARCHIVES.items()}
+        try:
+            stored_build_id = upload_archives(zip_dir, app_id, sizes, client)
+        except ArchiveUploadError as ex:
+            return f"deployment failed: {ex}"
+
+    with contextlib.ExitStack() as archives:
+        zips = None
+        if stored_build_id is not None:
+            payload["stored_build_id"] = stored_build_id
+        else:
+            zips = [
+                ("files", (name, archives.enter_context((zip_dir / name).open("rb"))))
+                for name in ARCHIVES.values()
+            ]
+        response = httpx.post(
+            urljoin(constants.Hosting.HOSTING_SERVICE, "/api/v1/deployments"),
+            data=payload,
+            files=zips,
+            headers=authorization_header(client.token),
+            timeout=55,
+        )
     try:
         response.raise_for_status()
     except httpx.HTTPStatusError as ex:
@@ -1997,10 +2270,7 @@ def _security_review_detail(response: Any) -> str:
         a JSON object with a ``detail`` field.
 
     """
-    try:
-        return str(response.json()["detail"])
-    except (ValueError, TypeError, KeyError):
-        return "internal server error"
+    return _response_detail(response, "internal server error")
 
 
 def submit_security_review(zip_bytes: bytes, client: AuthenticatedClient) -> str:

--- a/tests/units/reflex_cli/utils/test_hosting.py
+++ b/tests/units/reflex_cli/utils/test_hosting.py
@@ -298,10 +298,14 @@ def test_submit_security_review_uploads_then_submits(mocker: MockerFixture):
         "content_length": len(b"zip-bytes"),
         "content_type": "application/zip",
     }
-    # Bytes PUT straight to storage with the returned headers, no auth header.
+    # Bytes PUT straight to storage with the returned headers, no auth header,
+    # carrying the exact length the signature pins.
     assert mock_put.call_args.args[0] == "https://bucket.s3/abc?sig=1"
     assert mock_put.call_args.kwargs["content"] == b"zip-bytes"
-    assert mock_put.call_args.kwargs["headers"] == {"Content-Type": "application/zip"}
+    assert mock_put.call_args.kwargs["headers"] == {
+        "Content-Type": "application/zip",
+        "Content-Length": str(len(b"zip-bytes")),
+    }
     assert "X-API-TOKEN" not in mock_put.call_args.kwargs["headers"]
     # Job submitted by key, not by raw bytes.
     assert (

--- a/tests/units/reflex_cli/utils/test_hosting.py
+++ b/tests/units/reflex_cli/utils/test_hosting.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import json
 import logging
+import time
+from pathlib import Path
+from typing import Any
 from unittest.mock import mock_open
 
 import click
@@ -10,6 +13,7 @@ import pytest
 from pytest_mock import MockerFixture, MockFixture
 from reflex_cli.utils.exceptions import NotAuthenticatedError, TokenValidationError
 from reflex_cli.utils.hosting import (
+    UPLOAD_CHUNK_SIZE,
     AuthenticatedClient,
     ScaleParams,
     ScaleType,
@@ -687,58 +691,363 @@ def test_create_app_omits_provider_when_none(mocker: MockerFixture):
     assert "provider" not in mock_post.call_args.kwargs["json"]
 
 
-def test_create_deployment_forwards_description(mocker: MockerFixture):
-    """A per-deployment note is sent as the multipart description field."""
-    mock_post = mocker.patch("httpx.post", return_value=_ok_body(mocker, "dep-1"))
+def _reservation(deployment_id: str, suffix: str = "") -> dict[str, Any]:
+    """Build a ``/deployments/reserve`` response body.
+
+    Args:
+        deployment_id: The id the reservation minted.
+        suffix: Appended to both signed URLs, to tell one reservation's targets
+            from another's within a test.
+
+    Returns:
+        The response body the reserve endpoint would return.
+    """
+    return {
+        "deployment_id": deployment_id,
+        "backend": {
+            "url": f"https://storage.invalid/backend{suffix}",
+            "headers": {"Content-Type": "application/zip"},
+        },
+        "frontend": {
+            "url": f"https://storage.invalid/frontend{suffix}",
+            "headers": {"Content-Type": "application/zip"},
+        },
+        "expires_in": 1800,
+    }
+
+
+def _put_response(mocker: MockerFixture, status_code: int):
+    """Build a mock storage response for a signed archive PUT.
+
+    Args:
+        mocker: The pytest-mock fixture.
+        status_code: The status the storage service answered with.
+
+    Returns:
+        A mock response, raising on ``raise_for_status`` when it is a refusal.
+    """
+    response = mocker.Mock()
+    response.status_code = status_code
+    if status_code >= 400:
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "refused", request=mocker.Mock(), response=response
+        )
+    else:
+        response.raise_for_status.return_value = None
+    return response
+
+
+@pytest.fixture
+def zip_dir(tmp_path: Path) -> Path:
+    """A directory holding a build's two archives.
+
+    Args:
+        tmp_path: The pytest temporary directory.
+
+    Returns:
+        The directory, with ``backend.zip`` and ``frontend.zip`` written.
+    """
+    (tmp_path / "backend.zip").write_bytes(b"backend archive " * 300)
+    (tmp_path / "frontend.zip").write_bytes(b"frontend archive " * 5000)
+    return tmp_path
+
+
+def _deploy(zip_dir: Path, app_id: str | None = "app-1", **kwargs: Any) -> str:
+    """Run ``create_deployment`` over ``zip_dir`` with the boilerplate filled in.
+
+    Args:
+        zip_dir: The directory holding the archives.
+        app_id: The app to deploy, or None to leave the CLI without one.
+        **kwargs: Overrides for any other ``create_deployment`` argument.
+
+    Returns:
+        Whatever ``create_deployment`` returned.
+    """
+    return create_deployment(**{
+        "zip_dir": zip_dir,
+        "client": _CLIENT,
+        "app_name": "n",
+        "project_id": None,
+        "regions": None,
+        "hostname": None,
+        "vmtype": None,
+        "secrets": None,
+        "packages": None,
+        "strategy": None,
+        "app_id": app_id,
+        **kwargs,
+    })
+
+
+def _capturing_put(
+    mocker: MockerFixture, uploaded: dict[str, bytes], expired: str = ""
+) -> Any:
+    """A stand-in for httpx.put that drains the streamed body it is handed.
+
+    Args:
+        mocker: The pytest-mock fixture.
+        uploaded: Filled in with each URL's uploaded bytes.
+        expired: URLs *not* containing this marker answer 403, the way a
+            presigned URL past its window does. Empty means every URL works.
+
+    Returns:
+        A side effect for a patched ``httpx.put``.
+    """
+
+    def put(url: str, **kwargs: Any):
+        body = b"".join(kwargs["content"])
+        if expired and expired not in url:
+            return _put_response(mocker, 403)
+        uploaded[url] = body
+        return _put_response(mocker, 200)
+
+    return put
+
+
+@pytest.fixture
+def deploy_env(mocker: MockerFixture):
+    """Pin the version strings ``create_deployment`` stamps onto a submission.
+
+    Args:
+        mocker: The pytest-mock fixture.
+    """
     mocker.patch("importlib.metadata.version", return_value="0.1.99")
     mocker.patch("reflex_cli.utils.dependency.get_reflex_version", return_value="1.0")
-    mocker.patch("pathlib.Path.open", mock_open(read_data=b"zip"))
-    from pathlib import Path
 
-    create_deployment(
-        zip_dir=Path("/tmp"),
-        client=_CLIENT,
-        app_name="n",
-        project_id=None,
-        regions=None,
-        hostname=None,
-        vmtype=None,
-        secrets=None,
-        packages=None,
-        strategy=None,
-        app_id="app-1",
-        description="my note",
+
+@pytest.mark.usefixtures("deploy_env")
+def test_create_deployment_forwards_description(mocker: MockerFixture, zip_dir: Path):
+    """A per-deployment note is sent as the submit description field."""
+    mock_post = mocker.patch(
+        "httpx.post",
+        side_effect=[
+            _ok_body(mocker, _reservation("dep-1")),
+            _ok_body(mocker, "dep-1"),
+        ],
     )
+    mocker.patch("httpx.put", side_effect=_capturing_put(mocker, {}))
+
+    _deploy(zip_dir, description="my note")
+
     assert mock_post.call_args.kwargs["data"]["description"] == "my note"
 
 
+@pytest.mark.usefixtures("deploy_env")
 @pytest.mark.parametrize("vmtype", ["c2m2", None])
-def test_create_deployment_forwards_vmtype(mocker: MockerFixture, vmtype: str | None):
+def test_create_deployment_forwards_vmtype(
+    mocker: MockerFixture, zip_dir: Path, vmtype: str | None
+):
     """A requested VM type reaches the submit body; nothing is sent otherwise."""
-    mock_post = mocker.patch("httpx.post", return_value=_ok_body(mocker, "dep-1"))
-    mocker.patch("importlib.metadata.version", return_value="0.1.99")
-    mocker.patch("reflex_cli.utils.dependency.get_reflex_version", return_value="1.0")
-    mocker.patch("pathlib.Path.open", mock_open(read_data=b"zip"))
-    from pathlib import Path
-
-    create_deployment(
-        zip_dir=Path("/tmp"),
-        client=_CLIENT,
-        app_name="n",
-        project_id=None,
-        regions=None,
-        hostname=None,
-        vmtype=vmtype,
-        secrets=None,
-        packages=None,
-        strategy=None,
-        app_id="app-1",
+    mock_post = mocker.patch(
+        "httpx.post",
+        side_effect=[
+            _ok_body(mocker, _reservation("dep-1")),
+            _ok_body(mocker, "dep-1"),
+        ],
     )
+    mocker.patch("httpx.put", side_effect=_capturing_put(mocker, {}))
+
+    _deploy(zip_dir, vmtype=vmtype)
+
     data = mock_post.call_args.kwargs["data"]
     if vmtype is None:
         assert "vm_type" not in data
     else:
         assert data["vm_type"] == vmtype
+
+
+@pytest.mark.usefixtures("deploy_env")
+def test_create_deployment_uploads_archives_directly(
+    mocker: MockerFixture, zip_dir: Path
+):
+    """The archives go straight to storage and only their id is submitted."""
+    post = mocker.patch(
+        "httpx.post",
+        side_effect=[
+            _ok_body(mocker, _reservation("dep-1")),
+            _ok_body(mocker, "dep-1"),
+        ],
+    )
+    uploaded: dict[str, bytes] = {}
+    put = mocker.patch("httpx.put", side_effect=_capturing_put(mocker, uploaded))
+
+    assert _deploy(zip_dir) == "dep-1"
+
+    reserve = post.call_args_list[0]
+    assert reserve.args[0].endswith("/api/v1/deployments/reserve")
+    assert reserve.kwargs["json"] == {
+        "app_id": "app-1",
+        "backend_size": (zip_dir / "backend.zip").stat().st_size,
+        "frontend_size": (zip_dir / "frontend.zip").stat().st_size,
+    }
+
+    # Every byte, and only those bytes: the size is signed into the URL, so a
+    # body that does not match it exactly is a signature the store will refuse.
+    assert uploaded == {
+        "https://storage.invalid/backend": (zip_dir / "backend.zip").read_bytes(),
+        "https://storage.invalid/frontend": (zip_dir / "frontend.zip").read_bytes(),
+    }
+    for call in put.call_args_list:
+        name = call.args[0].rsplit("/", 1)[-1] + ".zip"
+        assert call.kwargs["headers"] == {
+            "Content-Type": "application/zip",
+            "Content-Length": str((zip_dir / name).stat().st_size),
+        }
+
+    submit = post.call_args_list[1]
+    assert submit.args[0].endswith("/api/v1/deployments")
+    assert submit.kwargs["data"]["stored_build_id"] == "dep-1"
+    assert submit.kwargs["files"] is None
+
+
+@pytest.mark.usefixtures("deploy_env")
+def test_create_deployment_reserves_again_when_the_window_expires(
+    mocker: MockerFixture, zip_dir: Path
+):
+    """A lapsed signature is recovered by reserving, and re-uploading both."""
+    post = mocker.patch(
+        "httpx.post",
+        side_effect=[
+            _ok_body(mocker, _reservation("dep-1")),
+            _ok_body(mocker, _reservation("dep-2", suffix="-retry")),
+            _ok_body(mocker, "dep-2"),
+        ],
+    )
+    uploaded: dict[str, bytes] = {}
+    mocker.patch(
+        "httpx.put", side_effect=_capturing_put(mocker, uploaded, expired="-retry")
+    )
+
+    assert _deploy(zip_dir) == "dep-2"
+
+    # The second reservation minted a new id naming a new prefix, so both
+    # archives went up under it -- not just the one whose PUT expired.
+    assert set(uploaded) == {
+        "https://storage.invalid/backend-retry",
+        "https://storage.invalid/frontend-retry",
+    }
+    assert post.call_args_list[2].kwargs["data"]["stored_build_id"] == "dep-2"
+
+
+@pytest.mark.usefixtures("deploy_env")
+def test_create_deployment_gives_up_after_one_more_window(
+    mocker: MockerFixture, zip_dir: Path
+):
+    """Past two signed windows the link is the problem, and the user is told."""
+    post = mocker.patch(
+        "httpx.post",
+        side_effect=[
+            _ok_body(mocker, _reservation("dep-1")),
+            _ok_body(mocker, _reservation("dep-2", suffix="-retry")),
+        ],
+    )
+    mocker.patch("httpx.put", side_effect=_capturing_put(mocker, {}, expired="never"))
+
+    result = _deploy(zip_dir)
+
+    assert "deployment failed" in result
+    assert "too slow" in result
+    # Two reservations and no submission: nothing was ever in the bucket.
+    assert post.call_count == 2
+
+
+@pytest.mark.usefixtures("deploy_env")
+def test_create_deployment_relays_when_the_control_plane_cannot_reserve(
+    mocker: MockerFixture, zip_dir: Path
+):
+    """A 404 is the route being absent, so the archives are relayed instead."""
+    missing = mocker.Mock()
+    missing.status_code = 404
+    post = mocker.patch("httpx.post", side_effect=[missing, _ok_body(mocker, "dep-1")])
+    put = mocker.patch("httpx.put")
+
+    assert _deploy(zip_dir) == "dep-1"
+
+    put.assert_not_called()
+    submit = post.call_args_list[1]
+    assert "stored_build_id" not in submit.kwargs["data"]
+    assert [name for _, (name, _) in submit.kwargs["files"]] == [
+        "backend.zip",
+        "frontend.zip",
+    ]
+
+
+@pytest.mark.usefixtures("deploy_env")
+def test_create_deployment_relays_without_an_app_id(
+    mocker: MockerFixture, zip_dir: Path
+):
+    """With no app id there is nothing to reserve against, so nothing is."""
+    post = mocker.patch("httpx.post", return_value=_ok_body(mocker, "dep-1"))
+    put = mocker.patch("httpx.put")
+
+    assert _deploy(zip_dir, app_id=None) == "dep-1"
+
+    put.assert_not_called()
+    post.assert_called_once()
+    assert post.call_args.kwargs["files"] is not None
+
+
+@pytest.mark.usefixtures("deploy_env")
+def test_create_deployment_surfaces_a_refused_reservation(
+    mocker: MockerFixture, zip_dir: Path
+):
+    """What the control plane said about the refusal is what the user reads."""
+    detail = "backend.zip is 0 bytes; an archive must be between 1 byte and 5 GiB"
+    post = mocker.patch("httpx.post", return_value=_error(mocker, 400, detail))
+    put = mocker.patch("httpx.put")
+
+    assert _deploy(zip_dir) == f"deployment failed: {detail}"
+
+    put.assert_not_called()
+    post.assert_called_once()
+
+
+@pytest.mark.usefixtures("deploy_env")
+def test_create_deployment_surfaces_an_unreachable_control_plane(
+    mocker: MockerFixture, zip_dir: Path
+):
+    """A reserve that never gets an answer is reported, not raised at the user."""
+    mocker.patch("httpx.post", side_effect=httpx.ConnectError("no route to host"))
+    put = mocker.patch("httpx.put")
+
+    result = _deploy(zip_dir)
+
+    assert result.startswith(
+        "deployment failed: could not reach the deployment service"
+    )
+    put.assert_not_called()
+
+
+@pytest.mark.usefixtures("deploy_env")
+def test_a_failed_archive_abandons_the_other_mid_stream(
+    mocker: MockerFixture, tmp_path: Path
+):
+    """One archive failing stops the other rather than letting it finish."""
+    chunks = 8
+    (tmp_path / "backend.zip").write_bytes(b"b")
+    (tmp_path / "frontend.zip").write_bytes(b"f" * (chunks * UPLOAD_CHUNK_SIZE))
+    mocker.patch("httpx.post", return_value=_ok_body(mocker, _reservation("dep-1")))
+    read = {}
+
+    def put(url: str, **kwargs: Any):
+        if "backend" in url:
+            return _put_response(mocker, 500)
+        read[url] = 0
+        for chunk in kwargs["content"]:
+            time.sleep(0.05)
+            read[url] += len(chunk)
+        return _put_response(mocker, 200)
+
+    mocker.patch("httpx.put", side_effect=put)
+
+    result = _deploy(tmp_path)
+
+    # The backend's failure is the one worth reporting, and the frontend stopped
+    # partway rather than streaming megabytes into a deployment that cannot be.
+    assert (
+        result == "deployment failed: could not upload the build to storage: HTTP 500"
+    )
+    assert read["https://storage.invalid/frontend"] < chunks * UPLOAD_CHUNK_SIZE
 
 
 def test_get_app_history_includes_description_and_can_rollback(mocker: MockerFixture):

--- a/tests/units/reflex_cli/utils/test_hosting.py
+++ b/tests/units/reflex_cli/utils/test_hosting.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
-import time
+import threading
 from pathlib import Path
 from typing import Any
 from unittest.mock import mock_open
@@ -18,6 +18,8 @@ from reflex_cli.utils.hosting import (
     ScaleParams,
     ScaleType,
     SecurityReviewError,
+    _archive_chunks,
+    _UploadAbandonedError,
     authenticated_token,
     create_app,
     create_deployment,
@@ -1018,36 +1020,44 @@ def test_create_deployment_surfaces_an_unreachable_control_plane(
     put.assert_not_called()
 
 
+def test_archive_chunks_stop_once_the_other_upload_failed(tmp_path: Path):
+    """The stream ends at the next chunk boundary, not at the end of the file."""
+    archive = tmp_path / "frontend.zip"
+    archive.write_bytes(b"f" * (4 * UPLOAD_CHUNK_SIZE))
+    abandoned = threading.Event()
+
+    chunks = _archive_chunks(archive, lambda _n: None, abandoned)
+    first = next(chunks)
+    abandoned.set()
+    with pytest.raises(_UploadAbandonedError):
+        next(chunks)
+
+    # One chunk off disk, not the other three: the point of abandoning is the
+    # bytes that never go up.
+    assert len(first) == UPLOAD_CHUNK_SIZE
+
+
 @pytest.mark.usefixtures("deploy_env")
-def test_a_failed_archive_abandons_the_other_mid_stream(
-    mocker: MockerFixture, tmp_path: Path
+def test_an_abandoned_archive_does_not_mask_the_real_failure(
+    mocker: MockerFixture, zip_dir: Path
 ):
-    """One archive failing stops the other rather than letting it finish."""
-    chunks = 8
-    (tmp_path / "backend.zip").write_bytes(b"b")
-    (tmp_path / "frontend.zip").write_bytes(b"f" * (chunks * UPLOAD_CHUNK_SIZE))
+    """The archive that actually failed is the one whose error reaches the user."""
     mocker.patch("httpx.post", return_value=_ok_body(mocker, _reservation("dep-1")))
-    read = {}
 
     def put(url: str, **kwargs: Any):
         if "backend" in url:
             return _put_response(mocker, 500)
-        read[url] = 0
-        for chunk in kwargs["content"]:
-            time.sleep(0.05)
-            read[url] += len(chunk)
-        return _put_response(mocker, 200)
+        # What the frontend's stream does once the backend has set the flag.
+        # Raised here rather than raced into, so the assertion below does not
+        # depend on which thread the scheduler runs first.
+        raise _UploadAbandonedError
 
     mocker.patch("httpx.put", side_effect=put)
 
-    result = _deploy(tmp_path)
-
-    # The backend's failure is the one worth reporting, and the frontend stopped
-    # partway rather than streaming megabytes into a deployment that cannot be.
     assert (
-        result == "deployment failed: could not upload the build to storage: HTTP 500"
+        _deploy(zip_dir)
+        == "deployment failed: could not upload the build to storage: HTTP 500"
     )
-    assert read["https://storage.invalid/frontend"] < chunks * UPLOAD_CHUNK_SIZE
 
 
 def test_get_app_history_includes_description_and_can_rollback(mocker: MockerFixture):


### PR DESCRIPTION
Closes ENG-11230. Client half of the presigned upload work; the control-plane half is [flexgen#5113](https://github.com/reflex-dev/flexgen/pull/5113).

`reflex deploy` posted both zips as multipart to `POST /deployments`, where the web process relayed them into a blocking boto3 `upload_fileobj` inside the request handler. The builder path stopped doing that in ENG-9725; the CLI path did not.

It now calls `POST /deployments/reserve`, PUTs both archives to the signed keys it gets back, and submits only the returned deployment id.

Touches `packages/reflex-hosting-cli` only — no reflex-base change, so this does not move the package's reflex-base floor.

## Decisions worth a second look

**`Content-Length` is set explicitly on each PUT.** The exact byte count is part of the signature, and httpx would otherwise send a generator body chunked, which the signature does not match. `Request._prepare` skips `Transfer-Encoding` precisely when `Content-Length` is already set. Verified over a real socket rather than assumed — sized, not chunked, exact byte count.

**A 404 from `/deployments/reserve` means the route is absent, not the app.** Nothing the endpoint itself refuses with is a 404: an unknown app and an out-of-range size are 400, a missing permission is 403. So a 404 falls back to relaying, as does a caller with no app id to reserve against. The multipart path is otherwise unchanged and stays for the overlap.

**A 403 on a PUT is a lapsed signature, and re-reserving is the recovery.** A fresh reservation mints a fresh deployment id naming a fresh prefix, so *both* archives go up again under it — the one that already succeeded is not somewhere the new deployment will look. Budget is two windows; past that the link is the problem and the user is told so rather than looped.

**The two uploads run concurrently, with a byte-oriented progress bar each.** A silent multi-minute PUT is worse than the relay it replaces, which at least streamed. But neither archive is worth finishing alone — the build submits under one id — so the first failure abandons its sibling at the next chunk boundary rather than leaving the user watching a large upload complete into a deployment that cannot happen.

**Both presigned upload paths now share one PUT.** `submit_security_review` signed its own, and its comment claimed setting `Content-Length` manually breaks the signature — the opposite of what this path needs. Verified against httpx 0.28.1: for a bytes body an explicit length is byte-identical to the derived one; for a stream, *omitting* it yields a chunked body the signature rejects. `presigned_put` holds that invariant once and both callers use it, so the scan path also picks up the per-operation timeouts in place of a flat 120s covering connect and pool. Retry, progress and abandonment deliberately stay with the deploy path — they follow from having two large archives, not from the upload being presigned.

**`transfer_progress` lives in this package, not beside `progress` in reflex-base.** Only the deploy upload wants it, and a new name in reflex-base would raise this package's reflex-base floor for no benefit — the CLI releases on its own schedule. It uses nothing reflex-base does not already owe the CLI: `is_json_mode` is what the re-exported `progress` already calls to stay quiet under JSON output.

## Known tradeoffs

- R2 answers 403 for both an expired signature and a genuinely bad one, so a permanently-broken signature costs one extra reservation before the user hears about it. Narrowing it means parsing the vendor's XML error vocabulary.
- Abandonment is checked between chunks, so on a link stalled mid-write it takes effect when that 256 KiB write completes — bounded by the write timeout rather than by the size of the archive.
- The "over 100MB" 413 message is now reachable only on the relay path. On the direct path an oversized archive gets the control plane's own `ArchiveSizeError` text, which is accurate but worded differently.

## Testing

10 new tests in `tests/units/reflex_cli/utils/test_hosting.py` covering the reserve request shape, exact-bytes/exact-headers on both PUTs, expiry recovery re-uploading both archives under the new id, the retry budget, both relay fallbacks, a refused reservation, an unreachable control plane, and mid-stream abandonment. The two existing `create_deployment` tests moved onto real archives since they now traverse the upload path.

Full unit suite green (7656 passed, 17 skipped); `ruff check`, `ruff format --check`, `pyright`, and `scripts/check_min_deps.py` clean.

Not included, per the ticket: moving `SUPPORTED_CLI_THRESHOLD` server-side, which waits until enough of the fleet has upgraded.
