### PR TITLE
fix: avoid duplicating inner tag in MemoComponent wrapper tag

### DIFF
--- a/news/7004.bugfix.md
+++ b/news/7004.bugfix.md
@@ -1,0 +1,1 @@
+Memo wrappers no longer duplicate the wrapped component's tag when computing the generated component name, so `MemoComponent` instances get stable, collision-free names instead of a doubled tag prefix.

--- a/packages/reflex-base/news/6955.bugfix.md
+++ b/packages/reflex-base/news/6955.bugfix.md
@@ -1,0 +1,1 @@
+Auto-memoized `@rx.memo` wrapper tags no longer duplicate the wrapped component's tag. `MemoComponent._compute_memo_tag` now skips the `self.tag` segment, which is already embedded in the dynamic subclass `__qualname__` (`MemoComponent_<tag>`), so generated wrapper names read as `Memocomponent_<tag>_<hash>` instead of `Memocomponent_<tag>_<tag>_<hash>`.

--- a/packages/reflex-base/src/reflex_base/components/memo.py
+++ b/packages/reflex-base/src/reflex_base/components/memo.py
@@ -398,6 +398,34 @@ class MemoComponent(Component):
             children: The children of the component (ignored).
         """
 
+    def _compute_memo_tag(self) -> str:
+        """Compute a stable tag name for this memo component.
+
+        Overrides ``Component._compute_memo_tag`` to avoid duplicating the
+        wrapped component's tag. For a ``MemoComponent`` the dynamic subclass
+        ``__qualname__`` is ``MemoComponent_<tag>`` (see
+        :func:`_get_memo_component_class`), which already encodes the inner
+        tag. Appending ``self.tag`` again would produce the inner tag twice
+        (e.g. ``Memocomponent_card_98ffd1e1_card_98ffd1e1_<hash>``).
+
+        The class identity is still preserved via the qualname prefix, so the
+        collision guarantee from the base implementation holds.
+
+        Returns:
+            The stable tag name.
+        """
+        from reflex_base.components.memoize_helpers import (
+            MemoizationStrategy,
+            get_memoization_strategy,
+        )
+
+        comp_hash = self._get_component_hash(
+            shallow=get_memoization_strategy(self) == MemoizationStrategy.PASSTHROUGH
+        )
+        return format.format_state_name(
+            f"{type(self).__qualname__}_{comp_hash}"
+        ).capitalize()
+
     def _post_init(self, **kwargs):
         """Initialize the memo component.
 

--- a/tests/units/compiler/test_memoize_plugin.py
+++ b/tests/units/compiler/test_memoize_plugin.py
@@ -2593,3 +2593,35 @@ def test_each_memo_wrapper_emits_one_component_module_file() -> None:
         "for Plain, one for WithProp, and one snapshot wrapper for the "
         f"LeafComponent boundary. Got: {sorted(ctx.memoize_wrappers)}"
     )
+
+
+def test_memo_wrapper_tag_contains_inner_tag_once() -> None:
+    """Auto-memo wrapper tags must not duplicate the wrapped component's tag.
+
+    Regression test for #6955: ``MemoComponent._compute_memo_tag`` previously
+    concatenated ``type(self).__qualname__`` (which already embeds the inner
+    tag as ``MemoComponent_<inner_tag>``) with ``self.tag`` again, producing
+    names like ``Memocomponent_plain_abc123_plain_abc123_<hash>``. The inner
+    tag must appear exactly once in the wrapper tag.
+    """
+    ctx, _page_ctx = _compile_single_page(lambda: Plain.create(STATE_VAR))
+
+    assert len(ctx.memoize_wrappers) == 1, (
+        f"Expected exactly one auto-memo wrapper, got: {sorted(ctx.memoize_wrappers)}"
+    )
+    wrapper_tag = next(iter(ctx.memoize_wrappers))
+    # The inner component's tag is "Plain"; after format_state_name it becomes
+    # lowercase "plain" in the wrapper tag. Count occurrences of the inner tag
+    # segment (case-insensitive, word-bounded to avoid matching hash substrings).
+    inner_tag_lower = Plain.tag.lower()
+    # Split on underscores and count exact matches of the inner tag
+    segments = wrapper_tag.lower().split("_")
+    inner_tag_occurrences = segments.count(inner_tag_lower)
+    assert inner_tag_occurrences == 1, (
+        f"Inner tag '{Plain.tag}' should appear exactly once in wrapper tag, "
+        f"found {inner_tag_occurrences} times. wrapper_tag={wrapper_tag}"
+    )
+    # The wrapper tag should still start with the MemoComponent prefix
+    assert wrapper_tag.lower().startswith("memocomponent"), (
+        f"Wrapper tag should keep the MemoComponent prefix, got: {wrapper_tag}"
+    )


### PR DESCRIPTION
Override _compute_memo_tag on MemoComponent to skip the self.tag segment, which is already embedded in the dynamic subclass __qualname__ (MemoComponent_<tag>). Previously the wrapper tag contained the inner tag twice (e.g. Memocomponent_card_98ffd1e1_card_98ffd1e1_<hash>).

Adds a regression test asserting the inner tag appears exactly once.

Closes #6955

### All Submissions:

- [ ] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [ ] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### New Feature Submission:

- [ ] Does your submission pass the tests?
- [ ] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.

    a. Give a descriptive title to your PR.

    b. Describe your changes.

    c. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/7004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

