### PR TITLE
fix(hosting-cli): repair main after the whoami/token merge

### DIFF
--- a/packages/reflex-hosting-cli/src/reflex_cli/v2/auth.py
+++ b/packages/reflex-hosting-cli/src/reflex_cli/v2/auth.py
@@ -9,10 +9,9 @@ import os
 import sys
 
 import click
-from reflex_base.utils import log
 
 from reflex_cli import constants
-from reflex_cli.utils import console
+from reflex_cli.utils import console, log
 from reflex_cli.utils.exceptions import TokenValidationError
 
 logger = logging.getLogger(__name__)

--- a/tests/units/reflex_cli/utils/test_log.py
+++ b/tests/units/reflex_cli/utils/test_log.py
@@ -90,6 +90,7 @@ def test_reflex_base_adopts_the_cli_logger_without_being_imported():
     [
         "reflex_cli.utils.hosting",
         "reflex_cli.v2.apps",
+        "reflex_cli.v2.auth",
         "reflex_cli.v2.cli",
         "reflex_cli.v2.deployments",
         "reflex_cli.v2.gcp",

--- a/tests/units/reflex_cli/v2/test_auth.py
+++ b/tests/units/reflex_cli/v2/test_auth.py
@@ -12,12 +12,10 @@ from reflex_cli.utils import hosting
 from reflex_cli.utils.exceptions import TokenAccessDeniedError, TokenValidationError
 from reflex_cli.v2.auth import token_fingerprint
 from reflex_cli.v2.deployments import hosting_cli
-from typer import Typer
-from typer.main import get_command
 
-hosting_cli = (
-    get_command(hosting_cli) if isinstance(hosting_cli, Typer) else hosting_cli
-)
+from .utils import as_click_command
+
+hosting_cli = as_click_command(hosting_cli)
 
 runner = CliRunner()
 


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### What happened

reflex-dev/reflex#6918 (`reflex cloud whoami` / `reflex cloud token`, merged as dfb4ef0db13edd5f8291a33556f5339ccef57390) was branched before reflex-dev/reflex#6939 and reflex-dev/reflex#6893 landed. Nothing conflicted textually, so it merged cleanly and broke `main` on two fronts:

**1. Unit tests — `test_cli_imports_without_reflex_base[reflex_cli.v2.deployments]`**

`reflex_cli/v2/auth.py` imports `reflex_base.utils.log` at module scope, but reflex-dev/reflex#6939 made reflex-base optional precisely because it does not exist on the reflex versions the hosting CLI advertises support for (`MINIMUM_REFLEX_VERSION` predates the workspace split). `reflex_cli/v2/deployments.py` imports `auth` unconditionally, so on reflex older than 0.9 importing *any* hosting CLI command raised `ImportError: No module named 'reflex_base'`:

```
packages/reflex-hosting-cli/src/reflex_cli/v2/deployments.py:16: in <module>
    from reflex_cli.v2.auth import token_command, whoami_command
packages/reflex-hosting-cli/src/reflex_cli/v2/auth.py:12: in <module>
    from reflex_base.utils import log
E   ImportError: No module named 'reflex_base'
```

**2. Pre-commit — 22 pyright errors in `tests/units/reflex_cli/v2/test_auth.py`**

The test resolved the CLI with an inline `get_command(hosting_cli) if isinstance(hosting_cli, Typer) else hosting_cli`, which types as `Group | Command`. Since the typer upgrade in reflex-dev/reflex#6893 vendored click, that is not assignable to `click.Command`, so every one of the 22 `runner.invoke(hosting_cli, ...)` calls failed the `pyright` hook:

```
error: Argument of type "Group | Command" cannot be assigned to parameter "cli" of type "Command" in function "invoke"
    "typer._click.core.Command" is not assignable to "click.core.Command" (reportArgumentType)
```

### The fix

- `auth.py` resolves `log` through `reflex_cli.utils.log` — the shim every other CLI module already uses, which re-exports reflex-base's `SUCCESS` when it is importable and defines its own otherwise. On reflex 0.9 and up this is the identical object, so there is no behavior change.
- `reflex_cli.v2.auth` is added to `test_cli_imports_without_reflex_base`'s module list, so the guard names the module directly instead of only catching it transitively through `deployments`. It fails without the `auth.py` change.
- `test_auth.py` uses `as_click_command`, the helper reflex-dev/reflex#6893 added for exactly this and which the sibling CLI tests already use, instead of casting inline.

### Verification

Both failures reproduce on `9f7f82c5` (current `main`) and are gone here:

- `uv run pytest tests/units/reflex_cli` — 444 passed (was 1 failed)
- `uv run pytest tests/units` — 7766 passed, 18 skipped. The only remaining failures, `test_processes.py::test_is_process_on_port_free_port` and `::test_is_process_on_port_concurrent_access`, are pre-existing and environmental (this sandbox has no IPv6: `Address family not supported by protocol`); they fail identically on `main` at `dfb4ef0d^`.
- `uv run pre-commit run --all-files` — all hooks pass (ruff-format, ruff-check, codespell, update-pyi-files, pyright, ty, biome)

No news fragment: reflex-dev/reflex#6918 and reflex-dev/reflex#6939 are both unreleased (latest tag is `reflex-hosting-cli-v0.1.70`, before either merged), so the broken import never shipped and there is nothing user-facing to describe. Please apply `skip-changelog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNTSjh5JBcVFfTx7Jvn3DT

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNTSjh5JBcVFfTx7Jvn3DT)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/6954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

