### PR TITLE
Document Moment mount callbacks as a breaking change

### DIFF
--- a/docs/library/data-display/moment.md
+++ b/docs/library/data-display/moment.md
@@ -195,7 +195,14 @@ If you want to update the date every second, you can use the `interval` prop.
 rx.moment(interval=1000, format="HH:mm:ss")
 ```
 
-Even better, you can actually link an event handler to the `on_change` prop that will be called every time the date is updated:
+The `on_change` event fires when the component mounts and whenever the date is updated.
+Starting with `reflex-components-moment` 0.9.4, this includes static dates and
+`interval=0`: disabling periodic updates does not suppress the initial event.
+It fires again when the component remounts, such as after a reload or route navigation.
+React Strict Mode can invoke the mount event twice in development, so handlers with
+side effects should account for repeated calls.
+
+Connect an event handler with the `on_change` prop:
 
 ```python demo exec
 class MomentLiveState(rx.State):

--- a/packages/reflex-components-moment/news/+moment-mount-event.breaking.md
+++ b/packages/reflex-components-moment/news/+moment-mount-event.breaking.md
@@ -1,0 +1,1 @@
+`rx.moment` now fires `on_change` on mount and remount, including for static dates and `interval=0`. Handlers with side effects should account for the initial call and for React Strict Mode invoking it twice in development.

--- a/packages/reflex-components-moment/src/reflex_components_moment/moment.py
+++ b/packages/reflex-components-moment/src/reflex_components_moment/moment.py
@@ -113,7 +113,7 @@ class Moment(NoSSRComponent, MemoizationLeaf):
     locale: Var[str] = field(doc="The locale to use when rendering.")
 
     on_change: EventHandler[passthrough_event_spec(str)] = field(
-        doc="Fires when the date changes."
+        doc="Fires when the component mounts and when the date changes, including when interval is 0. React Strict Mode can invoke the mount event twice in development."
     )
 
     def add_imports(self) -> ImportDict:

--- a/pyi_hashes.json
+++ b/pyi_hashes.json
@@ -41,7 +41,7 @@
   "packages/reflex-components-gridjs/src/reflex_components_gridjs/datatable.pyi": "2ce1c076ecf5c2fa4945b4abdbf2f91d",
   "packages/reflex-components-lucide/src/reflex_components_lucide/icon.pyi": "1e331a3d6420b97e5b1ce7f63ad53de8",
   "packages/reflex-components-markdown/src/reflex_components_markdown/markdown.pyi": "79d0a59b1ba12a2f2c4a09fa6b5c776f",
-  "packages/reflex-components-moment/src/reflex_components_moment/moment.pyi": "92cc72695f0868cdbcec912e916541f2",
+  "packages/reflex-components-moment/src/reflex_components_moment/moment.pyi": "daced5d112ad61e46eb5355033744bba",
   "packages/reflex-components-plotly/src/reflex_components_plotly/plotly.pyi": "beb057e382e527224597c320dbb72385",
   "packages/reflex-components-radix/src/reflex_components_radix/__init__.pyi": "a77352f60fb6f4135b5d08a6e56efa6d",
   "packages/reflex-components-radix/src/reflex_components_radix/primitives/__init__.pyi": "bbd4d1a4fa73275a882c33ba485d0165",


### PR DESCRIPTION
`rx.moment` now invokes `on_change` on mount and remount after the react-moment 2.0.2 upgrade, including for static dates and `interval=0`. Document this as a breaking behavior change and explain repeated mount callbacks in development Strict Mode in the guide and generated prop documentation.

Addresses prerelease finding 002. The runtime behavior is retained as requested.

Validation: regenerated component stubs (only the Moment hash changed); Ruff lint and formatting pass for the component. Reviewed the diff for consistency with the recorded dev/prod and remount verification.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/7085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

