### PR TITLE
Fix demo_form_dialog to omit trigger when not provided

### DIFF
--- a/packages/reflex-components-internal/src/reflex_components_internal/blocks/demo_form.py
+++ b/packages/reflex-components-internal/src/reflex_components_internal/blocks/demo_form.py
@@ -404,11 +404,9 @@ def demo_form_dialog(
     Returns:
         A Reflex dialog component containing the demo form
     """
-    if trigger is None:
-        trigger = rx.fragment()
     class_name = cn("w-auto", props.pop("class_name", ""))
     return dialog.root(
-        dialog.trigger(render_=trigger),
+        dialog.trigger(render_=trigger) if trigger is not None else None,
         dialog.portal(
             dialog.backdrop(),
             dialog.popup(

--- a/tests/units/reflex_components_internal/blocks/test_demo_form.py
+++ b/tests/units/reflex_components_internal/blocks/test_demo_form.py
@@ -7,6 +7,7 @@ from reflex_components_internal.blocks.demo_form import demo_form_dialog
 import reflex as rx
 
 RENDER_PROP_PATTERN = re.compile(r"render:\(jsx\((\w+)")
+TRIGGER_LABEL = "Show me the demo form"
 
 
 def test_demo_form_dialog_omits_trigger_when_not_given() -> None:
@@ -21,7 +22,11 @@ def test_demo_form_dialog_omits_trigger_when_not_given() -> None:
 
 def test_demo_form_dialog_renders_given_trigger() -> None:
     """A dialog with a trigger renders it through the trigger's render prop."""
-    rendered = str(demo_form_dialog(trigger=rx.el.button("Book a Demo")))
+    # The dialog body has fixed copy of its own, so the label must be one that
+    # only the trigger can contribute.
+    assert TRIGGER_LABEL not in str(demo_form_dialog())
+
+    rendered = str(demo_form_dialog(trigger=rx.el.button(TRIGGER_LABEL)))
 
     assert "Dialog.Trigger" in rendered
-    assert "Book a Demo" in rendered
+    assert TRIGGER_LABEL in rendered

--- a/tests/units/reflex_components_internal/blocks/test_demo_form.py
+++ b/tests/units/reflex_components_internal/blocks/test_demo_form.py
@@ -1,0 +1,27 @@
+"""Tests for the demo form block."""
+
+import re
+
+from reflex_components_internal.blocks.demo_form import demo_form_dialog
+
+import reflex as rx
+
+RENDER_PROP_PATTERN = re.compile(r"render:\(jsx\((\w+)")
+
+
+def test_demo_form_dialog_omits_trigger_when_not_given() -> None:
+    """A dialog without a trigger renders no trigger instead of an empty fragment."""
+    rendered = str(demo_form_dialog())
+
+    assert "Dialog.Trigger" not in rendered
+    # A Fragment cannot receive the props and ref that a base-ui render prop
+    # forwards to it, which makes React complain at runtime.
+    assert "Fragment" not in RENDER_PROP_PATTERN.findall(rendered)
+
+
+def test_demo_form_dialog_renders_given_trigger() -> None:
+    """A dialog with a trigger renders it through the trigger's render prop."""
+    rendered = str(demo_form_dialog(trigger=rx.el.button("Book a Demo")))
+
+    assert "Dialog.Trigger" in rendered
+    assert "Book a Demo" in rendered


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

Fixed `demo_form_dialog()` to properly handle the case when no trigger is provided. Previously, the function would create an empty `rx.fragment()` as a fallback trigger, which caused React runtime warnings because Fragment components cannot receive the props and ref that base-ui's render prop forwards to them.

**Changes:**
- Removed the automatic `rx.fragment()` fallback when `trigger` is `None`
- Modified the dialog to conditionally render `dialog.trigger()` only when a trigger is explicitly provided
- This prevents Fragment from being used as a render prop target, eliminating React warnings

### Testing

- [x] Added unit tests in `tests/units/reflex_components_internal/blocks/test_demo_form.py`:
  - `test_demo_form_dialog_omits_trigger_when_not_given()`: Verifies that no trigger is rendered when none is provided
  - `test_demo_form_dialog_renders_given_trigger()`: Verifies that a provided trigger is properly rendered

Both tests pass and validate the fix works as intended.

https://claude.ai/code/session_01FcXXMZnAkNtwBj7v2bshXH

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/6940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

