### PR TITLE
fix(scripts): resolve *.dev pins inside the build env in check_min_deps

### DIFF
--- a/scripts/check_min_deps.py
+++ b/scripts/check_min_deps.py
@@ -20,7 +20,11 @@ workspace package to an unreleased ``*.dev`` version (e.g. ``reflex-base >= 0.9.
 while that version is still unpublished, which would otherwise make resolution from PyPI
 impossible. For such pins — and only those — the depended-on package is installed editable
 from its local workspace checkout in both environments, so every *non-dev* dependency is
-still required to resolve from PyPI.
+still required to resolve from PyPI. An editable on the command line is invisible to the
+isolated build environment uv creates to build the checked package itself — and the root
+package's build hook re-resolves the runtime dependencies there
+(``require-runtime-dependencies``) — so each dev-pinned sibling is additionally built into
+a local wheel exposed via ``--find-links``, which build-environment resolution does consult.
 
 Run with ``uv run python scripts/check_min_deps.py [package ...]``. With no arguments,
 every checkable package is validated. ``--check-dev-pins [package ...]`` instead scans the
@@ -134,7 +138,9 @@ class Package:
     """Project dirs of sibling workspace packages this package pins to a ``*.dev`` release.
 
     These are installed editable from the local checkout (rather than PyPI) in both
-    resolutions, because the pinned development version is not published.
+    resolutions, because the pinned development version is not published. They are also
+    built into local wheels served via ``--find-links`` so the pin resolves inside the
+    isolated build environment, which cannot see the editables.
     """
 
     def install_target(self) -> str:
@@ -365,12 +371,39 @@ def _pyright_errors(report: dict) -> dict[tuple[str, int, int, str], str]:
     return errors
 
 
+def _build_dev_wheels(package: Package, wheel_dir: Path) -> str | None:
+    """Build the package's dev-pinned siblings into wheels for build-env resolution.
+
+    The ``-e`` editables added in :func:`_resolve_and_check` satisfy a ``*.dev`` pin only
+    in the top-level resolution. When the checked package's build hook requires the runtime
+    dependencies (the root package's does, to regenerate ``.pyi`` stubs), uv resolves the
+    pin again inside an isolated build environment that only consults package indexes, so
+    the sibling must also be available as a wheel via ``--find-links``.
+
+    Args:
+        package: The package whose dev-pinned siblings should be built.
+        wheel_dir: Directory to place the built wheels in.
+
+    Returns:
+        ``None`` on success, or the captured build output of the failing wheel build.
+    """
+    for source in package.local_dev_sources:
+        build = _run(
+            ["uv", "build", "--wheel", "--out-dir", str(wheel_dir), str(source)],
+            cwd=REPO_ROOT,
+        )
+        if build.returncode != 0:
+            return build.stdout
+    return None
+
+
 def _resolve_and_check(
     package: Package,
     python_version: str,
     venv: Path,
     config: Path,
     lowest: bool,
+    dev_wheel_dir: Path | None = None,
 ) -> tuple[dict[tuple[str, int, int, str], str] | None, str]:
     """Install a package into an isolated venv and run pyright against its source.
 
@@ -380,6 +413,9 @@ def _resolve_and_check(
         venv: Directory in which to create the virtualenv.
         config: Path to the pyright options config.
         lowest: Whether to pin direct dependencies to their declared minimums.
+        dev_wheel_dir: Directory of prebuilt sibling wheels (see
+            :func:`_build_dev_wheels`), passed via ``--find-links`` so ``*.dev`` pins
+            resolve inside the isolated build environment.
 
     Returns:
         A ``(errors, detail)`` tuple. ``errors`` is the pyright error map, or ``None`` if
@@ -403,10 +439,14 @@ def _resolve_and_check(
         install_cmd += ["--resolution", "lowest-direct"]
     install_cmd += ["-e", package.install_target()]
     # ``--no-sources`` forces every dependency to resolve from PyPI; the lone exception is a
-    # sibling pinned to an unpublished ``*.dev`` release, which is provided here as an explicit
-    # editable from its local checkout so resolution can succeed without reaching PyPI for it.
+    # sibling pinned to an unpublished ``*.dev`` release, provided two ways: as an explicit
+    # editable from its local checkout for the top-level resolution, and as a prebuilt wheel
+    # via ``--find-links`` for the isolated build environment, which re-resolves the pin when
+    # the package's build hook requires the runtime dependencies but cannot see editables.
     for source in package.local_dev_sources:
         install_cmd += ["-e", str(source)]
+    if dev_wheel_dir is not None:
+        install_cmd += ["--find-links", str(dev_wheel_dir)]
     install = _run(install_cmd, cwd=REPO_ROOT)
     if install.returncode != 0:
         return None, install.stdout
@@ -450,8 +490,26 @@ def check_package(package: Package, python_version: str) -> Result:
         config = tmp_path / "pyrightconfig.json"
         config.write_text(json.dumps({"reportIncompatibleMethodOverride": False}))
 
+        dev_wheel_dir: Path | None = None
+        if package.local_dev_sources:
+            dev_wheel_dir = tmp_path / "dev-wheels"
+            dev_wheel_dir.mkdir()
+            detail = _build_dev_wheels(package, dev_wheel_dir)
+            if detail is not None:
+                return Result(
+                    package.name,
+                    False,
+                    "resolution",
+                    f"building wheels for dev-pinned siblings failed:\n{detail}",
+                )
+
         baseline, detail = _resolve_and_check(
-            package, python_version, tmp_path / ".venv-latest", config, lowest=False
+            package,
+            python_version,
+            tmp_path / ".venv-latest",
+            config,
+            lowest=False,
+            dev_wheel_dir=dev_wheel_dir,
         )
         if baseline is None:
             return Result(
@@ -462,7 +520,12 @@ def check_package(package: Package, python_version: str) -> Result:
             )
 
         minimum, detail = _resolve_and_check(
-            package, python_version, tmp_path / ".venv-lowest", config, lowest=True
+            package,
+            python_version,
+            tmp_path / ".venv-lowest",
+            config,
+            lowest=True,
+            dev_wheel_dir=dev_wheel_dir,
         )
         if minimum is None:
             return Result(

--- a/tests/units/test_check_min_deps.py
+++ b/tests/units/test_check_min_deps.py
@@ -243,6 +243,137 @@ def test_resolve_and_check_appends_local_dev_sources_as_editables(
     # ...but the dev-pinned sibling is provided editable from its local checkout.
     assert install.count("-e") == 2
     assert str(dev_source) in install
+    # Without a prebuilt wheel dir there is nothing to serve to the build env.
+    assert "--find-links" not in install
+
+
+def test_resolve_and_check_serves_dev_wheel_dir_via_find_links(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    captured: list[list[str]] = []
+
+    class _Done:
+        returncode = 0
+        stdout = '{"generalDiagnostics": []}'
+
+    monkeypatch.setattr(
+        check_min_deps,
+        "_run",
+        lambda cmd, **kwargs: captured.append([str(c) for c in cmd]) or _Done(),
+    )
+    package = check_min_deps.Package(
+        name="reflex",
+        project_dir=check_min_deps.REPO_ROOT,
+        source_dir=check_min_deps.REPO_ROOT / "reflex",
+        extras=(),
+        local_dev_sources=(check_min_deps.REPO_ROOT / "packages" / "reflex-base",),
+    )
+
+    errors, _ = check_min_deps._resolve_and_check(
+        package,
+        "3.12",
+        tmp_path / "venv",
+        tmp_path / "cfg.json",
+        lowest=False,
+        dev_wheel_dir=tmp_path / "dev-wheels",
+    )
+
+    assert errors == {}
+    install = next(c for c in captured if c[:3] == ["uv", "pip", "install"])
+    assert install[install.index("--find-links") + 1] == str(tmp_path / "dev-wheels")
+
+
+def test_check_package_builds_dev_pinned_siblings_for_the_build_env(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Regression: a ``*.dev`` pin on the root package must resolve in the build env.
+
+    The root package's hatch hook declares ``require-runtime-dependencies``, so uv
+    re-resolves the runtime deps inside an isolated build environment that cannot see the
+    ``-e`` editables. The check must prebuild each dev-pinned sibling into a wheel and
+    pass the wheel directory to every install via ``--find-links``.
+    """
+    captured: list[list[str]] = []
+
+    class _Done:
+        returncode = 0
+        stdout = '{"generalDiagnostics": []}'
+
+    monkeypatch.setattr(
+        check_min_deps,
+        "_run",
+        lambda cmd, **kwargs: captured.append([str(c) for c in cmd]) or _Done(),
+    )
+    dev_source = check_min_deps.REPO_ROOT / "packages" / "reflex-base"
+    package = check_min_deps.Package(
+        name="reflex",
+        project_dir=check_min_deps.REPO_ROOT,
+        source_dir=check_min_deps.REPO_ROOT / "reflex",
+        extras=(),
+        local_dev_sources=(dev_source,),
+    )
+
+    result = check_min_deps.check_package(package, "3.12")
+
+    assert result.ok
+    build = next(c for c in captured if c[:3] == ["uv", "build", "--wheel"])
+    assert build[-1] == str(dev_source)
+    wheel_dir = build[build.index("--out-dir") + 1]
+    installs = [c for c in captured if c[:3] == ["uv", "pip", "install"]]
+    assert len(installs) == 2
+    for install in installs:
+        assert install[install.index("--find-links") + 1] == wheel_dir
+
+
+def test_check_package_without_dev_pins_builds_no_wheels(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    captured: list[list[str]] = []
+
+    class _Done:
+        returncode = 0
+        stdout = '{"generalDiagnostics": []}'
+
+    monkeypatch.setattr(
+        check_min_deps,
+        "_run",
+        lambda cmd, **kwargs: captured.append([str(c) for c in cmd]) or _Done(),
+    )
+    package = check_min_deps.Package(
+        name="reflex",
+        project_dir=check_min_deps.REPO_ROOT,
+        source_dir=check_min_deps.REPO_ROOT / "reflex",
+        extras=(),
+    )
+
+    assert check_min_deps.check_package(package, "3.12").ok
+    assert not any(c[:2] == ["uv", "build"] for c in captured)
+    assert not any("--find-links" in c for c in captured)
+
+
+def test_check_package_reports_failed_dev_wheel_build(monkeypatch: pytest.MonkeyPatch):
+    class _Failed:
+        returncode = 1
+        stdout = "wheel build exploded"
+
+    def fake_run(cmd: list[str], **kwargs: object) -> _Failed:
+        assert [str(c) for c in cmd[:2]] == ["uv", "build"]
+        return _Failed()
+
+    monkeypatch.setattr(check_min_deps, "_run", fake_run)
+    package = check_min_deps.Package(
+        name="reflex",
+        project_dir=check_min_deps.REPO_ROOT,
+        source_dir=check_min_deps.REPO_ROOT / "reflex",
+        extras=(),
+        local_dev_sources=(check_min_deps.REPO_ROOT / "packages" / "reflex-base",),
+    )
+
+    result = check_min_deps.check_package(package, "3.12")
+
+    assert not result.ok
+    assert result.stage == "resolution"
+    assert "wheel build exploded" in result.detail
 
 
 def _write_pyproject(path: Path, dependencies: list[str], optional: str = "") -> Path:


### PR DESCRIPTION
Replaces #6956 with a different approach, per review feedback there.

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed? (#6956 is superseded by this PR)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

## Problem

`scripts/check_min_deps.py` resolves `*.dev` sibling pins from the local workspace via the `local_dev_sources` escape hatch, which adds the dev-pinned sibling as an `-e` editable on the install command. That only covers the **top-level** resolution: the root `reflex` package's hatch hook declares `require-runtime-dependencies = true`, so uv re-resolves every runtime dependency inside the isolated **build environment** it creates to build `reflex` itself — and that resolution only consults package indexes, never the command-line editables. A dev pin like `reflex-hosting-cli >= 0.1.70.post1.dev0` therefore fails at `build-system.requires` resolution before the escape hatch is ever considered.

#6956 worked around this with `HATCH_BUILD_NO_HOOKS=true`, but that disables `.pyi` stub generation, which the check relies on (pyright runs against the installed version).

## Fix

Extend the escape hatch to the build environment: prebuild each dev-pinned sibling into a wheel (`uv build --wheel`, once per checked package, shared by both resolutions) and pass the wheel directory via `--find-links`, which uv **does** propagate into build-env resolution. The sibling is still installed editable at the top level, build hooks stay fully enabled, and with no dev pins the install command is unchanged.

## Verification

- Root pyproject temporarily pinned to `reflex-hosting-cli >= 0.1.70.post1.dev0` (unpublished on PyPI, satisfied by the local checkout's dynamic version `0.1.70.post29.dev0`): before → `Failed to resolve requirements from build-system.requires`; after → `PASS reflex`, with build hooks enabled.
- New regression tests assert the wheel build happens, both installs receive `--find-links` with the wheel dir, nothing changes without dev pins, and a failed wheel build surfaces as a resolution failure. They fail on the unfixed script; the full module suite (47 tests) passes with it.
- `uv run ruff check`, `ruff format --check`, and `pyright` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ao5dUsF7f5zwzpFAeRkesY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ao5dUsF7f5zwzpFAeRkesY)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/6958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

