### PR TITLE
perf: deduplicate imports as they merge, not once at the end

### DIFF
--- a/packages/reflex-base/news/7012.bugfix.md
+++ b/packages/reflex-base/news/7012.bugfix.md
@@ -1,0 +1,1 @@
+Compiling unchanged source twice now produces the same files. Import order came from a `set`, whose iteration order varies with `PYTHONHASHSEED`, and a library's imports were not deduplicated against themselves; both fed the content hash a memoized component is named from, so each compile renamed those components and invalidated downstream build caches for no reason.

--- a/packages/reflex-base/news/7012.performance.md
+++ b/packages/reflex-base/news/7012.performance.md
@@ -1,0 +1,1 @@
+Compiling an app with many components is substantially faster. Imports are now deduplicated as they are merged rather than only at the end, so naming a memoized component no longer costs work proportional to the size of its subtree. An app with 80 routes and 42,268 components went from 263s to 48s.

--- a/packages/reflex-base/src/reflex_base/utils/imports.py
+++ b/packages/reflex-base/src/reflex_base/utils/imports.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 from collections import defaultdict
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 
 # Absolute import paths beginning with one of these reserved ``.web``
 # subdirectories are rewritten to ``$``-prefixed module specifiers.
@@ -15,6 +15,97 @@ ABSOLUTE_IMPORT_PREFIXES = (
     "/public/",
     "/app_components/",
 )
+
+
+def _sort_key(var: ImportVar) -> tuple[bool | str, ...]:
+    """Impose a total order on import vars, for batches that arrive unordered.
+
+    Each optional field contributes whether it is set before it contributes its
+    value, so `None` orders against a `str` or a `bool` rather than raising and
+    without being flattened onto one. Stringifying instead would collide
+    `tag=None` with `tag="None"`, and a stable sort would then leave that pair
+    in whatever order the set produced.
+
+    Distinct import vars always differ in a field, so this separates any two
+    that a set can hold at once.
+
+    Args:
+        var: The import var to order.
+
+    Returns:
+        A tuple ordering this var against any other.
+    """
+    return (
+        var.tag is None,
+        var.tag or "",
+        var.alias is None,
+        var.alias or "",
+        var.package_path,
+        var.is_default is None,
+        bool(var.is_default),
+        var.install is None,
+        bool(var.install),
+        var.render is None,
+        bool(var.render),
+    )
+
+
+def _as_import_vars(fields: Iterable[str | ImportVar]) -> list[ImportVar]:
+    """Normalize a batch of imports, ordering it if it arrived unordered.
+
+    A `set` iterates in an order that varies with PYTHONHASHSEED, and the
+    merge preserves the order it is given, so a set reaching this untouched
+    would put the hash seed back into the emitted imports and into every
+    component hash derived from them.
+
+    Args:
+        fields: The tags or import vars to normalize.
+
+    Returns:
+        The import vars, sorted when the input had no order of its own.
+    """
+    converted = [
+        ImportVar(field) if isinstance(field, str) else field for field in fields
+    ]
+    if isinstance(fields, (set, frozenset)):
+        converted.sort(key=_sort_key)
+    return converted
+
+
+def _accumulate(
+    all_imports: defaultdict[str, list[ImportVar]],
+    seen: dict[str, set[ImportVar]],
+    lib: str,
+    fields: Iterable[ImportVar],
+) -> None:
+    """Add `fields` to `all_imports[lib]`, skipping ones already there.
+
+    A library's first batch has nothing accumulated to collide with, so it only
+    needs deduplicating against itself, and a batch of one cannot even do that.
+    Most batches are one entry and so cost nothing. From the second batch
+    onward the library earns a lookup set, which is what stops a tag shared
+    across a subtree being carried once per node.
+
+    Args:
+        all_imports: The accumulator to add to, modified in place.
+        seen: Per-library lookup sets, built on demand and modified in place.
+        lib: The library the fields belong to.
+        fields: The import vars to add.
+    """
+    existing = all_imports[lib]
+    if not existing:
+        if not isinstance(fields, (list, tuple)):
+            fields = list(fields)
+        # One entry cannot duplicate anything, and most batches are one entry.
+        existing.extend(fields if len(fields) < 2 else dict.fromkeys(fields))
+        return
+    known = seen.get(lib)
+    if known is None:
+        known = seen[lib] = set(existing)
+    for field in fields:
+        if field not in known:
+            known.add(field)
+            existing.append(field)
 
 
 def merge_parsed_imports(
@@ -29,9 +120,10 @@ def merge_parsed_imports(
         The merged import dicts.
     """
     all_imports: defaultdict[str, list[ImportVar]] = defaultdict(list)
+    seen: dict[str, set[ImportVar]] = {}
     for import_dict in imports:
         for lib, fields in import_dict.items():
-            all_imports[lib].extend(fields)
+            _accumulate(all_imports, seen, lib, fields)
     return all_imports
 
 
@@ -47,20 +139,21 @@ def merge_imports(
         The merged import dicts.
     """
     all_imports: defaultdict[str, list[ImportVar]] = defaultdict(list)
+    seen: dict[str, set[ImportVar]] = {}
     for import_dict in imports:
         for lib, fields in (
             import_dict if isinstance(import_dict, tuple) else import_dict.items()
         ):
             # If the lib is an absolute path, we need to prefix it with a $
             lib = "$" + lib if lib.startswith(ABSOLUTE_IMPORT_PREFIXES) else lib
-            if isinstance(fields, (list, tuple, set)):
-                all_imports[lib].extend(
-                    ImportVar(field) if isinstance(field, str) else field
-                    for field in fields
-                )
+            if isinstance(fields, (list, tuple, set, frozenset)):
+                _accumulate(all_imports, seen, lib, _as_import_vars(fields))
             else:
-                all_imports[lib].append(
-                    ImportVar(fields) if isinstance(fields, str) else fields
+                _accumulate(
+                    all_imports,
+                    seen,
+                    lib,
+                    (ImportVar(fields) if isinstance(fields, str) else fields,),
                 )
     return all_imports
 
@@ -81,7 +174,7 @@ def parse_imports(
         if isinstance(maybe_tags, ImportVar)
         else [ImportVar(tag=maybe_tags)]
         if isinstance(maybe_tags, str)
-        else [ImportVar(tag=tag) if isinstance(tag, str) else tag for tag in maybe_tags]
+        else _as_import_vars(maybe_tags)
         for package, maybe_tags in imports.items()
     }
 
@@ -99,7 +192,9 @@ def collapse_imports(
     """
     return {
         lib: (
-            list(set(import_vars))
+            # dict.fromkeys, not set: set order varies with PYTHONHASHSEED, so
+            # identical compiles would emit different memo names.
+            list(dict.fromkeys(import_vars))
             if isinstance(import_vars, list)
             else list(import_vars)
         )

--- a/tests/units/utils/test_imports.py
+++ b/tests/units/utils/test_imports.py
@@ -1,9 +1,15 @@
+from typing import cast
+
 import pytest
 from reflex_base.utils.imports import (
+    ImmutableImportDict,
     ImportDict,
     ImportVar,
     ParsedImportDict,
+    _sort_key,
+    collapse_imports,
     merge_imports,
+    merge_parsed_imports,
     parse_imports,
 )
 
@@ -118,3 +124,108 @@ def test_merge_imports(input_1, input_2, output):
 )
 def test_parse_imports(input: ImportDict, output: ParsedImportDict):
     assert parse_imports(input) == output
+
+
+def test_merge_imports_deduplicates():
+    """A tag merged from many subtrees is carried once, not once per subtree.
+
+    `_get_all_imports` merges every descendant's imports on the way up, so
+    without this a node's list grows with the size of its subtree rather than
+    with the number of distinct imports it has.
+    """
+    one: ImportDict = {"react": ["Component"]}
+    merged = merge_imports(*([one] * 50))
+
+    assert merged["react"] == [ImportVar("Component")]
+
+
+def test_merge_parsed_imports_deduplicates():
+    one: ParsedImportDict = {"react": [ImportVar("Component"), ImportVar("useState")]}
+    merged = merge_parsed_imports(*([one] * 50))
+
+    assert merged["react"] == [ImportVar("Component"), ImportVar("useState")]
+
+
+def test_merge_imports_keeps_first_seen_order():
+    merged = merge_imports(
+        {"react": ["useMemo", "Component"]},
+        {"react": ["useState", "Component"]},
+    )
+
+    assert merged["react"] == [
+        ImportVar("useMemo"),
+        ImportVar("Component"),
+        ImportVar("useState"),
+    ]
+
+
+def test_collapse_imports_is_order_preserving():
+    """Collapsing must not depend on PYTHONHASHSEED.
+
+    `list(set(...))` made import order vary per process, and memo names are
+    hashed from that order, so two compiles of identical source disagreed.
+    """
+    tags = [f"Tag{i:02d}" for i in range(30)]
+    collapsed = collapse_imports({"react": [ImportVar(tag) for tag in tags] * 3})
+
+    assert collapsed["react"] == [ImportVar(tag) for tag in tags]
+
+
+def test_merge_deduplicates_within_a_single_batch():
+    """A library carried by one dict only is still deduplicated against itself.
+
+    The accumulator skips the lookup set for a library's first batch, since
+    there is nothing accumulated to collide with. That batch can still repeat a
+    tag internally, and on a real app 465 of 966,807 first batches did.
+    """
+    merged = merge_imports({"react": ["Component", "useState", "Component"]})
+    assert merged["react"] == [ImportVar("Component"), ImportVar("useState")]
+
+    parsed = merge_parsed_imports({
+        "react": [ImportVar("Component"), ImportVar("useState"), ImportVar("Component")]
+    })
+    assert parsed["react"] == [ImportVar("Component"), ImportVar("useState")]
+
+
+def test_a_set_of_imports_is_given_a_deterministic_order():
+    """A `set` iterates by PYTHONHASHSEED, and the merge preserves what it gets.
+
+    Both entry points accept one -- `merge_imports` by an isinstance check and
+    `parse_imports` by iterating whatever it is handed -- so a set left
+    untouched would put the hash seed back into the emitted imports and into
+    every component hash derived from them.
+    """
+    tags = {f"Tag{i:02d}" for i in range(20)}
+    ordered = [ImportVar(tag) for tag in sorted(tags)]
+    # Cast because a set is not in `ImportTypes`, yet both functions accept one
+    # at runtime and untyped callers do pass them.
+    batch = {"react": tags}
+
+    assert merge_imports(cast("ImportDict", batch))["react"] == ordered
+    assert parse_imports(cast("ImmutableImportDict", batch))["react"] == ordered
+
+
+def test_the_sort_key_separates_every_distinct_import_var():
+    """A collision would leave that pair in whatever order the set produced.
+
+    Sorting is stable, so two vars sharing a key keep their input order, and for
+    a set that order is the hash seed's. Stringifying the fields collided
+    `tag=None` with `tag="None"`, and `install=None` with `install=False`.
+    """
+    variants = {
+        ImportVar(tag=None),
+        ImportVar(tag="None"),
+        ImportVar(tag=""),
+        ImportVar(tag="x", alias=None),
+        ImportVar(tag="x", alias="None"),
+        ImportVar(tag="x", is_default=None),
+        ImportVar(tag="x", is_default=False),
+        ImportVar(tag="x", is_default=True),
+        ImportVar(tag="x", install=None),
+        ImportVar(tag="x", install=False),
+        ImportVar(tag="x", render=None),
+        ImportVar(tag="x", render=False),
+        ImportVar(tag="x", package_path="/other"),
+    }
+
+    assert len({_sort_key(var) for var in variants}) == len(variants)


### PR DESCRIPTION
## What

`merge_imports` and `merge_parsed_imports` concatenated without deduplicating, and `collapse_imports` deduplicated through a `set`. This makes the merges dedupe as they go, and makes the collapse preserve first-seen order.

## Why it is slow

`Component._get_all_imports` merges every descendant's imports on the way up the tree. Because the merge only concatenated, a tag shared across a subtree was carried once per node rather than once, so each node's import list grew with the size of its subtree instead of with the number of distinct imports it actually has.

Nothing consumed those duplicates, since `collapse_imports` dropped them at the end, once per page. But `_get_component_hash`, which names every auto-memoized component, hashes the node's whole recursive import dict, so the cost landed there instead.

Measured on an app with 80 routes and 42,268 components (7,036 memo wrappers):

| | |
|---|---|
| `_update_deterministic_hash` calls | 248,572,401 |
| share of compile spent hashing | ~65% |
| one `Button`: values hashed | 2,263,441 |
| one `Button`: distinct objects behind them | 133 |
| that Button's hash | 3.5s |

That Button has no children. The 2.26M came from 323,296 `ImportVar` visits over 21 distinct import vars.

## Result

`reflex compile` on that app, run back to back on the same machine:

| | before | after |
|---|---|---|
| compiler | 263s | 48s |

## Reproducibility

`collapse_imports` used `list(set(import_vars))`, whose iteration order over `ImportVar` varies with `PYTHONHASHSEED`. Two compiles of identical source therefore emitted imports in different orders, and since import order feeds `_get_component_hash`, every memo name derived from it changed too.

On the same app, two consecutive runs of unmodified reflex rewrote 113 of 157 generated files with different memo names. With this change both runs agree byte for byte.

That is worth having on its own: stable output means a bundler and its downstream caches see unchanged modules when nothing changed.

Deduplicating a library's first batch against itself, added in review below, turned out to be load-bearing for this too. Those repeats varied per process, so they moved the memo hash even once import order was stable. On the app above, the two fixes together take it from 113 differing files to **0**, byte-identical between `PYTHONHASHSEED=1` and `PYTHONHASHSEED=999983`.

## On the CodSpeed regression

`test_get_all_imports` is genuinely slower, and the first version of this PR was worse than what is here now. Worth being precise about what that benchmark measures.

It times `_get_all_imports()` alone. Deduplicating is pure cost inside that call; the payoff is a much smaller dict, and it is collected by whoever *consumes* the result. On `_complicated_page`, the result goes from 277 entries to 19 (14.6x), and on `_stateful_page` from 61 to 10. The benchmark pays for that reduction and never uses it, so it can only show the cost side. The whole-compile benchmarks are unaffected, and the app above spends 65% of its compile hashing exactly what shrank.

I still narrowed it rather than leaving it. A library's first batch has nothing accumulated to collide with, so it is deduplicated against itself and no further, and a batch of one entry skips even that; only from the second batch does a library earn a lookup set. Locally, on `_complicated_page` over 300 calls: base 0.101s, dedupe-everywhere 0.255s, this version 0.170s.

The batch-of-one guard is doing real work there. Deduplicating every first batch unconditionally costs 36% (0.165s to 0.225s in one run of the same comparison), because the average first batch is 1.4 entries and it allocates a dict a million times for batches that cannot duplicate. The guard gets the same correctness for 9%.

I also tried and dropped two further ideas: inlining the accumulator to avoid a call per library made no measurable difference (0.124s vs 0.125s), and caching `ImportVar.__hash__` bought ~10% on the micro but needed a typing workaround to keep the cache out of `fields()`, which is where `_update_deterministic_hash` would have picked it up. Neither seemed worth the complexity, but say the word if you would rather have them.

## Tests

Four regression tests in `tests/units/utils/test_imports.py`, each confirmed to fail against the current implementation before the fix:

- `test_merge_imports_deduplicates`
- `test_merge_parsed_imports_deduplicates`
- `test_merge_imports_keeps_first_seen_order`
- `test_collapse_imports_is_order_preserving`

The existing `test_merge_imports` compares with `set(...)` on both sides, so it could not have caught either problem.

Full unit suite: 8007 passed, 18 skipped. `pre-commit` clean.

One unrelated flake to note: `tests/units/test_state.py::test_state_manager_lock_expire` and its `_contend` sibling fail intermittently under full-suite load, on a wall-clock redis lock expiry. Across alternating full-suite runs they failed with this change and also without it, and always pass when `test_state.py` runs on its own.

## Notes

- Both merges still return a `defaultdict(list)`, so no caller sees a changed return type.
- Deduplicating is semantically a no-op, since `collapse_imports` already removed these duplicates before anything was emitted. This only stops them being built and hashed in the first place.
- There is more headroom here. `_get_all_imports` is still recomputed from scratch at every node rather than cached, which is a separate quadratic. Left for its own PR, since components are mutated during compile and a cache needs an invalidation story.

