### PR TITLE
Clear fatal-error interrupt window unconditionally on body exit

### DIFF
--- a/news/+interrupt-window-followup.bugfix.md
+++ b/news/+interrupt-window-followup.bugfix.md
@@ -1,0 +1,1 @@
+Fixed an edge in the new fatal-error interrupt handling where a task failing after the with-body raised its own exception could deliver a stray SIGINT to unrelated caller code.

--- a/reflex/utils/processes.py
+++ b/reflex/utils/processes.py
@@ -354,11 +354,14 @@ def run_concurrently_context(
             # Don't enter (and block in) the body if a task has already failed.
             raise_first_failure(tasks)
 
-            # Yield control back to the main thread while tasks are running.
-            yield tasks
-
-            with interrupt_lock:
-                in_body = False
+            try:
+                # Yield control back to the main thread while tasks are running.
+                yield tasks
+            finally:
+                # However the body exits, stop interrupting the main thread:
+                # tasks outlive this context (shutdown below does not wait).
+                with interrupt_lock:
+                    in_body = False
 
             # Get the results in the order completed to check any exceptions.
             for task in futures.as_completed(tasks):
@@ -367,8 +370,6 @@ def run_concurrently_context(
         except KeyboardInterrupt:
             # Raised by wake_main_thread for a failed task, or a real Ctrl+C;
             # surface the task's own error when there is one.
-            with interrupt_lock:
-                in_body = False
             raise_first_failure(tasks)
             raise
     finally:

--- a/reflex/utils/processes.py
+++ b/reflex/utils/processes.py
@@ -351,15 +351,17 @@ def run_concurrently_context(
             task.add_done_callback(wake_main_thread)
 
         try:
-            # Don't enter (and block in) the body if a task has already failed.
-            raise_first_failure(tasks)
-
             try:
+                # Don't enter (and block in) the body if a task has already
+                # failed.
+                raise_first_failure(tasks)
+
                 # Yield control back to the main thread while tasks are running.
                 yield tasks
             finally:
-                # However the body exits, stop interrupting the main thread:
-                # tasks outlive this context (shutdown below does not wait).
+                # Whether the pre-check or the body raised, stop interrupting
+                # the main thread: tasks outlive this context (shutdown below
+                # does not wait).
                 with interrupt_lock:
                     in_body = False
 

--- a/tests/units/utils/test_processes.py
+++ b/tests/units/utils/test_processes.py
@@ -183,6 +183,8 @@ def test_run_concurrently_context_unblocks_main_thread_on_task_failure():
         # Simulate the backend blocking the main thread (e.g. granian serve()).
         block.wait(timeout=10)
 
+    # The failed task must interrupt the main thread well before the body's
+    # own 10s wait expires; 5 seconds leaves headroom on slow CI runners.
     assert time.monotonic() - start < 5, (
         "task failure did not interrupt the blocked main thread"
     )
@@ -203,3 +205,26 @@ def test_run_concurrently_propagates_task_exception():
 
     with pytest.raises(RuntimeError, match="boom"):
         run_concurrently(_fail)
+
+
+def test_run_concurrently_context_no_interrupt_after_body_exception():
+    """A task failing after the body raised must not interrupt the caller.
+
+    The executor is shut down without waiting, so a task can fail after the
+    context has unwound; the caller's own exception must propagate untouched
+    instead of a stray KeyboardInterrupt landing in unrelated code.
+    """
+
+    def _fail_late():
+        time.sleep(0.3)
+        raise SystemExit(1)
+
+    with (
+        pytest.raises(ValueError, match="body failed"),
+        run_concurrently_context(_fail_late),
+    ):
+        msg = "body failed"
+        raise ValueError(msg)
+    # Give the late-failing task time to finish; a stale interrupt would
+    # surface as KeyboardInterrupt here and fail this test.
+    time.sleep(0.6)

--- a/tests/units/utils/test_processes.py
+++ b/tests/units/utils/test_processes.py
@@ -241,3 +241,42 @@ def test_run_concurrently_context_no_interrupt_after_body_exception():
     # give signal delivery a moment so it would surface as KeyboardInterrupt
     # here (delivery latency is microseconds; 0.1s is generous headroom).
     time.sleep(0.1)
+
+
+def test_run_concurrently_context_no_interrupt_after_pre_body_failure():
+    """A failure racing context entry must not leave the interrupt armed.
+
+    With one task already failed and another still running, the pre-body
+    failure check can raise before the body is ever entered; the surviving
+    task's later failure must not interrupt the caller after the context has
+    unwound. When the fast failure instead loses the race to context entry,
+    the body path exercises the same invariant, so both orderings assert
+    identically.
+    """
+    task_may_fail = threading.Event()
+    late_finished = threading.Event()
+
+    def _fail_fast():
+        raise SystemExit(2)
+
+    def _fail_on_release():
+        try:
+            task_may_fail.wait(timeout=DEFAULT_TIMEOUT)
+            raise SystemExit(3)
+        finally:
+            late_finished.set()
+
+    with (
+        pytest.raises(SystemExit),
+        run_concurrently_context(_fail_fast, _fail_on_release),
+    ):
+        # Reached only when the fast failure loses the race to context entry;
+        # its interrupt then surfaces here and converts to the task's error.
+        task_may_fail.wait(timeout=DEFAULT_TIMEOUT)
+
+    # The context has unwound; only now may the surviving task fail.
+    task_may_fail.set()
+    assert late_finished.wait(timeout=DEFAULT_TIMEOUT), "task did not finish"
+    # The interrupt callback runs within microseconds of the task finishing;
+    # a stale interrupt would surface as KeyboardInterrupt in this window.
+    time.sleep(0.1)

--- a/tests/units/utils/test_processes.py
+++ b/tests/units/utils/test_processes.py
@@ -214,17 +214,30 @@ def test_run_concurrently_context_no_interrupt_after_body_exception():
     context has unwound; the caller's own exception must propagate untouched
     instead of a stray KeyboardInterrupt landing in unrelated code.
     """
+    task_may_fail = threading.Event()
+    interrupt_callback_ran = threading.Event()
 
-    def _fail_late():
-        time.sleep(0.3)
+    def _fail_on_release():
+        # Hold the failure until the context has fully unwound below.
+        task_may_fail.wait(timeout=DEFAULT_TIMEOUT)
         raise SystemExit(1)
 
     with (
         pytest.raises(ValueError, match="body failed"),
-        run_concurrently_context(_fail_late),
+        run_concurrently_context(_fail_on_release) as tasks,
     ):
+        # Done callbacks run in registration order, so this fires strictly
+        # after the context's own interrupt callback has run for the task.
+        tasks[0].add_done_callback(lambda _t: interrupt_callback_ran.set())
         msg = "body failed"
         raise ValueError(msg)
-    # Give the late-failing task time to finish; a stale interrupt would
-    # surface as KeyboardInterrupt here and fail this test.
-    time.sleep(0.6)
+
+    # The context has unwound (in_body cleared); only now may the task fail.
+    task_may_fail.set()
+    assert interrupt_callback_ran.wait(timeout=DEFAULT_TIMEOUT), (
+        "worker task did not finish"
+    )
+    # A stale interrupt would already have been sent by the callback above;
+    # give signal delivery a moment so it would surface as KeyboardInterrupt
+    # here (delivery latency is microseconds; 0.1s is generous headroom).
+    time.sleep(0.1)


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### Description

Follow-up to #6990 (merged while this review round was in flight), addressing the two review threads that were still open there:

1. **cubic's finding is valid**: `run_concurrently_context` cleared `in_body` only on the normal post-body path and in the `KeyboardInterrupt` handler. If the with-body raises any other exception, `in_body` stays `True` — and since the executor shuts down with `wait=False`, a task failing after the context has unwound could still deliver a stray SIGINT into unrelated caller code. The fix wraps the `yield` in a `try/finally` that clears `in_body` however the body exits, replacing the two scattered clears — a net simplification of the mechanism, not an addition (per the review discussion, no extra guarded setup path).
2. **greptile's nit**: the hang regression test's bare `5`-second assertion threshold now carries a comment explaining its relationship to the body's 10s wait.

Adds `test_run_concurrently_context_no_interrupt_after_body_exception`, which pins the escaped-interrupt case (late-failing task + body exception → the body's own `ValueError` propagates, no stray `KeyboardInterrupt`).

### Test Plan

- `uv run pytest tests/units/utils/test_processes.py -k run_concurrently`: 4 passed (the new test plus the three from #6990).
- `uv run ruff check` / `ruff format --check` clean on changed files; `uv run pyright` 0 errors on changed files.
- `reflex-release changelog-check --base-ref origin/main` passes.
- The two `test_is_process_on_port_*` failures in this sandbox are pre-existing on clean main here (container network stack), unrelated to the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EMjBXPozsNeQNSBZecNH8x

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMjBXPozsNeQNSBZecNH8x)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/6994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

