### PR TITLE
Cache stable builtin literal dispatch checks

### DIFF
--- a/packages/reflex-base/news/+literal-dispatch-cache.performance.md
+++ b/packages/reflex-base/news/+literal-dispatch-cache.performance.md
@@ -1,0 +1,1 @@
+Reduce repeated type checks when creating literal Vars and collecting their metadata, while preserving custom literal registrations.

--- a/packages/reflex-base/src/reflex_base/vars/base.py
+++ b/packages/reflex-base/src/reflex_base/vars/base.py
@@ -116,6 +116,66 @@ _var_subclasses: list[VarSubclassEntry] = []
 _var_literal_subclasses: list[tuple[type[LiteralVar], VarSubclassEntry]] = []
 
 
+_BUILTIN_LITERAL_TYPES = frozenset((
+    type(None),
+    bool,
+    int,
+    float,
+    str,
+    list,
+    tuple,
+    dict,
+    set,
+    range,
+))
+
+
+@functools.cache
+def _builtin_literal_dispatch(
+    value_type: type,
+) -> tuple[tuple[type[LiteralVar], tuple[GenericType, ...] | None], ...]:
+    """Skip stable type checks while retaining dynamic checks in registry order.
+
+    Args:
+        value_type: An exact builtin type without custom instance attributes.
+
+    Returns:
+        Candidate literal classes and their remaining checks. None marks a
+        guaranteed match, after any higher-priority dynamic checks.
+    """
+    candidates = []
+    for literal, entry in _var_literal_subclasses[::-1]:
+        if all(type(python_type) is type for python_type in entry.python_types):
+            if issubclass(value_type, entry.python_types):
+                candidates.append((literal, None))
+                break
+        else:
+            # ABC virtual registration and custom __instancecheck__ remain live.
+            candidates.append((literal, entry.python_types))
+    return tuple(candidates)
+
+
+def _literal_var_subclass(value: Any) -> type[LiteralVar] | None:
+    """Resolve a literal class without caching value-sensitive instance checks.
+
+    Args:
+        value: The value to dispatch.
+
+    Returns:
+        The highest-priority matching literal class, if any.
+    """
+    value_type = type(value)
+    if type(value_type) is type and value_type in _BUILTIN_LITERAL_TYPES:
+        for literal, python_types in _builtin_literal_dispatch(value_type):
+            if python_types is None or isinstance(value, python_types):
+                return literal
+    else:
+        for literal, entry in _var_literal_subclasses[::-1]:
+            if isinstance(value, entry.python_types):
+                return literal
+    return None
+
+
 @functools.cache
 def _var_subclass_for_conversion(python_type: GenericType) -> VarSubclassEntry | None:
     """Find the registry entry ``Var.to`` maps a python type to.
@@ -186,6 +246,7 @@ def _clear_var_subclass_lookup_caches() -> None:
     _var_subclass_for_conversion.cache_clear()
     _var_subclass_matching_python_types.cache_clear()
     _var_subclass_for_var_output.cache_clear()
+    _builtin_literal_dispatch.cache_clear()
 
 
 def _register_var_subclass_entry(entry: VarSubclassEntry) -> None:
@@ -1650,6 +1711,7 @@ class LiteralVar(Var[VAR_TYPE]):
                 _var_literal_subclasses.remove(var_literal_subclass)
 
         _var_literal_subclasses.append((cls, var_subclass))
+        _builtin_literal_dispatch.cache_clear()
 
     @classmethod
     def _create_literal_var(
@@ -1677,9 +1739,8 @@ class LiteralVar(Var[VAR_TYPE]):
                 return value
             return value._replace(merge_var_data=_var_data)
 
-        for literal_subclass, var_subclass in _var_literal_subclasses[::-1]:
-            if isinstance(value, var_subclass.python_types):
-                return literal_subclass.create(value, _var_data=_var_data)
+        if (literal_subclass := _literal_var_subclass(value)) is not None:
+            return literal_subclass.create(value, _var_data=_var_data)
 
         if (
             (as_var_method := getattr(value, "_as_var", None)) is not None
@@ -1759,9 +1820,8 @@ class LiteralVar(Var[VAR_TYPE]):
         if isinstance(value, Var):
             return value._get_all_var_data()
 
-        for literal_subclass, var_subclass in _var_literal_subclasses[::-1]:
-            if isinstance(value, var_subclass.python_types):
-                return literal_subclass._get_all_var_data_without_creating_var(value)
+        if (literal_subclass := _literal_var_subclass(value)) is not None:
+            return literal_subclass._get_all_var_data_without_creating_var(value)
 
         if (
             (as_var_method := getattr(value, "_as_var", None)) is not None

--- a/tests/benchmarks/test_literal_dispatch.py
+++ b/tests/benchmarks/test_literal_dispatch.py
@@ -1,0 +1,22 @@
+"""Benchmarks for literal construction and metadata dispatch."""
+
+import pytest
+from pytest_codspeed import BenchmarkFixture
+from reflex_base.vars.base import LiteralVar
+
+
+@pytest.mark.parametrize("metadata", [False, True])
+def test_literal_row_dispatch(metadata: bool, benchmark: BenchmarkFixture) -> None:
+    """Measure dispatch on a mixed builtin row with the normal registry.
+
+    Args:
+        metadata: Whether to collect metadata instead of constructing literals.
+        benchmark: The CodSpeed benchmark fixture.
+    """
+    row = {"id": 1, "name": "Alice", "score": 0.5, "active": True}
+    operation = (
+        LiteralVar._get_all_var_data_without_creating_var_dispatch
+        if metadata
+        else LiteralVar.create
+    )
+    benchmark(lambda: tuple(operation(value) for value in row.values()))

--- a/tests/units/reflex_base/vars/test_literal_dispatch.py
+++ b/tests/units/reflex_base/vars/test_literal_dispatch.py
@@ -1,0 +1,218 @@
+"""Literal dispatch priority and extension behavior."""
+
+import builtins
+import dataclasses
+from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from reflex_base.utils.types import GenericType
+from reflex_base.vars import base
+from reflex_base.vars.base import LiteralVar, Var, VarData
+from reflex_base.vars.number import LiteralNumberVar
+
+
+@pytest.fixture(autouse=True)
+def isolated_registry(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Keep test registrations out of the process-wide registry."""
+    monkeypatch.setattr(base, "_var_subclasses", base._var_subclasses.copy())
+    monkeypatch.setattr(
+        base, "_var_literal_subclasses", base._var_literal_subclasses.copy()
+    )
+    yield
+    base._clear_var_subclass_lookup_caches()
+
+
+def register_literal(python_type: GenericType, marker: str) -> type[LiteralVar]:
+    """Register a literal whose generated expression identifies its handler.
+
+    Args:
+        python_type: The registered Python type.
+        marker: The generated expression and hook.
+
+    Returns:
+        The newly registered literal class.
+    """
+
+    class CustomVar(Var, python_types=python_type):
+        """Var used to register one test type."""
+
+    class CustomLiteral(LiteralVar, CustomVar):
+        """Literal used to observe dispatch decisions."""
+
+        @classmethod
+        def create(cls, value: Any, _var_data: VarData | None = None) -> Var:
+            """Create the marker Var for a selected value.
+
+            Args:
+                value: The selected value.
+                _var_data: Additional Var metadata.
+
+            Returns:
+                The marker Var.
+            """
+            return cls(_js_expr=marker, _var_type=int, _var_data=_var_data)
+
+        @classmethod
+        def _get_all_var_data_without_creating_var(cls, value: Any) -> VarData:
+            """Return marker metadata for a selected value.
+
+            Args:
+                value: The selected value.
+
+            Returns:
+                The marker metadata.
+            """
+            return VarData(hooks={marker: None})
+
+    return CustomLiteral
+
+
+def dispatch(value: Any, metadata: bool) -> Var | VarData | None:
+    """Exercise either literal dispatcher with the same registry.
+
+    Args:
+        value: The value to dispatch.
+        metadata: Whether to use the metadata dispatcher.
+
+    Returns:
+        The selected literal or metadata.
+    """
+    if metadata:
+        return LiteralVar._get_all_var_data_without_creating_var_dispatch(value)
+    return LiteralVar.create(value)
+
+
+@pytest.mark.parametrize("metadata", [False, True])
+def test_builtin_dispatch_skips_stable_isinstance_checks(
+    metadata: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Repeated builtin dispatch avoids rechecking ordinary registered types."""
+    numeric_types = next(
+        entry.python_types
+        for literal, entry in base._var_literal_subclasses
+        if literal is LiteralNumberVar
+    )
+    checks = []
+
+    def record_isinstance(value: Any, classinfo: Any) -> bool:
+        """Record the type tuples tested by the real dispatcher.
+
+        Args:
+            value: The dispatched value.
+            classinfo: The type or tuple of types to test.
+
+        Returns:
+            The actual instance check result.
+        """
+        checks.append(classinfo)
+        return builtins.isinstance(value, classinfo)
+
+    monkeypatch.setattr(base, "isinstance", record_isinstance, raising=False)
+    dispatch(42, metadata)
+    checks.clear()
+    dispatch(43, metadata)
+    assert all(classinfo is not numeric_types for classinfo in checks)
+
+
+@pytest.mark.parametrize("metadata", [False, True])
+def test_literal_registration_invalidates_dispatch(metadata: bool) -> None:
+    """A later literal registration still takes priority after cache warmup."""
+    dispatch(1, metadata)
+    register_literal(int, "first")
+    result = dispatch(1, metadata)
+    assert (
+        result == VarData(hooks={"first": None}) if metadata else str(result) == "first"
+    )
+    register_literal(int, "second")
+    result = dispatch(1, metadata)
+    assert (
+        result == VarData(hooks={"second": None})
+        if metadata
+        else str(result) == "second"
+    )
+
+
+@pytest.mark.parametrize("metadata", [False, True])
+def test_value_sensitive_instance_checks_keep_priority(metadata: bool) -> None:
+    """Custom metaclasses are checked for every value before stable matches."""
+    checked = []
+
+    class PositiveMeta(type):
+        """Match positive integers without claiming all integer values."""
+
+        def __instancecheck__(cls, value: Any) -> bool:
+            checked.append(value)
+            return type(value) is int and value > 0
+
+    class Positive(metaclass=PositiveMeta):
+        """Registered type with a value-dependent instance check."""
+
+    register_literal(int, "ordinary")
+    register_literal(Positive, "positive")
+    for value, expected in [(0, "ordinary"), (1, "positive"), (-1, "ordinary")]:
+        result = dispatch(value, metadata)
+        assert (
+            result == VarData(hooks={expected: None})
+            if metadata
+            else str(result) == expected
+        )
+    assert checked == [0, 1, -1]
+
+
+@pytest.mark.parametrize("metadata", [False, True])
+def test_abc_registration_remains_visible(metadata: bool) -> None:
+    """Virtual ABC registration affects dispatch without a new literal class."""
+
+    class VirtualABC(ABC):
+        """ABC whose virtual subclasses change after cache warmup."""
+
+        @abstractmethod
+        def marker(self) -> None:
+            """Identify implementations of this test ABC."""
+
+    register_literal(int, "ordinary")
+    register_literal(VirtualABC, "virtual")
+    before = dispatch(1, metadata)
+    assert (
+        before == VarData(hooks={"ordinary": None})
+        if metadata
+        else str(before) == "ordinary"
+    )
+    VirtualABC.register(int)
+    after = dispatch(1, metadata)
+    assert (
+        after == VarData(hooks={"virtual": None})
+        if metadata
+        else str(after) == "virtual"
+    )
+
+
+def test_dataclass_slots_replaces_cached_literal() -> None:
+    """Recreated dataclass classes replace the original literal registration."""
+    literal = register_literal(int, "custom")
+    assert type(LiteralVar.create(1)) is literal
+    recreated = dataclasses.dataclass(eq=False, frozen=True, slots=True)(literal)
+    assert recreated is not literal
+    assert type(LiteralVar.create(1)) is recreated
+
+
+@pytest.mark.parametrize("metadata", [False, True])
+def test_custom_values_keep_instance_class_behavior(metadata: bool) -> None:
+    """Only exact builtin values may use type-based dispatch decisions."""
+
+    class SpoofedInteger:
+        """Expose an integer __class__ to Python's instance checks."""
+
+        @property
+        def __class__(self):
+            return int
+
+    register_literal(int, "integer")
+    result = dispatch(SpoofedInteger(), metadata)
+    assert (
+        result == VarData(hooks={"integer": None})
+        if metadata
+        else str(result) == "integer"
+    )


### PR DESCRIPTION
Literal creation and metadata collection repeatedly scan registrations whose ordinary type checks cannot change for exact builtin inputs. Cache an ordered plan that skips those stable checks while executing custom metaclass, Pydantic and ABC checks on every value in their original order. Literal registration invalidates the plan; ABC virtual registration stays visible because ABC checks are never cached. Custom runtime types keep the existing dispatch path.

On a 1,000-row mixed-builtin workload, literal rendering fell from **17.17 to 16.16 ms (5.9%)** and metadata collection from **7.69 to 6.58 ms (14.5%)**. These are nine interleaved rounds against main on Python 3.14.5 / Apple M5 Pro with the normal registry loaded. Output is identical. The single-page compile result was within noise; no overall compile speedup is claimed.

Validation:

- Full unit suite: 8,308 passed, 18 skipped, 75.96% coverage; 376 focused Var tests passed.
- Regressions cover value-sensitive checks, registration precedence, ABC virtual subclasses, dataclass slot recreation, and custom `__class__` behavior.
- CodSpeed dispatch benchmarks, repository-wide Ruff and Pyright passed.
- The full run emitted `cached_property` destructor warnings at interpreter shutdown. A control using the original resolver with the new cache never populated reproduced them (8,306 passed, two performance tests deselected); targeted runs exit cleanly. No destructor behavior is changed here.

Independent of the other performance drafts; based directly on main.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/7063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

