### PR TITLE
Replace the outdated-dependency shell filters with a configured script

### DIFF
--- a/.github/workflows/check_outdated_dependencies.yml
+++ b/.github/workflows/check_outdated_dependencies.yml
@@ -25,20 +25,9 @@ jobs:
           run-uv-sync: true
 
       - name: Check outdated backend dependencies
-        run: |
-          outdated=$(uv pip list --outdated)
-          echo "Outdated:"
-          echo "$outdated"
-
-          filtered_outdated=$(echo "$outdated" | grep -vE 'pyright|ruff' || true)
-
-          if [ ! -z "$filtered_outdated" ]; then
-            echo "Outdated dependencies found:"
-            echo "$filtered_outdated"
-            exit 1
-          else
-            echo "All dependencies are up to date. (pyright and ruff are ignored)"
-          fi
+        # Not `--script`: that resolves an isolated env, and `uv pip list` would then
+        # inspect it instead of the project's synced environment.
+        run: uv run python scripts/check_outdated_deps.py backend
 
   frontend:
     runs-on: ubuntu-latest
@@ -71,22 +60,6 @@ jobs:
         run: |
           uv run --active --no-sync bash scripts/integration.sh ./docs/app prod
       - name: Check outdated frontend dependencies
-        working-directory: ./docs/app/.web
-        run: |
-          raw_outdated=$(bun outdated)
-          outdated=$(echo "$raw_outdated" | grep -vE '\|\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\|' || true)
-          echo "Outdated:"
-          echo "$outdated"
-
-          # Ignore 3rd party dependencies that are not updated.
-          filtered_outdated=$(echo "$outdated" | grep -vE 'Package|@chakra-ui|lucide-react|@splinetool/runtime|ag-grid-react|framer-motion|ag-grid' || true)
-          no_extra=$(echo "$filtered_outdated" | grep -vE '\|\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-\-' || true)
-
-
-          if [ ! -z "$no_extra" ]; then
-            echo "Outdated dependencies found:"
-            echo "$filtered_outdated"
-            exit 1
-          else
-            echo "All dependencies are up to date. (3rd party packages are ignored)"
-          fi
+        # `--script` here: this job only syncs docs/app, and the frontend check reads
+        # bun and package.json rather than the Python environment.
+        run: uv run --script scripts/check_outdated_deps.py frontend --web-dir ./docs/app/.web

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -269,6 +269,7 @@ preview = true
 "*/blank.py" = ["I001"]
 "docs/package/scripts/*.py" = ["INP001"]
 "scripts/check_min_deps.py" = ["T201"]
+"scripts/check_outdated_deps.py" = ["T201"]
 "scripts/verify_pyi.py" = ["T201"]
 
 [tool.pytest.ini_options]
@@ -415,6 +416,34 @@ showcontent = true
 directory = "misc"
 name = "Miscellaneous"
 showcontent = true
+
+# Packages that must not be reported by scripts/check_outdated_deps.py. An entry matches by
+# exact name, or by prefix when it ends in `*`.
+#
+# `*_held` is for packages blocked on work we own: the script errors if one is already at its
+# latest version, since that means the blocker is gone and the entry should be deleted.
+# `*_pinned` is for packages we do not drive -- pinned by policy or owned by another repo --
+# where reaching latest says nothing about whether the entry can go, so staleness is not
+# checked.
+[tool.check-outdated-deps]
+backend_held = []
+backend_pinned = [
+    # Linters are pinned deliberately and bumped on their own cadence.
+    "pyright",
+    "ruff",
+]
+frontend_held = []
+frontend_pinned = [
+    # Pinned in other repos (reflex-enterprise and friends), so their versions are not
+    # ours to advance.
+    "@chakra-ui/*",
+    "lucide-react",
+    "@splinetool/runtime",
+    "framer-motion",
+    # ag-grid-community, -enterprise and -react release in lockstep; the shell filter
+    # needed both `ag-grid` and `ag-grid-react` to cover them.
+    "ag-grid*",
+]
 
 [tool.uv]
 required-version = ">=0.9.17"

--- a/scripts/check_outdated_deps.py
+++ b/scripts/check_outdated_deps.py
@@ -259,7 +259,7 @@ def frontend_packages(web_dir: Path) -> tuple[list[str], list[str]]:
         ``(outdated, declared)`` package names.
 
     Raises:
-        CheckError: If ``package.json`` is missing or unparseable.
+        CheckError: If ``package.json`` is missing or unparsable.
     """
     outdated = parse_bun_outdated(_run(["bun", "outdated"], cwd=web_dir))
 

--- a/scripts/check_outdated_deps.py
+++ b/scripts/check_outdated_deps.py
@@ -1,0 +1,357 @@
+"""Report outdated backend and frontend dependencies, ignoring deliberately held packages.
+
+Wraps ``uv pip list --outdated`` (backend) and ``bun outdated`` (frontend) and fails when
+anything outside the configured hold lists is behind its latest release. The hold lists live
+in the root ``pyproject.toml`` under ``[tool.check-outdated-deps]`` rather than in this
+script, so adding or removing one is a config change:
+
+    [tool.check-outdated-deps]
+    backend_held = ["pydantic-core", "pyee", "redis"]
+    backend_pinned = ["pyright", "ruff"]
+    frontend_held = ["react-moment", "plotly.js"]
+    frontend_pinned = ["@chakra-ui/*", "ag-grid*"]
+
+An entry matches a package by exact name, or by prefix when it ends in ``*``. Prefix entries
+are what cover a whole scope (``@chakra-ui/*``) or a release-locked family (``ag-grid*``,
+which is three separate packages moving together).
+
+The two lists differ in whether staleness is checked. ``*_held`` is for packages blocked on
+work we own, so a hold that is no longer doing anything is an error: if a held package is
+installed but absent from the outdated report it is already at its latest version and the
+entry should be deleted, and if it matches no installed package at all it is stale in a
+different way. ``*_pinned`` is for packages we do not drive -- pinned by policy, or owned by
+another repo -- where reaching latest says nothing about whether the entry can go, so only
+suppression applies.
+
+Run with ``uv run python scripts/check_outdated_deps.py {backend,frontend}``. The frontend
+check needs a compiled app, so it takes the directory holding the generated
+``package.json`` (``--web-dir``, default ``.``) and must run where ``bun`` can see the
+installed tree.
+"""
+
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "tomli; python_version < '3.11'",
+# ]
+# ///
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+REPO_ROOT = Path(__file__).parent.parent
+
+CONFIG_TABLE = "check-outdated-deps"
+
+# `bun outdated` tags rows outside `dependencies` in the package cell.
+BUN_ANNOTATIONS = (" (dev)", " (peer)", " (optional)")
+
+# The dependency sections `bun outdated` reports on, and so the ones a held entry can
+# legitimately name.
+BUN_DEPENDENCY_FIELDS = (
+    "dependencies",
+    "devDependencies",
+    "peerDependencies",
+    "optionalDependencies",
+)
+
+
+class CheckError(Exception):
+    """A dependency check failed, with a message meant for the console."""
+
+
+def _load_config(kind: str) -> tuple[list[str], list[str]]:
+    """Read the hold lists for one side of the check out of the root ``pyproject.toml``.
+
+    Args:
+        kind: Either ``"backend"`` or ``"frontend"``.
+
+    Returns:
+        ``(held, pinned)`` package patterns, in declaration order.
+
+    Raises:
+        CheckError: If the config table or either list is missing or malformed.
+    """
+    with (REPO_ROOT / "pyproject.toml").open("rb") as f:
+        config = tomllib.load(f).get("tool", {}).get(CONFIG_TABLE)
+    if config is None:
+        msg = f"pyproject.toml is missing the [tool.{CONFIG_TABLE}] table"
+        raise CheckError(msg)
+
+    lists = []
+    for key in (f"{kind}_held", f"{kind}_pinned"):
+        patterns = config.get(key)
+        if patterns is None:
+            msg = f"[tool.{CONFIG_TABLE}] is missing the `{key}` list"
+            raise CheckError(msg)
+        if not isinstance(patterns, list) or not all(
+            isinstance(name, str) for name in patterns
+        ):
+            msg = f"[tool.{CONFIG_TABLE}] `{key}` must be a list of strings"
+            raise CheckError(msg)
+        lists.append(patterns)
+    return lists[0], lists[1]
+
+
+def matches(pattern: str, package: str) -> bool:
+    """Check whether a hold pattern covers a package name.
+
+    Args:
+        pattern: A hold entry: an exact package name, or a prefix ending in ``*``.
+        package: The package name to test.
+
+    Returns:
+        Whether the pattern covers the package.
+    """
+    if pattern.endswith("*"):
+        return package.startswith(pattern[:-1])
+    return package == pattern
+
+
+def partition(
+    outdated: Iterable[str],
+    installed: Iterable[str],
+    held: Sequence[str],
+    pinned: Sequence[str] = (),
+) -> tuple[list[str], list[str], list[str]]:
+    """Split packages into the reportable, the suppressed, and the stale holds.
+
+    Args:
+        outdated: Names of packages behind their latest release.
+        installed: Names of every installed/declared package.
+        held: Patterns for packages blocked on work we own; checked for staleness.
+        pinned: Patterns for packages we do not drive; suppressed but never stale.
+
+    Returns:
+        ``(reportable, suppressed, stale_holds)`` — the outdated packages nothing covers,
+        the outdated packages either list covers, and the ``held`` patterns that no longer
+        suppress anything (each annotated with why).
+    """
+    outdated = list(outdated)
+    installed_set = set(installed)
+    covering = [*held, *pinned]
+
+    reportable: list[str] = []
+    suppressed: list[str] = []
+    for name in outdated:
+        covered = any(matches(pattern, name) for pattern in covering)
+        (suppressed if covered else reportable).append(name)
+
+    stale_holds = []
+    for pattern in held:
+        covered = [name for name in installed_set if matches(pattern, name)]
+        if not covered:
+            stale_holds.append(f"{pattern} (matches no installed package)")
+            continue
+        if not any(matches(pattern, name) for name in outdated):
+            at_latest = ", ".join(sorted(covered))
+            stale_holds.append(f"{pattern} (already at latest: {at_latest})")
+
+    return reportable, suppressed, sorted(stale_holds)
+
+
+def _run(command: Sequence[str], cwd: Path | None = None) -> str:
+    """Run a command and return its stdout.
+
+    Args:
+        command: The command and its arguments.
+        cwd: Directory to run in, or None for the current directory.
+
+    Returns:
+        The command's stdout.
+
+    Raises:
+        CheckError: If the command is unavailable or exits non-zero.
+    """
+    try:
+        result = subprocess.run(
+            command, cwd=cwd, capture_output=True, text=True, check=False
+        )
+    except FileNotFoundError as exc:
+        msg = f"`{command[0]}` is not available on PATH"
+        raise CheckError(msg) from exc
+    if result.returncode != 0:
+        msg = f"`{' '.join(command)}` failed:\n{result.stderr.strip()}"
+        raise CheckError(msg)
+    return result.stdout
+
+
+def backend_packages() -> tuple[list[str], list[str]]:
+    """Collect the backend outdated and installed package names via uv.
+
+    Returns:
+        ``(outdated, installed)`` package names.
+
+    Raises:
+        CheckError: If uv's JSON output cannot be parsed.
+    """
+    try:
+        outdated = [
+            entry["name"]
+            for entry in json.loads(
+                _run(["uv", "pip", "list", "--outdated", "--format", "json"])
+            )
+        ]
+        installed = [
+            entry["name"]
+            for entry in json.loads(_run(["uv", "pip", "list", "--format", "json"]))
+        ]
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        msg = f"could not parse `uv pip list` output: {exc}"
+        raise CheckError(msg) from exc
+    return outdated, installed
+
+
+def parse_bun_outdated(output: str) -> list[str]:
+    """Extract package names from a ``bun outdated`` table.
+
+    Bun renders a markdown-style table whose package column is right-padded, with ``|---|``
+    rules between rows and a ``Package`` header. Everything but the data rows is dropped.
+
+    Rows for anything outside ``dependencies`` carry a behavior annotation in the package
+    cell (``tailwindcss (dev)``, ``react (peer)``, ``clsx (optional)``), which is stripped
+    so the bare name is what gets matched. npm names cannot contain spaces, so the suffix is
+    unambiguous.
+
+    Args:
+        output: Raw stdout from ``bun outdated``.
+
+    Returns:
+        The outdated package names, without behavior annotations.
+    """
+    names = []
+    for line in output.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|") or set(stripped) <= set("|-"):
+            continue
+        name = stripped.split("|")[1].strip()
+        for annotation in BUN_ANNOTATIONS:
+            if name.endswith(annotation):
+                name = name[: -len(annotation)].rstrip()
+                break
+        if not name or name == "Package":
+            continue
+        names.append(name)
+    return names
+
+
+def frontend_packages(web_dir: Path) -> tuple[list[str], list[str]]:
+    """Collect the frontend outdated and declared package names via bun.
+
+    Args:
+        web_dir: Directory holding the generated ``package.json``.
+
+    Returns:
+        ``(outdated, declared)`` package names.
+
+    Raises:
+        CheckError: If ``package.json`` is missing or unparseable.
+    """
+    outdated = parse_bun_outdated(_run(["bun", "outdated"], cwd=web_dir))
+
+    package_json = web_dir / "package.json"
+    try:
+        with package_json.open() as f:
+            manifest = json.load(f)
+    except FileNotFoundError as exc:
+        msg = f"{package_json} not found; compile the app before checking"
+        raise CheckError(msg) from exc
+    except json.JSONDecodeError as exc:
+        msg = f"could not parse {package_json}: {exc}"
+        raise CheckError(msg) from exc
+
+    declared = [
+        name for field in BUN_DEPENDENCY_FIELDS for name in manifest.get(field, {})
+    ]
+    return outdated, declared
+
+
+def report(kind: str, outdated: list[str], installed: list[str]) -> int:
+    """Print the outcome for one side of the check and return its exit code.
+
+    Args:
+        kind: Either ``"backend"`` or ``"frontend"``.
+        outdated: Names of packages behind their latest release.
+        installed: Names of every installed/declared package.
+
+    Returns:
+        0 if everything outdated is deliberately held, 1 otherwise.
+    """
+    held, pinned = _load_config(kind)
+    reportable, suppressed, stale_holds = partition(outdated, installed, held, pinned)
+
+    if suppressed:
+        print(f"Held back ({len(suppressed)}), not reported:")
+        for name in sorted(suppressed):
+            print(f"  {name}")
+
+    exit_code = 0
+
+    if reportable:
+        print(f"\nOutdated {kind} dependencies found:")
+        for name in sorted(reportable):
+            print(f"  {name}")
+        exit_code = 1
+    else:
+        print(f"\nAll {kind} dependencies are up to date.")
+
+    if stale_holds:
+        print(
+            f"\nStale `{kind}_held` entries in [tool.{CONFIG_TABLE}] "
+            "(remove them, the hold is no longer needed):"
+        )
+        for entry in stale_holds:
+            print(f"  {entry}")
+        exit_code = 1
+
+    return exit_code
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the requested dependency check.
+
+    Args:
+        argv: Command-line arguments, or None to read ``sys.argv``.
+
+    Returns:
+        The process exit code.
+    """
+    parser = argparse.ArgumentParser(
+        description="Report outdated dependencies, ignoring deliberately held packages."
+    )
+    parser.add_argument("kind", choices=("backend", "frontend"))
+    parser.add_argument(
+        "--web-dir",
+        type=Path,
+        default=Path(),
+        help="directory holding the generated package.json (frontend only)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        if args.kind == "backend":
+            outdated, installed = backend_packages()
+        else:
+            outdated, installed = frontend_packages(args.web_dir)
+        return report(args.kind, outdated, installed)
+    except CheckError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/units/test_check_outdated_deps.py
+++ b/tests/units/test_check_outdated_deps.py
@@ -1,0 +1,185 @@
+"""Unit tests for scripts/check_outdated_deps.py (the outdated-dependency checker)."""
+
+import sys
+
+import pytest
+
+# The script relies on ``tomllib`` (stdlib only on 3.11+); on 3.10 it falls back to the
+# ``tomli`` backport. Skip the whole module when neither is available, so the tests still
+# run on 3.10 whenever ``tomli`` happens to be installed.
+if sys.version_info < (3, 11):
+    pytest.importorskip(
+        "tomli", reason="check_outdated_deps requires tomli on Python < 3.11"
+    )
+
+from scripts import check_outdated_deps
+
+
+@pytest.mark.parametrize(
+    ("pattern", "package", "expected"),
+    [
+        ("tailwindcss", "tailwindcss", True),
+        # The bug the old grep-based filter had to be anchored against: a bare name must
+        # not swallow the packages that merely share its prefix.
+        ("tailwindcss", "tailwindcss-animated", False),
+        ("tailwindcss", "@tailwindcss/postcss", False),
+        ("plotly.js", "plotly.js", True),
+        ("plotly.js", "plotly.js-locales", False),
+        ("plotly.js", "react-plotly.js", False),
+        ("ag-grid*", "ag-grid-community", True),
+        ("ag-grid*", "ag-grid-enterprise", True),
+        ("ag-grid*", "ag-grid-react", True),
+        ("ag-grid*", "ag-charts-react", False),
+        ("@chakra-ui/*", "@chakra-ui/react", True),
+        ("@chakra-ui/*", "@chakra-ui-fork/react", False),
+    ],
+)
+def test_matches(pattern: str, package: str, expected: bool):
+    assert check_outdated_deps.matches(pattern, package) is expected
+
+
+def test_partition_suppresses_only_held_packages():
+    reportable, suppressed, stale = check_outdated_deps.partition(
+        outdated=["tailwindcss", "tailwindcss-animated", "recharts"],
+        installed=["tailwindcss", "tailwindcss-animated", "recharts"],
+        held=["tailwindcss"],
+    )
+    assert reportable == ["tailwindcss-animated", "recharts"]
+    assert suppressed == ["tailwindcss"]
+    assert stale == []
+
+
+def test_partition_flags_hold_already_at_latest():
+    """A held package that is installed but not outdated no longer needs its hold."""
+    reportable, suppressed, stale = check_outdated_deps.partition(
+        outdated=["recharts"],
+        installed=["recharts", "redis"],
+        held=["redis"],
+    )
+    assert reportable == ["recharts"]
+    assert suppressed == []
+    assert stale == ["redis (already at latest: redis)"]
+
+
+def test_partition_flags_hold_matching_nothing():
+    _, _, stale = check_outdated_deps.partition(
+        outdated=["recharts"], installed=["recharts"], held=["removed-package"]
+    )
+    assert stale == ["removed-package (matches no installed package)"]
+
+
+def test_partition_prefix_hold_stays_live_while_any_member_is_outdated():
+    """A lockstep family keeps its hold as long as one of its packages is behind."""
+    _, suppressed, stale = check_outdated_deps.partition(
+        outdated=["ag-grid-react"],
+        installed=["ag-grid-community", "ag-grid-enterprise", "ag-grid-react"],
+        held=["ag-grid*"],
+    )
+    assert suppressed == ["ag-grid-react"]
+    assert stale == []
+
+
+def test_parse_bun_outdated_handles_padded_columns():
+    """Bun right-pads the package column and interleaves `|---|` rules between rows."""
+    output = """bun outdated v1.4.0 (34cbb9a40)
+|--------------------------------------------------|
+| Package              | Current | Update | Latest |
+|----------------------|---------|--------|--------|
+| @tailwindcss/postcss | 4.3.0   | 4.3.0  | 4.3.3  |
+|----------------------|---------|--------|--------|
+| tailwindcss          | 4.3.0   | 4.3.0  | 4.3.3  |
+|--------------------------------------------------|
+"""
+    assert check_outdated_deps.parse_bun_outdated(output) == [
+        "@tailwindcss/postcss",
+        "tailwindcss",
+    ]
+
+
+def test_parse_bun_outdated_strips_behavior_annotations():
+    """Bun tags rows outside `dependencies` with `(dev)`, `(peer)` or `(optional)`.
+
+    The docs app declares tailwindcss under devDependencies, so leaving the annotation on
+    would stop it matching its `frontend_held` entry and fail the job it is meant to pass.
+    """
+    output = """bun outdated v1.4.0 (34cbb9a40)
+|--------------------------------------------------------|
+| Package                    | Current | Update | Latest |
+|----------------------------|---------|--------|--------|
+| @tailwindcss/postcss (dev) | 4.3.0   | 4.3.0  | 4.3.3  |
+|----------------------------|---------|--------|--------|
+| tailwindcss (dev)          | 4.3.0   | 4.3.0  | 4.3.3  |
+|----------------------------|---------|--------|--------|
+| react (peer)               | 19.2.0  | 19.2.0 | 19.2.8 |
+|----------------------------|---------|--------|--------|
+| clsx (optional)            | 2.1.0   | 2.1.0  | 2.1.1  |
+|--------------------------------------------------------|
+"""
+    assert check_outdated_deps.parse_bun_outdated(output) == [
+        "@tailwindcss/postcss",
+        "tailwindcss",
+        "react",
+        "clsx",
+    ]
+
+
+def test_annotated_dev_row_is_suppressed_by_its_hold():
+    """End to end for the regression: a `(dev)` row still matches its exact hold entry."""
+    outdated = check_outdated_deps.parse_bun_outdated(
+        "| Package           | Current | Update | Latest |\n"
+        "| tailwindcss (dev) | 4.3.0   | 4.3.0  | 4.3.3  |\n"
+    )
+    reportable, suppressed, stale = check_outdated_deps.partition(
+        outdated=outdated, installed=["tailwindcss"], held=["tailwindcss"]
+    )
+    assert reportable == []
+    assert suppressed == ["tailwindcss"]
+    assert stale == []
+
+
+def test_bun_dependency_fields_cover_every_reported_section():
+    """Bun reports peer and optional deps too, so the declared set must include them."""
+    assert check_outdated_deps.BUN_DEPENDENCY_FIELDS == (
+        "dependencies",
+        "devDependencies",
+        "peerDependencies",
+        "optionalDependencies",
+    )
+
+
+def test_parse_bun_outdated_empty_when_nothing_outdated():
+    assert (
+        check_outdated_deps.parse_bun_outdated("bun outdated v1.4.0 (34cbb9a40)\n")
+        == []
+    )
+
+
+def test_pinned_packages_are_suppressed_but_never_stale():
+    """A package we do not drive stays suppressed even once it reaches latest.
+
+    `pyright` and `ruff` are pinned by policy rather than blocked on anything, so being at
+    their latest version does not mean the entry can be removed.
+    """
+    reportable, suppressed, stale = check_outdated_deps.partition(
+        outdated=["ruff"],
+        installed=["ruff", "pyright"],
+        held=[],
+        pinned=["ruff", "pyright"],
+    )
+    assert reportable == []
+    assert suppressed == ["ruff"]
+    assert stale == []
+
+
+def test_load_config_reads_the_repo_config():
+    """The real pyproject.toml must expose all four lists, since CI relies on them."""
+    for kind in ("backend", "frontend"):
+        held, pinned = check_outdated_deps._load_config(kind)
+        assert isinstance(held, list)
+        assert isinstance(pinned, list)
+        assert all(isinstance(entry, str) for entry in [*held, *pinned])
+
+    # The linters are pinned rather than held: they are at their latest most of the time,
+    # and the hold is policy, not a blocker.
+    assert "ruff" in check_outdated_deps._load_config("backend")[1]
+    assert "ag-grid*" in check_outdated_deps._load_config("frontend")[1]


### PR DESCRIPTION
Split out of #7019 so the tooling change lands on its own and the pin bumps rebase onto it.

The check lived as two inline shell blocks in `check_outdated_dependencies.yml`, so it could not be run outside CI, and the ignored package names were baked into grep patterns over the rendered report. `scripts/check_outdated_deps.py {backend,frontend}` now does the work and the workflow is two one-line steps, with the ignored names in `[tool.check-outdated-deps]` in the root `pyproject.toml`.

This is pure infrastructure: it carries over exactly the filters `main` already had and changes no pins.

### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Changes

**Matching is on parsed package names, not a regex over the table.** That removes the anchoring the grep needed to avoid swallowing siblings: a bare `tailwindcss` entry can no longer match `tailwindcss-animated`, and a `plotly.js` entry cannot match `plotly.js-locales` or `react-plotly.js`. Entries ending in `*` opt into prefix matching where it is actually wanted — `@chakra-ui/*` for the scope, `ag-grid*` for the three packages that release in lockstep (which the shell filter covered with both `ag-grid` and `ag-grid-react`).

**Two config keys, because the two reasons a package is ignored want different treatment.**

- `*_held` — blocked on work we own. A held package already at its latest version means the blocker is gone and the entry should be deleted, so that **errors**. This keeps the list from accumulating entries that suppress nothing.
- `*_pinned` — pinned by policy or owned by another repo (`pyright`, `ruff`, the reflex-enterprise packages, the `ag-grid` family). Reaching latest says nothing about whether the entry can go, so staleness is not checked.

Both lists start as the filters `main` already had, all of which are `*_pinned`. `*_held` is empty here and is where blocker-driven entries land — #7019 fills it in.

A side benefit of the staleness check: a typo'd entry reports `matches no installed package` instead of silently suppressing nothing.

### Two parser details, verified against a real Bun 1.4.0 install rather than assumed

- Bun **right-pads** the package column, so the name is trimmed out of the cell rather than matched as a fixed-width field.
- Bun **annotates rows outside `dependencies`** in that cell — `tailwindcss (dev)`, `react (peer)`, `clsx (optional)`:

  ```
  | Package                    | Current | Update | Latest |
  |----------------------------|---------|--------|--------|
  | @tailwindcss/postcss (dev) | 4.3.0   | 4.3.0  | 4.3.3  |
  | react (peer)               | 19.2.0  | 19.2.0 | 19.2.8 |
  | clsx (optional)            | 2.1.0   | 2.1.0  | 2.1.1  |
  ```

  The annotation is stripped before matching (npm names cannot contain spaces, so the suffix is unambiguous). This matters as soon as anything held is a devDependency — the docs app declares both Tailwind packages that way. Correspondingly, the declared-name set used for staleness covers all four sections Bun reports on, not just `dependencies` and `devDependencies`.

### Note on how the two jobs invoke the script

They differ deliberately, and both carry a comment saying why:

- **backend** runs in the project's synced environment, because `uv pip list` inspects the active env. Using `--script` there resolves an isolated env, and the check then reports "all up to date" while verifying nothing — a green check that checks nothing, worse than the shell it replaces.
- **frontend** uses `--script`, because that job only syncs `docs/app` and the frontend path reads Bun plus `package.json` rather than the Python environment.

### Testing

Note this workflow only triggers on `release/**` pushes and `workflow_dispatch`, so **the job does not run on this PR**. That is part of the point of making it runnable locally.

- `tests/units/test_check_outdated_deps.py` — 23 cases: exact/prefix matching including the sibling-swallowing regressions, both staleness modes, pinned-never-stale, Bun's padded table, all three annotation kinds, and an end-to-end case asserting a `(dev)` row is suppressed by its exact hold.
- Both real invocations exercised against this checkout, not just the unit tests:

  ```
  $ uv run python scripts/check_outdated_deps.py backend
  Held back (1), not reported:
    ruff
  Outdated backend dependencies found:
    alembic, bidict, charset-normalizer, ...

  $ uv run --script scripts/check_outdated_deps.py frontend --web-dir <app>/.web
  ```

- `uv run ruff check .` / `ruff format --check .`, `uv run pyright`, and `uv lock --check` clean.

No news fragment: `root_source_dirs` is `reflex/`, and this touches only `.github/`, `scripts/`, `tests/` and `pyproject.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKQ4ARC2vkE5iKoULyaczz

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKQ4ARC2vkE5iKoULyaczz)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/7037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

