### PR TITLE
fix: allow static IDs in document-root head components

### DIFF
--- a/news/+document-root-static-id.bugfix.md
+++ b/news/+document-root-static-id.bugfix.md
@@ -1,0 +1,1 @@
+Allow static IDs on document-root head components without generating React hooks.

--- a/reflex/compiler/utils.py
+++ b/reflex/compiler/utils.py
@@ -562,6 +562,42 @@ def compile_experimental_function_memo(
     )
 
 
+def _literalize_static_ids(component: BaseComponent) -> None:
+    """Replace static component IDs with literal variables, recursively.
+
+    Args:
+        component: The component or nested component to update in place.
+    """
+    if not isinstance(component, Component):
+        return
+    if component.id is not None and not isinstance(component.id, Var):
+        component.id = Var.create(component.id)
+    for child in component.children:
+        _literalize_static_ids(child)
+    for child in component._get_components_in_props():
+        _literalize_static_ids(child)
+
+
+def _without_static_id_refs(component: Component) -> Component:
+    """Copy a head component so its static IDs do not generate refs.
+
+    Document roots cannot contain hooks, but a static component ID normally
+    creates a ``useRef`` hook. Preserve the ID as an HTML attribute while making
+    it a literal variable so it does not create a ref in the document root.
+
+    Args:
+        component: The head component to copy.
+
+    Returns:
+        A copied component with static IDs represented as literal variables.
+    """
+    if not component._get_all_refs():
+        return component
+    component = copy.deepcopy(component)
+    _literalize_static_ids(component)
+    return component
+
+
 def create_document_root(
     head_components: Sequence[Component] | None = None,
     html_lang: str | None = None,
@@ -581,39 +617,6 @@ def create_document_root(
         The document root.
     """
     from reflex.utils.misc import preload_color_theme
-
-    def document_root_component(component: Component) -> Component:
-        """Copy a head component without generating refs from static IDs.
-
-        Document roots cannot contain hooks, but a static component ID normally
-        creates a ``useRef`` hook. Preserve the ID as an HTML attribute while
-        making it a literal variable so it does not create a ref in the
-        document root.
-
-        Returns:
-            A copied component with static IDs represented as literal variables.
-        """
-        if not component._get_all_refs():
-            return component
-        component = copy.deepcopy(component)
-
-        def literalize_static_ids(component: BaseComponent) -> None:
-            """Replace static component IDs with literal variables recursively.
-
-            Args:
-                component: The component or nested component to update.
-            """
-            if not isinstance(component, Component):
-                return
-            if component.id is not None and not isinstance(component.id, Var):
-                component.id = Var.create(component.id)
-            for child in component.children:
-                literalize_static_ids(child)
-            for child in component._get_components_in_props():
-                literalize_static_ids(child)
-
-        literalize_static_ids(component)
-        return component
 
     existing_meta_types = set()
 
@@ -660,7 +663,7 @@ def create_document_root(
 
     head_components = [
         *theme_preload_components,
-        *(document_root_component(component) for component in head_components or []),
+        *(_without_static_id_refs(component) for component in head_components or []),
         *maybe_head_components,
         *always_head_components,
     ]

--- a/reflex/compiler/utils.py
+++ b/reflex/compiler/utils.py
@@ -17,7 +17,7 @@ from typing import Any, TypedDict
 from urllib.parse import urlparse
 
 from reflex_base import constants
-from reflex_base.components.component import Component, ComponentStyle
+from reflex_base.components.component import BaseComponent, Component, ComponentStyle
 from reflex_base.components.memo import (
     MemoComponentDefinition,
     MemoFunctionDefinition,
@@ -582,6 +582,34 @@ def create_document_root(
     """
     from reflex.utils.misc import preload_color_theme
 
+    def document_root_component(component: Component) -> Component:
+        """Copy a head component without generating refs from static IDs.
+
+        Document roots cannot contain hooks, but a static component ID normally
+        creates a ``useRef`` hook. Preserve the ID as an HTML attribute while
+        making it a literal variable so it does not create a ref in the
+        document root.
+
+        Returns:
+            A copied component with static IDs represented as literal variables.
+        """
+        if not component._get_all_refs():
+            return component
+        component = copy.deepcopy(component)
+
+        def literalize_static_ids(component: BaseComponent) -> None:
+            if not isinstance(component, Component):
+                return
+            if component.id is not None and not isinstance(component.id, Var):
+                component.id = Var.create(component.id)
+            for child in component.children:
+                literalize_static_ids(child)
+            for child in component._get_components_in_props():
+                literalize_static_ids(child)
+
+        literalize_static_ids(component)
+        return component
+
     existing_meta_types = set()
 
     for component in head_components or []:
@@ -627,7 +655,7 @@ def create_document_root(
 
     head_components = [
         *theme_preload_components,
-        *(head_components or []),
+        *(document_root_component(component) for component in head_components or []),
         *maybe_head_components,
         *always_head_components,
     ]

--- a/reflex/compiler/utils.py
+++ b/reflex/compiler/utils.py
@@ -598,6 +598,11 @@ def create_document_root(
         component = copy.deepcopy(component)
 
         def literalize_static_ids(component: BaseComponent) -> None:
+            """Replace static component IDs with literal variables recursively.
+
+            Args:
+                component: The component or nested component to update.
+            """
             if not isinstance(component, Component):
                 return
             if component.id is not None and not isinstance(component.id, Var):

--- a/tests/units/compiler/test_compiler_utils.py
+++ b/tests/units/compiler/test_compiler_utils.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import asyncio
 
 import pytest
-from reflex.constants.state import FIELD_MARKER
-from reflex.state import State
-from reflex.vars.base import computed_var
 from reflex_components_core.base.fragment import Fragment
 from reflex_components_core.base.script import Script
 
 from reflex.compiler.utils import compile_state, create_document_root
+from reflex.constants.state import FIELD_MARKER
+from reflex.state import State
+from reflex.vars.base import computed_var
 
 
 class CompileStateState(State):

--- a/tests/units/compiler/test_compiler_utils.py
+++ b/tests/units/compiler/test_compiler_utils.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import asyncio
 
 import pytest
-
-from reflex.compiler.utils import compile_state
 from reflex.constants.state import FIELD_MARKER
 from reflex.state import State
 from reflex.vars.base import computed_var
+from reflex_components_core.base.fragment import Fragment
+from reflex_components_core.base.script import Script
+
+from reflex.compiler.utils import compile_state, create_document_root
 
 
 class CompileStateState(State):
@@ -48,3 +50,41 @@ async def test_compile_state_resolves_async_computed_vars_with_running_event_loo
     assert values[f"a{FIELD_MARKER}"] == 1
     assert values[f"b{FIELD_MARKER}"] == 2
     assert values[f"async_value{FIELD_MARKER}"] == "resolved"
+
+
+def test_document_root_allows_static_id_on_head_script():
+    """A head script's ID should remain an HTML attribute without a hook."""
+    head_script = Script.create(src="/probe.js", id="head-probe")
+    document_root = create_document_root(head_components=[head_script])
+
+    rendered = str(document_root.render())
+    assert not document_root._get_all_hooks()
+    assert 'id:"head-probe"' in rendered
+    assert "ref_head_probe" not in rendered
+    assert head_script._get_all_hooks()
+    assert "ref_head_probe" in str(head_script.render())
+
+
+def test_document_root_literalizes_nested_ids_without_mutating_original():
+    """Nested head IDs are literalized on a copy of the user component."""
+    nested_script = Script.create(src="/probe.js", id="nested-probe")
+    head_component = Fragment.create(nested_script)
+    document_root = create_document_root(head_components=[head_component])
+
+    rendered = str(document_root.render())
+    assert not document_root._get_all_hooks()
+    assert 'id:"nested-probe"' in rendered
+    assert "ref_nested_probe" not in rendered
+    assert head_component._get_all_hooks()
+    assert nested_script._get_all_hooks()
+
+
+def test_document_root_controls_preserve_no_id_and_page_refs():
+    """IDs outside the document root keep their normal ref behavior."""
+    document_root = create_document_root(
+        head_components=[Script.create(src="/probe.js")]
+    )
+    page_script = Script.create(src="/probe.js", id="page-probe")
+
+    assert not document_root._get_all_hooks()
+    assert page_script._get_all_hooks()


### PR DESCRIPTION
### Summary

- preserve static IDs on document-root head components without emitting React refs
- handle nested head components on a copy so page-level ref behavior and user components remain unchanged

Closes #6979

### Validation

- focused compiler and script tests: 9 passed
- full unit suite: 7,989 passed, 20 skipped; 14 unrelated sdist-config failures reproduced unchanged on the exact base
- Ruff check/format and targeted Pyright passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/7005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

