### PR TITLE
Pin PYTHONHASHSEED in the benchmark workflow

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -16,6 +16,9 @@ env:
   NODE_OPTIONS: "--max_old_space_size=8192"
   APP_HARNESS_HEADLESS: 1
   PYTHONUNBUFFERED: 1
+  # Randomized string hashing shifts dict probe sequences run to run, which the
+  # instrumented benchmarks can pick up as drift unrelated to the code change.
+  PYTHONHASHSEED: 0
 
 jobs:
   benchmarks:


### PR DESCRIPTION
Python randomizes string hashing per process, so dict probe sequences differ between two runs of the same code. The instrumented benchmarks are sensitive enough to pick that up as a few percent of drift on a commit that never touched the measured code path, which makes real regressions harder to spot.

Pinning `PYTHONHASHSEED: 0` for the workflow removes that source of run-to-run variation.

CodSpeed doesn't call out `PYTHONHASHSEED` specifically, but this is the same idea as their [Keep Benchmarks Deterministic](https://codspeed.io/docs/guides/how-to-benchmark-python-code#keep-benchmarks-deterministic) guidance, applied to the interpreter rather than to the benchmark body. Their write-up on [unrelated benchmark regressions](https://codspeed.io/blog/unrelated-benchmark-regression) covers the wider class of environment-driven drift this belongs to.

Only the workflow env changes; no package source is touched.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/6993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

