### PR TITLE
Complete frontend_path validation for Win32-trimmed and empty segments

### DIFF
--- a/packages/reflex-base/news/+frontend-path-trimming.bugfix.md
+++ b/packages/reflex-base/news/+frontend-path-trimming.bugfix.md
@@ -1,0 +1,1 @@
+Reject `frontend_path` segments with trailing dots or spaces that Windows trims, and empty segments from repeated slashes, before they can produce inconsistent build paths. A single leading or trailing slash remains supported.

--- a/packages/reflex-base/src/reflex_base/config.py
+++ b/packages/reflex-base/src/reflex_base/config.py
@@ -297,10 +297,10 @@ def _is_plain_path_segment(segment: str) -> bool:
         segment: One slash-delimited, non-empty segment of a configured path prefix.
 
     Returns:
-        False for ``.`` and ``..``, and for anything Windows would treat as a
-        separator, drive, or root: backslashes, ``C:``-style prefixes, UNC paths.
+        False for empty segments, trailing dots or spaces, and anything Windows
+        would treat as a separator, drive, or root.
     """
-    if segment == "..":
+    if segment.endswith((".", " ")):
         return False
     windows = PureWindowsPath(segment)
     return not windows.anchor and windows.parts == (segment,)
@@ -612,14 +612,18 @@ class Config(BaseConfig):
         # frontend_path also names the directory below the build output that the
         # built frontend is relocated into and served from, so every segment must
         # be a plain directory name on POSIX and Windows alike.
-        for segment in self.frontend_path.split("/"):
-            if segment and not _is_plain_path_segment(segment):
-                msg = (
-                    f"frontend_path {self.frontend_path!r} contains {segment!r}, "
-                    "which is not a plain directory name "
-                    "(no '.', '..', backslashes, or drive letters)."
-                )
-                raise ConfigError(msg)
+        if self.frontend_path not in ("", "/"):
+            for segment in (
+                self.frontend_path.removeprefix("/").removesuffix("/").split("/")
+            ):
+                if not _is_plain_path_segment(segment):
+                    msg = (
+                        f"frontend_path {self.frontend_path!r} contains {segment!r}, "
+                        "which is not a plain directory name "
+                        "(no empty segments, trailing dots or spaces, backslashes, "
+                        "or drive letters)."
+                    )
+                    raise ConfigError(msg)
 
         if self.backend_path and not self.backend_path.startswith("/"):
             self.backend_path = f"/{self.backend_path}"

--- a/tests/units/test_config.py
+++ b/tests/units/test_config.py
@@ -206,6 +206,13 @@ def test_invalid_frontend_compression_formats(base_config_values: dict[str, Any]
         "/\\\\",
         "/app/\\",
         "\\\\server\\share",
+        "/app.",
+        "/app ",
+        "/ .",
+        "/.. ",
+        "/app./sub",
+        "//srv",
+        "/app//sub",
     ],
 )
 def test_frontend_path_rejects_unsafe_segments(
@@ -225,14 +232,17 @@ def test_frontend_path_rejects_unsafe_segments(
     ("frontend_path", "expected"),
     [
         ("v1.2/..app/.hidden", "/v1.2/..app/.hidden"),
-        ("/app//sub", "/app//sub"),
+        ("", ""),
+        ("/", "/"),
+        ("/app/", "/app/"),
+        ("/my app", "/my app"),
         ("/v1:beta", "/v1:beta"),
     ],
 )
 def test_frontend_path_allows_plain_names(
     base_config_values: dict[str, Any], frontend_path: str, expected: str
 ):
-    """Names merely containing dots or colons, and empty segments, are not traversal.
+    """Plain names and an optional trailing slash remain supported.
 
     Args:
         base_config_values: Minimal valid Config kwargs.


### PR DESCRIPTION
The frontend-path guard added in #7044 still accepts directory names that Win32 trims and repeated separators. Reject trailing dots/spaces and empty internal segments before building or relocating the frontend, while retaining root paths, one optional trailing slash, interior spaces, and ordinary dotted names.

Addresses prerelease finding 014.

Validation: seven new unsafe-path cases failed before the fix; all 142 config tests pass afterward. Ruff lint and formatting pass. Reviewed boundary cases for empty/root prefixes and legitimate names.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/7105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

