### PR TITLE
Fix reflex run hanging after fatal error in the frontend thread

### DIFF
--- a/news/+node-error-hang.bugfix.md
+++ b/news/+node-error-hang.bugfix.md
@@ -1,0 +1,1 @@
+`reflex run` no longer hangs forever when a fatal error (e.g. the node minimum-version check on the npm path) exits the frontend worker thread while the backend blocks the main thread; the failure now interrupts the main thread and the CLI exits promptly with the original error.

--- a/reflex/utils/processes.py
+++ b/reflex/utils/processes.py
@@ -10,6 +10,8 @@ import signal
 import socket
 import subprocess
 import sys
+import threading
+from _thread import interrupt_main
 from collections.abc import Callable, Generator, Sequence
 from concurrent import futures
 from contextlib import closing
@@ -262,11 +264,32 @@ def new_process(
     return fn(non_empty_args, **kwargs)
 
 
+def _interrupt_main_thread():
+    """Deliver a SIGINT to the main thread to break it out of a blocking call.
+
+    A real signal is required on POSIX so the main thread's blocking C call
+    (e.g. a lock wait or a server loop) returns with EINTR and runs the SIGINT
+    handler; `interrupt_main` alone only sets a pending flag there. On Windows
+    `interrupt_main` sets the SIGINT event that blocking waits monitor.
+    """
+    if sys.platform == "win32":
+        interrupt_main()
+    else:
+        main_ident = threading.main_thread().ident
+        if main_ident is not None:
+            signal.pthread_kill(main_ident, signal.SIGINT)
+
+
 @contextlib.contextmanager
 def run_concurrently_context(
     *fns: Callable[..., Any] | tuple[Callable[..., Any], ...],
 ) -> Generator[list[futures.Future], None, None]:
     """Run functions concurrently in a thread pool.
+
+    If a function fails while the with-body is still executing, the main
+    thread is interrupted so the failure propagates promptly instead of being
+    swallowed while the body blocks (e.g. a fatal frontend preflight error
+    raising SystemExit while the backend serves on the main thread).
 
     Args:
         *fns: The functions to run.
@@ -282,20 +305,72 @@ def run_concurrently_context(
     # Convert the functions to tuples.
     fns = tuple(fn if isinstance(fn, tuple) else (fn,) for fn in fns)
 
+    in_body = True
+    interrupt_lock = threading.Lock()
+    interrupt_sent = False
+
+    def wake_main_thread(task: futures.Future):
+        """Interrupt the main thread once when a task fails during the body.
+
+        Args:
+            task: The completed future to inspect.
+        """
+        nonlocal interrupt_sent
+        if task.cancelled() or task.exception() is None:
+            return
+        if threading.current_thread() is threading.main_thread():
+            # Invoked inline on an already-failed task; the main thread is not
+            # blocked, so the pre-yield failure check below surfaces the error.
+            return
+        with interrupt_lock:
+            if in_body and not interrupt_sent:
+                interrupt_sent = True
+                _interrupt_main_thread()
+
+    def raise_first_failure(tasks: list[futures.Future]):
+        """Re-raise the first exception found among the completed tasks.
+
+        Args:
+            tasks: The futures to inspect.
+        """
+        for task in tasks:
+            if (
+                task.done()
+                and not task.cancelled()
+                and (exc := task.exception()) is not None
+            ):
+                raise exc from None
+
     # Run the functions concurrently.
     executor = None
     try:
         executor = futures.ThreadPoolExecutor(max_workers=len(fns))
         # Submit the tasks.
         tasks = [executor.submit(*fn) for fn in fns]
+        for task in tasks:
+            task.add_done_callback(wake_main_thread)
 
-        # Yield control back to the main thread while tasks are running.
-        yield tasks
+        try:
+            # Don't enter (and block in) the body if a task has already failed.
+            raise_first_failure(tasks)
 
-        # Get the results in the order completed to check any exceptions.
-        for task in futures.as_completed(tasks):
-            # if task throws something, we let it bubble up immediately
-            task.result()
+            # Yield control back to the main thread while tasks are running.
+            yield tasks
+
+            with interrupt_lock:
+                in_body = False
+
+            # Get the results in the order completed to check any exceptions.
+            for task in futures.as_completed(tasks):
+                # if task throws something, we let it bubble up immediately
+                task.result()
+        except KeyboardInterrupt:
+            # Raised by wake_main_thread for a failed task, or a real Ctrl+C;
+            # surface the task's own error when there is one.
+            with interrupt_lock:
+                in_body = False
+            raise_first_failure(tasks)
+            raise
     finally:
         # Shutdown the executor
         if executor:

--- a/tests/units/utils/test_processes.py
+++ b/tests/units/utils/test_processes.py
@@ -2,13 +2,18 @@
 
 import socket
 import threading
+import time
 from contextlib import closing
 from unittest import mock
 
 import pytest
 
 from reflex.testing import DEFAULT_TIMEOUT, AppHarness
-from reflex.utils.processes import is_process_on_port
+from reflex.utils.processes import (
+    is_process_on_port,
+    run_concurrently,
+    run_concurrently_context,
+)
 
 
 def test_is_process_on_port_free_port():
@@ -153,3 +158,48 @@ def test_is_process_on_port_concurrent_access():
     assert AppHarness._poll_for(
         lambda: shared is not None and not is_process_on_port(shared)
     )
+
+
+def _raise_system_exit():
+    """Simulate a fatal preflight error in a worker task.
+
+    Raises:
+        SystemExit: Always, mimicking a fatal CLI error path.
+    """
+    raise SystemExit(1)
+
+
+def test_run_concurrently_context_unblocks_main_thread_on_task_failure():
+    """A task raising SystemExit interrupts a blocked with-body and propagates.
+
+    Regression test for `reflex run` hanging forever when a fatal error (e.g.
+    the node version check) exits a frontend worker thread while the backend
+    blocks the main thread.
+    """
+    block = threading.Event()
+    start = time.monotonic()
+
+    with pytest.raises(SystemExit), run_concurrently_context(_raise_system_exit):
+        # Simulate the backend blocking the main thread (e.g. granian serve()).
+        block.wait(timeout=10)
+
+    assert time.monotonic() - start < 5, (
+        "task failure did not interrupt the blocked main thread"
+    )
+
+
+def test_run_concurrently_context_reraises_real_keyboard_interrupt():
+    """A KeyboardInterrupt in the with-body propagates when no task failed."""
+    with pytest.raises(KeyboardInterrupt), run_concurrently_context(lambda: None):
+        raise KeyboardInterrupt
+
+
+def test_run_concurrently_propagates_task_exception():
+    """An exception raised by a task propagates out of run_concurrently."""
+
+    def _fail():
+        msg = "boom"
+        raise RuntimeError(msg)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        run_concurrently(_fail)


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

## Defect

FINDING-011 (MEDIUM) from the 0.9.9a1 pre-release testing round: `reflex run` hangs indefinitely after a fatal node-version error on the npm path. With an outdated node first on `PATH` and `REFLEX_USE_NPM=1`, `js_runtimes.validate_frontend_dependencies` correctly prints "Reflex requires node version 22.22.0 or higher..." and raises `SystemExit(1)` — but that happens inside the `run_frontend` task submitted to a `ThreadPoolExecutor` by `processes.run_concurrently_context`. The `SystemExit` only kills the worker thread: the futures are checked after the with-body, and in dev mode the main thread blocks forever serving the backend (granian `serve()`), so the error is swallowed and the process never exits (it kept the backend serving with no frontend until killed by timeout). The same swallowing applies to any fatal error raised by an executor task consumed through this helper.

## Fix

`run_concurrently_context` now surfaces task failures to the main thread:

- A done-callback on each future interrupts the main thread when a task fails while the with-body is executing. On POSIX this must be a real signal (`signal.pthread_kill(main_thread, SIGINT)`) so a blocking C call (lock wait, server loop) returns with `EINTR` and runs the SIGINT handler — `_thread.interrupt_main()` only sets a pending flag there and never wakes a blocked main thread. On Windows `interrupt_main()` is the right mechanism (it sets the SIGINT event that blocking waits monitor).
- The delivered SIGINT either triggers the backend server's own graceful-shutdown handler (granian/uvicorn), letting the existing post-body `as_completed` check re-raise the task's exception, or raises `KeyboardInterrupt` in the body, which the context manager now catches and converts back into the failed task's own exception. A genuine Ctrl+C with no failed task propagates unchanged.
- A task that already failed before the body starts is re-raised up front so the main thread never enters (and blocks in) the body; only one interrupt is ever sent per context, and no interrupt is sent once the body has finished, so `run_concurrently` (empty body) keeps its existing error semantics.

## Test plan

- New regression test `tests/units/utils/test_processes.py::test_run_concurrently_context_unblocks_main_thread_on_task_failure`: a task raising `SystemExit` while the with-body blocks on an `Event.wait(timeout=10)` must propagate promptly. Against unfixed main it fails (the body blocks the full 10s before the error surfaces — the unit-scale version of the infinite hang); with the fix it passes in milliseconds. Two companion tests cover genuine `KeyboardInterrupt` passthrough and `run_concurrently` exception propagation.
- 300-iteration in-process stress of the failure path (instant and delayed task failure, blocked body, and the empty-body `run_concurrently` path): no hang, no escaped `KeyboardInterrupt`.
- End-to-end repro from the finding: fresh blank app, fake `node` shim printing `v22.12.0`, `REFLEX_USE_NPM=1 reflex run` — unfixed main runs until killed (`timeout` exit 124 after 90s); with the fix the process prints the node version error, "Reflex app stopped.", and exits code 1 in ~5s.
- `uv run ruff check .` and `uv run ruff format .` clean; `uv run pyright reflex tests` 0 errors; `uv run pytest tests/units/utils` passes (629 passed; the only 2 failures are pre-existing on clean main in this sandbox, which lacks IPv6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMjBXPozsNeQNSBZecNH8x

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMjBXPozsNeQNSBZecNH8x)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/6990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

