### PR TITLE
Preserve hybrid_property frontend types on current Pyright

### DIFF
--- a/packages/reflex-base/news/+hybrid-property-pyright.bugfix.md
+++ b/packages/reflex-base/news/+hybrid-property-pyright.bugfix.md
@@ -1,0 +1,1 @@
+Preserve class-level `hybrid_property` frontend types on Pyright 1.1.412 and later instead of resolving them to `Any`.

--- a/packages/reflex-base/src/reflex_base/vars/hybrid_property.py
+++ b/packages/reflex-base/src/reflex_base/vars/hybrid_property.py
@@ -299,9 +299,11 @@ class HybridProperty(_PropertyBase, Generic[_T, _O, _V]):
     # vars. The `_V` default in the `self` annotations keeps these from matching
     # once a var function has declared a type of its own. Only access on a state
     # produces a var; on any other class the descriptor itself is returned.
+    # Preserve `_O` in `self`: nested `Any` makes newer Pyright versions treat
+    # these overloads as ambiguous and discard the frontend return type.
     @overload
     def __get__(
-        self: HybridProperty[bool, Any, Var[Any] | None],
+        self: HybridProperty[bool, _O, Var[Any] | None],
         instance: None,
         owner: type[BaseState],
         /,
@@ -309,7 +311,7 @@ class HybridProperty(_PropertyBase, Generic[_T, _O, _V]):
 
     @overload
     def __get__(
-        self: HybridProperty[bool | None, Any, Var[Any] | None],
+        self: HybridProperty[bool | None, _O, Var[Any] | None],
         instance: None,
         owner: type[BaseState],
         /,
@@ -317,7 +319,7 @@ class HybridProperty(_PropertyBase, Generic[_T, _O, _V]):
 
     @overload
     def __get__(
-        self: HybridProperty[_INT, Any, Var[Any] | None],
+        self: HybridProperty[_INT, _O, Var[Any] | None],
         instance: None,
         owner: type[BaseState],
         /,
@@ -325,7 +327,7 @@ class HybridProperty(_PropertyBase, Generic[_T, _O, _V]):
 
     @overload
     def __get__(
-        self: HybridProperty[_INT | None, Any, Var[Any] | None],
+        self: HybridProperty[_INT | None, _O, Var[Any] | None],
         instance: None,
         owner: type[BaseState],
         /,
@@ -333,7 +335,7 @@ class HybridProperty(_PropertyBase, Generic[_T, _O, _V]):
 
     @overload
     def __get__(
-        self: HybridProperty[_FLOAT, Any, Var[Any] | None],
+        self: HybridProperty[_FLOAT, _O, Var[Any] | None],
         instance: None,
         owner: type[BaseState],
         /,
@@ -341,7 +343,7 @@ class HybridProperty(_PropertyBase, Generic[_T, _O, _V]):
 
     @overload
     def __get__(
-        self: HybridProperty[_FLOAT | None, Any, Var[Any] | None],
+        self: HybridProperty[_FLOAT | None, _O, Var[Any] | None],
         instance: None,
         owner: type[BaseState],
         /,
@@ -349,7 +351,7 @@ class HybridProperty(_PropertyBase, Generic[_T, _O, _V]):
 
     @overload
     def __get__(
-        self: HybridProperty[_STR, Any, Var[Any] | None],
+        self: HybridProperty[_STR, _O, Var[Any] | None],
         instance: None,
         owner: type[BaseState],
         /,
@@ -357,7 +359,7 @@ class HybridProperty(_PropertyBase, Generic[_T, _O, _V]):
 
     @overload
     def __get__(
-        self: HybridProperty[_STR | None, Any, Var[Any] | None],
+        self: HybridProperty[_STR | None, _O, Var[Any] | None],
         instance: None,
         owner: type[BaseState],
         /,
@@ -365,7 +367,7 @@ class HybridProperty(_PropertyBase, Generic[_T, _O, _V]):
 
     @overload
     def __get__(
-        self: HybridProperty[_MAPPING, Any, Var[Any] | None],
+        self: HybridProperty[_MAPPING, _O, Var[Any] | None],
         instance: None,
         owner: type[BaseState],
         /,
@@ -373,7 +375,7 @@ class HybridProperty(_PropertyBase, Generic[_T, _O, _V]):
 
     @overload
     def __get__(
-        self: HybridProperty[_MAPPING | None, Any, Var[Any] | None],
+        self: HybridProperty[_MAPPING | None, _O, Var[Any] | None],
         instance: None,
         owner: type[BaseState],
         /,
@@ -381,7 +383,7 @@ class HybridProperty(_PropertyBase, Generic[_T, _O, _V]):
 
     @overload
     def __get__(
-        self: HybridProperty[_SEQUENCE, Any, Var[Any] | None],
+        self: HybridProperty[_SEQUENCE, _O, Var[Any] | None],
         instance: None,
         owner: type[BaseState],
         /,
@@ -389,7 +391,7 @@ class HybridProperty(_PropertyBase, Generic[_T, _O, _V]):
 
     @overload
     def __get__(
-        self: HybridProperty[_SEQUENCE | None, Any, Var[Any] | None],
+        self: HybridProperty[_SEQUENCE | None, _O, Var[Any] | None],
         instance: None,
         owner: type[BaseState],
         /,

--- a/tests/units/vars/test_hybrid_property.py
+++ b/tests/units/vars/test_hybrid_property.py
@@ -5,11 +5,87 @@ from collections.abc import Generator
 import pytest
 from reflex_base.registry import RegistrationContext
 from reflex_base.utils.exceptions import HybridPropertyError
+from reflex_base.vars.number import BooleanVar, NumberVar
+from reflex_base.vars.object import ObjectVar
+from reflex_base.vars.sequence import ArrayVar, StringVar
 from typing_extensions import assert_type
 
 import reflex as rx
 from reflex.experimental import hybrid_property
 from reflex.vars import Var
+
+
+def test_hybrid_property_access_types():
+    """Resolve frontend types on state classes and Python types on instances."""
+
+    class TypedHybridState(rx.State):
+        name: str = "Ada"
+        count: int = 2
+        maybe_count: int | None = None
+        values: list[int] = [1, 2]
+        mapping: dict[str, int] = {"a": 1}
+
+        @hybrid_property
+        def greeting(self) -> str:
+            return f"Hello {self.name}"
+
+        @hybrid_property
+        def doubled(self) -> int:
+            return self.count * 2
+
+        @hybrid_property
+        def positive(self) -> bool:
+            return self.count > 0
+
+        @hybrid_property
+        def half(self) -> float:
+            return self.count / 2
+
+        @hybrid_property
+        def optional(self) -> int | None:
+            return self.maybe_count
+
+        @hybrid_property
+        def items(self) -> list[int]:
+            return self.values
+
+        @hybrid_property
+        def lookup(self) -> dict[str, int]:
+            return self.mapping
+
+        @hybrid_property
+        def custom(self) -> int:  # pyright: ignore[reportRedeclaration]
+            return self.count
+
+        @custom.var
+        @classmethod
+        def custom(cls) -> StringVar:
+            return Var.create("frontend")
+
+    assert_type(TypedHybridState.greeting, StringVar)
+    assert_type(TypedHybridState.doubled, NumberVar[int])
+    assert_type(TypedHybridState.positive, BooleanVar)
+    assert_type(TypedHybridState.half, NumberVar[float])
+    assert_type(TypedHybridState.optional, NumberVar[int] | None)
+    assert_type(TypedHybridState.items, ArrayVar[list[int]])
+    assert_type(TypedHybridState.lookup, ObjectVar[dict[str, int]])
+    assert_type(TypedHybridState.custom, StringVar)
+
+    state = TypedHybridState(_reflex_internal_init=True)  # pyright: ignore[reportCallIssue]
+    assert_type(state.greeting, str)
+    assert_type(state.doubled, int)
+    assert_type(state.positive, bool)
+    assert_type(state.half, float)
+    assert_type(state.optional, int | None)
+    assert_type(state.items, list[int])
+    assert_type(state.lookup, dict[str, int])
+    assert_type(state.custom, int)
+
+    class Child(TypedHybridState):
+        pass
+
+    assert_type(Child.greeting, StringVar)
+    assert_type(Child.custom, StringVar)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Class-level `hybrid_property` access resolves to `Any` on Pyright 1.1.412+ because its descriptor overloads erase the owning class to nested `Any`. Preserve the owner type variable in each overload so current Pyright selects the frontend return type while instance access retains the Python type.

Addresses prerelease finding 005. This is a typing-only implementation change with no extra runtime checks.

Validation: the new class-access assertions failed on Pyright 1.1.414 before the fix. They now pass on both current 1.1.414 and repo-pinned 1.1.411, covering scalar, container, optional, custom frontend, and inherited properties plus instance access. All 35 hybrid-property unit tests and Ruff checks pass. Diff reviewed for overload ordering and preservation of explicit `.var` return types.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/7106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

