### PR TITLE
Update reflex-base dependency version to 0.9.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   "starlette >=1.3.1",
   "typing_extensions >=4.13.0",
   "wrapt >=1.17.0,<2.2",
-  "reflex-base >= 0.9.8",
+  "reflex-base >= 0.9.9",
   "reflex-components-code >= 0.9.0",
   "reflex-components-core >= 0.9.6",
   "reflex-components-dataeditor >= 0.9.0",
@@ -45,10 +45,6 @@ dependencies = [
   "reflex-components-react-player >= 0.9.0",
   "reflex-components-recharts >= 0.9.0",
   "reflex-components-sonner >= 0.9.0",
-  # `reflex deploy` now lives in reflex_cli.v2.deploy, which older releases do
-  # not carry. Until the release that adds it ships, this is the workspace
-  # development version, following the same convention as the other unreleased
-  # sibling pins; replace it with the published version at release.
   "reflex-hosting-cli >= 0.1.71",
 ]
 


### PR DESCRIPTION
Align in-tree deps after release

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/7000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

