### PR TITLE
fix(scripts): let check_min_deps honour *.dev pins on the root package

### DIFF
--- a/scripts/check_min_deps.py
+++ b/scripts/check_min_deps.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -407,7 +408,13 @@ def _resolve_and_check(
     # editable from its local checkout so resolution can succeed without reaching PyPI for it.
     for source in package.local_dev_sources:
         install_cmd += ["-e", str(source)]
-    install = _run(install_cmd, cwd=REPO_ROOT)
+    # The root package's hatch hook declares ``require-runtime-dependencies``, which would
+    # make the isolated build env resolve every runtime dep from PyPI — including ``*.dev``
+    # pins that only the editable sources above can satisfy. The hook only regenerates
+    # ``.pyi`` stubs, which this check does not need, so disable hooks for the build.
+    install = _run(
+        install_cmd, cwd=REPO_ROOT, env={**os.environ, "HATCH_BUILD_NO_HOOKS": "true"}
+    )
     if install.returncode != 0:
         return None, install.stdout
 


### PR DESCRIPTION
## Problem

`scripts/check_min_deps.py` resolves `*.dev` sibling pins from the local workspace via `-e`. That works for sub-packages but not for the root `reflex` package: its hatch hook declares `require-runtime-dependencies = true`, so uv's isolated build env resolves every runtime dep from PyPI (`--no-sources`). A pin like `reflex-hosting-cli >= 0.1.70.dev1` fails during `build-system.requires` resolution, before the editable checkout is ever considered.

## Fix

Run the install with `HATCH_BUILD_NO_HOOKS=true`. Hatchling then drops the custom hook and its dependencies (incl. runtime deps) from the build env. The hook only regenerates `.pyi` stubs, which this check does not use.

## Verification

- Root pyproject temporarily pinned to `reflex-hosting-cli >= 0.1.70.dev1`: before → `Failed to resolve requirements from build-system.requires`; after → `PASS reflex`.
- Stock pyproject: `reflex` and `reflex-components-core` still PASS.

Note: a dev pin must not exceed the sibling's local dynamic version (newest tag + `.postN`), e.g. `0.1.70.dev1` while the newest hosting-cli tag is `v0.1.70`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/6956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

