### PR TITLE
Note potentially breaking state-delta key ordering

### DIFF
--- a/news/+state-delta-order.breaking.md
+++ b/news/+state-delta-order.breaking.md
@@ -1,0 +1,1 @@
+State deltas may emit state entries and variable keys in a different order. Values are unchanged, but downstream snapshots or tests comparing serialized deltas as text may need updating; compare parsed JSON objects or normalize key order instead.


### PR DESCRIPTION
State-delta key ordering changed in this release, including the order of computed and base vars and the order of state entries. Add a potentially breaking changelog note for consumers comparing serialized deltas as text, with guidance to compare parsed objects or normalize ordering.

Addresses prerelease finding 030. Documentation only; reviewed against the recorded before/after delta examples, which contain the same keys and values.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/7087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

