### PR TITLE
Correct the OTLP HTTP exporter setup examples

### DIFF
--- a/docs/api-reference/observability.md
+++ b/docs/api-reference/observability.md
@@ -27,8 +27,13 @@ exactly as `opentelemetry-instrument` would:
 
 ```bash
 OTEL_SERVICE_NAME=my_app OTEL_TRACES_EXPORTER=otlp OTEL_METRICS_EXPORTER=otlp \
-OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4318 reflex run
+  OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
+  OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4318 reflex run
 ```
+
+The protocol setting selects the HTTP exporter installed above for both traces
+and metrics. Without it, `otlp` defaults to gRPC and requires the separate gRPC
+exporter package.
 
 To build the providers yourself, pass them instead:
 `instrument(tracer_provider=..., meter_provider=...)`, from a module that is

--- a/packages/reflex-otel/README.md
+++ b/packages/reflex-otel/README.md
@@ -20,8 +20,13 @@ Configure the SDK the way you prefer:
 
   ```bash
   OTEL_SERVICE_NAME=myapp OTEL_TRACES_EXPORTER=otlp OTEL_METRICS_EXPORTER=otlp \
-  OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4318 reflex run
+    OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf \
+    OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4318 reflex run
   ```
+
+  Install `opentelemetry-exporter-otlp-proto-http` for this HTTP/protobuf
+  configuration. Without the protocol setting, `otlp` defaults to gRPC and
+  requires the separate gRPC exporter package.
 
 - Or build the providers yourself and pass them:
   `ReflexInstrumentor().instrument(tracer_provider=provider, meter_provider=meter_provider)`.

--- a/packages/reflex-otel/news/+http-exporter-setup.docs.md
+++ b/packages/reflex-otel/news/+http-exporter-setup.docs.md
@@ -1,0 +1,1 @@
+Correct the environment-variable setup example to select HTTP/protobuf for the installed OTLP HTTP exporter.


### PR DESCRIPTION
The environment-based OpenTelemetry recipe installs the OTLP HTTP exporter, but `OTEL_TRACES_EXPORTER=otlp` defaults to gRPC. Set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` in both documented commands so tracing and metrics use the installed exporter.

Addresses prerelease finding 027. This change is limited to the requested documentation correction.

Validation: in an ephemeral uv environment with the HTTP exporter installed, the SDK's environment configuration resolves both trace and metric exporters to `opentelemetry.exporter.otlp.proto.http`. Diff reviewed for consistency between README and guide.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/7086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

