### PR TITLE
test_media: Replace URL we don't control

### DIFF
--- a/tests/integration/test_media.py
+++ b/tests/integration/test_media.py
@@ -50,7 +50,7 @@ def MediaApp():
 
         @rx.var
         def img_from_url(self) -> Image.Image:
-            img_url = "https://picsum.photos/id/1/200/300"
+            img_url = "https://raw.githubusercontent.com/reflex-dev/reflex/dd96aea556948ea95217ef1d8b5431546dc58363/docs/images/reflex_dark.svg"
             img_resp = httpx.get(img_url, follow_redirects=True)
             img_bytes = img_resp.content
             return Image.open(io.BytesIO(img_bytes))

--- a/tests/integration/test_media.py
+++ b/tests/integration/test_media.py
@@ -50,7 +50,7 @@ def MediaApp():
 
         @rx.var
         def img_from_url(self) -> Image.Image:
-            img_url = "https://raw.githubusercontent.com/reflex-dev/reflex/dd96aea556948ea95217ef1d8b5431546dc58363/docs/images/reflex_dark.svg"
+            img_url = "https://raw.githubusercontent.com/reflex-dev/reflex/dd96aea556948ea95217ef1d8b5431546dc58363//docs/images/reflex-image-generation-app.png"
             img_resp = httpx.get(img_url, follow_redirects=True)
             img_bytes = img_resp.content
             return Image.open(io.BytesIO(img_bytes))
@@ -193,8 +193,13 @@ def test_media_app(media_app: AppHarness):
 
     from_url_img_src = from_url_img.get_attribute("src")
     assert from_url_img_src is not None
-    assert from_url_img_src.startswith("data:image/jpeg;base64")
-    assert check_image_loaded(driver, from_url_img, expected_height=300)
+    assert from_url_img_src.startswith("data:image/png;base64")
+    assert check_image_loaded(
+        driver,
+        from_url_img,
+        expected_width=1280,
+        expected_height=733,
+    )
 
     uploaded_img_src = uploaded_img.get_attribute("src")
     assert uploaded_img_src is not None


### PR DESCRIPTION
picsum.photos is getting rate limited, and that shouldn't be a reason that our tests fail

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/7009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

