### PR TITLE
Fix IPv6 availability detection in process port tests

### DIFF
--- a/tests/units/utils/test_processes.py
+++ b/tests/units/utils/test_processes.py
@@ -16,6 +16,30 @@ from reflex.utils.processes import (
 )
 
 
+def _ipv6_available() -> bool:
+    """Check whether the host can actually bind IPv6 sockets.
+
+    `socket.has_ipv6` only reflects build-time support; sandboxes and containers
+    frequently compile it in but have no IPv6 stack, which makes
+    `is_process_on_port` report every port as occupied.
+
+    Returns:
+        Whether an IPv6 socket can be created and bound.
+    """
+    try:
+        with closing(socket.socket(socket.AF_INET6, socket.SOCK_STREAM)) as sock:
+            sock.bind(("", 0))
+    except OSError:
+        return False
+    return True
+
+
+requires_ipv6 = pytest.mark.skipif(
+    not _ipv6_available(), reason="IPv6 is not available on this system"
+)
+
+
+@requires_ipv6
 def test_is_process_on_port_free_port():
     """Test is_process_on_port returns False when port is free."""
     # Find a free port
@@ -27,6 +51,7 @@ def test_is_process_on_port_free_port():
     assert not is_process_on_port(free_port)
 
 
+@requires_ipv6
 def test_is_process_on_port_occupied_port():
     """Test is_process_on_port returns True when port is occupied."""
     # Create a server socket to occupy a port
@@ -43,26 +68,23 @@ def test_is_process_on_port_occupied_port():
         server_socket.close()
 
 
+@requires_ipv6
 def test_is_process_on_port_ipv6():
     """Test is_process_on_port works with IPv6."""
-    # Test with IPv6 socket
+    server_socket = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    server_socket.bind(("", 0))
+    server_socket.listen(1)
+
+    occupied_port = server_socket.getsockname()[1]
+
     try:
-        server_socket = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
-        server_socket.bind(("", 0))
-        server_socket.listen(1)
-
-        occupied_port = server_socket.getsockname()[1]
-
-        try:
-            # Port should be occupied on IPv6
-            assert is_process_on_port(occupied_port)
-        finally:
-            server_socket.close()
-    except OSError:
-        # IPv6 might not be available on some systems
-        pytest.skip("IPv6 not available on this system")
+        # Port should be occupied on IPv6
+        assert is_process_on_port(occupied_port)
+    finally:
+        server_socket.close()
 
 
+@requires_ipv6
 def test_is_process_on_port_both_protocols():
     """Test is_process_on_port detects occupation on either IPv4 or IPv6."""
     # Create IPv4 server
@@ -118,6 +140,7 @@ def test_is_process_on_port_permission_error():
         assert result is True
 
 
+@requires_ipv6
 def test_is_process_on_port_concurrent_access():
     """Test is_process_on_port works correctly with concurrent access."""
     shared = None

--- a/tests/units/utils/test_processes.py
+++ b/tests/units/utils/test_processes.py
@@ -10,32 +10,17 @@ import pytest
 
 from reflex.testing import DEFAULT_TIMEOUT, AppHarness
 from reflex.utils.processes import (
+    _can_bind_at_any_port,
     is_process_on_port,
     run_concurrently,
     run_concurrently_context,
 )
 
-
-def _ipv6_available() -> bool:
-    """Check whether the host can actually bind IPv6 sockets.
-
-    `socket.has_ipv6` only reflects build-time support; sandboxes and containers
-    frequently compile it in but have no IPv6 stack, which makes
-    `is_process_on_port` report every port as occupied.
-
-    Returns:
-        Whether an IPv6 socket can be created and bound.
-    """
-    try:
-        with closing(socket.socket(socket.AF_INET6, socket.SOCK_STREAM)) as sock:
-            sock.bind(("", 0))
-    except OSError:
-        return False
-    return True
-
-
+# `socket.has_ipv6` only reflects build-time support; without a runtime IPv6
+# stack every port looks occupied to `is_process_on_port`'s default families.
 requires_ipv6 = pytest.mark.skipif(
-    not _ipv6_available(), reason="IPv6 is not available on this system"
+    not _can_bind_at_any_port(socket.AF_INET6),
+    reason="IPv6 is not available on this system",
 )
 
 

--- a/tests/units/utils/test_processes.py
+++ b/tests/units/utils/test_processes.py
@@ -24,7 +24,6 @@ requires_ipv6 = pytest.mark.skipif(
 )
 
 
-@requires_ipv6
 def test_is_process_on_port_free_port():
     """Test is_process_on_port returns False when port is free."""
     # Find a free port
@@ -33,10 +32,9 @@ def test_is_process_on_port_free_port():
         free_port = sock.getsockname()[1]
 
     # Port should be free after socket is closed
-    assert not is_process_on_port(free_port)
+    assert not is_process_on_port(free_port, (socket.AF_INET,))
 
 
-@requires_ipv6
 def test_is_process_on_port_occupied_port():
     """Test is_process_on_port returns True when port is occupied."""
     # Create a server socket to occupy a port
@@ -48,7 +46,7 @@ def test_is_process_on_port_occupied_port():
 
     try:
         # Port should be occupied
-        assert is_process_on_port(occupied_port)
+        assert is_process_on_port(occupied_port, (socket.AF_INET,))
     finally:
         server_socket.close()
 
@@ -69,7 +67,6 @@ def test_is_process_on_port_ipv6():
         server_socket.close()
 
 
-@requires_ipv6
 def test_is_process_on_port_both_protocols():
     """Test is_process_on_port detects occupation on either IPv4 or IPv6."""
     # Create IPv4 server
@@ -81,7 +78,7 @@ def test_is_process_on_port_both_protocols():
 
     try:
         # Should detect IPv4 occupation
-        assert is_process_on_port(port)
+        assert is_process_on_port(port, (socket.AF_INET,))
     finally:
         ipv4_socket.close()
 
@@ -125,7 +122,6 @@ def test_is_process_on_port_permission_error():
         assert result is True
 
 
-@requires_ipv6
 def test_is_process_on_port_concurrent_access():
     """Test is_process_on_port works correctly with concurrent access."""
     shared = None
@@ -156,7 +152,7 @@ def test_is_process_on_port_concurrent_access():
 
         # Port should be occupied while server is running (both bound-only and listening)
         assert AppHarness._poll_for(
-            lambda: shared is not None and is_process_on_port(shared)
+            lambda: shared is not None and is_process_on_port(shared, (socket.AF_INET,))
         )
     finally:
         do_close.set()
@@ -164,7 +160,7 @@ def test_is_process_on_port_concurrent_access():
 
     # Give it a moment for the socket to be fully released
     assert AppHarness._poll_for(
-        lambda: shared is not None and not is_process_on_port(shared)
+        lambda: shared is not None and not is_process_on_port(shared, (socket.AF_INET,))
     )
 
 


### PR DESCRIPTION
### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Description

`is_process_on_port` checks both `AF_INET` and `AF_INET6` by default. On hosts where IPv6 is compiled in but there is no runtime IPv6 stack (common in sandboxes and containers), the IPv6 bind always fails, so the function reports every port as occupied. That makes `test_is_process_on_port_free_port` fail, and makes the tests that assert a port is occupied pass for the wrong reason.

This PR makes the four IPv4-only tests pass `address_families=(socket.AF_INET,)` explicitly, mirroring how `handle_port` calls the function, so they keep running everywhere. `test_is_process_on_port_ipv6` replaces its inline try/except with a `requires_ipv6` skip marker built on the production `_can_bind_at_any_port(socket.AF_INET6)` probe.

Production is unaffected: `handle_port` already filters unusable address families before calling `is_process_on_port`.

### Testing

- `uv run pytest tests/units/utils/test_processes.py` passes on an IPv6-enabled host.
- Only `test_is_process_on_port_ipv6` skips on hosts where an `AF_INET6` socket cannot be bound.

https://claude.ai/code/session_019AAS3cmbSxsVQFAauBeZSN
