### PR TITLE
Fix reflex-hosting-cli on v0.7.6.post

### DIFF
--- a/packages/reflex-hosting-cli/news/6963.bugfix.md
+++ b/packages/reflex-hosting-cli/news/6963.bugfix.md
@@ -1,0 +1,1 @@
+Fix version comparison bug that broke compatibility with reflex-0.7.6.post1

--- a/packages/reflex-hosting-cli/src/reflex_cli/v2/cli.py
+++ b/packages/reflex-hosting-cli/src/reflex_cli/v2/cli.py
@@ -924,11 +924,12 @@ def deploy(
         import importlib.metadata
 
         rx_version = version.parse(importlib.metadata.version("reflex"))
-        breaking_version = version.parse("0.7.6")
+        # The 7-argument export_fn (with upload_db) landed in reflex 0.7.7.
+        breaking_release = (0, 7, 7)
         # Try zipping backend first
         try:
-            # Check if the reflex version is >= 0.7.6
-            if rx_version <= breaking_version:
+            # Check if the reflex version predates 0.7.7
+            if rx_version.release < breaking_release:
                 export_fn(
                     str(temporary_dir_path),
                     server_url,
@@ -955,8 +956,8 @@ def deploy(
 
         # Zip frontend
         try:
-            # Check if the reflex version is >= 0.7.6
-            if rx_version <= breaking_version:
+            # Check if the reflex version predates 0.7.7
+            if rx_version.release < breaking_release:
                 export_fn(
                     str(temporary_dir_path), server_url, host_url, True, False, True
                 )  # pyright: ignore[reportCallIssue]


### PR DESCRIPTION
Logic was comparing PEP 440 versions, which had an unintended effect for pre and post release version markers. The new "release" based check ignores pre/post/alpha releases and only compares against the version tuple (0, 7, 7).

Verified empirically with published version numbers.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/6963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

