### PR TITLE
ENG-9166: Suggestions for otel 1/3

### DIFF
--- a/packages/reflex-base/news/6227.feature.md
+++ b/packages/reflex-base/news/6227.feature.md
@@ -1,1 +1,1 @@
-Add inert OpenTelemetry trace points and metrics around event handler execution, state acquisition and socket messages (`reflex_base.otel`); they cost one boolean check until the `reflex-otel` package enables them.
+Add inert OpenTelemetry trace points and metrics around event handler execution, state acquisition and socket messages (`reflex_base.otel`); they cost one boolean check, and import nothing from `opentelemetry`, until the `reflex-otel` package enables them (`reflex-base` itself does not depend on `opentelemetry-api`).

--- a/packages/reflex-base/pyproject.toml
+++ b/packages/reflex-base/pyproject.toml
@@ -8,7 +8,6 @@ authors = [{ name = "Khaleel Al-Adhami", email = "khaleel@reflex.dev" }]
 maintainers = [{ name = "Khaleel Al-Adhami", email = "khaleel@reflex.dev" }]
 requires-python = ">=3.10"
 dependencies = [
-  "opentelemetry-api >=1.30.0,<2.0",
   "packaging >=24.2,<27",
   "rich >=13,<16",
   "typing_extensions >=4.13.0",

--- a/packages/reflex-base/src/reflex_base/event/processor/base_state_processor.py
+++ b/packages/reflex-base/src/reflex_base/event/processor/base_state_processor.py
@@ -521,8 +521,7 @@ class BaseStateEventProcessor(EventProcessor):
                 # Ensure the event context is set for the exception handler.
                 EventContext.set(ev_ctx)
                 if otel.enabled:
-                    # Chain the handler's events under the failed event's parent context
-                    # (its remote or enqueuing span); parent_txid links them to it.
+                    # Chain the handler's events under the failed event's span.
                     otel.attach_context(ev_ctx.otel_context)
             if events := self.backend_exception_handler(ex):
                 await chain_updates(

--- a/packages/reflex-base/src/reflex_base/event/processor/event_processor.py
+++ b/packages/reflex-base/src/reflex_base/event/processor/event_processor.py
@@ -495,6 +495,9 @@ class EventProcessor:
                 self._root_context,
                 token=token,
                 emit_delta_impl=_emit_delta_impl,
+                # Like fork(): the handler span nests under the caller's span
+                # (the upload request, a custom route).
+                otel_context=otel.capture_context(),
             ),
         )
 

--- a/packages/reflex-base/src/reflex_base/otel.py
+++ b/packages/reflex-base/src/reflex_base/otel.py
@@ -12,6 +12,7 @@ provider is available.
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Awaitable, Callable, Iterator, Mapping
 from contextlib import contextmanager
 from time import perf_counter
@@ -230,6 +231,22 @@ def remote_context(carrier: Mapping[str, Any]) -> _AttachedContext:
     return _AttachedContext(_remote_propagator.extract(fields, context=Context()))
 
 
+def _session_id(token: str) -> str:
+    """Pseudonymous session id for a client token.
+
+    The token authorizes access to the session's state, so it must not leave
+    the process in telemetry; a truncated digest still correlates one
+    session's spans.
+
+    Args:
+        token: The client token.
+
+    Returns:
+        The first 16 hex digits of the token's SHA-256.
+    """
+    return hashlib.sha256(token.encode()).hexdigest()[:16]
+
+
 def _code_function_name(fn: Callable[..., Any], fallback: str) -> str:
     """Fully qualified name of a handler, per the ``code.*`` semantic conventions.
 
@@ -274,7 +291,7 @@ def event_span(
     attributes: dict[str, Any] = {
         **metric_attributes,
         ATTR_EVENT_TXID: ctx.txid,
-        ATTR_SESSION_ID: ctx.token,
+        ATTR_SESSION_ID: _session_id(ctx.token),
         ATTR_CODE_FUNCTION_NAME: _code_function_name(handler.fn, event.name),
     }
     # An event whose parent span is local (a chained event) is an internal

--- a/packages/reflex-base/src/reflex_base/otel.py
+++ b/packages/reflex-base/src/reflex_base/otel.py
@@ -18,9 +18,10 @@ from time import perf_counter
 from typing import TYPE_CHECKING, Any
 
 from opentelemetry import context as otel_context
-from opentelemetry import metrics, propagate, trace
+from opentelemetry import metrics, trace
 from opentelemetry.context import Context
 from opentelemetry.trace import SpanKind
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 
 from reflex_base.constants.base import Reflex
 
@@ -47,8 +48,14 @@ METRIC_STATE_ACQUIRE_DURATION = "reflex.state.acquire.duration"
 METRIC_WEBSOCKET_MESSAGE_SIZE = "reflex.websocket.message.size"
 METRIC_WEBSOCKET_CONNECTIONS = "reflex.websocket.connections"
 
-# Key of the W3C trace context carried in an event payload sent by the frontend.
+# Keys of the W3C trace context carried in an event payload sent by the frontend.
 TRACEPARENT_FIELD = "traceparent"
+TRACESTATE_FIELD = "tracestate"
+
+# The event payload is unauthenticated client input, so only the W3C trace
+# context is read from it (never the global propagator: a client could
+# otherwise plant baggage that every instrumented downstream call forwards).
+_remote_propagator = TraceContextTextMapPropagator()
 
 # Histogram bucket advisories: seconds (semconv http.server.request.duration) and bytes.
 _DURATION_BUCKETS = (
@@ -204,9 +211,11 @@ class _AttachedContext:
 def remote_context(carrier: Mapping[str, Any]) -> _AttachedContext:
     """Make the trace context carried by a frontend event the current context.
 
-    Only call when ``enabled``. Events that carry no ``traceparent`` start a
-    new trace: the websocket connection span (if any) is deliberately not
-    used as their parent.
+    Only call when ``enabled``. Events that carry no usable ``traceparent``
+    start a new trace: the websocket connection span (if any) is deliberately
+    not used as their parent. Only string ``traceparent``/``tracestate``
+    fields are read; anything else a client sends is ignored, so this never
+    raises on hostile input.
 
     Args:
         carrier: The raw event fields received from the frontend.
@@ -214,7 +223,11 @@ def remote_context(carrier: Mapping[str, Any]) -> _AttachedContext:
     Returns:
         A context manager to run the enqueue under.
     """
-    return _AttachedContext(propagate.extract(carrier, context=Context()))
+    fields: dict[str, str] = {}
+    for key in (TRACEPARENT_FIELD, TRACESTATE_FIELD):
+        if isinstance(value := carrier.get(key), str):
+            fields[key] = value
+    return _AttachedContext(_remote_propagator.extract(fields, context=Context()))
 
 
 def _code_function_name(fn: Callable[..., Any], fallback: str) -> str:

--- a/packages/reflex-base/src/reflex_base/otel.py
+++ b/packages/reflex-base/src/reflex_base/otel.py
@@ -246,16 +246,17 @@ def event_span(
         ATTR_SESSION_ID: ctx.token,
         ATTR_CODE_FUNCTION_NAME: getattr(handler.fn, "__qualname__", event.name),
     }
-    if ctx.parent_txid:
-        attributes[ATTR_EVENT_PARENT_TXID] = ctx.parent_txid
     # An event whose parent span is local (a chained event) is an internal
     # step of that request; anything else is a new inbound request.
     parent = trace.get_current_span(ctx.otel_context).get_span_context()
-    kind = (
-        SpanKind.INTERNAL
-        if parent.is_valid and not parent.is_remote
-        else SpanKind.SERVER
-    )
+    if parent.is_valid and not parent.is_remote:
+        kind = SpanKind.INTERNAL
+        # Only a chained event has a parent event. A top-level event is forked
+        # from the processor's root context, whose txid carries no information.
+        if ctx.parent_txid:
+            attributes[ATTR_EVENT_PARENT_TXID] = ctx.parent_txid
+    else:
+        kind = SpanKind.SERVER
     with _tracer.start_as_current_span(
         event.name, context=ctx.otel_context, kind=kind, attributes=attributes
     ) as span:

--- a/packages/reflex-base/src/reflex_base/otel.py
+++ b/packages/reflex-base/src/reflex_base/otel.py
@@ -7,7 +7,10 @@ instrumentation installed the cost is one attribute read: no span is started,
 nothing is recorded, and nothing from ``opentelemetry`` is imported.
 
 The ``reflex-otel`` package flips the flag via :func:`enable` once a tracer
-provider is available.
+provider is available. ``enable`` also binds the OpenTelemetry API modules the
+trace points use as globals of this module: a trace point runs per event, so
+it must not carry an import statement, which costs a ``sys.modules`` lookup
+even when the module is already loaded.
 """
 
 from __future__ import annotations
@@ -21,8 +24,9 @@ from typing import TYPE_CHECKING, Any
 from reflex_base.constants.base import Reflex
 
 if TYPE_CHECKING:
-    # opentelemetry-api is a dependency of reflex-otel, not of reflex-base:
-    # it is imported lazily, by enable() and the trace points it turns on.
+    # opentelemetry-api is a dependency of reflex-otel, not of reflex-base: it
+    # is imported by enable(), which binds ``context_api`` and ``trace`` here.
+    from opentelemetry import context as context_api
     from opentelemetry import metrics, trace
     from opentelemetry.context import Context
     from opentelemetry.propagators.textmap import TextMapPropagator
@@ -171,11 +175,14 @@ def enable(
             e.g. the OpenTelemetry ASGI middleware. Applied by the app when it
             builds its ASGI app.
     """
-    global _tracer, _remote_propagator, enabled, asgi_middleware
+    global _tracer, _remote_propagator, enabled, asgi_middleware, context_api, trace
     if enabled:
         # Re-creating the instruments on another meter would log duplicate
         # instrument warnings; reconfiguring goes through disable() first.
         return
+    # The API modules stay bound after disable(): the trace points only run
+    # while enabled, and attach_context() may still see a captured context.
+    from opentelemetry import context as context_api
     from opentelemetry import metrics, trace
     from opentelemetry.trace.propagation.tracecontext import (
         TraceContextTextMapPropagator,
@@ -221,9 +228,7 @@ def capture_context() -> Context | None:
     """
     if not enabled:
         return None
-    from opentelemetry import context as otel_context
-
-    return otel_context.get_current()
+    return context_api.get_current()
 
 
 def attach_context(context: Context | None) -> None:
@@ -233,9 +238,7 @@ def attach_context(context: Context | None) -> None:
         context: The context to attach; None is ignored.
     """
     if context is not None:
-        from opentelemetry import context as otel_context
-
-        otel_context.attach(context)
+        context_api.attach(context)
 
 
 class _AttachedContext:
@@ -253,9 +256,7 @@ class _AttachedContext:
 
     def __enter__(self) -> None:
         """Attach the context."""
-        from opentelemetry import context as otel_context
-
-        self._token = otel_context.attach(self._context)
+        self._token = context_api.attach(self._context)
 
     def __exit__(self, *exc_info: object) -> None:
         """Detach the context.
@@ -263,9 +264,7 @@ class _AttachedContext:
         Args:
             *exc_info: Ignored exception details.
         """
-        from opentelemetry import context as otel_context
-
-        otel_context.detach(self._token)
+        context_api.detach(self._token)
 
 
 def remote_context(carrier: Mapping[str, Any]) -> _AttachedContext:
@@ -283,14 +282,14 @@ def remote_context(carrier: Mapping[str, Any]) -> _AttachedContext:
     Returns:
         A context manager to run the enqueue under.
     """
-    from opentelemetry.context import Context
-
     assert _remote_propagator is not None
     fields: dict[str, str] = {}
     for key in (TRACEPARENT_FIELD, TRACESTATE_FIELD):
         if isinstance(value := carrier.get(key), str):
             fields[key] = value
-    return _AttachedContext(_remote_propagator.extract(fields, context=Context()))
+    return _AttachedContext(
+        _remote_propagator.extract(fields, context=context_api.Context())
+    )
 
 
 def _session_id(token: str) -> str:
@@ -345,9 +344,6 @@ def event_span(
     Yields:
         The active span.
     """
-    from opentelemetry import trace
-    from opentelemetry.trace import SpanKind
-
     assert _tracer is not None
     handler = registered_handler.handler
     metric_attributes = {
@@ -364,13 +360,13 @@ def event_span(
     # step of that request; anything else is a new inbound message.
     parent = trace.get_current_span(ctx.otel_context).get_span_context()
     if parent.is_valid and not parent.is_remote:
-        kind = SpanKind.INTERNAL
+        kind = trace.SpanKind.INTERNAL
         # Only a chained event has a parent event. A top-level event is forked
         # from the processor's root context, whose txid carries no information.
         if ctx.parent_txid:
             attributes[ATTR_EVENT_PARENT_TXID] = ctx.parent_txid
     else:
-        kind = SpanKind.CONSUMER
+        kind = trace.SpanKind.CONSUMER
     with _tracer.start_as_current_span(
         event.name, context=ctx.otel_context, kind=kind, attributes=attributes
     ) as span:

--- a/packages/reflex-base/src/reflex_base/otel.py
+++ b/packages/reflex-base/src/reflex_base/otel.py
@@ -217,6 +217,23 @@ def remote_context(carrier: Mapping[str, Any]) -> _AttachedContext:
     return _AttachedContext(propagate.extract(carrier, context=Context()))
 
 
+def _code_function_name(fn: Callable[..., Any], fallback: str) -> str:
+    """Fully qualified name of a handler, per the ``code.*`` semantic conventions.
+
+    Args:
+        fn: The handler function.
+        fallback: Value to use when the function has no qualified name.
+
+    Returns:
+        ``module.qualname``, or the fallback.
+    """
+    qualname = getattr(fn, "__qualname__", None)
+    if qualname is None:
+        return fallback
+    module = getattr(fn, "__module__", None)
+    return f"{module}.{qualname}" if module else qualname
+
+
 @contextmanager
 def event_span(
     event: Event, ctx: EventContext, registered_handler: RegisteredEventHandler
@@ -244,7 +261,7 @@ def event_span(
         **metric_attributes,
         ATTR_EVENT_TXID: ctx.txid,
         ATTR_SESSION_ID: ctx.token,
-        ATTR_CODE_FUNCTION_NAME: getattr(handler.fn, "__qualname__", event.name),
+        ATTR_CODE_FUNCTION_NAME: _code_function_name(handler.fn, event.name),
     }
     # An event whose parent span is local (a chained event) is an internal
     # step of that request; anything else is a new inbound request.

--- a/packages/reflex-base/src/reflex_base/otel.py
+++ b/packages/reflex-base/src/reflex_base/otel.py
@@ -241,8 +241,9 @@ def event_span(
     """Open the span for one event handler execution and record its duration.
 
     Chained events are INTERNAL children of the span that enqueued them;
-    events that arrive from the frontend are SERVER spans (a new trace, or a
-    child of the browser's remote span).
+    events that arrive from the frontend are CONSUMER spans (a new trace, or
+    a child of the browser's PRODUCER span): the browser fires an event over
+    the socket and does not wait for it, which is messaging, not RPC.
 
     Args:
         event: The event being processed.
@@ -264,7 +265,7 @@ def event_span(
         ATTR_CODE_FUNCTION_NAME: _code_function_name(handler.fn, event.name),
     }
     # An event whose parent span is local (a chained event) is an internal
-    # step of that request; anything else is a new inbound request.
+    # step of that request; anything else is a new inbound message.
     parent = trace.get_current_span(ctx.otel_context).get_span_context()
     if parent.is_valid and not parent.is_remote:
         kind = SpanKind.INTERNAL
@@ -273,7 +274,7 @@ def event_span(
         if ctx.parent_txid:
             attributes[ATTR_EVENT_PARENT_TXID] = ctx.parent_txid
     else:
-        kind = SpanKind.SERVER
+        kind = SpanKind.CONSUMER
     with _tracer.start_as_current_span(
         event.name, context=ctx.otel_context, kind=kind, attributes=attributes
     ) as span:

--- a/packages/reflex-base/src/reflex_base/otel.py
+++ b/packages/reflex-base/src/reflex_base/otel.py
@@ -291,6 +291,13 @@ def event_span(
     with _tracer.start_as_current_span(
         event.name, context=ctx.otel_context, kind=kind, attributes=attributes
     ) as span:
+        # From here on the event context describes this event's execution:
+        # anything chained from it, including the events the backend exception
+        # handler returns after a failure, parents under this span. The
+        # context is frozen; this is the one place that extends it.
+        object.__setattr__(
+            ctx, "otel_context", trace.set_span_in_context(span, ctx.otel_context)
+        )
         # Record while the span is still current: exporter latency stays out
         # of the sample and exemplars keep the trace/span IDs.
         start = perf_counter()

--- a/packages/reflex-base/src/reflex_base/otel.py
+++ b/packages/reflex-base/src/reflex_base/otel.py
@@ -60,8 +60,8 @@ TRACESTATE_FIELD = "tracestate"
 # The event payload is unauthenticated client input, so only the W3C trace
 # context is read from it (never the global propagator: a client could
 # otherwise plant baggage that every instrumented downstream call forwards).
-# Created by enable().
-_remote_propagator: TextMapPropagator | None = None
+# Bound by enable().
+_remote_propagator: TextMapPropagator
 
 # Histogram bucket advisories: seconds (semconv http.server.request.duration) and bytes.
 _DURATION_BUCKETS = (
@@ -115,8 +115,8 @@ class _NoOpInstrument:
 
 _NOOP_INSTRUMENT = _NoOpInstrument()
 
-# Set by enable(); the trace points only run while enabled.
-_tracer: trace.Tracer | None = None
+# Bound by enable(); the trace points only run while enabled.
+_tracer: trace.Tracer
 _event_duration: metrics.Histogram | _NoOpInstrument = _NOOP_INSTRUMENT
 _state_acquire_duration: metrics.Histogram | _NoOpInstrument = _NOOP_INSTRUMENT
 _message_size: metrics.Histogram | _NoOpInstrument = _NOOP_INSTRUMENT
@@ -202,10 +202,12 @@ def enable(
 
 
 def disable() -> None:
-    """Turn the trace points off and drop the tracer and instruments."""
+    """Turn the trace points off and reset the metric instruments.
+
+    The tracer, the propagator and the API modules stay bound: the trace
+    points only run while enabled, and :func:`enable` rebinds them.
+    """
     global \
-        _tracer, \
-        _remote_propagator, \
         enabled, \
         asgi_middleware, \
         _event_duration, \
@@ -214,8 +216,6 @@ def disable() -> None:
         _ws_connections
     enabled = False
     asgi_middleware = None
-    _tracer = None
-    _remote_propagator = None
     _event_duration = _state_acquire_duration = _NOOP_INSTRUMENT
     _message_size = _ws_connections = _NOOP_INSTRUMENT
 
@@ -282,7 +282,6 @@ def remote_context(carrier: Mapping[str, Any]) -> _AttachedContext:
     Returns:
         A context manager to run the enqueue under.
     """
-    assert _remote_propagator is not None
     fields: dict[str, str] = {}
     for key in (TRACEPARENT_FIELD, TRACESTATE_FIELD):
         if isinstance(value := carrier.get(key), str):
@@ -344,7 +343,6 @@ def event_span(
     Yields:
         The active span.
     """
-    assert _tracer is not None
     handler = registered_handler.handler
     metric_attributes = {
         ATTR_EVENT_NAME: event.name,

--- a/packages/reflex-base/src/reflex_base/otel.py
+++ b/packages/reflex-base/src/reflex_base/otel.py
@@ -3,8 +3,8 @@
 The framework calls into this module at a small number of fixed points (event
 dispatch, event context forks, state acquisition, socket messages). Every entry
 point checks the module-level ``enabled`` flag first, so with no
-instrumentation installed the cost is one attribute read: no span is started
-and nothing is recorded (only no-op API objects exist, created at import).
+instrumentation installed the cost is one attribute read: no span is started,
+nothing is recorded, and nothing from ``opentelemetry`` is imported.
 
 The ``reflex-otel`` package flips the flag via :func:`enable` once a tracer
 provider is available.
@@ -18,15 +18,15 @@ from contextlib import contextmanager
 from time import perf_counter
 from typing import TYPE_CHECKING, Any
 
-from opentelemetry import context as otel_context
-from opentelemetry import metrics, trace
-from opentelemetry.context import Context
-from opentelemetry.trace import SpanKind
-from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
-
 from reflex_base.constants.base import Reflex
 
 if TYPE_CHECKING:
+    # opentelemetry-api is a dependency of reflex-otel, not of reflex-base:
+    # it is imported lazily, by enable() and the trace points it turns on.
+    from opentelemetry import metrics, trace
+    from opentelemetry.context import Context
+    from opentelemetry.propagators.textmap import TextMapPropagator
+
     from reflex_base.event import Event
     from reflex_base.event.context import EventContext
     from reflex_base.registry import RegisteredEventHandler
@@ -56,7 +56,8 @@ TRACESTATE_FIELD = "tracestate"
 # The event payload is unauthenticated client input, so only the W3C trace
 # context is read from it (never the global propagator: a client could
 # otherwise plant baggage that every instrumented downstream call forwards).
-_remote_propagator = TraceContextTextMapPropagator()
+# Created by enable().
+_remote_propagator: TextMapPropagator | None = None
 
 # Histogram bucket advisories: seconds (semconv http.server.request.duration) and bytes.
 _DURATION_BUCKETS = (
@@ -85,12 +86,37 @@ enabled: bool = False
 # Wraps the app's ASGI callable when set (installed by enable()).
 asgi_middleware: Callable[[ASGIApp], ASGIApp] | None = None
 
-_tracer: trace.Tracer = trace.NoOpTracer()
-_noop_meter = metrics.NoOpMeter(INSTRUMENTATION_NAME)
-_event_duration = _noop_meter.create_histogram(METRIC_EVENT_DURATION)
-_state_acquire_duration = _noop_meter.create_histogram(METRIC_STATE_ACQUIRE_DURATION)
-_message_size = _noop_meter.create_histogram(METRIC_WEBSOCKET_MESSAGE_SIZE)
-_ws_connections = _noop_meter.create_up_down_counter(METRIC_WEBSOCKET_CONNECTIONS)
+
+class _NoOpInstrument:
+    """Stand-in for the metric instruments while instrumentation is off."""
+
+    __slots__ = ()
+
+    def record(self, *args: Any, **kwargs: Any) -> None:
+        """Drop a measurement.
+
+        Args:
+            *args: Ignored.
+            **kwargs: Ignored.
+        """
+
+    def add(self, *args: Any, **kwargs: Any) -> None:
+        """Drop an increment.
+
+        Args:
+            *args: Ignored.
+            **kwargs: Ignored.
+        """
+
+
+_NOOP_INSTRUMENT = _NoOpInstrument()
+
+# Set by enable(); the trace points only run while enabled.
+_tracer: trace.Tracer | None = None
+_event_duration: metrics.Histogram | _NoOpInstrument = _NOOP_INSTRUMENT
+_state_acquire_duration: metrics.Histogram | _NoOpInstrument = _NOOP_INSTRUMENT
+_message_size: metrics.Histogram | _NoOpInstrument = _NOOP_INSTRUMENT
+_ws_connections: metrics.UpDownCounter | _NoOpInstrument = _NOOP_INSTRUMENT
 
 
 def _create_instruments(meter: metrics.Meter) -> None:
@@ -145,11 +171,17 @@ def enable(
             e.g. the OpenTelemetry ASGI middleware. Applied by the app when it
             builds its ASGI app.
     """
-    global _tracer, enabled, asgi_middleware
+    global _tracer, _remote_propagator, enabled, asgi_middleware
     if enabled:
         # Re-creating the instruments on another meter would log duplicate
         # instrument warnings; reconfiguring goes through disable() first.
         return
+    from opentelemetry import metrics, trace
+    from opentelemetry.trace.propagation.tracecontext import (
+        TraceContextTextMapPropagator,
+    )
+
+    _remote_propagator = TraceContextTextMapPropagator()
     _tracer = trace.get_tracer(
         INSTRUMENTATION_NAME, Reflex.VERSION, tracer_provider=tracer_provider
     )
@@ -164,11 +196,21 @@ def enable(
 
 def disable() -> None:
     """Turn the trace points off and drop the tracer and instruments."""
-    global _tracer, enabled, asgi_middleware
+    global \
+        _tracer, \
+        _remote_propagator, \
+        enabled, \
+        asgi_middleware, \
+        _event_duration, \
+        _state_acquire_duration, \
+        _message_size, \
+        _ws_connections
     enabled = False
     asgi_middleware = None
-    _tracer = trace.NoOpTracer()
-    _create_instruments(_noop_meter)
+    _tracer = None
+    _remote_propagator = None
+    _event_duration = _state_acquire_duration = _NOOP_INSTRUMENT
+    _message_size = _ws_connections = _NOOP_INSTRUMENT
 
 
 def capture_context() -> Context | None:
@@ -177,7 +219,11 @@ def capture_context() -> Context | None:
     Returns:
         The current context when tracing is enabled, otherwise None.
     """
-    return otel_context.get_current() if enabled else None
+    if not enabled:
+        return None
+    from opentelemetry import context as otel_context
+
+    return otel_context.get_current()
 
 
 def attach_context(context: Context | None) -> None:
@@ -187,6 +233,8 @@ def attach_context(context: Context | None) -> None:
         context: The context to attach; None is ignored.
     """
     if context is not None:
+        from opentelemetry import context as otel_context
+
         otel_context.attach(context)
 
 
@@ -205,6 +253,8 @@ class _AttachedContext:
 
     def __enter__(self) -> None:
         """Attach the context."""
+        from opentelemetry import context as otel_context
+
         self._token = otel_context.attach(self._context)
 
     def __exit__(self, *exc_info: object) -> None:
@@ -213,6 +263,8 @@ class _AttachedContext:
         Args:
             *exc_info: Ignored exception details.
         """
+        from opentelemetry import context as otel_context
+
         otel_context.detach(self._token)
 
 
@@ -231,6 +283,9 @@ def remote_context(carrier: Mapping[str, Any]) -> _AttachedContext:
     Returns:
         A context manager to run the enqueue under.
     """
+    from opentelemetry.context import Context
+
+    assert _remote_propagator is not None
     fields: dict[str, str] = {}
     for key in (TRACEPARENT_FIELD, TRACESTATE_FIELD):
         if isinstance(value := carrier.get(key), str):
@@ -290,6 +345,10 @@ def event_span(
     Yields:
         The active span.
     """
+    from opentelemetry import trace
+    from opentelemetry.trace import SpanKind
+
+    assert _tracer is not None
     handler = registered_handler.handler
     metric_attributes = {
         ATTR_EVENT_NAME: event.name,

--- a/packages/reflex-base/src/reflex_base/otel.py
+++ b/packages/reflex-base/src/reflex_base/otel.py
@@ -132,6 +132,9 @@ def enable(
 ) -> None:
     """Turn the trace points and metrics on.
 
+    A second call while enabled is ignored: call :func:`disable` first to
+    switch providers.
+
     Args:
         tracer_provider: The provider to obtain the tracer from. Defaults to
             the global provider, which may be configured later; the returned
@@ -143,6 +146,10 @@ def enable(
             builds its ASGI app.
     """
     global _tracer, enabled, asgi_middleware
+    if enabled:
+        # Re-creating the instruments on another meter would log duplicate
+        # instrument warnings; reconfiguring goes through disable() first.
+        return
     _tracer = trace.get_tracer(
         INSTRUMENTATION_NAME, Reflex.VERSION, tracer_provider=tracer_provider
     )
@@ -356,3 +363,34 @@ def record_connection(delta: int) -> None:
         delta: ``1`` on connect, ``-1`` on disconnect.
     """
     _ws_connections.add(delta)
+
+
+__all__ = [
+    "ATTR_CODE_FUNCTION_NAME",
+    "ATTR_ERROR_TYPE",
+    "ATTR_EVENT_BACKGROUND",
+    "ATTR_EVENT_NAME",
+    "ATTR_EVENT_PARENT_TXID",
+    "ATTR_EVENT_TXID",
+    "ATTR_NETWORK_IO_DIRECTION",
+    "ATTR_SESSION_ID",
+    "INSTRUMENTATION_NAME",
+    "METRIC_EVENT_DURATION",
+    "METRIC_STATE_ACQUIRE_DURATION",
+    "METRIC_WEBSOCKET_CONNECTIONS",
+    "METRIC_WEBSOCKET_MESSAGE_SIZE",
+    "TRACEPARENT_FIELD",
+    "TRACESTATE_FIELD",
+    "ASGIApp",
+    "asgi_middleware",
+    "attach_context",
+    "capture_context",
+    "disable",
+    "enable",
+    "enabled",
+    "event_span",
+    "record_connection",
+    "record_message_size",
+    "record_state_acquired",
+    "remote_context",
+]

--- a/packages/reflex-base/src/reflex_base/utils/log.py
+++ b/packages/reflex-base/src/reflex_base/utils/log.py
@@ -62,6 +62,7 @@ PACKAGE_LOGGER_NAMES = (
     "reflex_components_lucide",
     "reflex_components_plotly",
     "reflex_components_react_player",
+    "reflex_otel",
 )
 
 # The single logger the reflex sinks attach to; parent of every package logger.

--- a/packages/reflex-otel/README.md
+++ b/packages/reflex-otel/README.md
@@ -56,7 +56,10 @@ Metrics:
 | `reflex.websocket.message.size` | histogram | By | `network.io.direction` (`transmit`/`receive`); default `sio` only |
 | `reflex.websocket.connections` | up-down counter | `{connection}` | |
 
-Plus the ASGI middleware's `http.server.*` metrics.
+Plus the ASGI middleware's `http.server.*` metrics. The instrumentor opts the
+middleware into the stable HTTP semantic conventions
+(`OTEL_SEMCONV_STABILITY_OPT_IN=http`) unless that variable is already set,
+so request attributes use the same generation of names as Reflex's own.
 
 ## Options
 

--- a/packages/reflex-otel/README.md
+++ b/packages/reflex-otel/README.md
@@ -64,7 +64,8 @@ Plus the ASGI middleware's `http.server.*` metrics.
 (comma-separated URL patterns skipped by the ASGI middleware; defaults to
 `OTEL_PYTHON_REFLEX_EXCLUDED_URLS`, else `OTEL_PYTHON_EXCLUDED_URLS`, else
 `/ping` plus the compiled frontend's `/assets/` when the backend serves it,
-as `reflex run --env prod` does on one port; pass `""` to exclude nothing) and the ASGI hooks
+as `reflex run --env prod` does on one port; pass `""`, or set the variable
+to an empty string, to exclude nothing) and the ASGI hooks
 `server_request_hook`, `client_request_hook`, `client_response_hook`.
 Call `instrument()` before the app is served: `uninstrument()` turns the
 framework trace points off again, but an ASGI middleware that was already

--- a/packages/reflex-otel/README.md
+++ b/packages/reflex-otel/README.md
@@ -63,7 +63,8 @@ Plus the ASGI middleware's `http.server.*` metrics.
 `instrument()` accepts `tracer_provider`, `meter_provider`, `excluded_urls`
 (comma-separated URL patterns skipped by the ASGI middleware; defaults to
 `OTEL_PYTHON_REFLEX_EXCLUDED_URLS`, else `OTEL_PYTHON_EXCLUDED_URLS`, else
-`/ping`; pass `""` to exclude nothing) and the ASGI hooks
+`/ping` plus the compiled frontend's `/assets/` when the backend serves it,
+as `reflex run --env prod` does on one port; pass `""` to exclude nothing) and the ASGI hooks
 `server_request_hook`, `client_request_hook`, `client_response_hook`.
 Call `instrument()` before the app is served: `uninstrument()` turns the
 framework trace points off again, but an ASGI middleware that was already

--- a/packages/reflex-otel/README.md
+++ b/packages/reflex-otel/README.md
@@ -41,6 +41,12 @@ Traces:
 - HTTP requests and the websocket connection are wrapped in the standard
   OpenTelemetry ASGI middleware (per-message websocket spans are off).
 
+What leaves the process: event and handler names, a pseudonymous
+`session.id` (a truncated SHA-256 of the client token, never the token
+itself), exception types, messages and stack traces of failed handlers, and
+the ASGI middleware's request attributes with the `token` query parameter of
+the websocket URL redacted. Event payloads and state are never recorded.
+
 Metrics:
 
 | Instrument | Type | Unit | Attributes |

--- a/packages/reflex-otel/README.md
+++ b/packages/reflex-otel/README.md
@@ -30,8 +30,14 @@ Traces:
 - One span per event handler run, named after the event: `CONSUMER` for
   events sent by the frontend (a new trace, or a child of the browser's
   `PRODUCER` span when the event carries a `traceparent` field), `INTERNAL`
-  for chained events, which are children of the span that enqueued them. `traceparent`/`tracestate`
-  are consumed and never reach the handler.
+  for chained events, which are children of the span that enqueued them.
+  Only string `traceparent`/`tracestate` fields are read from the event;
+  they never reach the handler, and `baggage` or anything else a client
+  sends is ignored. The sampled flag of a client `traceparent` is honoured
+  by the SDK's default parent-based sampler, so a client decides whether its
+  own events are recorded; use `ParentBased(root=..., remote_parent_sampled=...,
+  remote_parent_not_sampled=...)` or `OTEL_TRACES_SAMPLER=always_on` to keep
+  that decision on the server.
 - HTTP requests and the websocket connection are wrapped in the standard
   OpenTelemetry ASGI middleware (per-message websocket spans are off).
 

--- a/packages/reflex-otel/README.md
+++ b/packages/reflex-otel/README.md
@@ -8,20 +8,30 @@ from reflex_otel import ReflexInstrumentor
 ReflexInstrumentor().instrument()
 ```
 
-The package registers an `opentelemetry_instrumentor` entry point, so
-`opentelemetry-instrument reflex run` enables it too (the auto-instrumentation
-`sitecustomize` reaches the backend worker through the inherited `PYTHONPATH`).
-Configure a tracer provider and a meter provider (for example with
-`opentelemetry-sdk`) to export the data.
+Nothing in the app module needs guarding: a second `instrument()` is a silent
+no-op, so the line above can run every time the module is imported.
 
-Reflex hot reload re-imports the app module in-process, so guard one-time SDK
-setup:
+Configure the SDK the way you prefer:
 
-```python
-if not ReflexInstrumentor().is_instrumented_by_opentelemetry:
-    trace.set_tracer_provider(provider)
-    ReflexInstrumentor().instrument(tracer_provider=provider)
-```
+- Set the standard variables and let `instrument()` do it. When
+  `OTEL_TRACES_EXPORTER` or `OTEL_METRICS_EXPORTER` is set and no SDK provider
+  has been installed yet, `instrument()` configures `opentelemetry-sdk` from
+  the `OTEL_*` environment, exactly as `opentelemetry-instrument` would:
+
+  ```bash
+  OTEL_SERVICE_NAME=myapp OTEL_TRACES_EXPORTER=otlp OTEL_METRICS_EXPORTER=otlp \
+  OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4318 reflex run
+  ```
+
+- Or build the providers yourself and pass them:
+  `ReflexInstrumentor().instrument(tracer_provider=provider, meter_provider=meter_provider)`.
+  Do that from a module that is imported once (not the app module, which
+  test harnesses may re-import) or the SDK warns about overriding providers.
+
+- Or use no code at all: the package registers an `opentelemetry_instrumentor`
+  entry point, so `opentelemetry-instrument reflex run` enables it (the
+  auto-instrumentation `sitecustomize` reaches the backend worker through the
+  inherited `PYTHONPATH`).
 
 ## What you get
 

--- a/packages/reflex-otel/README.md
+++ b/packages/reflex-otel/README.md
@@ -27,10 +27,10 @@ if not ReflexInstrumentor().is_instrumented_by_opentelemetry:
 
 Traces:
 
-- One span per event handler run, named after the event: `SERVER` for events
-  sent by the frontend (a new trace, or a child of the browser span when the
-  event carries a `traceparent` field), `INTERNAL` for chained events, which
-  are children of the span that enqueued them. `traceparent`/`tracestate`
+- One span per event handler run, named after the event: `CONSUMER` for
+  events sent by the frontend (a new trace, or a child of the browser's
+  `PRODUCER` span when the event carries a `traceparent` field), `INTERNAL`
+  for chained events, which are children of the span that enqueued them. `traceparent`/`tracestate`
   are consumed and never reach the handler.
 - HTTP requests and the websocket connection are wrapped in the standard
   OpenTelemetry ASGI middleware (per-message websocket spans are off).

--- a/packages/reflex-otel/pyproject.toml
+++ b/packages/reflex-otel/pyproject.toml
@@ -15,6 +15,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# Keep in sync with _instruments in reflex_otel/__init__.py; re-pin to the first
+# reflex-base release that ships reflex_base/otel.py before publishing.
 instruments = ["reflex-base >= 0.9.7.post45.dev0"]
 
 [project.entry-points.opentelemetry_instrumentor]

--- a/packages/reflex-otel/pyproject.toml
+++ b/packages/reflex-otel/pyproject.toml
@@ -11,13 +11,15 @@ dependencies = [
   "opentelemetry-api >=1.30.0,<2.0",
   "opentelemetry-instrumentation >=0.49b0,<1.0",
   "opentelemetry-instrumentation-asgi >=0.49b0,<1.0",
-  "reflex-base >= 0.9.7.post45.dev0",
+  "reflex-base >= 0.9.10.post2.dev0",
 ]
 
 [project.optional-dependencies]
-# Keep in sync with _instruments in reflex_otel/__init__.py; re-pin to the first
-# reflex-base release that ships reflex_base/otel.py before publishing.
-instruments = ["reflex-base >= 0.9.7.post45.dev0"]
+# Keep in sync with _instruments in reflex_otel/__init__.py (a test enforces it).
+# A dev floor above every published reflex-base release: the release tooling
+# lifts it to the earliest published version that satisfies it, so it must
+# exclude the releases that lack reflex_base/otel.py.
+instruments = ["reflex-base >= 0.9.10.post2.dev0"]
 
 [project.entry-points.opentelemetry_instrumentor]
 reflex = "reflex_otel:ReflexInstrumentor"

--- a/packages/reflex-otel/pyproject.toml
+++ b/packages/reflex-otel/pyproject.toml
@@ -11,15 +11,11 @@ dependencies = [
   "opentelemetry-api >=1.30.0,<2.0",
   "opentelemetry-instrumentation >=0.49b0,<1.0",
   "opentelemetry-instrumentation-asgi >=0.49b0,<1.0",
+  # A dev floor above every published reflex-base release: the release tooling
+  # lifts it to the earliest published version that satisfies it, which is the
+  # first release to ship reflex_base/otel.py.
   "reflex-base >= 0.9.10.post2.dev0",
 ]
-
-[project.optional-dependencies]
-# Keep in sync with _instruments in reflex_otel/__init__.py (a test enforces it).
-# A dev floor above every published reflex-base release: the release tooling
-# lifts it to the earliest published version that satisfies it, so it must
-# exclude the releases that lack reflex_base/otel.py.
-instruments = ["reflex-base >= 0.9.10.post2.dev0"]
 
 [project.entry-points.opentelemetry_instrumentor]
 reflex = "reflex_otel:ReflexInstrumentor"

--- a/packages/reflex-otel/pyproject.toml
+++ b/packages/reflex-otel/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   # A dev floor above every published reflex-base release: the release tooling
   # lifts it to the earliest published version that satisfies it, which is the
   # first release to ship reflex_base/otel.py.
-  "reflex-base >= 0.9.10.post2.dev0",
+  "reflex-base >= 0.9.10.post3.dev0",
 ]
 
 [project.entry-points.opentelemetry_instrumentor]

--- a/packages/reflex-otel/src/reflex_otel/__init__.py
+++ b/packages/reflex-otel/src/reflex_otel/__init__.py
@@ -27,9 +27,10 @@ logger = logging.getLogger(__name__)
 os.environ.setdefault("OTEL_SEMCONV_STABILITY_OPT_IN", "http")
 
 # Must match the `instruments` extra in pyproject.toml (a test enforces it).
-# Re-pin both to the first reflex-base release that ships reflex_base/otel.py
-# before publishing: earlier releases satisfy this floor but lack the module.
-_instruments = ("reflex-base >= 0.9.7.post45.dev0",)
+# A dev floor above every published reflex-base release: the release tooling
+# lifts it to the earliest published version that satisfies it, which is the
+# first release to ship reflex_base/otel.py.
+_instruments = ("reflex-base >= 0.9.10.post2.dev0",)
 
 # Per-message websocket spans are noise; Reflex emits one span per event instead.
 _ASGI_EXCLUDED_SPANS: list[Literal["receive", "send"]] = ["receive", "send"]

--- a/packages/reflex-otel/src/reflex_otel/__init__.py
+++ b/packages/reflex-otel/src/reflex_otel/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 from collections.abc import Callable, Collection
@@ -14,6 +15,8 @@ from reflex_base.environment import environment
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Span
+
+logger = logging.getLogger(__name__)
 
 _instruments = ("reflex-base >= 0.9.7.post45.dev0",)
 
@@ -123,6 +126,10 @@ class ReflexInstrumentor(BaseInstrumentor):
                 ``server_request_hook``, ``client_request_hook`` and
                 ``client_response_hook`` are forwarded to the ASGI middleware.
         """
+        if os.environ.get("OTEL_SDK_DISABLED", "").strip().lower() == "true":
+            # The SDK is a no-op; skip the per-event trace points as well.
+            logger.info("OTEL_SDK_DISABLED is set; Reflex trace points stay off.")
+            return
         # Imported here so `from reflex_otel import OtelPlugin` in rxconfig.py
         # stays cheap for CLI processes that never instrument.
         from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware

--- a/packages/reflex-otel/src/reflex_otel/__init__.py
+++ b/packages/reflex-otel/src/reflex_otel/__init__.py
@@ -26,12 +26,6 @@ logger = logging.getLogger(__name__)
 # runs, so it is set as early as this package can: at import.
 os.environ.setdefault("OTEL_SEMCONV_STABILITY_OPT_IN", "http")
 
-# Must match the `instruments` extra in pyproject.toml (a test enforces it).
-# A dev floor above every published reflex-base release: the release tooling
-# lifts it to the earliest published version that satisfies it, which is the
-# first release to ship reflex_base/otel.py.
-_instruments = ("reflex-base >= 0.9.10.post2.dev0",)
-
 # Per-message websocket spans are noise; Reflex emits one span per event instead.
 _ASGI_EXCLUDED_SPANS: list[Literal["receive", "send"]] = ["receive", "send"]
 # Frontend health polling; override with excluded_urls or the variables below.
@@ -162,12 +156,16 @@ class ReflexInstrumentor(BaseInstrumentor):
         super().instrument(**kwargs)
 
     def instrumentation_dependencies(self) -> Collection[str]:
-        """Return the packages this instrumentor targets.
+        """Return the requirements the base class checks before instrumenting.
+
+        Empty on purpose: reflex-base is a hard dependency of this package, so
+        the resolver already enforces its floor at install time. A runtime
+        re-check would only reject the workspace's own development builds.
 
         Returns:
-            The dependency specifiers for the instrumented package.
+            No requirements.
         """
-        return _instruments
+        return ()
 
     def _instrument(self, **kwargs: Any) -> None:
         """Turn on the Reflex trace points.

--- a/packages/reflex-otel/src/reflex_otel/__init__.py
+++ b/packages/reflex-otel/src/reflex_otel/__init__.py
@@ -19,8 +19,12 @@ _instruments = ("reflex-base >= 0.9.7.post45.dev0",)
 
 # Per-message websocket spans are noise; Reflex emits one span per event instead.
 _ASGI_EXCLUDED_SPANS: list[Literal["receive", "send"]] = ["receive", "send"]
-# Frontend health polling; override with excluded_urls / OTEL_PYTHON_REFLEX_EXCLUDED_URLS.
+# Frontend health polling; override with excluded_urls or the variables below.
 _DEFAULT_EXCLUDED_URLS = "/ping"
+_EXCLUDED_URLS_ENV_VARS = (
+    "OTEL_PYTHON_REFLEX_EXCLUDED_URLS",
+    "OTEL_PYTHON_EXCLUDED_URLS",
+)
 # The websocket connects with ?token=<client token>; the token authorizes access
 # to the session's state, so it is stripped from the URL attributes the ASGI
 # middleware records (old and current HTTP semantic conventions).
@@ -128,9 +132,11 @@ class ReflexInstrumentor(BaseInstrumentor):
         meter_provider = kwargs.get("meter_provider")
         excluded_urls = kwargs.get("excluded_urls")
         if excluded_urls is None:
-            excluded_urls = os.environ.get(
-                "OTEL_PYTHON_REFLEX_EXCLUDED_URLS"
-            ) or os.environ.get("OTEL_PYTHON_EXCLUDED_URLS")
+            # A variable set to "" means "exclude nothing", like an empty kwarg.
+            for name in _EXCLUDED_URLS_ENV_VARS:
+                if (value := os.environ.get(name)) is not None:
+                    excluded_urls = value
+                    break
 
         def asgi_middleware(app: otel.ASGIApp) -> otel.ASGIApp:
             # Defaults resolve when the app builds its ASGI callable: only then

--- a/packages/reflex-otel/src/reflex_otel/__init__.py
+++ b/packages/reflex-otel/src/reflex_otel/__init__.py
@@ -18,6 +18,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Must match the `instruments` extra in pyproject.toml (a test enforces it).
+# Re-pin both to the first reflex-base release that ships reflex_base/otel.py
+# before publishing: earlier releases satisfy this floor but lack the module.
 _instruments = ("reflex-base >= 0.9.7.post45.dev0",)
 
 # Per-message websocket spans are noise; Reflex emits one span per event instead.

--- a/packages/reflex-otel/src/reflex_otel/__init__.py
+++ b/packages/reflex-otel/src/reflex_otel/__init__.py
@@ -8,6 +8,7 @@ import re
 from collections.abc import Callable, Collection
 from typing import TYPE_CHECKING, Any, Literal
 
+from opentelemetry import trace
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from reflex_base import otel
 from reflex_base.config import get_config
@@ -35,6 +36,8 @@ _EXCLUDED_URLS_ENV_VARS = (
 # to the session's state, so it is stripped from the URL attributes the ASGI
 # middleware records (old and current HTTP semantic conventions).
 _URL_ATTRIBUTES = ("http.url", "url.full", "url.query")
+# Setting either asks for the SDK to be configured from the environment.
+_EXPORTER_ENV_VARS = ("OTEL_TRACES_EXPORTER", "OTEL_METRICS_EXPORTER")
 _TOKEN_PARAM = re.compile(r"\btoken=[^&#]*")
 _REDACTED_TOKEN = "token=REDACTED"
 
@@ -52,6 +55,36 @@ def _default_excluded_urls() -> str:
         assets = re.escape(get_config().prepend_frontend_path("/assets/"))
         patterns.append(f"^[a-z]+://[^/]+{assets}")
     return ",".join(patterns)
+
+
+def _configure_sdk_from_environment() -> None:
+    """Install SDK providers from the ``OTEL_*`` environment when nobody has yet.
+
+    Runs only when an exporter is requested through ``OTEL_TRACES_EXPORTER``
+    or ``OTEL_METRICS_EXPORTER`` and the global tracer provider is still the
+    API's proxy, i.e. neither the app nor ``opentelemetry-instrument`` set the
+    SDK up. It is what lets an app module enable telemetry with a single,
+    repeatable ``instrument()`` call instead of building providers itself.
+    """
+    if not any(os.environ.get(name) for name in _EXPORTER_ENV_VARS):
+        return
+    if not isinstance(trace.get_tracer_provider(), trace.ProxyTracerProvider):
+        return
+    try:
+        # The configurator behind opentelemetry-instrument and the distro package.
+        from opentelemetry.sdk._configuration import _OTelSDKConfigurator
+    except ImportError:
+        logger.warning(
+            "OTEL_TRACES_EXPORTER / OTEL_METRICS_EXPORTER are set but "
+            "opentelemetry-sdk is not installed; nothing is exported."
+        )
+        return
+    try:
+        _OTelSDKConfigurator().configure()
+    except Exception:
+        logger.exception(
+            "Configuring the OpenTelemetry SDK from the environment failed:"
+        )
 
 
 def _redact_token(span: Span, scope: Any) -> None:
@@ -107,6 +140,19 @@ class ReflexInstrumentor(BaseInstrumentor):
     HTTP metrics as well.
     """
 
+    def instrument(self, **kwargs: Any) -> None:
+        """Turn the Reflex trace points on, once per process.
+
+        A second call is a silent no-op, so the call needs no guard even when
+        the app module is imported more than once (test harnesses do that).
+
+        Args:
+            **kwargs: See :meth:`_instrument`.
+        """
+        if self.is_instrumented_by_opentelemetry:
+            return
+        super().instrument(**kwargs)
+
     def instrumentation_dependencies(self) -> Collection[str]:
         """Return the packages this instrumentor targets.
 
@@ -120,7 +166,9 @@ class ReflexInstrumentor(BaseInstrumentor):
 
         Args:
             **kwargs: ``tracer_provider`` and ``meter_provider`` select the
-                providers (default: the global ones). ``excluded_urls`` is a
+                providers (default: the global ones; when neither is given,
+                ``OTEL_TRACES_EXPORTER`` / ``OTEL_METRICS_EXPORTER`` set and no
+                SDK installed yet, the SDK is configured from ``OTEL_*``). ``excluded_urls`` is a
                 comma-separated list of URL patterns the ASGI middleware skips
                 (default: ``OTEL_PYTHON_REFLEX_EXCLUDED_URLS``, else
                 ``OTEL_PYTHON_EXCLUDED_URLS``, else ``/ping`` plus the compiled
@@ -145,6 +193,8 @@ class ReflexInstrumentor(BaseInstrumentor):
 
         tracer_provider = kwargs.get("tracer_provider")
         meter_provider = kwargs.get("meter_provider")
+        if tracer_provider is None and meter_provider is None:
+            _configure_sdk_from_environment()
         excluded_urls = kwargs.get("excluded_urls")
         if excluded_urls is None:
             # A variable set to "" means "exclude nothing", like an empty kwarg.

--- a/packages/reflex-otel/src/reflex_otel/__init__.py
+++ b/packages/reflex-otel/src/reflex_otel/__init__.py
@@ -19,6 +19,13 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Reflex's own attributes follow the current semantic conventions; the contrib
+# ASGI middleware still defaults to the old HTTP names unless opted in, which
+# would mix both generations in one trace. The contrib packages read the
+# variable once per process, the first time any instrumentor's instrument()
+# runs, so it is set as early as this package can: at import.
+os.environ.setdefault("OTEL_SEMCONV_STABILITY_OPT_IN", "http")
+
 # Must match the `instruments` extra in pyproject.toml (a test enforces it).
 # Re-pin both to the first reflex-base release that ships reflex_base/otel.py
 # before publishing: earlier releases satisfy this floor but lack the module.
@@ -181,11 +188,6 @@ class ReflexInstrumentor(BaseInstrumentor):
             # The SDK is a no-op; skip the per-event trace points as well.
             logger.info("OTEL_SDK_DISABLED is set; Reflex trace points stay off.")
             return
-        # Reflex's own attributes follow the current semantic conventions; the
-        # ASGI middleware still defaults to the old HTTP names unless opted in,
-        # which would mix both generations in one trace. The variable is read
-        # once per process, before the first middleware is built.
-        os.environ.setdefault("OTEL_SEMCONV_STABILITY_OPT_IN", "http")
         # Imported here so `from reflex_otel import OtelPlugin` in rxconfig.py
         # stays cheap for CLI processes that never instrument.
         from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware

--- a/packages/reflex-otel/src/reflex_otel/__init__.py
+++ b/packages/reflex-otel/src/reflex_otel/__init__.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from reflex_base import otel
+from reflex_base.config import get_config
+from reflex_base.environment import environment
 
 if TYPE_CHECKING:
     from opentelemetry.trace import Span
@@ -25,6 +27,21 @@ _DEFAULT_EXCLUDED_URLS = "/ping"
 _URL_ATTRIBUTES = ("http.url", "url.full", "url.query")
 _TOKEN_PARAM = re.compile(r"\btoken=[^&#]*")
 _REDACTED_TOKEN = "token=REDACTED"
+
+
+def _default_excluded_urls() -> str:
+    """URL patterns the ASGI middleware skips unless configured otherwise.
+
+    Returns:
+        The frontend health poll, plus the compiled frontend's static assets
+        when the backend serves them (``reflex run --env prod`` on one port),
+        where every chunk of a page load would otherwise get a span.
+    """
+    patterns = [_DEFAULT_EXCLUDED_URLS]
+    if environment.REFLEX_MOUNT_FRONTEND_COMPILED_APP.get():
+        assets = re.escape(get_config().prepend_frontend_path("/assets/"))
+        patterns.append(f"^[a-z]+://[^/]+{assets}")
+    return ",".join(patterns)
 
 
 def _redact_token(span: Span, scope: Any) -> None:
@@ -96,8 +113,9 @@ class ReflexInstrumentor(BaseInstrumentor):
                 providers (default: the global ones). ``excluded_urls`` is a
                 comma-separated list of URL patterns the ASGI middleware skips
                 (default: ``OTEL_PYTHON_REFLEX_EXCLUDED_URLS``, else
-                ``OTEL_PYTHON_EXCLUDED_URLS``, else ``/ping``; pass ``""`` to
-                exclude nothing).
+                ``OTEL_PYTHON_EXCLUDED_URLS``, else ``/ping`` plus the compiled
+                frontend's ``/assets/`` when the backend serves it; pass ``""``
+                to exclude nothing).
                 ``server_request_hook``, ``client_request_hook`` and
                 ``client_response_hook`` are forwarded to the ASGI middleware.
         """
@@ -110,20 +128,21 @@ class ReflexInstrumentor(BaseInstrumentor):
         meter_provider = kwargs.get("meter_provider")
         excluded_urls = kwargs.get("excluded_urls")
         if excluded_urls is None:
-            excluded_urls = (
-                os.environ.get("OTEL_PYTHON_REFLEX_EXCLUDED_URLS")
-                or os.environ.get("OTEL_PYTHON_EXCLUDED_URLS")
-                or _DEFAULT_EXCLUDED_URLS
-            )
-        # opentelemetry-instrumentation-asgi < 0.56b0 stores a str verbatim and
-        # then calls .url_disabled() on it, failing every request; parse first.
-        if isinstance(excluded_urls, str):
-            excluded_urls = parse_excluded_urls(excluded_urls)
+            excluded_urls = os.environ.get(
+                "OTEL_PYTHON_REFLEX_EXCLUDED_URLS"
+            ) or os.environ.get("OTEL_PYTHON_EXCLUDED_URLS")
 
         def asgi_middleware(app: otel.ASGIApp) -> otel.ASGIApp:
+            # Defaults resolve when the app builds its ASGI callable: only then
+            # is it known whether the compiled frontend is mounted into it.
+            urls = _default_excluded_urls() if excluded_urls is None else excluded_urls
+            # opentelemetry-instrumentation-asgi < 0.56b0 stores a str verbatim
+            # and then calls .url_disabled() on it, failing every request.
+            if isinstance(urls, str):
+                urls = parse_excluded_urls(urls)
             return OpenTelemetryMiddleware(
                 app,
-                excluded_urls=excluded_urls,
+                excluded_urls=urls,
                 server_request_hook=_server_request_hook(
                     kwargs.get("server_request_hook")
                 ),

--- a/packages/reflex-otel/src/reflex_otel/__init__.py
+++ b/packages/reflex-otel/src/reflex_otel/__init__.py
@@ -130,6 +130,11 @@ class ReflexInstrumentor(BaseInstrumentor):
             # The SDK is a no-op; skip the per-event trace points as well.
             logger.info("OTEL_SDK_DISABLED is set; Reflex trace points stay off.")
             return
+        # Reflex's own attributes follow the current semantic conventions; the
+        # ASGI middleware still defaults to the old HTTP names unless opted in,
+        # which would mix both generations in one trace. The variable is read
+        # once per process, before the first middleware is built.
+        os.environ.setdefault("OTEL_SEMCONV_STABILITY_OPT_IN", "http")
         # Imported here so `from reflex_otel import OtelPlugin` in rxconfig.py
         # stays cheap for CLI processes that never instrument.
         from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware

--- a/packages/reflex-otel/src/reflex_otel/__init__.py
+++ b/packages/reflex-otel/src/reflex_otel/__init__.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Collection
-from typing import Any, Literal
+import re
+from collections.abc import Callable, Collection
+from typing import TYPE_CHECKING, Any, Literal
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from reflex_base import otel
+
+if TYPE_CHECKING:
+    from opentelemetry.trace import Span
 
 _instruments = ("reflex-base >= 0.9.7.post45.dev0",)
 
@@ -15,6 +19,49 @@ _instruments = ("reflex-base >= 0.9.7.post45.dev0",)
 _ASGI_EXCLUDED_SPANS: list[Literal["receive", "send"]] = ["receive", "send"]
 # Frontend health polling; override with excluded_urls / OTEL_PYTHON_REFLEX_EXCLUDED_URLS.
 _DEFAULT_EXCLUDED_URLS = "/ping"
+# The websocket connects with ?token=<client token>; the token authorizes access
+# to the session's state, so it is stripped from the URL attributes the ASGI
+# middleware records (old and current HTTP semantic conventions).
+_URL_ATTRIBUTES = ("http.url", "url.full", "url.query")
+_TOKEN_PARAM = re.compile(r"\btoken=[^&#]*")
+_REDACTED_TOKEN = "token=REDACTED"
+
+
+def _redact_token(span: Span, scope: Any) -> None:
+    """Strip the client token from a server span's URL attributes.
+
+    Args:
+        span: The span the ASGI middleware opened for the request.
+        scope: The ASGI scope (unused).
+    """
+    attributes = getattr(span, "attributes", None)
+    if not attributes:
+        return
+    for key in _URL_ATTRIBUTES:
+        value = attributes.get(key)
+        if isinstance(value, str) and "token=" in value:
+            span.set_attribute(key, _TOKEN_PARAM.sub(_REDACTED_TOKEN, value))
+
+
+def _server_request_hook(
+    user_hook: Callable[[Span, Any], None] | None,
+) -> Callable[[Span, Any], None]:
+    """Chain the token redaction in front of the user's server request hook.
+
+    Args:
+        user_hook: The hook passed to ``instrument()``, if any.
+
+    Returns:
+        The hook to install on the ASGI middleware.
+    """
+    if user_hook is None:
+        return _redact_token
+
+    def hook(span: Span, scope: Any) -> None:
+        _redact_token(span, scope)
+        user_hook(span, scope)
+
+    return hook
 
 
 class ReflexInstrumentor(BaseInstrumentor):
@@ -77,7 +124,9 @@ class ReflexInstrumentor(BaseInstrumentor):
             return OpenTelemetryMiddleware(
                 app,
                 excluded_urls=excluded_urls,
-                server_request_hook=kwargs.get("server_request_hook"),
+                server_request_hook=_server_request_hook(
+                    kwargs.get("server_request_hook")
+                ),
                 client_request_hook=kwargs.get("client_request_hook"),
                 client_response_hook=kwargs.get("client_response_hook"),
                 tracer_provider=tracer_provider,

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -1940,6 +1940,20 @@ async def health(_request: Request) -> JSONResponse:
     return JSONResponse(content=health_status, status_code=status_code)
 
 
+def _utf8_size(data: str) -> int:
+    """Size of a serialized message in UTF-8 bytes.
+
+    ASCII payloads (the common case) are sized without encoding a copy.
+
+    Args:
+        data: The serialized message.
+
+    Returns:
+        The number of bytes the message occupies on the wire.
+    """
+    return len(data) if data.isascii() else len(data.encode())
+
+
 def _sio_dumps(obj: Any, **kwargs: Any) -> str:
     """Serialize an outgoing Socket.IO packet, recording its size when telemetry is on.
 
@@ -1952,7 +1966,7 @@ def _sio_dumps(obj: Any, **kwargs: Any) -> str:
     """
     data = format.json_dumps(obj, **kwargs)
     if otel.enabled:
-        otel.record_message_size(len(data.encode()), "transmit")
+        otel.record_message_size(_utf8_size(data), "transmit")
     return data
 
 
@@ -1968,7 +1982,7 @@ def _sio_loads(data: str | bytes, **kwargs: Any) -> Any:
     """
     if otel.enabled:
         otel.record_message_size(
-            len(data.encode()) if isinstance(data, str) else len(data), "receive"
+            _utf8_size(data) if isinstance(data, str) else len(data), "receive"
         )
     return json.loads(data, **kwargs)
 

--- a/tests/units/conftest.py
+++ b/tests/units/conftest.py
@@ -579,7 +579,6 @@ def active_tracer() -> trace.Tracer:
     Returns:
         The tracer.
     """
-    assert otel._tracer is not None
     return otel._tracer
 
 

--- a/tests/units/conftest.py
+++ b/tests/units/conftest.py
@@ -9,6 +9,7 @@ from unittest import mock
 
 import pytest
 import pytest_asyncio
+from opentelemetry import trace
 from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import InMemoryMetricReader
 from opentelemetry.sdk.trace import TracerProvider
@@ -570,6 +571,16 @@ def otel_metrics(otel_sdk) -> InMemoryMetricReader:
         The metric reader.
     """
     return otel_sdk[1]
+
+
+def active_tracer() -> trace.Tracer:
+    """The tracer bound by the enabled otel_sdk fixture.
+
+    Returns:
+        The tracer.
+    """
+    assert otel._tracer is not None
+    return otel._tracer
 
 
 def metric_points(reader: InMemoryMetricReader, name: str) -> list:

--- a/tests/units/reflex_base/event/processor/test_base_state_processor.py
+++ b/tests/units/reflex_base/event/processor/test_base_state_processor.py
@@ -5,10 +5,11 @@ import dataclasses
 import logging
 import traceback
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, cast
 
 import pytest
 import pytest_asyncio
+from opentelemetry.trace import SpanKind, StatusCode
 from reflex_base import otel
 from reflex_base.constants import CompileVars
 from reflex_base.constants.state import FIELD_MARKER
@@ -19,7 +20,7 @@ from reflex_base.registry import RegistrationContext
 import reflex as rx
 from reflex import event
 from reflex.app import App
-from reflex.event import Event
+from reflex.event import Event, EventSpec
 from reflex.istate.manager.memory import StateManagerMemory
 from reflex.istate.manager.token import BaseStateToken
 from reflex.middleware.middleware import Middleware
@@ -747,6 +748,53 @@ async def test_failed_context_enter_does_not_mark_the_proxy_entered(
         object.__setattr__(root_ctx.state_manager, "modify_state_with_links", original)
 
     assert proxy._self_entered_context is False
+
+
+async def test_backend_exception_handler_events_parent_under_failed_span(
+    wired_app: App,
+    real_base_state_processor: BaseStateEventProcessor,
+    token: str,
+    otel_exporter,
+):
+    """Events returned by the backend exception handler are children of the failed span.
+
+    Args:
+        wired_app: The App wired to the processor's state manager.
+        real_base_state_processor: The unmocked BaseStateEventProcessor.
+        token: The client token.
+        otel_exporter: In-memory span exporter with tracing enabled.
+    """
+
+    class RecoverState(State):
+        @event
+        def fail(self):
+            msg = "boom"
+            raise RuntimeError(msg)
+
+        @event
+        def recover(self):
+            pass
+
+    def recover_from(_ex: Exception) -> EventSpec:
+        return cast("EventSpec", RecoverState.recover())
+
+    real_base_state_processor.backend_exception_handler = recover_from
+    async with real_base_state_processor as processor:
+        await processor.enqueue(token, Event.from_event_type(RecoverState.fail())[0])
+        await processor.join(5)
+
+    spans = {s.name.rsplit(".", 1)[-1]: s for s in otel_exporter.get_finished_spans()}
+    failed, recovery = spans["fail"], spans["recover"]
+    assert failed.status.status_code == StatusCode.ERROR
+    assert recovery.parent is not None
+    assert recovery.parent.span_id == failed.context.span_id
+    assert recovery.kind == SpanKind.INTERNAL
+    assert failed.attributes is not None
+    assert recovery.attributes is not None
+    assert (
+        recovery.attributes[otel.ATTR_EVENT_PARENT_TXID]
+        == failed.attributes[otel.ATTR_EVENT_TXID]
+    )
 
 
 async def test_execute_event_records_state_acquire_duration(

--- a/tests/units/reflex_base/event/processor/test_event_processor.py
+++ b/tests/units/reflex_base/event/processor/test_event_processor.py
@@ -1149,4 +1149,4 @@ async def test_event_spans_chain_parent_child(token: str, otel_exporter):
         child.attributes[otel.ATTR_EVENT_PARENT_TXID]
         == parent.attributes[otel.ATTR_EVENT_TXID]
     )
-    assert child.attributes[otel.ATTR_SESSION_ID] == token
+    assert child.attributes[otel.ATTR_SESSION_ID] == otel._session_id(token)

--- a/tests/units/reflex_base/event/processor/test_event_processor.py
+++ b/tests/units/reflex_base/event/processor/test_event_processor.py
@@ -1120,7 +1120,7 @@ async def test_event_spans_chain_parent_child(token: str, otel_exporter):
     parent = spans["_chaining_handler"]
     child = spans["_logging_handler"]
     assert parent.parent is None
-    assert parent.kind == SpanKind.SERVER
+    assert parent.kind == SpanKind.CONSUMER
     assert child.parent is not None
     assert child.parent.span_id == parent.context.span_id
     assert child.kind == SpanKind.INTERNAL

--- a/tests/units/reflex_base/event/processor/test_event_processor.py
+++ b/tests/units/reflex_base/event/processor/test_event_processor.py
@@ -1104,6 +1104,27 @@ async def test_no_spans_when_otel_disabled(
     tracer.start_as_current_span.assert_not_called()
 
 
+async def test_stream_delta_span_nests_under_caller(token: str, otel_exporter):
+    """enqueue_stream_delta captures the caller's trace context like enqueue().
+
+    Args:
+        token: The client token.
+        otel_exporter: In-memory span exporter with tracing enabled.
+    """
+    ep = EventProcessor(graceful_shutdown_timeout=2)
+    ep.configure()
+    async with ep:
+        event = Event.from_event_type(delta_event())[0]
+        with otel._tracer.start_as_current_span("POST /_upload") as http_span:
+            async for _ in ep.enqueue_stream_delta(token, event):
+                pass
+    spans = {s.name: s for s in otel_exporter.get_finished_spans()}
+    handler = spans[event.name]
+    assert handler.parent is not None
+    assert handler.parent.span_id == http_span.get_span_context().span_id
+    assert handler.kind == SpanKind.INTERNAL
+
+
 async def test_event_spans_chain_parent_child(token: str, otel_exporter):
     """Each event gets a span; chained events are children of the enqueuing span.
 

--- a/tests/units/reflex_base/event/processor/test_event_processor.py
+++ b/tests/units/reflex_base/event/processor/test_event_processor.py
@@ -21,6 +21,7 @@ from reflex_base.event.processor.future import EventFuture
 from reflex_base.registry import RegistrationContext
 
 from reflex.event import Event, EventHandler
+from tests.units.conftest import active_tracer
 
 # Module-level log so event handlers can record what happened.
 _CALL_LOG: list[dict[str, Any]] = []
@@ -1115,7 +1116,7 @@ async def test_stream_delta_span_nests_under_caller(token: str, otel_exporter):
     ep.configure()
     async with ep:
         event = Event.from_event_type(delta_event())[0]
-        with otel._tracer.start_as_current_span("POST /_upload") as http_span:
+        with active_tracer().start_as_current_span("POST /_upload") as http_span:
             async for _ in ep.enqueue_stream_delta(token, event):
                 pass
     spans = {s.name: s for s in otel_exporter.get_finished_spans()}

--- a/tests/units/reflex_base/event/processor/test_event_processor.py
+++ b/tests/units/reflex_base/event/processor/test_event_processor.py
@@ -1099,7 +1099,8 @@ async def test_no_spans_when_otel_disabled(
     """
     assert otel.enabled is False
     tracer = Mock()
-    monkeypatch.setattr(otel, "_tracer", tracer)
+    # Nothing has bound the tracer yet in a process that never enabled tracing.
+    monkeypatch.setattr(otel, "_tracer", tracer, raising=False)
     async with mock_event_processor as ep:
         await ep.enqueue(token, Event.from_event_type(noop_event())[0])
     tracer.start_as_current_span.assert_not_called()

--- a/tests/units/reflex_base/test_otel.py
+++ b/tests/units/reflex_base/test_otel.py
@@ -199,6 +199,56 @@ def test_remote_context_uses_traceparent(otel_exporter: InMemorySpanExporter):
     assert format(span.parent.span_id, "016x") == "b7ad6b7169203331"
 
 
+@pytest.mark.parametrize(
+    "carrier",
+    [
+        {"traceparent": 123},
+        {"traceparent": None},
+        {"traceparent": ["a"]},
+        {"traceparent": {"x": 1}},
+        {"traceparent": "garbage"},
+        {"traceparent": "00-" + "0" * 32 + "-b7ad6b7169203331-01"},
+        {
+            "traceparent": "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+            "tracestate": 5,
+        },
+        {
+            "traceparent": "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+            "tracestate": "==,,bad",
+        },
+        {"baggage": 7},
+    ],
+)
+def test_remote_context_never_raises_on_unusable_fields(
+    carrier: dict, otel_exporter: InMemorySpanExporter
+):
+    """Hostile or malformed payload fields are ignored, never an exception."""
+    registered = RegisteredEventHandler(handler=EventHandler(fn=_handler), states=())
+    with otel.remote_context(carrier):
+        ctx = _ctx().fork()
+    with otel.event_span(Event(name="e"), ctx, registered):
+        pass
+    (span,) = otel_exporter.get_finished_spans()
+    if (
+        isinstance(carrier.get("traceparent"), str)
+        and "0af7651916cd" in carrier["traceparent"]
+    ):
+        assert span.parent is not None
+        assert (
+            format(span.parent.trace_id, "032x") == "0af7651916cd43dd8448eb211c80319c"
+        )
+    else:
+        assert span.parent is None
+
+
+def test_remote_context_ignores_baggage():
+    """Only the trace context is taken from the client, never baggage."""
+    from opentelemetry import baggage
+
+    with otel.remote_context({"baggage": "user=admin,tenant=evil"}):
+        assert baggage.get_all() == {}
+
+
 def test_remote_context_without_traceparent_starts_new_trace(
     otel_exporter: InMemorySpanExporter,
 ):

--- a/tests/units/reflex_base/test_otel.py
+++ b/tests/units/reflex_base/test_otel.py
@@ -65,12 +65,28 @@ def test_event_span_attributes(otel_exporter: InMemorySpanExporter):
     assert finished.attributes == {
         otel.ATTR_EVENT_NAME: "state.sub.handler",
         otel.ATTR_EVENT_TXID: ctx.txid,
-        otel.ATTR_EVENT_PARENT_TXID: "parent123",
         otel.ATTR_EVENT_BACKGROUND: False,
         otel.ATTR_SESSION_ID: "tok",
         otel.ATTR_CODE_FUNCTION_NAME: "_handler",
     }
     assert finished.status.status_code == StatusCode.UNSET
+
+
+def test_parent_txid_only_for_chained_events(otel_exporter: InMemorySpanExporter):
+    """Top-level events are forked from the root context; its txid is noise."""
+    registered = RegisteredEventHandler(handler=EventHandler(fn=_handler), states=())
+    traceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+    with otel.remote_context({"traceparent": traceparent}):
+        remote_ctx = _ctx().fork()
+    with otel.event_span(Event(name="top"), remote_ctx, registered):
+        chained_ctx = _ctx().fork()
+    with otel.event_span(Event(name="chained"), chained_ctx, registered):
+        pass
+    top, chained = otel_exporter.get_finished_spans()
+    assert top.attributes is not None
+    assert chained.attributes is not None
+    assert otel.ATTR_EVENT_PARENT_TXID not in top.attributes
+    assert chained.attributes[otel.ATTR_EVENT_PARENT_TXID] == chained_ctx.parent_txid
 
 
 def test_event_span_records_exception(otel_exporter: InMemorySpanExporter):

--- a/tests/units/reflex_base/test_otel.py
+++ b/tests/units/reflex_base/test_otel.py
@@ -1,6 +1,8 @@
 """Tests for the reflex_base.otel trace points."""
 
 import asyncio
+import subprocess
+import sys
 from time import perf_counter
 
 import pytest
@@ -14,7 +16,7 @@ from reflex_base.event.context import EventContext
 from reflex_base.registry import RegisteredEventHandler
 
 from reflex.event import Event, EventHandler
-from tests.units.conftest import metric_points
+from tests.units.conftest import active_tracer, metric_points
 
 
 def _ctx(token: str = "tok", parent_txid: str | None = None) -> EventContext:
@@ -30,6 +32,18 @@ async def _handler():
     """A no-op handler."""
 
 
+def test_disabled_path_imports_no_opentelemetry():
+    """reflex-base does not depend on opentelemetry-api; nothing loads it until enable()."""
+    code = (
+        "import sys; import reflex_base.otel; import reflex_base.event.context; "
+        "print(sorted(m for m in sys.modules if m.startswith('opentelemetry')))"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code], check=True, capture_output=True, text=True
+    )
+    assert out.stdout.strip() == "[]"
+
+
 def test_disabled_by_default():
     assert otel.enabled is False
     assert otel.capture_context() is None
@@ -41,7 +55,7 @@ def test_enable_disable_toggle():
     assert otel.capture_context() is not None
     otel.disable()
     assert otel.enabled is False
-    assert isinstance(otel._tracer, trace.NoOpTracer)
+    assert otel._tracer is None
 
 
 def test_enable_is_idempotent_until_disabled():
@@ -58,7 +72,7 @@ def test_enable_is_idempotent_until_disabled():
     try:
         otel.enable(tracer_provider=providers[0])
         otel.enable(tracer_provider=providers[1])
-        with otel._tracer.start_as_current_span("x"):
+        with active_tracer().start_as_current_span("x"):
             pass
         assert len(first.get_finished_spans()) == 1
         assert second.get_finished_spans() == ()
@@ -68,7 +82,7 @@ def test_enable_is_idempotent_until_disabled():
 
 
 def test_capture_context_returns_current(otel_exporter: InMemorySpanExporter):
-    with otel._tracer.start_as_current_span("outer") as span:
+    with active_tracer().start_as_current_span("outer") as span:
         captured = otel.capture_context()
     assert captured is not None
     assert trace.get_current_span(captured) is span
@@ -138,7 +152,7 @@ def test_event_span_parents_under_captured_context(
     otel_exporter: InMemorySpanExporter,
 ):
     registered = RegisteredEventHandler(handler=EventHandler(fn=_handler), states=())
-    with otel._tracer.start_as_current_span("root") as root:
+    with active_tracer().start_as_current_span("root") as root:
         child_ctx = _ctx().fork()
     assert child_ctx.otel_context is not None
     with otel.event_span(Event(name="child"), child_ctx, registered):
@@ -273,7 +287,7 @@ def test_remote_context_never_raises_on_unusable_fields(
         assert span.parent is None
 
 
-def test_remote_context_ignores_baggage():
+def test_remote_context_ignores_baggage(otel_exporter: InMemorySpanExporter):
     """Only the trace context is taken from the client, never baggage."""
     from opentelemetry import baggage
 
@@ -285,7 +299,7 @@ def test_remote_context_without_traceparent_starts_new_trace(
     otel_exporter: InMemorySpanExporter,
 ):
     registered = RegisteredEventHandler(handler=EventHandler(fn=_handler), states=())
-    with otel._tracer.start_as_current_span("websocket"), otel.remote_context({}):
+    with active_tracer().start_as_current_span("websocket"), otel.remote_context({}):
         ctx = _ctx().fork()
     with otel.event_span(Event(name="e"), ctx, registered):
         pass
@@ -303,7 +317,7 @@ def test_asgi_middleware_hook_toggles():
 
 
 def test_attach_context(otel_exporter: InMemorySpanExporter):
-    with otel._tracer.start_as_current_span("outer") as outer:
+    with active_tracer().start_as_current_span("outer") as outer:
         captured = otel.capture_context()
     otel.attach_context(None)
     assert not trace.get_current_span().get_span_context().is_valid

--- a/tests/units/reflex_base/test_otel.py
+++ b/tests/units/reflex_base/test_otel.py
@@ -67,7 +67,7 @@ def test_event_span_attributes(otel_exporter: InMemorySpanExporter):
         otel.ATTR_EVENT_TXID: ctx.txid,
         otel.ATTR_EVENT_BACKGROUND: False,
         otel.ATTR_SESSION_ID: "tok",
-        otel.ATTR_CODE_FUNCTION_NAME: "_handler",
+        otel.ATTR_CODE_FUNCTION_NAME: f"{__name__}._handler",
     }
     assert finished.status.status_code == StatusCode.UNSET
 

--- a/tests/units/reflex_base/test_otel.py
+++ b/tests/units/reflex_base/test_otel.py
@@ -1,6 +1,8 @@
 """Tests for the reflex_base.otel trace points."""
 
 import asyncio
+import dis
+import inspect
 import subprocess
 import sys
 from time import perf_counter
@@ -42,6 +44,28 @@ def test_disabled_path_imports_no_opentelemetry():
         [sys.executable, "-c", code], check=True, capture_output=True, text=True
     )
     assert out.stdout.strip() == "[]"
+
+
+def test_trace_points_carry_no_import_statement():
+    """The per-event trace points do not pay for an import lookup on every call.
+
+    enable() binds the API modules once; an import statement inside a trace
+    point would still cost a ``sys.modules`` lookup after the module is loaded.
+    """
+    trace_points = (
+        otel.capture_context,
+        otel.attach_context,
+        otel.remote_context,
+        inspect.unwrap(otel.event_span),
+        otel._AttachedContext.__enter__,
+        otel._AttachedContext.__exit__,
+        otel.record_state_acquired,
+        otel.record_message_size,
+        otel.record_connection,
+    )
+    for trace_point in trace_points:
+        opnames = {inst.opname for inst in dis.get_instructions(trace_point)}
+        assert "IMPORT_NAME" not in opnames, trace_point.__qualname__
 
 
 def test_disabled_by_default():

--- a/tests/units/reflex_base/test_otel.py
+++ b/tests/units/reflex_base/test_otel.py
@@ -44,6 +44,29 @@ def test_enable_disable_toggle():
     assert isinstance(otel._tracer, trace.NoOpTracer)
 
 
+def test_enable_is_idempotent_until_disabled():
+    """A second enable() keeps the first providers; disable() resets."""
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+    first, second = InMemorySpanExporter(), InMemorySpanExporter()
+    providers = []
+    for exporter in (first, second):
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        providers.append(provider)
+    try:
+        otel.enable(tracer_provider=providers[0])
+        otel.enable(tracer_provider=providers[1])
+        with otel._tracer.start_as_current_span("x"):
+            pass
+        assert len(first.get_finished_spans()) == 1
+        assert second.get_finished_spans() == ()
+    finally:
+        otel.disable()
+    assert otel.enabled is False
+
+
 def test_capture_context_returns_current(otel_exporter: InMemorySpanExporter):
     with otel._tracer.start_as_current_span("outer") as span:
         captured = otel.capture_context()

--- a/tests/units/reflex_base/test_otel.py
+++ b/tests/units/reflex_base/test_otel.py
@@ -60,7 +60,7 @@ def test_event_span_attributes(otel_exporter: InMemorySpanExporter):
         assert trace.get_current_span() is span
     (finished,) = otel_exporter.get_finished_spans()
     assert finished.name == "state.sub.handler"
-    assert finished.kind == SpanKind.SERVER
+    assert finished.kind == SpanKind.CONSUMER
     assert finished.parent is None
     assert finished.attributes == {
         otel.ATTR_EVENT_NAME: "state.sub.handler",
@@ -192,7 +192,7 @@ def test_remote_context_uses_traceparent(otel_exporter: InMemorySpanExporter):
     with otel.event_span(Event(name="e"), ctx, registered):
         pass
     (span,) = otel_exporter.get_finished_spans()
-    assert span.kind == SpanKind.SERVER
+    assert span.kind == SpanKind.CONSUMER
     assert span.parent is not None
     assert span.parent.is_remote
     assert format(span.parent.trace_id, "032x") == "0af7651916cd43dd8448eb211c80319c"

--- a/tests/units/reflex_base/test_otel.py
+++ b/tests/units/reflex_base/test_otel.py
@@ -79,7 +79,7 @@ def test_enable_disable_toggle():
     assert otel.capture_context() is not None
     otel.disable()
     assert otel.enabled is False
-    assert otel._tracer is None
+    assert otel.capture_context() is None
 
 
 def test_enable_is_idempotent_until_disabled():

--- a/tests/units/reflex_base/test_otel.py
+++ b/tests/units/reflex_base/test_otel.py
@@ -66,10 +66,19 @@ def test_event_span_attributes(otel_exporter: InMemorySpanExporter):
         otel.ATTR_EVENT_NAME: "state.sub.handler",
         otel.ATTR_EVENT_TXID: ctx.txid,
         otel.ATTR_EVENT_BACKGROUND: False,
-        otel.ATTR_SESSION_ID: "tok",
+        otel.ATTR_SESSION_ID: otel._session_id("tok"),
         otel.ATTR_CODE_FUNCTION_NAME: f"{__name__}._handler",
     }
     assert finished.status.status_code == StatusCode.UNSET
+
+
+def test_session_id_is_not_the_token():
+    """The token authorizes state access; only a stable digest is exported."""
+    digest = otel._session_id("secret-token")
+    assert "secret-token" not in digest
+    assert len(digest) == 16
+    assert digest == otel._session_id("secret-token")
+    assert digest != otel._session_id("other-token")
 
 
 def test_parent_txid_only_for_chained_events(otel_exporter: InMemorySpanExporter):

--- a/tests/units/reflex_otel/test_init.py
+++ b/tests/units/reflex_otel/test_init.py
@@ -35,6 +35,18 @@ def test_instrument_is_idempotent(instrumentor: ReflexInstrumentor):
     assert otel.enabled is True
 
 
+def test_sdk_disabled_keeps_trace_points_off(
+    instrumentor: ReflexInstrumentor, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+    instrumentor.instrument()
+    assert instrumentor.is_instrumented_by_opentelemetry
+    assert otel.enabled is False
+    assert otel.asgi_middleware is None
+    instrumentor.uninstrument()
+    assert otel.enabled is False
+
+
 def test_dependencies_target_reflex_base(instrumentor: ReflexInstrumentor):
     (dep,) = instrumentor.instrumentation_dependencies()
     assert dep.startswith("reflex-base")

--- a/tests/units/reflex_otel/test_init.py
+++ b/tests/units/reflex_otel/test_init.py
@@ -9,6 +9,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.util.http import ExcludeList
 from reflex_base import otel
+from reflex_base.environment import environment
 from reflex_otel import ReflexInstrumentor
 
 
@@ -73,6 +74,28 @@ def test_excluded_urls_only_defaults_when_omitted(
     # .url_disabled() on them; always hand it a parsed ExcludeList.
     assert isinstance(wrapped.excluded_urls, ExcludeList)
     assert wrapped.excluded_urls.url_disabled("/ping") is ping_disabled
+
+
+@pytest.mark.parametrize("mounted", [False, True])
+def test_default_exclusions_cover_mounted_frontend_assets(
+    instrumentor: ReflexInstrumentor, monkeypatch: pytest.MonkeyPatch, mounted: bool
+):
+    """Static chunks served by the backend in prod mode get no spans by default."""
+    monkeypatch.setenv(
+        environment.REFLEX_MOUNT_FRONTEND_COMPILED_APP.name, str(mounted).lower()
+    )
+    instrumentor.instrument(tracer_provider=TracerProvider())
+    assert otel.asgi_middleware is not None
+
+    async def app(scope, receive, send): ...
+
+    wrapped = otel.asgi_middleware(app)
+    assert isinstance(wrapped, OpenTelemetryMiddleware)
+    excluded = wrapped.excluded_urls
+    assert isinstance(excluded, ExcludeList)
+    assert excluded.url_disabled("http://h/ping")
+    assert excluded.url_disabled("http://h/assets/index-abc.js") is mounted
+    assert not excluded.url_disabled("http://h/api/assets/list")
 
 
 async def test_asgi_span_redacts_client_token(instrumentor: ReflexInstrumentor):

--- a/tests/units/reflex_otel/test_init.py
+++ b/tests/units/reflex_otel/test_init.py
@@ -5,6 +5,8 @@ from collections.abc import Generator
 import pytest
 from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
 from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.util.http import ExcludeList
 from reflex_base import otel
 from reflex_otel import ReflexInstrumentor
@@ -71,6 +73,50 @@ def test_excluded_urls_only_defaults_when_omitted(
     # .url_disabled() on them; always hand it a parsed ExcludeList.
     assert isinstance(wrapped.excluded_urls, ExcludeList)
     assert wrapped.excluded_urls.url_disabled("/ping") is ping_disabled
+
+
+async def test_asgi_span_redacts_client_token(instrumentor: ReflexInstrumentor):
+    """The websocket connect URL carries the client token; spans must not."""
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    seen: list[str] = []
+    instrumentor.instrument(
+        tracer_provider=provider,
+        server_request_hook=lambda span, scope: seen.append(scope["path"]),
+    )
+    assert otel.asgi_middleware is not None
+
+    async def app(scope, receive, send):
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    async def receive():  # noqa: RUF029
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        pass
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/_event/",
+        "raw_path": b"/_event/",
+        "query_string": b"token=secret-token&transport=websocket&EIO=4",
+        "headers": [],
+        "scheme": "http",
+        "server": ("localhost", 80),
+        "http_version": "1.1",
+    }
+    await otel.asgi_middleware(app)(scope, receive, send)
+    (span,) = exporter.get_finished_spans()
+    assert span.attributes is not None
+    urls = [v for v in span.attributes.values() if isinstance(v, str) and "token=" in v]
+    assert urls, span.attributes
+    assert all("secret-token" not in v and "token=REDACTED" in v for v in urls)
+    assert all("secret-token" not in str(v) for v in span.attributes.values())
+    # The user's own hook still runs, after the redaction.
+    assert seen == ["/_event/"]
 
 
 async def test_asgi_middleware_handles_requests(instrumentor: ReflexInstrumentor):

--- a/tests/units/reflex_otel/test_init.py
+++ b/tests/units/reflex_otel/test_init.py
@@ -76,6 +76,37 @@ def test_excluded_urls_only_defaults_when_omitted(
     assert wrapped.excluded_urls.url_disabled("/ping") is ping_disabled
 
 
+@pytest.mark.parametrize(
+    ("variable", "value", "ping_disabled"),
+    [
+        ("OTEL_PYTHON_REFLEX_EXCLUDED_URLS", "", False),
+        ("OTEL_PYTHON_EXCLUDED_URLS", "", False),
+        ("OTEL_PYTHON_REFLEX_EXCLUDED_URLS", "/health", False),
+        ("OTEL_PYTHON_EXCLUDED_URLS", "/ping,/health", True),
+    ],
+)
+def test_excluded_urls_env_empty_means_none(
+    instrumentor: ReflexInstrumentor,
+    monkeypatch: pytest.MonkeyPatch,
+    variable: str,
+    value: str,
+    ping_disabled: bool,
+):
+    """A variable set to an empty string disables the defaults, like an empty kwarg."""
+    monkeypatch.delenv("OTEL_PYTHON_REFLEX_EXCLUDED_URLS", raising=False)
+    monkeypatch.delenv("OTEL_PYTHON_EXCLUDED_URLS", raising=False)
+    monkeypatch.setenv(variable, value)
+    instrumentor.instrument(tracer_provider=TracerProvider())
+    assert otel.asgi_middleware is not None
+
+    async def app(scope, receive, send): ...
+
+    wrapped = otel.asgi_middleware(app)
+    assert isinstance(wrapped, OpenTelemetryMiddleware)
+    assert isinstance(wrapped.excluded_urls, ExcludeList)
+    assert wrapped.excluded_urls.url_disabled("/ping") is ping_disabled
+
+
 @pytest.mark.parametrize("mounted", [False, True])
 def test_default_exclusions_cover_mounted_frontend_assets(
     instrumentor: ReflexInstrumentor, monkeypatch: pytest.MonkeyPatch, mounted: bool

--- a/tests/units/reflex_otel/test_init.py
+++ b/tests/units/reflex_otel/test_init.py
@@ -4,10 +4,8 @@ import os
 import subprocess
 import sys
 from collections.abc import Generator
-from pathlib import Path
 
 import pytest
-import reflex_otel
 from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -15,12 +13,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from opentelemetry.util.http import ExcludeList
 from reflex_base import otel
 from reflex_base.environment import environment
-from reflex_otel import ReflexInstrumentor, _instruments
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    import tomli as tomllib
+from reflex_otel import ReflexInstrumentor
 
 
 @pytest.fixture
@@ -158,19 +151,9 @@ def test_opts_into_stable_http_semconv(
     assert ("http.scheme" in keys) is expect_old
 
 
-def test_dependencies_target_reflex_base(instrumentor: ReflexInstrumentor):
-    (dep,) = instrumentor.instrumentation_dependencies()
-    assert dep.startswith("reflex-base")
-
-
-def test_instruments_match_pyproject_extra():
-    """The floor the instrumentor checks at runtime is the one the package declares."""
-    pyproject = Path(reflex_otel.__file__).parents[2] / "pyproject.toml"
-    extra = tomllib.loads(pyproject.read_text())["project"]["optional-dependencies"]
-    assert list(_instruments) == extra["instruments"]
-    assert [
-        str(dep) for dep in ReflexInstrumentor().instrumentation_dependencies()
-    ] == extra["instruments"]
+def test_no_runtime_dependency_check(instrumentor: ReflexInstrumentor):
+    """reflex-base is a hard dependency: the resolver enforces the floor, not instrument()."""
+    assert instrumentor.instrumentation_dependencies() == ()
 
 
 def test_instrument_installs_asgi_middleware(instrumentor: ReflexInstrumentor):

--- a/tests/units/reflex_otel/test_init.py
+++ b/tests/units/reflex_otel/test_init.py
@@ -1,6 +1,7 @@
 """Tests for the reflex_otel instrumentor."""
 
 import os
+import subprocess
 import sys
 from collections.abc import Generator
 from pathlib import Path
@@ -38,10 +39,51 @@ def test_instrument_toggles_trace_points(instrumentor: ReflexInstrumentor):
     assert otel.enabled is False
 
 
-def test_instrument_is_idempotent(instrumentor: ReflexInstrumentor):
-    instrumentor.instrument()
-    instrumentor.instrument()
+def test_instrument_is_idempotent(
+    instrumentor: ReflexInstrumentor, caplog: pytest.LogCaptureFixture
+):
+    """A re-imported app module calls instrument() again; that must stay silent."""
+    with caplog.at_level("WARNING"):
+        instrumentor.instrument()
+        instrumentor.instrument()
     assert otel.enabled is True
+    assert "already instrumented" not in caplog.text
+
+
+def test_instrument_configures_sdk_from_environment():
+    """With OTEL_*_EXPORTER set and no SDK installed, instrument() sets the SDK up."""
+    code = (
+        "from opentelemetry import trace; from reflex_base import otel; "
+        "from reflex_otel import ReflexInstrumentor; "
+        "ReflexInstrumentor().instrument(); ReflexInstrumentor().instrument(); "
+        "print(type(trace.get_tracer_provider()).__name__, otel.enabled)"
+    )
+    env = {
+        **os.environ,
+        "OTEL_TRACES_EXPORTER": "console",
+        "OTEL_METRICS_EXPORTER": "none",
+        "OTEL_LOGS_EXPORTER": "none",
+    }
+    out = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert out.stdout.split() == ["TracerProvider", "True"]
+    assert "already instrumented" not in out.stderr
+    # Without the exporter variables the SDK is left alone (proxy provider).
+    env.pop("OTEL_TRACES_EXPORTER")
+    env["OTEL_METRICS_EXPORTER"] = ""
+    out = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert out.stdout.split() == ["ProxyTracerProvider", "True"]
 
 
 def test_sdk_disabled_keeps_trace_points_off(

--- a/tests/units/reflex_otel/test_init.py
+++ b/tests/units/reflex_otel/test_init.py
@@ -1,9 +1,12 @@
 """Tests for the reflex_otel instrumentor."""
 
 import os
+import sys
 from collections.abc import Generator
+from pathlib import Path
 
 import pytest
+import reflex_otel
 from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -11,7 +14,12 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from opentelemetry.util.http import ExcludeList
 from reflex_base import otel
 from reflex_base.environment import environment
-from reflex_otel import ReflexInstrumentor
+from reflex_otel import ReflexInstrumentor, _instruments
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 
 @pytest.fixture
@@ -66,6 +74,16 @@ def test_opts_into_stable_http_semconv(
 def test_dependencies_target_reflex_base(instrumentor: ReflexInstrumentor):
     (dep,) = instrumentor.instrumentation_dependencies()
     assert dep.startswith("reflex-base")
+
+
+def test_instruments_match_pyproject_extra():
+    """The floor the instrumentor checks at runtime is the one the package declares."""
+    pyproject = Path(reflex_otel.__file__).parents[2] / "pyproject.toml"
+    extra = tomllib.loads(pyproject.read_text())["project"]["optional-dependencies"]
+    assert list(_instruments) == extra["instruments"]
+    assert [
+        str(dep) for dep in ReflexInstrumentor().instrumentation_dependencies()
+    ] == extra["instruments"]
 
 
 def test_instrument_installs_asgi_middleware(instrumentor: ReflexInstrumentor):

--- a/tests/units/reflex_otel/test_init.py
+++ b/tests/units/reflex_otel/test_init.py
@@ -1,5 +1,6 @@
 """Tests for the reflex_otel instrumentor."""
 
+import os
 from collections.abc import Generator
 
 import pytest
@@ -45,6 +46,21 @@ def test_sdk_disabled_keeps_trace_points_off(
     assert otel.asgi_middleware is None
     instrumentor.uninstrument()
     assert otel.enabled is False
+
+
+@pytest.mark.parametrize("preset", [None, "http/dup"])
+def test_opts_into_stable_http_semconv(
+    instrumentor: ReflexInstrumentor,
+    monkeypatch: pytest.MonkeyPatch,
+    preset: str | None,
+):
+    """The middleware uses the stable HTTP names unless the operator chose otherwise."""
+    if preset is None:
+        monkeypatch.delenv("OTEL_SEMCONV_STABILITY_OPT_IN", raising=False)
+    else:
+        monkeypatch.setenv("OTEL_SEMCONV_STABILITY_OPT_IN", preset)
+    instrumentor.instrument(tracer_provider=TracerProvider())
+    assert os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] == (preset or "http")
 
 
 def test_dependencies_target_reflex_base(instrumentor: ReflexInstrumentor):

--- a/tests/units/reflex_otel/test_init.py
+++ b/tests/units/reflex_otel/test_init.py
@@ -98,19 +98,64 @@ def test_sdk_disabled_keeps_trace_points_off(
     assert otel.enabled is False
 
 
-@pytest.mark.parametrize("preset", [None, "http/dup"])
+_SEMCONV_PROBE = """
+import asyncio, os
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from reflex_base import otel
+from reflex_otel import ReflexInstrumentor
+
+exporter = InMemorySpanExporter()
+provider = TracerProvider()
+provider.add_span_processor(SimpleSpanProcessor(exporter))
+ReflexInstrumentor().instrument(tracer_provider=provider)
+
+async def app(scope, receive, send):
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({"type": "http.response.body", "body": b""})
+
+async def receive():
+    return {"type": "http.request", "body": b"", "more_body": False}
+
+async def send(message):
+    pass
+
+scope = {"type": "http", "method": "GET", "path": "/x", "raw_path": b"/x", "query_string": b"",
+         "headers": [], "scheme": "http", "server": ("localhost", 80), "http_version": "1.1"}
+asyncio.run(otel.asgi_middleware(app)(scope, receive, send))
+(span,) = exporter.get_finished_spans()
+print(os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"], sorted(span.attributes))
+"""
+
+
+@pytest.mark.parametrize(
+    ("preset", "expect_new", "expect_old"),
+    [(None, True, False), ("http/dup", True, True)],
+)
 def test_opts_into_stable_http_semconv(
-    instrumentor: ReflexInstrumentor,
-    monkeypatch: pytest.MonkeyPatch,
-    preset: str | None,
+    preset: str | None, expect_new: bool, expect_old: bool
 ):
-    """The middleware uses the stable HTTP names unless the operator chose otherwise."""
-    if preset is None:
-        monkeypatch.delenv("OTEL_SEMCONV_STABILITY_OPT_IN", raising=False)
-    else:
-        monkeypatch.setenv("OTEL_SEMCONV_STABILITY_OPT_IN", preset)
-    instrumentor.instrument(tracer_provider=TracerProvider())
-    assert os.environ["OTEL_SEMCONV_STABILITY_OPT_IN"] == (preset or "http")
+    """The middleware emits the stable HTTP names unless the operator chose otherwise.
+
+    The contrib packages read the variable once per process, so this runs in a
+    fresh interpreter.
+    """
+    env = {k: v for k, v in os.environ.items() if k != "OTEL_SEMCONV_STABILITY_OPT_IN"}
+    if preset is not None:
+        env["OTEL_SEMCONV_STABILITY_OPT_IN"] = preset
+    out = subprocess.run(
+        [sys.executable, "-c", _SEMCONV_PROBE],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    ).stdout
+    value, _, keys = out.partition(" ")
+    assert value == (preset or "http")
+    # Server spans carry url.scheme/url.path under the stable conventions.
+    assert ("url.scheme" in keys) is expect_new
+    assert ("http.scheme" in keys) is expect_old
 
 
 def test_dependencies_target_reflex_base(instrumentor: ReflexInstrumentor):

--- a/tests/units/test_app.py
+++ b/tests/units/test_app.py
@@ -4369,18 +4369,24 @@ def test_call_app_wraps_with_otel_asgi_middleware():
 
 
 def test_sio_json_records_message_sizes(otel_metrics):
-    """Socket.IO packet serialization records sizes in both directions."""
+    """Socket.IO packet serialization records UTF-8 sizes in both directions."""
     data = _sio_dumps({"a": "é"}, separators=(",", ":"))
     assert data == '{"a":"é"}'
     assert _sio_loads(data) == {"a": "é"}
     assert _sio_loads(data.encode()) == {"a": "é"}
+    # ASCII payloads take the fast path that sizes without encoding a copy.
+    ascii_data = _sio_dumps({"b": "x"}, separators=(",", ":"))
+    assert _sio_loads(ascii_data) == {"b": "x"}
     points = {
         p.attributes[otel.ATTR_NETWORK_IO_DIRECTION]: p.sum
         for p in metric_points(otel_metrics, otel.METRIC_WEBSOCKET_MESSAGE_SIZE)
     }
     size = len(data.encode())
     assert size == len(data) + 1
-    assert points == {"transmit": size, "receive": 2 * size}
+    assert points == {
+        "transmit": size + len(ascii_data),
+        "receive": 2 * size + len(ascii_data),
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/units/test_app.py
+++ b/tests/units/test_app.py
@@ -71,7 +71,7 @@ from reflex.model import Model
 from reflex.state import BaseState, OnLoadInternalState, State, reload_state_module
 from reflex.utils import exec as exec_utils
 
-from .conftest import chdir, metric_points
+from .conftest import active_tracer, chdir, metric_points
 from .states import GenState
 from .states.upload import (
     ChildFileUploadState,
@@ -4408,7 +4408,7 @@ async def test_on_event_uses_frontend_traceparent(otel_exporter):
     ns._token_manager.sid_to_token["sid"] = "tok"
 
     traceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
-    with otel._tracer.start_as_current_span("websocket"):
+    with active_tracer().start_as_current_span("websocket"):
         await ns.on_event("sid", {"name": "state.h", "traceparent": traceparent})
         await ns.on_event("sid", {"name": "state.h"})
     remote, fresh = seen

--- a/uv.lock
+++ b/uv.lock
@@ -598,7 +598,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -676,7 +676,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
@@ -1016,7 +1016,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1892,15 +1892,15 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "cycler", marker = "python_full_version < '3.11'" },
-    { name = "fonttools", marker = "python_full_version < '3.11'" },
-    { name = "kiwisolver", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pillow", marker = "python_full_version < '3.11'" },
-    { name = "pyparsing", marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
 wheels = [
@@ -1976,16 +1976,16 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "cycler", marker = "python_full_version >= '3.11'" },
-    { name = "fonttools", marker = "python_full_version >= '3.11'" },
-    { name = "kiwisolver", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "pillow", marker = "python_full_version >= '3.11'" },
-    { name = "pyparsing", marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/64/f9a391af28f518b11ad45a8a712353c94a0aefce09d3703200e5c54b610a/matplotlib-3.11.1.tar.gz", hash = "sha256:69647db5746941c793d6e445a4cd349323ffb87d9cc958c2ad84a659b4832d30", size = 32612045, upload-time = "2026-07-18T03:39:46.63Z" }
 wheels = [
@@ -2626,10 +2626,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "pytz", marker = "python_full_version < '3.11'" },
-    { name = "tzdata", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -2698,10 +2698,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/be/4f/5f3422a2afec5ffc46308b79e53291365a93748b498ac2e58bead0197916/pandas-3.0.5.tar.gz", hash = "sha256:dca3734d6ab7c906e6730f0788b0a1dbb9f2467731f9711f77995c8e9d62d712", size = 4658219, upload-time = "2026-07-22T22:19:28.819Z" }
 wheels = [
@@ -3907,7 +3907,6 @@ dev = [
 name = "reflex-base"
 source = { editable = "packages/reflex-base" }
 dependencies = [
-    { name = "opentelemetry-api" },
     { name = "packaging" },
     { name = "platformdirs" },
     { name = "rich" },
@@ -3921,7 +3920,6 @@ pydantic = [
 
 [package.metadata]
 requires-dist = [
-    { name = "opentelemetry-api", specifier = ">=1.30.0,<2.0" },
     { name = "packaging", specifier = ">=24.2,<27" },
     { name = "platformdirs", specifier = ">=4.3.7,<5.0" },
     { name = "pydantic", marker = "extra == 'pydantic'", specifier = ">=2.12.0,<3.0" },
@@ -4427,7 +4425,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -4488,7 +4486,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -4567,7 +4565,7 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -4255,20 +4255,13 @@ dependencies = [
     { name = "reflex-base" },
 ]
 
-[package.optional-dependencies]
-instruments = [
-    { name = "reflex-base" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "opentelemetry-api", specifier = ">=1.30.0,<2.0" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.49b0,<1.0" },
     { name = "opentelemetry-instrumentation-asgi", specifier = ">=0.49b0,<1.0" },
     { name = "reflex-base", editable = "packages/reflex-base" },
-    { name = "reflex-base", marker = "extra == 'instruments'", editable = "packages/reflex-base" },
 ]
-provides-extras = ["instruments"]
 
 [[package]]
 name = "reflex-pyplot"


### PR DESCRIPTION
Review follow-ups for #6899 (built-in trace points in reflex-base and the `reflex-otel` instrumentor), one finding per commit so each patch can be reviewed on its own. The findings come from a production-readiness pass over the stack: demo apps against OTLP/HTTP, OTLP/gRPC and console exporters, hostile event payloads, uploads, chained and background events, and the zero-code `opentelemetry-instrument` path.

### What changes

**Security and privacy**
- The client token no longer leaves the process. `session.id` is a truncated SHA-256 of the token, and `token=` is redacted from `http.url` / `url.full` / `url.query` on ASGI spans.
- Only the W3C `traceparent` / `tracestate` strings are read from an event payload, through a dedicated propagator. Baggage or malformed fields sent by a client are ignored and never raise.

**Span correctness**
- Events from the browser are CONSUMER spans, paired with the browser's PRODUCER span; chained events are INTERNAL children.
- `reflex.event.parent_txid` is set only on chained events, and `code.function.name` is fully qualified.
- Stream-delta handlers nest under the caller's span, and the events returned by the backend exception handler parent under the failed event's span.
- Socket message sizes are measured without encoding a copy.

**Configuration and defaults**
- The ASGI middleware uses the stable HTTP semantic conventions. `OTEL_SEMCONV_STABILITY_OPT_IN=http` is set at import time unless already set, before any contrib instrumentor reads it.
- The mounted frontend's asset prefix is excluded from ASGI spans by default, an empty excluded-URLs variable is honoured, and so is `OTEL_SDK_DISABLED=true`.
- `ReflexInstrumentor().instrument()` is self-sufficient: it is a no-op when already instrumented, so the app module needs no `is_instrumented_by_opentelemetry` guard, and it configures the SDK from `OTEL_TRACES_EXPORTER` / `OTEL_METRICS_EXPORTER` when no provider has been set.

**Packaging**
- `opentelemetry-api` is a dependency of `reflex-otel` only. reflex-base imports nothing from opentelemetry until `enable()` runs, and `enable()` binds the API modules, tracer and propagator once, so no trace point carries an import statement or an `assert`.
- The reflex-base floor is `>= 0.9.10.post3.dev0`, the smallest dev version above the newest published release. The release tooling lifts it onto the next reflex-base release automatically. The runtime dependency re-check (`instrumentation_dependencies()` and the `instruments` extra) is gone: reflex-base is a hard dependency and the resolver enforces the floor.
- `py.typed`, `__all__`, `reflex_otel` registered as a logging package, README rewritten around the fixed behaviour.

### Review notes

- `http.target` needs no redaction: at the floor (0.49b0) and current ASGI instrumentation it holds the bare path; the query string only reaches `http.url` and `url.query`, which are redacted.
- `OTEL_SDK_DISABLED` is read once at `instrument()` time, as the SDK's own providers read it once at construction. Toggling it in a running process is not a supported flow; `uninstrument()` then `instrument()` resets.

### Follow-up work (out of scope here)

- `reflex.websocket.connections` is an up/down counter and drifts if instrumentation is toggled while sockets are open (connections opened before `instrument()` are counted down but never up). An observable gauge over the live session map cannot drift.
- Handler exception messages and stack traces are exported verbatim, which is standard OpenTelemetry behaviour. A `record_exception` switch on `instrument()` would let deployments opt out; the docs already say what leaves the process.
- The reflex-base floor has to chase the 0.9.10 hotfix line (`post1`, `post2` so far) until reflex-base ships a release from main, because the workspace versions itself as `0.9.10.post<distance>.dev0` and cannot express "the next minor". The min-deps job fails loudly if a published release ever satisfies the floor.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update (the `reflex-otel` README is updated here; the docs page is updated in #7070)

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them? (each commit message carries its rationale)
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally? (full unit suite, `check_min_deps.py` for reflex-base and reflex-otel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsnJbeBU5w6piuxSJoz9gy

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/7069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture>``&lt;source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;&lt;source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"&gt;&lt;img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;``</picture></a>
<!-- End of auto-generated description by cubic. -->
