### PR TITLE
Sync uv.lock with the testing extra in pyproject.toml

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3865,6 +3865,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.26,<1.0" },
     { name = "packaging", specifier = ">=24.2,<27" },
     { name = "psutil", marker = "sys_platform == 'win32'", specifier = ">=7.0.0,<8.0" },
+    { name = "psutil", marker = "extra == 'testing'", specifier = ">=7.0.0,<8.0" },
     { name = "pydantic", marker = "extra == 'db'", specifier = ">=2.12.0,<3.0" },
     { name = "python-multipart", specifier = ">=0.0.32,<1.0" },
     { name = "python-socketio", specifier = ">=5.12.0,<6.0" },
@@ -3885,12 +3886,14 @@ requires-dist = [
     { name = "reflex-components-sonner", editable = "packages/reflex-components-sonner" },
     { name = "reflex-hosting-cli", editable = "packages/reflex-hosting-cli" },
     { name = "rich", specifier = ">=13,<16" },
+    { name = "selenium", marker = "extra == 'testing'", specifier = ">=4.0.0,<5.0" },
     { name = "sqlmodel", marker = "extra == 'db'", specifier = ">=0.0.24,<0.1" },
     { name = "starlette", specifier = ">=1.3.1" },
     { name = "typing-extensions", specifier = ">=4.13.0" },
+    { name = "uvicorn", marker = "extra == 'testing'", specifier = ">=0.34.0,<1.0" },
     { name = "wrapt", specifier = ">=1.17.0,<2.4" },
 ]
-provides-extras = ["db", "pydantic"]
+provides-extras = ["db", "pydantic", "testing"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

- [x] Repository maintenance (lockfile sync, no code or dependency version changes)

### Description

#7008 added a `testing` optional-dependency group (`psutil`, `selenium`, `uvicorn`) to the root `pyproject.toml`, but the accompanying `uv.lock` update was incomplete. On `main`, `uv lock --check` fails, and every `uv sync` or `uv run` rewrites `uv.lock`, so unrelated branches keep picking up a stray lockfile diff.

This PR regenerates `uv.lock` with plain `uv lock` (no `--upgrade`). The diff is limited to the `reflex` package's `[package.metadata]` section:

- three `requires-dist` entries with `marker = "extra == 'testing'"` for `psutil`, `selenium`, and `uvicorn`
- `"testing"` appended to `provides-extras`

No resolved dependency versions changed. `uv lock --check` passes on this branch.

Not user-facing, so no `news/` fragment; labeled `skip-changelog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KpSPsdMoxxXp3xqsDUpvVS