### PR TITLE
Serve SPA fallback with 200 for routable paths in prod static serving

### DIFF
--- a/news/6996.bugfix.md
+++ b/news/6996.bugfix.md
@@ -1,0 +1,1 @@
+Serve valid dynamic-route URLs (e.g. `/articles/7`) with HTTP 200 instead of 404 when loaded directly in self-hosted prod static serving, reserving 404 for genuinely unknown paths.

--- a/packages/reflex-base/news/6996.bugfix.md
+++ b/packages/reflex-base/news/6996.bugfix.md
@@ -1,0 +1,1 @@
+Add the `routes.json` manifest name constant, written at compile time so the prod static file server can tell routable SPA paths from unknown ones.

--- a/packages/reflex-base/src/reflex_base/constants/base.py
+++ b/packages/reflex-base/src/reflex_base/constants/base.py
@@ -58,6 +58,9 @@ class Dirs(SimpleNamespace):
     ENV_JSON = "env.json"
     # The name of the reflex json file.
     REFLEX_JSON = "reflex.json"
+    # JSON-encoded list of the app's page routes, written at compile time so the
+    # prod static file server can tell routable SPA paths from unknown ones.
+    ROUTES_MANIFEST = "routes.json"
     # The name of the postcss config file.
     POSTCSS_JS = "postcss.config.js"
     # The name of the states directory.

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -786,7 +786,7 @@ class App(MiddlewareMixin, LifespanMixin):
         if environment.REFLEX_MOUNT_FRONTEND_COMPILED_APP.get():
             from reflex.utils.exec import get_frontend_mount
 
-            asgi_app.routes.append(get_frontend_mount())
+            asgi_app.routes.append(get_frontend_mount(router=self.router))
 
         if self.api_transformer is not None:
             api_transformers: Sequence[Starlette | Callable[[ASGIApp], ASGIApp]] = (
@@ -1314,6 +1314,15 @@ class App(MiddlewareMixin, LifespanMixin):
         if save_page:
             self._pages[route] = component
 
+    @property
+    def _page_routes(self) -> list[str]:
+        """Get all registered page routes in registration order.
+
+        Returns:
+            The deduplicated list of page routes.
+        """
+        return list(dict.fromkeys([*self._unevaluated_pages, *self._pages]))
+
     @functools.cached_property
     def router(self) -> Callable[[str], str | None]:
         """The route computer function.
@@ -1323,7 +1332,7 @@ class App(MiddlewareMixin, LifespanMixin):
         """
         from reflex.route import get_router
 
-        return get_router(list(dict.fromkeys([*self._unevaluated_pages, *self._pages])))
+        return get_router(self._page_routes)
 
     def get_load_events(self, path: str) -> list[IndividualEventType[()]]:
         """Get the load events for a route.

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -1316,7 +1316,7 @@ class App(MiddlewareMixin, LifespanMixin):
 
     @property
     def _page_routes(self) -> list[str]:
-        """Get all registered page routes in registration order.
+        """All registered page routes in registration order.
 
         Returns:
             The deduplicated list of page routes.

--- a/reflex/compiler/compiler.py
+++ b/reflex/compiler/compiler.py
@@ -1418,6 +1418,13 @@ def compile_app(
         prerender_routes=prerender_routes,
     )
 
+    # Persist the route table so the standalone prod static server can serve
+    # routable SPA paths with 200 and reserve 404 for unknown ones.
+    compile_results.append((
+        constants.Dirs.ROUTES_MANIFEST,
+        json.dumps(app._page_routes),
+    ))
+
     if is_prod_mode():
         purge_web_pages_dir()
     else:

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import functools
 import hashlib
 import importlib.util
 import json
@@ -12,7 +13,7 @@ import platform
 import re
 import subprocess
 import sys
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Any, NamedTuple, TypedDict
 
@@ -340,8 +341,44 @@ def notify_app_running():
     console.rule("[bold green]App Running")
 
 
-def get_frontend_mount():
+def _match_with_frontend_path(
+    router: Callable[[str], str | None], path: str
+) -> str | None:
+    """Match a mount-relative path against a route matcher expecting the frontend path.
+
+    Args:
+        router: The app route matcher.
+        path: The request path with the frontend path prefix already stripped.
+
+    Returns:
+        The matching route, or None if no route matches.
+    """
+    return router(get_config().prepend_frontend_path(path))
+
+
+def get_routes_manifest_router() -> Callable[[str], str | None] | None:
+    """Build a route matcher from the routes manifest written at compile time.
+
+    Returns:
+        A route matcher, or None when no manifest exists.
+    """
+    from reflex.route import get_router
+
+    manifest = get_web_dir() / constants.Dirs.ROUTES_MANIFEST
+    try:
+        routes = json.loads(manifest.read_text())
+    except (OSError, ValueError):
+        return None
+    return get_router(routes)
+
+
+def get_frontend_mount(router: Callable[[str], str | None] | None = None):
     """Get a Starlette Mount for the compiled frontend static files.
+
+    Args:
+        router: Optional route matcher (e.g. ``app.router``) used to serve
+            routable SPA paths with status 200 instead of 404. When None, a
+            matcher is built from the compiled routes manifest if present.
 
     Returns:
         A Mount serving the compiled frontend static files.
@@ -352,6 +389,13 @@ def get_frontend_mount():
     from reflex.utils.precompressed_staticfiles import PrecompressedStaticFiles
 
     config = get_config()
+
+    if router is None:
+        router = get_routes_manifest_router()
+    if router is not None and config.frontend_path:
+        # The mount strips the frontend path from request paths, but the route
+        # matcher expects it present (it strips the prefix itself).
+        router = functools.partial(_match_with_frontend_path, router)
 
     static_dir = (
         prerequisites.get_web_dir()
@@ -365,6 +409,7 @@ def get_frontend_mount():
             directory=static_dir,
             html=True,
             encodings=config.frontend_compression_formats,
+            router=router,
         ),
         name="frontend",
     )

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -341,6 +341,24 @@ def notify_app_running():
     console.rule("[bold green]App Running")
 
 
+def _match_routable_page(router: Callable[[str], str | None], path: str) -> str | None:
+    """Match a path against the app routes, treating the 404 page as unroutable.
+
+    The compiler registers a synthetic ``404`` page, so a literal ``/404``
+    request would otherwise count as routable and lose its 404 status.
+
+    Args:
+        router: The app route matcher.
+        path: The request path.
+
+    Returns:
+        The matching route, or None when the path matches no route or only the
+        404 page.
+    """
+    route = router(path)
+    return route if route != constants.Page404.SLUG else None
+
+
 def _match_with_frontend_path(
     router: Callable[[str], str | None], path: str
 ) -> str | None:
@@ -392,10 +410,12 @@ def get_frontend_mount(router: Callable[[str], str | None] | None = None):
 
     if router is None:
         router = get_routes_manifest_router()
-    if router is not None and config.frontend_path:
-        # The mount strips the frontend path from request paths, but the route
-        # matcher expects it present (it strips the prefix itself).
-        router = functools.partial(_match_with_frontend_path, router)
+    if router is not None:
+        router = functools.partial(_match_routable_page, router)
+        if config.frontend_path:
+            # The mount strips the frontend path from request paths, but the
+            # route matcher expects it present (it strips the prefix itself).
+            router = functools.partial(_match_with_frontend_path, router)
 
     static_dir = (
         prerequisites.get_web_dir()

--- a/reflex/utils/precompressed_staticfiles.py
+++ b/reflex/utils/precompressed_staticfiles.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 import stat
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from functools import lru_cache
 from mimetypes import guess_type
@@ -72,6 +72,7 @@ class PrecompressedStaticFiles(StaticFiles):
         self,
         *args,
         encodings: Sequence[str] = (),
+        router: Callable[[str], str | None] | None = None,
         **kwargs,
     ):
         """Initialize the static file server.
@@ -79,10 +80,15 @@ class PrecompressedStaticFiles(StaticFiles):
         Args:
             *args: Passed through to ``StaticFiles``.
             encodings: Ordered list of supported precompressed formats.
+            router: Optional route matcher taking the request path (with leading
+                slash) and returning the matching app route, or ``None``. Paths
+                with no on-disk file that match a route are served the SPA
+                fallback with status 200 instead of 404.
             **kwargs: Passed through to ``StaticFiles``.
         """
         super().__init__(*args, **kwargs)
         self._encodings = tuple(_SUPPORTED_ENCODINGS[name] for name in encodings)
+        self._router = router
 
     def _select_sidecar(
         self, full_path: str | PathLike[str], scope: Scope
@@ -178,16 +184,24 @@ class PrecompressedStaticFiles(StaticFiles):
             The resolved static response for the request.
         """
         response = await super().get_response(path, scope)
-        # Starlette's get_response builds the 404.html fallback with bare FileResponse,
-        # bypassing file_response. Re-route it so the sidecar/Vary handling applies.
         if (
-            self._encodings
-            and self.html
+            self.html
             and isinstance(response, FileResponse)
             and response.status_code == 404
             and response.stat_result is not None
         ):
-            return self.file_response(
-                response.path, response.stat_result, scope, status_code=404
-            )
+            # SPA fallback: a path with no prerendered file that still matches
+            # the app's route table is a valid page, so serve it with 200 and
+            # reserve 404 for genuinely unknown paths.
+            if self._router is not None and self._router("/" + path) is not None:
+                return self.file_response(
+                    response.path, response.stat_result, scope, status_code=200
+                )
+            # Starlette's get_response builds the 404.html fallback with bare
+            # FileResponse, bypassing file_response. Re-route it so the
+            # sidecar/Vary handling applies.
+            if self._encodings:
+                return self.file_response(
+                    response.path, response.stat_result, scope, status_code=404
+                )
         return response

--- a/tests/integration/test_precompressed_frontend.py
+++ b/tests/integration/test_precompressed_frontend.py
@@ -31,6 +31,11 @@ def PrecompressedFrontendApp():
             rx.text("Hello from Reflex"),
         )
 
+    def article():
+        return rx.el.main(rx.heading("Article"))
+
+    app.add_page(article, route="articles/[id]")
+
 
 @pytest.fixture(scope="module")
 def all_compression_formats_env() -> Generator[None, None, None]:
@@ -114,3 +119,25 @@ def test_prod_frontend_serves_precompressed_404_fallback(
     assert headers["content-encoding"] == accept_encoding
     if magic is not None:
         assert body[: len(magic)] == magic
+
+
+@pytest.mark.parametrize("accept_encoding", ["identity", "gzip"])
+def test_prod_frontend_serves_dynamic_route_with_200(
+    prod_test_app: AppHarnessProd,
+    accept_encoding: str,
+):
+    """Direct loads of valid dynamic-route URLs get the SPA fallback with 200."""
+    assert prod_test_app.frontend_url is not None
+
+    status, headers, body = request_raw(
+        prod_test_app.frontend_url,
+        "/articles/7",
+        headers={"Accept-Encoding": accept_encoding},
+    )
+
+    assert status == 200
+    if accept_encoding == "gzip":
+        assert headers["content-encoding"] == "gzip"
+        assert body[:2] == b"\x1f\x8b"
+    else:
+        assert b"<html" in body.lower()

--- a/tests/units/test_app.py
+++ b/tests/units/test_app.py
@@ -261,6 +261,19 @@ def test_add_page_default_route(
     assert app._pages.keys() == {"index", "about"}
 
 
+def test_page_routes(app: App, index_page: ComponentCallable):
+    """Test that _page_routes lists registered routes without duplicates.
+
+    Args:
+        app: The app to test.
+        index_page: The index page.
+    """
+    app.add_page(index_page)
+    app.add_page(index_page, route="articles")
+    app._compile_page("index")
+    assert app._page_routes == ["index", "articles"]
+
+
 def test_add_page_set_route(app: App, index_page: ComponentCallable):
     """Test adding a page to an app.
 

--- a/tests/units/utils/test_exec.py
+++ b/tests/units/utils/test_exec.py
@@ -127,6 +127,15 @@ def test_get_routes_manifest_router_missing_manifest(
     assert exec_utils.get_routes_manifest_router() is None
 
 
+def test_get_routes_manifest_router_invalid_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Return None when the routes manifest is not valid JSON."""
+    monkeypatch.setenv(environment.REFLEX_WEB_WORKDIR.name, str(tmp_path))
+    (tmp_path / "routes.json").write_text("not valid json{")
+    assert exec_utils.get_routes_manifest_router() is None
+
+
 def test_get_routes_manifest_router_matches_dynamic_routes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):

--- a/tests/units/utils/test_exec.py
+++ b/tests/units/utils/test_exec.py
@@ -8,6 +8,7 @@ from pytest_mock import MockerFixture
 from reflex_base.environment import environment
 
 from reflex.utils import exec as exec_utils
+from reflex.utils.precompressed_staticfiles import PrecompressedStaticFiles
 
 DEV_BACKEND_RELOAD_ENV_NAME = environment.REFLEX_DEV_BACKEND_RELOAD_ACTIVE.name
 
@@ -116,3 +117,69 @@ def test_arbitrate_ssr_env_var_wins(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv(environment.REFLEX_SSR.name, "False")
 
     assert exec_utils.arbitrate_ssr(True) is False
+
+
+def test_get_routes_manifest_router_missing_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Return None when no routes manifest has been written."""
+    monkeypatch.setenv(environment.REFLEX_WEB_WORKDIR.name, str(tmp_path))
+    assert exec_utils.get_routes_manifest_router() is None
+
+
+def test_get_routes_manifest_router_matches_dynamic_routes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Build a matcher from the manifest that resolves dynamic routes."""
+    monkeypatch.setenv(environment.REFLEX_WEB_WORKDIR.name, str(tmp_path))
+    (tmp_path / "routes.json").write_text(
+        '["index", "articles/[id]", "posts/[[...splat]]", "404"]'
+    )
+
+    router = exec_utils.get_routes_manifest_router()
+
+    assert router is not None
+    assert router("/") == "index"
+    assert router("/articles/7") == "articles/[id]"
+    assert router("/posts/a/b") == "posts/[[...splat]]"
+    assert router("/definitely-not-a-page") is None
+
+
+def test_get_frontend_mount_builds_router_from_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """The frontend mount picks up the routes manifest when no router is given."""
+    monkeypatch.setenv(environment.REFLEX_WEB_WORKDIR.name, str(tmp_path))
+    (tmp_path / "build" / "client").mkdir(parents=True)
+    (tmp_path / "routes.json").write_text('["index", "articles/[id]"]')
+
+    mount = exec_utils.get_frontend_mount()
+
+    static_files = mount.app
+    assert isinstance(static_files, PrecompressedStaticFiles)
+    router = static_files._router
+    assert router is not None
+    assert router("/articles/7") == "articles/[id]"
+    assert router("/missing") is None
+
+
+def test_get_frontend_mount_router_respects_frontend_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """The mount-relative path is matched with the frontend path restored."""
+    from reflex_base.config import get_config
+
+    monkeypatch.setenv(environment.REFLEX_WEB_WORKDIR.name, str(tmp_path))
+    monkeypatch.setattr(get_config(), "frontend_path", "/sub")
+    (tmp_path / "build" / "client" / "sub").mkdir(parents=True)
+    (tmp_path / "routes.json").write_text('["index", "articles/[id]"]')
+
+    mount = exec_utils.get_frontend_mount()
+
+    static_files = mount.app
+    assert isinstance(static_files, PrecompressedStaticFiles)
+    router = static_files._router
+    assert router is not None
+    assert router("/articles/7") == "articles/[id]"
+    assert router("/") == "index"
+    assert router("/missing") is None

--- a/tests/units/utils/test_exec.py
+++ b/tests/units/utils/test_exec.py
@@ -183,3 +183,43 @@ def test_get_frontend_mount_router_respects_frontend_path(
     assert router("/articles/7") == "articles/[id]"
     assert router("/") == "index"
     assert router("/missing") is None
+
+
+def test_get_frontend_mount_router_excludes_synthetic_404_route(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A literal /404 request stays a 404 despite the compiled 404 page route."""
+    monkeypatch.setenv(environment.REFLEX_WEB_WORKDIR.name, str(tmp_path))
+    (tmp_path / "build" / "client").mkdir(parents=True)
+    (tmp_path / "routes.json").write_text('["index", "articles/[id]", "404"]')
+
+    mount = exec_utils.get_frontend_mount()
+
+    static_files = mount.app
+    assert isinstance(static_files, PrecompressedStaticFiles)
+    router = static_files._router
+    assert router is not None
+    assert router("/404") is None
+    assert router("/404/") is None
+    assert router("/articles/7") == "articles/[id]"
+
+
+def test_get_frontend_mount_explicit_router_excludes_synthetic_404_route(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """An explicitly passed app router is also filtered for the 404 page route."""
+    from reflex.route import get_router
+
+    monkeypatch.setenv(environment.REFLEX_WEB_WORKDIR.name, str(tmp_path))
+    (tmp_path / "build" / "client").mkdir(parents=True)
+
+    mount = exec_utils.get_frontend_mount(
+        router=get_router(["index", "articles/[id]", "404"])
+    )
+
+    static_files = mount.app
+    assert isinstance(static_files, PrecompressedStaticFiles)
+    router = static_files._router
+    assert router is not None
+    assert router("/404") is None
+    assert router("/articles/7") == "articles/[id]"

--- a/tests/units/utils/test_precompressed_staticfiles.py
+++ b/tests/units/utils/test_precompressed_staticfiles.py
@@ -96,6 +96,125 @@ async def test_precompressed_static_files_supports_html_404_fallback(tmp_path: P
     assert await _collect_body(response, scope) == b"compressed-404"
 
 
+def _articles_router(path: str) -> str | None:
+    return "articles/[id]" if path.startswith("/articles/") else None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("encodings", [[], ["gzip"]], ids=["identity", "gzip"])
+async def test_routable_spa_fallback_served_with_200(
+    tmp_path: Path, encodings: list[str]
+):
+    """Serve the SPA fallback with 200 for paths that match the route table."""
+    (tmp_path / "404.html").write_text("<html>spa-fallback</html>")
+
+    static_files = PrecompressedStaticFiles(
+        directory=tmp_path,
+        html=True,
+        encodings=encodings,
+        router=_articles_router,
+    )
+
+    scope = _scope("/articles/7")
+    response = await static_files.get_response("articles/7", scope)
+
+    assert isinstance(response, FileResponse)
+    assert response.status_code == 200
+    assert str(response.path).endswith("404.html")
+    assert response.media_type == "text/html"
+    assert await _collect_body(response, scope) == b"<html>spa-fallback</html>"
+
+
+@pytest.mark.asyncio
+async def test_routable_spa_fallback_serves_precompressed_sidecar(tmp_path: Path):
+    """Serve the precompressed fallback sidecar with 200 for routable paths."""
+    (tmp_path / "404.html").write_text("<html>spa-fallback</html>")
+    (tmp_path / "404.html.gz").write_bytes(b"compressed-fallback")
+
+    static_files = PrecompressedStaticFiles(
+        directory=tmp_path,
+        html=True,
+        encodings=["gzip"],
+        router=_articles_router,
+    )
+
+    scope = _scope("/articles/7", "gzip")
+    response = await static_files.get_response("articles/7", scope)
+
+    assert isinstance(response, FileResponse)
+    assert response.status_code == 200
+    assert str(response.path).endswith("404.html.gz")
+    assert response.headers["content-encoding"] == "gzip"
+    assert await _collect_body(response, scope) == b"compressed-fallback"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("encodings", [[], ["gzip"]], ids=["identity", "gzip"])
+async def test_unroutable_spa_fallback_kept_as_404(
+    tmp_path: Path, encodings: list[str]
+):
+    """Keep serving 404 for fallback paths that match no route."""
+    (tmp_path / "404.html").write_text("<html>spa-fallback</html>")
+
+    static_files = PrecompressedStaticFiles(
+        directory=tmp_path,
+        html=True,
+        encodings=encodings,
+        router=_articles_router,
+    )
+
+    scope = _scope("/definitely-not-a-page")
+    response = await static_files.get_response("definitely-not-a-page", scope)
+
+    assert isinstance(response, FileResponse)
+    assert response.status_code == 404
+    assert await _collect_body(response, scope) == b"<html>spa-fallback</html>"
+
+
+@pytest.mark.asyncio
+async def test_missing_file_with_extension_matching_route_serves_fallback_200(
+    tmp_path: Path,
+):
+    """A routable path is routable even when it looks like a file name."""
+    (tmp_path / "404.html").write_text("<html>spa-fallback</html>")
+
+    static_files = PrecompressedStaticFiles(
+        directory=tmp_path,
+        html=True,
+        encodings=[],
+        router=_articles_router,
+    )
+
+    response = await static_files.get_response(
+        "articles/report.pdf", _scope("/articles/report.pdf")
+    )
+
+    assert isinstance(response, FileResponse)
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_existing_file_not_rerouted_by_router(tmp_path: Path):
+    """Real files are served directly even when their path matches a route."""
+    (tmp_path / "articles").mkdir()
+    (tmp_path / "articles" / "7").write_text("real-file")
+
+    static_files = PrecompressedStaticFiles(
+        directory=tmp_path,
+        html=True,
+        encodings=[],
+        router=_articles_router,
+    )
+
+    scope = _scope("/articles/7")
+    response = await static_files.get_response("articles/7", scope)
+
+    assert isinstance(response, FileResponse)
+    assert response.status_code == 200
+    assert str(response.path).endswith("7")
+    assert await _collect_body(response, scope) == b"real-file"
+
+
 @pytest.mark.asyncio
 async def test_precompressed_static_files_prefers_best_accept_encoding(
     tmp_path: Path,

--- a/tests/units/utils/test_precompressed_staticfiles.py
+++ b/tests/units/utils/test_precompressed_staticfiles.py
@@ -97,6 +97,14 @@ async def test_precompressed_static_files_supports_html_404_fallback(tmp_path: P
 
 
 def _articles_router(path: str) -> str | None:
+    """Match paths belonging to the dynamic articles route.
+
+    Args:
+        path: The request path with leading slash.
+
+    Returns:
+        The articles route for paths under ``/articles/``, otherwise None.
+    """
     return "articles/[id]" if path.startswith("/articles/") else None
 
 
@@ -122,6 +130,10 @@ async def test_routable_spa_fallback_served_with_200(
     assert response.status_code == 200
     assert str(response.path).endswith("404.html")
     assert response.media_type == "text/html"
+    if encodings:
+        assert response.headers["vary"] == "Accept-Encoding"
+    else:
+        assert "vary" not in response.headers
     assert await _collect_body(response, scope) == b"<html>spa-fallback</html>"
 
 
@@ -145,6 +157,7 @@ async def test_routable_spa_fallback_serves_precompressed_sidecar(tmp_path: Path
     assert response.status_code == 200
     assert str(response.path).endswith("404.html.gz")
     assert response.headers["content-encoding"] == "gzip"
+    assert response.headers["vary"] == "Accept-Encoding"
     assert await _collect_body(response, scope) == b"compressed-fallback"
 
 


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

In self-hosted prod (`reflex run --env prod`), a direct load of a valid dynamic-route
URL (e.g. `/articles/7`) returned HTTP 404 with the SPA-fallback body, making valid
dynamic URLs indistinguishable from genuinely unknown paths — bad for SEO, uptime
monitors, and anything trusting status codes.

`PrecompressedStaticFiles` now accepts a route matcher: when Starlette's html-mode
`404.html` fallback is hit for a path that matches the app's route table, it is served
with status 200; unroutable paths keep the 404 status. The backend-mounted frontend
passes `app.router` directly; for the standalone prod static server (frontend-only
mode), the compiler persists the route table to `.web/routes.json` at compile time and
the mount builds a matcher from it, falling back to the previous behavior when no
manifest exists (the manifest lives outside `build/client`, so it is not publicly
served). Configured `frontend_path` prefixes are restored before matching since the
mount strips them from request paths.

Covered by new unit tests (routable → 200 incl. precompressed sidecars, unknown → 404,
real files unaffected, manifest loading, `frontend_path` handling) and an extended
`tests/integration/test_precompressed_frontend.py` with an `articles/[id]` page.

closes #6983

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/6996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

