### PR TITLE
Restore AdminDash route lookup through the public ASGI app

### DIFF
--- a/news/+admin-reverse-routing.bugfix.md
+++ b/news/+admin-reverse-routing.bugfix.md
@@ -1,0 +1,1 @@
+Fix `rx.AdminDash` pages failing with `NoMatchFound` by preserving named route lookup through the application's context middleware.

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -811,10 +811,8 @@ class App(MiddlewareMixin, LifespanMixin):
 
         top_asgi_app = Starlette(lifespan=self._run_lifespan_tasks)
         # Make sure Reflex contexts are attached for each request.
-        top_asgi_app.mount(
-            "",
-            self._context_middleware(asgi_app),
-        )
+        top_asgi_app.add_middleware(self._context_middleware)
+        top_asgi_app.mount("", asgi_app)
         App._add_cors(top_asgi_app)
         if otel.asgi_middleware is not None:
             return otel.asgi_middleware(top_asgi_app)

--- a/tests/units/test_app.py
+++ b/tests/units/test_app.py
@@ -440,6 +440,12 @@ def test_initialize_with_admin_dashboard(
     assert app.admin_dash.models[0] == test_model
 
 
+@pytest.mark.skipif(
+    not find_spec("starlette_admin")
+    or not find_spec("sqlmodel")
+    or not find_spec("pydantic"),
+    reason="starlette_admin not installed or sqlmodel not installed or pydantic not installed",
+)
 @pytest.mark.parametrize("with_transformer", [False, True])
 def test_admin_dashboard_routes_remain_reversible(
     test_model: type[Model],

--- a/tests/units/test_app.py
+++ b/tests/units/test_app.py
@@ -45,6 +45,7 @@ from starlette.applications import Starlette
 from starlette.datastructures import FormData, Headers, UploadFile
 from starlette.requests import ClientDisconnect
 from starlette.responses import StreamingResponse
+from starlette.testclient import TestClient
 from starlette_admin.auth import AuthProvider
 
 import reflex as rx
@@ -437,6 +438,37 @@ def test_initialize_with_admin_dashboard(
     assert app.admin_dash is not None
     assert len(app.admin_dash.models) > 0
     assert app.admin_dash.models[0] == test_model
+
+
+@pytest.mark.parametrize("with_transformer", [False, True])
+def test_admin_dashboard_routes_remain_reversible(
+    test_model: type[Model],
+    mocker: MockerFixture,
+    tmp_path: Path,
+    with_transformer: bool,
+):
+    """Serve admin pages through the public ASGI app with working named routes.
+
+    Args:
+        test_model: A model to list in the dashboard.
+        mocker: The mock fixture for skipping frontend compilation.
+        tmp_path: The directory for the dashboard database.
+        with_transformer: Whether another Starlette application wraps the API.
+    """
+    conf = rx.Config(app_name="testing", db_url=f"sqlite:///{tmp_path / 'admin.db'}")
+    mocker.patch("reflex_base.config._get_config", return_value=conf)
+    app = App(
+        admin_dash=AdminDash(models=[test_model]),
+        api_transformer=Starlette() if with_transformer else None,
+    )
+    mocker.patch.object(app, "_compile")
+    api = app()
+    assert isinstance(api, Starlette)
+    assert str(api.url_path_for("admin:index")) == "/admin/"
+    with TestClient(api) as client:
+        response = client.get("/admin/")
+    assert response.status_code == 200
+    assert "Reflex Admin Dashboard" in response.text
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
`rx.AdminDash` fails to render because wrapping the mounted Starlette app in a plain context-middleware function hides its named routes from the outer router. Install that function as middleware on the outer Starlette app and mount the actual API app, restoring URL reversal for admin templates.

Addresses prerelease finding 025 with a small routing fix. Request context setup is retained, including when a Starlette `api_transformer` wraps the API.

Validation: the regression test failed with `NoMatchFound` before the fix and now renders the public `/admin/` page with and without an API transformer. All 156 app unit tests pass with starlette-admin 1.0.0; all 7 selected admin/app-call tests also pass with 0.17.1. Ruff checks pass. Reviewed the middleware ordering and route visibility changes.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/7107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



CI follow-up: apply the same optional-database skip as neighboring AdminDash tests, so the no-database CI matrix does not construct a SQLModel fixture. All five AdminDash cases pass with database extras; both new parametrized cases skip when pydantic/sqlmodel/alembic/sqlalchemy are hidden from imports.
