### PR TITLE
Add click_element utility for robust element clicking in tests

### DIFF
--- a/tests/integration/test_dynamic_routes.py
+++ b/tests/integration/test_dynamic_routes.py
@@ -235,24 +235,18 @@ def test_on_load_navigate(
         token: The token visible in the driver browser.
     """
     assert dynamic_route.app_instance is not None
-    link = driver.find_element(By.ID, "link_page_next")
-    assert link
 
     exp_order = [f"/page/[page_id]-{ix}" for ix in range(10)]
     # click the link a few times
     for ix in range(10):
         # wait for navigation, then assert on url
         with poll_for_navigation(driver):
-            link.click()
+            click_element(driver, By.ID, "link_page_next")
         assert urlsplit(driver.current_url).path == f"/page/{ix}"
 
-        link = AppHarness.poll_for_or_raise_timeout(
-            lambda: driver.find_element(By.ID, "link_page_next")
-        )
         page_id_input = driver.find_element(By.ID, "page_id")
         raw_path_input = driver.find_element(By.ID, "raw_path")
 
-        assert link
         assert page_id_input
 
         assert dynamic_route.poll_for_value(
@@ -273,9 +267,8 @@ def test_on_load_navigate(
 
     # make sure internal nav still hydrates after redirect
     exp_order += ["/page/[page_id]-11"]
-    link = driver.find_element(By.ID, "link_page_next")
     with poll_for_navigation(driver):
-        link.click()
+        click_element(driver, By.ID, "link_page_next")
     poll_assert_event_order(driver, exp_order)
 
     # load same page with a query param and make sure it passes through
@@ -393,19 +386,15 @@ async def test_render_dynamic_arg(
             )
 
     assert_content("0", "")
-    next_page_link = driver.find_element(By.ID, "next-page")
-    assert next_page_link
     with poll_for_navigation(driver):
-        next_page_link.click()
+        click_element(driver, By.ID, "next-page")
     assert (
         driver.current_url.removesuffix("/")
         == f"{frontend_url.removesuffix('/')}/arg/1"
     )
     assert_content("1", "0")
-    next_page_link = driver.find_element(By.ID, "next-page")
-    assert next_page_link
     with poll_for_navigation(driver):
-        next_page_link.click()
+        click_element(driver, By.ID, "next-page")
     assert (
         driver.current_url.removesuffix("/")
         == f"{frontend_url.removesuffix('/')}/arg/2"

--- a/tests/integration/test_dynamic_routes.py
+++ b/tests/integration/test_dynamic_routes.py
@@ -12,7 +12,7 @@ from selenium.webdriver.common.by import By
 
 from reflex.testing import AppHarness, WebDriver
 
-from .utils import poll_assert_event_order, poll_for_navigation
+from .utils import click_element, poll_assert_event_order, poll_for_navigation
 
 
 def DynamicRoute():
@@ -300,9 +300,8 @@ def test_on_load_navigate(
 
     # next/link to a 404 and ensure we still hydrate
     exp_order += ["/404-no page id"]
-    link = driver.find_element(By.ID, "link_missing")
     with poll_for_navigation(driver):
-        link.click()
+        click_element(driver, By.ID, "link_missing")
 
     # hit a page that redirects back to dynamic page
     exp_order += ["on_load_redir-{'foo': 'bar', 'page_id': '0'}", "/page/[page_id]-0"]
@@ -330,29 +329,24 @@ def test_on_load_navigate_non_dynamic(
         driver: WebDriver instance.
     """
     assert dynamic_route.app_instance is not None
-    link = driver.find_element(By.ID, "link_page_x")
-    assert link
 
     with poll_for_navigation(driver):
-        link.click()
+        click_element(driver, By.ID, "link_page_x")
     assert urlsplit(driver.current_url).path.removesuffix("/") == "/static/x"
     poll_assert_event_order(driver, ["/static/x-no page id"])
 
     # go back to the index and navigate back to the static route
-    link = driver.find_element(By.ID, "link_index")
     with poll_for_navigation(driver):
-        link.click()
+        click_element(driver, By.ID, "link_index")
     assert urlsplit(driver.current_url).path.removesuffix("/") == ""
 
-    link = driver.find_element(By.ID, "link_page_x")
     with poll_for_navigation(driver):
-        link.click()
+        click_element(driver, By.ID, "link_page_x")
     assert urlsplit(driver.current_url).path.removesuffix("/") == "/static/x"
     poll_assert_event_order(driver, ["/static/x-no page id", "/static/x-no page id"])
 
     for _ in range(3):
-        link = driver.find_element(By.ID, "link_page_x")
-        link.click()
+        click_element(driver, By.ID, "link_page_x")
         assert urlsplit(driver.current_url).path.removesuffix("/") == "/static/x"
     poll_assert_event_order(driver, ["/static/x-no page id"] * 5)
 

--- a/tests/integration/test_event_chain.py
+++ b/tests/integration/test_event_chain.py
@@ -10,6 +10,7 @@ from selenium.webdriver.common.by import By
 
 from reflex.testing import AppHarness, WebDriver
 from tests.integration.utils import (
+    click_element,
     poll_assert_event_order,
     poll_assert_relative_event_order,
 )
@@ -622,11 +623,8 @@ def test_event_chain_on_mount(
     assert event_chain.frontend_url is not None
     driver.get(event_chain.frontend_url.removesuffix("/") + uri)
 
-    unmount_button = AppHarness.poll_for_or_raise_timeout(
-        lambda: driver.find_element(By.ID, "unmount")
-    )
     assert_token(event_chain, driver)
-    unmount_button.click()
+    click_element(driver, By.ID, "unmount")
 
     poll_assert_relative_event_order(driver, expected_counts, ordering_rules)
 

--- a/tests/integration/test_login_flow.py
+++ b/tests/integration/test_login_flow.py
@@ -126,12 +126,11 @@ def test_login_flow(
 
     login_sample.poll_for_content(login_button)
     with utils.poll_for_navigation(driver):
-        login_button.click()
+        utils.click_element(driver, By.ID, "login")
     assert driver.current_url.endswith("/login")
 
-    do_it_button = driver.find_element(By.ID, "doit")
     with utils.poll_for_navigation(driver):
-        do_it_button.click()
+        utils.click_element(driver, By.ID, "doit")
     assert driver.current_url == login_sample.frontend_url
 
     def check_auth_token_header():
@@ -143,8 +142,7 @@ def test_login_flow(
 
     assert AppHarness.poll_for_or_raise_timeout(check_auth_token_header) == "12345"
 
-    logout_button = driver.find_element(By.ID, "logout")
-    logout_button.click()
+    utils.click_element(driver, By.ID, "logout")
 
     state_name = login_sample.get_full_state_name(["_state"])
     AppHarness.expect(

--- a/tests/integration/test_navigation.py
+++ b/tests/integration/test_navigation.py
@@ -8,7 +8,7 @@ from selenium.webdriver.common.by import By
 
 from reflex.testing import AppHarness
 
-from .utils import SessionStorage, poll_for_navigation
+from .utils import SessionStorage, click_element, poll_for_navigation
 
 
 def NavigationApp():
@@ -69,26 +69,19 @@ def test_navigation_app(navigation_app: AppHarness):
     ss = SessionStorage(driver)
     assert AppHarness._poll_for(lambda: ss.get("token") is not None), "token not found"
 
-    internal_link = driver.find_element(By.ID, "internal")
-
     with poll_for_navigation(driver):
-        internal_link.click()
+        click_element(driver, By.ID, "internal")
     assert urlsplit(driver.current_url).path == "/internal"
     with poll_for_navigation(driver):
         driver.back()
 
-    external_link = AppHarness.poll_for_or_raise_timeout(
-        lambda: driver.find_element(By.ID, "external")
-    )
-    external2_link = driver.find_element(By.ID, "external2")
-
-    external_link.click()
+    click_element(driver, By.ID, "external")
     # Expect a new tab to open
     AppHarness.expect(lambda: len(driver.window_handles) == 2)
 
     # Switch back to the main tab
     driver.switch_to.window(driver.window_handles[0])
 
-    external2_link.click()
+    click_element(driver, By.ID, "external2")
     # Expect another new tab to open
     AppHarness.expect(lambda: len(driver.window_handles) == 3)

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -8,7 +8,10 @@ from contextlib import contextmanager
 from http.client import HTTPConnection
 from urllib.parse import urlsplit
 
-from selenium.common.exceptions import StaleElementReferenceException
+from selenium.common.exceptions import (
+    NoSuchElementException,
+    StaleElementReferenceException,
+)
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
 
@@ -72,21 +75,23 @@ def click_element(
     value: str,
     timeout: TimeoutType = None,
 ) -> None:
-    """Locate an element and click it, re-locating it if it goes stale.
+    """Locate an element and click it, tolerating the churn of a navigation.
 
     Client-side navigation swaps the DOM after the URL changes, so an element
-    located right after navigating can be unmounted before the click is
-    dispatched. Only a stale reference is retried: it is raised before the
-    click reaches the browser, so the click is never dispatched twice.
+    located right after navigating may not be rendered yet, or may be unmounted
+    before the click is dispatched. Both are retried until `timeout`, since both
+    are raised while locating or validating the element reference, never after
+    the click reaches the browser. Every other error, including an invalid
+    selector or an intercepted click, propagates on the first attempt.
 
     Args:
         driver: WebDriver instance.
         by: Locator strategy, one of the `By` constants.
         value: Locator value.
-        timeout: How long to keep re-locating a stale element.
+        timeout: How long to keep re-locating the element.
 
     Raises:
-        TimeoutError: if the element remained stale for the whole timeout.
+        TimeoutError: if the element could not be clicked within the timeout.
     """
     deadline = time.monotonic() + (
         DEFAULT_TIMEOUT if timeout is None else float(timeout)
@@ -94,9 +99,9 @@ def click_element(
     while True:
         try:
             driver.find_element(by, value).click()
-        except StaleElementReferenceException as exc:
+        except (NoSuchElementException, StaleElementReferenceException) as exc:
             if time.monotonic() >= deadline:
-                msg = f"Element {by}={value!r} remained stale while polling."
+                msg = f"Could not click element {by}={value!r} while polling."
                 raise TimeoutError(msg) from exc
             time.sleep(POLL_INTERVAL)
         else:

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Generator, Iterator, Sequence
 from contextlib import contextmanager
 from http.client import HTTPConnection
 from urllib.parse import urlsplit
 
+from selenium.common.exceptions import StaleElementReferenceException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
 
-from reflex.testing import AppHarness, TimeoutType
+from reflex.testing import DEFAULT_TIMEOUT, POLL_INTERVAL, AppHarness, TimeoutType
 
 
 def request_raw(
@@ -70,35 +72,35 @@ def click_element(
     value: str,
     timeout: TimeoutType = None,
 ) -> None:
-    """Locate an element and click it, retrying until the click lands.
+    """Locate an element and click it, re-locating it if it goes stale.
 
     Client-side navigation swaps the DOM after the URL changes, so an element
-    located right after navigating can go stale before the click is dispatched.
-    Re-locating on each attempt clicks whichever node is currently rendered.
+    located right after navigating can be unmounted before the click is
+    dispatched. Only a stale reference is retried: it is raised before the
+    click reaches the browser, so the click is never dispatched twice.
 
     Args:
         driver: WebDriver instance.
         by: Locator strategy, one of the `By` constants.
         value: Locator value.
-        timeout: Time to wait for the click to succeed.
+        timeout: How long to keep re-locating a stale element.
 
     Raises:
-        TimeoutError: if the element could not be clicked within the timeout.
+        TimeoutError: if the element remained stale for the whole timeout.
     """
-    last_exc: Exception | None = None
-
-    def _click() -> bool:
-        nonlocal last_exc
+    deadline = time.monotonic() + (
+        DEFAULT_TIMEOUT if timeout is None else float(timeout)
+    )
+    while True:
         try:
             driver.find_element(by, value).click()
-        except Exception as exc:
-            last_exc = exc
-            raise
-        return True
-
-    if not AppHarness._poll_for(_click, timeout=timeout):
-        msg = f"Could not click element {by}={value!r} while polling: {last_exc}"
-        raise TimeoutError(msg)
+        except StaleElementReferenceException as exc:
+            if time.monotonic() >= deadline:
+                msg = f"Element {by}={value!r} remained stale while polling."
+                raise TimeoutError(msg) from exc
+            time.sleep(POLL_INTERVAL)
+        else:
+            return
 
 
 def n_expected_events(exp_event_order: Sequence[str | set[str]]) -> int:

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -10,7 +10,7 @@ from urllib.parse import urlsplit
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
 
-from reflex.testing import AppHarness
+from reflex.testing import AppHarness, TimeoutType
 
 
 def request_raw(
@@ -62,6 +62,43 @@ def poll_for_navigation(
     yield
 
     AppHarness.expect(lambda: prev_url != driver.current_url, timeout=timeout)
+
+
+def click_element(
+    driver: WebDriver,
+    by: str,
+    value: str,
+    timeout: TimeoutType = None,
+) -> None:
+    """Locate an element and click it, retrying until the click lands.
+
+    Client-side navigation swaps the DOM after the URL changes, so an element
+    located right after navigating can go stale before the click is dispatched.
+    Re-locating on each attempt clicks whichever node is currently rendered.
+
+    Args:
+        driver: WebDriver instance.
+        by: Locator strategy, one of the `By` constants.
+        value: Locator value.
+        timeout: Time to wait for the click to succeed.
+
+    Raises:
+        TimeoutError: if the element could not be clicked within the timeout.
+    """
+    last_exc: Exception | None = None
+
+    def _click() -> bool:
+        nonlocal last_exc
+        try:
+            driver.find_element(by, value).click()
+        except Exception as exc:
+            last_exc = exc
+            raise
+        return True
+
+    if not AppHarness._poll_for(_click, timeout=timeout):
+        msg = f"Could not click element {by}={value!r} while polling: {last_exc}"
+        raise TimeoutError(msg)
 
 
 def n_expected_events(exp_event_order: Sequence[str | set[str]]) -> int:


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

Fixes a `StaleElementReferenceException` flake in `test_on_load_navigate_non_dynamic[prod]`, then applies the same fix to the other Selenium integration tests with the same shape.

**Problem:** `poll_for_navigation` returns as soon as `driver.current_url` changes, which happens when the router pushes history — before React swaps the route component. An element located in that window belongs to the outgoing tree and is unmounted before the click is dispatched. In the observed failure, `/` and `/static/x` render the same component, so `link_page_x` existed on both pages and was located on the page being navigated away from. Prod mode widens the window because the route chunk is fetched lazily.

**Solution:** `click_element(driver, by, value, timeout)` re-locates the element on every attempt, so it clicks whichever node is currently rendered.

Retries are confined to `NoSuchElementException` and `StaleElementReferenceException`. Both are raised while locating or validating the element reference, never after the click reaches the browser, so a click cannot be dispatched twice — which matters because these tests assert exact event counts. Everything else propagates on the first attempt, including `InvalidSelectorException` (it derives from `WebDriverException`, not `NoSuchElementException`) and `ElementClickInterceptedException`.

### Changes

1. **`tests/integration/utils.py`** — add `click_element()`: a deadline loop that re-locates and clicks, raising `TimeoutError` with the locator and the last error chained as `__cause__`.
2. **`tests/integration/test_dynamic_routes.py`** — all link clicks go through the helper: the `link_page_x`/`link_index` clicks in `test_on_load_navigate_non_dynamic` (the flaking test), the `link_page_next` loop and post-redirect click plus `link_missing` in `test_on_load_navigate`, and both `next-page` clicks in `test_render_dynamic_arg`. Cached element variables and their presence polls drop out, since the helper re-locates.
3. **`tests/integration/test_navigation.py`** — `external`/`external2`, located immediately after `driver.back()` and clicked later with a window switch in between; `internal` for consistency.
4. **`tests/integration/test_login_flow.py`** — `doit`, located as soon as the URL became `/login`; `login` and `logout` in the same flow.
5. **`tests/integration/test_event_chain.py`** — `unmount`, located right after `driver.get()` and clicked once `assert_token()` has waited out hydration (where the StrictMode remount lands).

Deliberately unchanged: single-expression `find_element(...).click()` calls, which have no window between locating and clicking (`test_auto_memo.py`, `test_deploy_url.py`), and clicks that never cross a navigation (`test_client_storage.py`, `test_connection_banner.py`, `test_upload.py` — those already re-locate after each refresh).

### Follow-up work (not in this PR)

`test_dynamic_routes.py` carries two `TODO: drop after flakiness is resolved` band-aids — `driver.implicitly_wait(30)` and an `await asyncio.sleep(3)` in `test_render_dynamic_arg`. Removing the implicit wait means converting every remaining bare `find_element` in that module to a polling lookup, and neither removal can be demonstrated except by repeated CI runs, so both are left for a later change.

### Testing

- `uv run ruff check .`, `uv run ruff format .` and `uv run pyright reflex tests` are clean.
- No new tests: this is a fix to test infrastructure, and the flake it removes is timing-dependent, so CI is the verification — `integration-app-harness` (Selenium, dev + prod) and `integration-tests` (Playwright) are green on the head commit.

### Checklist

- [x] Changes follow the guidelines in CONTRIBUTING.md
- [x] Code is linted and formatted
- [x] Docstring follows Google style with Args/Raises sections
- [x] Existing tests pass with the changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7hxgQtxcFzZC795xyftVS