### PR TITLE
perf: preload the app and fork production granian workers

### DIFF
--- a/news/+prod-fork-preload.performance.md
+++ b/news/+prod-fork-preload.performance.md
@@ -1,0 +1,1 @@
+Production backend workers on Linux are now forked from a supervisor that has already imported the app, so framework and app code are shared copy-on-write instead of re-imported per worker. A 4-worker blank app drops from about 720 MB to about 220 MB of proportional set size and starts faster. Set `REFLEX_BACKEND_START_METHOD=spawn` for apps that are not fork-safe.

--- a/packages/reflex-base/news/+prod-fork-preload.performance.md
+++ b/packages/reflex-base/news/+prod-fork-preload.performance.md
@@ -1,0 +1,1 @@
+Add the `REFLEX_BACKEND_START_METHOD` environment variable to choose how production backend workers are started (`fork`, `spawn`, or `forkserver`).

--- a/packages/reflex-base/src/reflex_base/environment.py
+++ b/packages/reflex-base/src/reflex_base/environment.py
@@ -708,6 +708,13 @@ class EnvironmentVariables:
     # Whether to run Granian in a spawn process. This enables Reflex to pick up on environment variable changes between hot reloads.
     REFLEX_STRICT_HOT_RELOAD: EnvVar[bool] = env_var(False)
 
+    # The multiprocessing start method for production backend workers. Unset means "fork" wherever
+    # the interpreter itself defaults to a fork-based method (Linux), so workers share the app
+    # preloaded by the supervisor. Set to "spawn" for apps that are not fork-safe.
+    REFLEX_BACKEND_START_METHOD: EnvVar[
+        Literal["fork", "spawn", "forkserver"] | None
+    ] = env_var(None)
+
     # The path to the reflex log file. If not set, the log file will be stored in the reflex user directory.
     REFLEX_LOG_FILE: EnvVar[Path | None] = env_var(None)
 

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -785,6 +785,43 @@ def run_uvicorn_backend_prod(
     )
 
 
+def _backend_start_method() -> str | None:
+    """Resolve the multiprocessing start method for production backend workers.
+
+    Returns:
+        The start method to force, or None to keep the interpreter default.
+    """
+    if (method := environment.REFLEX_BACKEND_START_METHOD.get()) is not None:
+        return method
+    import multiprocessing
+
+    # Python defaults to fork (<3.14) or forkserver (3.14+) on Linux and to
+    # spawn elsewhere; only where fork is already the platform norm do we rely
+    # on it so workers can share the supervisor's pages.
+    if multiprocessing.get_start_method() in ("fork", "forkserver"):
+        return "fork"
+    return None
+
+
+def _preload_for_fork(app_target: str | None) -> None:
+    """Import the app in the supervisor so forked workers share its pages.
+
+    Args:
+        app_target: The ASGI app target; None means the reflex app, which is
+            imported here. Any other target lives in an already-loaded module.
+    """
+    import gc
+
+    from reflex.utils import prerequisites
+
+    if app_target is None:
+        prerequisites.get_app()
+    # Freezing keeps worker GC passes from writing to the preloaded objects'
+    # headers, which would copy-on-write the shared pages private again.
+    gc.collect()
+    gc.freeze()
+
+
 def run_granian_backend_prod(
     host: str, port: int, loglevel: LogLevel, app_target: str | None = None
 ):
@@ -796,11 +833,18 @@ def run_granian_backend_prod(
         loglevel: The log level.
         app_target: The ASGI app target to run. Defaults to the reflex app instance.
     """
+    import multiprocessing
+
     from granian.constants import Interfaces
     from granian.log import LogLevels
     from granian.server import Server as Granian
 
     logger.debug("Using Granian for backend")
+
+    if (start_method := _backend_start_method()) is not None:
+        multiprocessing.set_start_method(start_method, force=True)
+        if start_method == "fork":
+            _preload_for_fork(app_target)
 
     granian_app = Granian(
         target=app_target or get_app_instance_from_file(),

--- a/reflex/utils/telemetry.py
+++ b/reflex/utils/telemetry.py
@@ -496,6 +496,16 @@ def _get_telemetry_executor() -> ThreadPoolExecutor:
     return _executor
 
 
+def _reset_executor_after_fork() -> None:
+    """Drop the inherited executor; its worker thread does not exist in the child."""
+    global _executor
+    _executor = None
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_executor_after_fork)
+
+
 def _current_registration_context() -> RegistrationContext | None:
     """Return the caller's RegistrationContext, or None if none is attached.
 

--- a/tests/units/test_telemetry.py
+++ b/tests/units/test_telemetry.py
@@ -801,3 +801,14 @@ def test_flush_returns_false_when_worker_does_not_drain_in_time():
     finally:
         release.set()
         blocker.result(timeout=5)
+
+
+def test_executor_is_recreated_after_fork():
+    """A forked child drops the inherited pool, whose thread it does not own."""
+    inherited = telemetry._get_telemetry_executor()
+
+    telemetry._reset_executor_after_fork()
+
+    fresh = telemetry._get_telemetry_executor()
+    assert fresh is not inherited
+    assert fresh.submit(lambda: 1).result(timeout=5) == 1

--- a/tests/units/utils/test_exec.py
+++ b/tests/units/utils/test_exec.py
@@ -1,5 +1,7 @@
 """Tests for development backend launchers in ``reflex.utils.exec``."""
 
+import gc
+import multiprocessing
 import os
 from pathlib import Path
 
@@ -8,6 +10,7 @@ from pytest_mock import MockerFixture
 from reflex_base.environment import environment
 
 from reflex.utils import exec as exec_utils
+from reflex.utils import prerequisites
 
 DEV_BACKEND_RELOAD_ENV_NAME = environment.REFLEX_DEV_BACKEND_RELOAD_ACTIVE.name
 
@@ -116,3 +119,97 @@ def test_arbitrate_ssr_env_var_wins(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv(environment.REFLEX_SSR.name, "False")
 
     assert exec_utils.arbitrate_ssr(True) is False
+
+
+def _fake_granian_prod(mocker: MockerFixture, calls: list[str]):
+    """Patch granian and the prod launcher's collaborators, recording call order."""
+    granian_server = pytest.importorskip("granian.server")
+
+    class FakeGranian:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def serve(self):
+            calls.append("serve")
+
+    mocker.patch.object(granian_server, "Server", FakeGranian)
+    mocker.patch.object(
+        exec_utils, "get_app_instance_from_file", return_value="app:app"
+    )
+    mocker.patch.object(exec_utils, "_get_backend_workers", return_value=1)
+    mocker.patch.object(
+        multiprocessing,
+        "set_start_method",
+        side_effect=lambda method, force=False: calls.append(f"start:{method}"),
+    )
+    mocker.patch.object(
+        prerequisites, "get_app", side_effect=lambda: calls.append("preload")
+    )
+    mocker.patch.object(gc, "freeze", side_effect=lambda: calls.append("freeze"))
+
+
+def test_run_granian_backend_prod_preloads_app_before_forking(
+    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+):
+    """With fork, the app is imported and the heap frozen before workers start."""
+    monkeypatch.setenv(environment.REFLEX_BACKEND_START_METHOD.name, "fork")
+    calls: list[str] = []
+    _fake_granian_prod(mocker, calls)
+
+    exec_utils.run_granian_backend_prod(
+        host="0.0.0.0", port=8000, loglevel=exec_utils.LogLevel.INFO
+    )
+
+    assert calls == ["start:fork", "preload", "freeze", "serve"]
+
+
+def test_run_granian_backend_prod_spawn_skips_preload(
+    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+):
+    """Spawned workers re-import the app, so the supervisor does not load it."""
+    monkeypatch.setenv(environment.REFLEX_BACKEND_START_METHOD.name, "spawn")
+    calls: list[str] = []
+    _fake_granian_prod(mocker, calls)
+
+    exec_utils.run_granian_backend_prod(
+        host="0.0.0.0", port=8000, loglevel=exec_utils.LogLevel.INFO
+    )
+
+    assert calls == ["start:spawn", "serve"]
+
+
+def test_run_granian_backend_prod_custom_target_only_freezes(
+    mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+):
+    """A non-reflex target lives in an already-imported module."""
+    monkeypatch.setenv(environment.REFLEX_BACKEND_START_METHOD.name, "fork")
+    calls: list[str] = []
+    _fake_granian_prod(mocker, calls)
+
+    exec_utils.run_granian_backend_prod(
+        host="0.0.0.0",
+        port=8000,
+        loglevel=exec_utils.LogLevel.INFO,
+        app_target="reflex.utils.exec:_frontend_prod_app",
+    )
+
+    assert calls == ["start:fork", "freeze", "serve"]
+
+
+@pytest.mark.parametrize(
+    ("default_method", "expected"),
+    [("fork", "fork"), ("forkserver", "fork"), ("spawn", None)],
+)
+def test_backend_start_method_follows_platform_default(
+    mocker: MockerFixture,
+    monkeypatch: pytest.MonkeyPatch,
+    default_method: str,
+    expected: str | None,
+):
+    """Fork is forced only where the interpreter already defaults to forking."""
+    monkeypatch.delenv(environment.REFLEX_BACKEND_START_METHOD.name, raising=False)
+    mocker.patch.object(
+        multiprocessing, "get_start_method", return_value=default_method
+    )
+
+    assert exec_utils._backend_start_method() == expected


### PR DESCRIPTION
## Summary

- On Linux, `run_granian_backend_prod` now forces the `fork` start method, imports the app in the supervisor, and runs `gc.collect(); gc.freeze()` before granian starts workers. Workers share the framework and app pages copy-on-write instead of each re-importing ~1,800 modules.
- `REFLEX_BACKEND_START_METHOD` (`fork` / `spawn` / `forkserver`) overrides the choice for apps that are not fork-safe. Unset keeps the interpreter default on macOS and Windows (`spawn`), so nothing changes there.
- A forked child inherits the telemetry `ThreadPoolExecutor` but not its worker thread, so any event submitted from a worker would queue forever. An `os.register_at_fork` hook drops the inherited pool in the child. This also affected dev mode on Python <= 3.13, where `fork` was already the Linux default.

## Measurement

Blank `reflex init` app, `GRANIAN_WORKERS=4`, `reflex run --env prod --backend-only`, Python 3.14, granian 2.8.1. PSS summed over the whole process tree from `/proc/<pid>/smaps_rollup`, after 32 `/ping` requests, median of 3 runs.

| | PSS | private dirty | port open after |
|---|---|---|---|
| main | 721 MB | 692 MB | 1.82 s |
| this PR | 223 MB | 70 MB | 1.07 s |

Per worker: 137 MB PSS → 41 MB PSS. The supervisor goes from a 137 MB private copy to 47 MB PSS with 172 MB shared.

Functional check: 8 socket.io clients against the forked workers, each sending two state events and receiving the expected deltas (`count` 1 then 2), no backend errors.

## Notes for review

- `telemetry.send("run-prod")` leaves the telemetry thread alive at fork time, so Python emits its hidden-by-default `DeprecationWarning` about forking a multi-threaded process. This is the same situation dev mode has had on Python <= 3.13. Draining the executor before forking would block startup on the telemetry HTTP request, so I did not add that.
- Granian respawns (crash or `workers_max_rss`) fork from the supervisor again, which still holds the pristine preloaded app.
- Worker count default (`cpu × 2 + 1`) and the lazy-import work in #7049 are separate; this PR gains more once #7049 shrinks the shared image, but has no code dependency on it.



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/7079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

