### PR TITLE
Avoid copying entire mappings during type inference

### DIFF
--- a/packages/reflex-base/news/+bounded-mapping-inference.performance.md
+++ b/packages/reflex-base/news/+bounded-mapping-inference.performance.md
@@ -1,0 +1,1 @@
+Avoid copying entire mappings when sampling their key and value types during compilation.

--- a/packages/reflex-base/src/reflex_base/vars/base.py
+++ b/packages/reflex-base/src/reflex_base/vars/base.py
@@ -19,6 +19,7 @@ from abc import ABCMeta
 from collections.abc import Callable, Coroutine, Iterable, Mapping, Sequence
 from dataclasses import _MISSING_TYPE, MISSING
 from decimal import Decimal
+from itertools import islice
 from types import CodeType, FunctionType
 from typing import (
     TYPE_CHECKING,
@@ -1986,8 +1987,8 @@ def figure_out_type(value: Any) -> types.GenericType:
             if not value:
                 return Mapping[NoReturn, NoReturn]
             return Mapping[
-                unionize(*{figure_out_type(k) for k in list(value.keys())[:100]}),
-                unionize(*{figure_out_type(v) for v in list(value.values())[:100]}),
+                unionize(*{figure_out_type(k) for k in islice(value.keys(), 100)}),
+                unionize(*{figure_out_type(v) for v in islice(value.values(), 100)}),
             ]
     return type(value)
 

--- a/tests/benchmarks/test_type_inference.py
+++ b/tests/benchmarks/test_type_inference.py
@@ -1,0 +1,17 @@
+"""Benchmarks for inference from container values."""
+
+import pytest
+from pytest_codspeed import BenchmarkFixture
+from reflex_base.vars.base import figure_out_type
+
+
+@pytest.mark.parametrize("size", [100, 10_000, 100_000])
+def test_mapping_type_inference(benchmark: BenchmarkFixture, size: int):
+    """Infer a mapping's type without work proportional to its size.
+
+    Args:
+        benchmark: The benchmark fixture.
+        size: The number of entries in the mapping.
+    """
+    value = {str(index): index for index in range(size)}
+    benchmark(figure_out_type, value)

--- a/tests/units/reflex_base/vars/test_base.py
+++ b/tests/units/reflex_base/vars/test_base.py
@@ -2,11 +2,18 @@
 
 import threading
 import typing
+from collections.abc import Mapping
 from typing import Any, Literal, TypeVar
 
 import pytest
 from reflex_base.utils.types import get_field_type
-from reflex_base.vars.base import EvenMoreBasicBaseState, Var, _linearize_bases, field
+from reflex_base.vars.base import (
+    EvenMoreBasicBaseState,
+    Var,
+    _linearize_bases,
+    field,
+    figure_out_type,
+)
 from reflex_base.vars.object import ObjectVar
 from reflex_base.vars.sequence import ArrayVar, StringVar
 from typing_extensions import TypeAliasType, TypeVarTuple, Unpack
@@ -14,6 +21,40 @@ from typing_extensions import TypeAliasType, TypeVarTuple, Unpack
 from reflex.state import State
 
 _MARKER_ATTR = "_marker"
+
+
+@pytest.mark.parametrize("size", [0, 1, 100, 101, 1000])
+def test_mapping_type_inference_bounds_iteration(size):
+    """Sampling does not iterate or retrieve values beyond the first 100 items."""
+    keys_seen = []
+    values_seen = []
+
+    class CountingMapping(Mapping):
+        def __len__(self):
+            return size
+
+        def __iter__(self):
+            for index in range(size):
+                keys_seen.append(index)
+                yield index
+
+        def __getitem__(self, key):
+            values_seen.append(key)
+            return str(key)
+
+    expected = Mapping[int, str] if size else Mapping[typing.NoReturn, typing.NoReturn]
+    assert figure_out_type(CountingMapping()) == expected
+    sampled = list(range(min(size, 100)))
+    assert keys_seen == sampled * 2
+    assert values_seen == sampled
+
+
+def test_mapping_type_inference_preserves_sample_boundary():
+    """The hundredth item contributes types, while later items do not."""
+    value: dict[Any, Any] = dict.fromkeys(range(99), 1)
+    value["last sampled"] = "included"
+    value[1.5] = ["not sampled"]
+    assert figure_out_type(value) == Mapping[int | str, int | str]
 
 
 def test_custom_field_attr_survives_annotated_rebuild():


### PR DESCRIPTION
Mapping type inference samples only 100 keys and values, but currently materializes every key and value before taking that sample. Use bounded iteration so inference keeps the same sample and resulting types without copying or retrieving the rest of a large mapping.

On a local CPython 3.14.5 / Apple M5 Pro benchmark, inference for a one-million-entry dict fell from 5.62 ms to 0.026 ms, with peak traced temporary allocation falling from 8 MB to 360 B. This measures the inference helper, not whole-app compilation. Added a CodSpeed benchmark across mapping sizes and regressions covering empty mappings, the exact sample boundary, and custom Mapping iteration/value access. The bounded-iteration regression fails on the unchanged base.

Validation:
- Full unit suite: 8,303 passed, 18 skipped; 75.95% coverage.
- Focused Var tests and new benchmark: 260 passed.
- Repository-wide Ruff check and format check passed.
- `pyright reflex tests` and changed-file type checks passed.

Independent of the other performance changes; based directly on main.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/7057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

