### PR TITLE
Handle payload-less client_error emits without raising TypeError

### DIFF
--- a/news/+client-error-noarg.bugfix.md
+++ b/news/+client-error-noarg.bugfix.md
@@ -1,0 +1,1 @@
+A `client_error` socket emit with no payload no longer raises an unhandled `TypeError` inside python-socketio's dispatch, which let any connected socket — even one without a valid token — spam asyncio tracebacks into the backend logs past the handler's rate limits. A missing payload is now dropped by the same guard that handles other malformed payloads.

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -2166,7 +2166,7 @@ class EventNamespace(AsyncNamespace):
         # Emit the test event.
         await self.emit(str(constants.SocketEvent.PING), "pong", to=sid)
 
-    async def on_client_error(self, sid: str, data: Any):
+    async def on_client_error(self, sid: str, data: Any = None):
         """Handle errors reported by the frontend.
 
         This is a dedicated socket event rather than a state event
@@ -2184,7 +2184,10 @@ class EventNamespace(AsyncNamespace):
 
         Args:
             sid: The Socket.IO session id.
-            data: The error data from the client.
+            data: The error data from the client. Defaults to None because
+                python-socketio dispatches a payload-less emit as
+                ``on_client_error(sid)``; the malformed-payload guard below
+                then drops it without raising.
         """
         if not isinstance(data, dict):
             logger.debug(f"Ignoring malformed client_error payload from SID {sid}.")

--- a/tests/units/test_app.py
+++ b/tests/units/test_app.py
@@ -4145,6 +4145,32 @@ async def test_client_error_malformed_payload_is_ignored(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("sid", ["known_sid", "unknown_sid"])
+async def test_client_error_no_argument_emit_is_ignored(
+    event_namespace: EventNamespace,
+    frontend_errors: list[str],
+    client_error_console: dict[str, list[str]],
+    sid: str,
+):
+    """A payload-less client_error emit is dropped like any malformed payload.
+
+    python-socketio dispatches ``emit("client_error")`` without a payload as
+    ``on_client_error(sid)``, so a missing ``data`` argument must not raise a
+    TypeError before the anti-abuse guards run.
+
+    Args:
+        event_namespace: The event namespace.
+        frontend_errors: Captured frontend exception handler messages.
+        client_error_console: Captured console messages.
+        sid: The Socket.IO session id to report from.
+    """
+    await event_namespace.on_client_error(sid)
+    assert not frontend_errors
+    assert not client_error_console["error"]
+    assert not client_error_console["warn"]
+
+
+@pytest.mark.asyncio
 async def test_client_error_unknown_sid_does_not_report_error(
     event_namespace: EventNamespace,
     frontend_errors: list[str],


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Defect

FINDING-004 (security-adjacent, medium) from the 0.9.9a1 pre-release testing batch: `EventNamespace.on_client_error(self, sid, data)` in `reflex/app.py` gave `data` no default. python-socketio dispatches events as `handler(sid, *data[1:])`, so an `emit("client_error")` with no payload calls `on_client_error(sid)` and raises `TypeError: missing 1 required positional argument: 'data'` during parameter binding — before the malformed-payload check, the unknown-SID gate, and the per-SID/per-window rate limiters introduced by #6827 ever run. The exception surfaces via asyncio's "Task exception was never retrieved" handler, so any connected socket — including one that never linked a valid token — could flood the backend logs with tracebacks at default loglevel, unsuppressable via `--loglevel`, defeating the anti-abuse hardening the handler carries.

### Fix

Default `data` to `None`. The existing `isinstance(data, dict)` guard then drops a payload-less emit at debug level exactly like any other malformed payload, so every anti-abuse guard runs first. Docstring updated to explain why the default exists; news fragment `news/+client-error-noarg.bugfix.md` added.

### Test plan

- New regression test `tests/units/test_app.py::test_client_error_no_argument_emit_is_ignored` (parametrized over known/unknown SID) simulates socketio's no-argument dispatch by calling `on_client_error(sid)` with no `data`, asserting no exception, no report through `frontend_exception_handler`, and no error/warning log records. It fails on unfixed main with the exact `TypeError` from the finding and passes with the fix.
- All 14 `client_error` tests and the full `tests/units/test_app.py` (145 tests) pass.
- `uv run ruff check .`, `uv run ruff format .`, and `uv run pyright reflex tests` (0 errors) are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMjBXPozsNeQNSBZecNH8x

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMjBXPozsNeQNSBZecNH8x)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/6984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

