### PR TITLE
Give forked backend workers distinct socket-owner identities

### DIFF
--- a/news/+forked-worker-token-identity.bugfix.md
+++ b/news/+forked-worker-token-identity.bugfix.md
@@ -1,0 +1,1 @@
+Give forked backend workers distinct socket-owner identities so Redis can deliver backend-initiated state updates to clients connected to another worker.

--- a/reflex/app.py
+++ b/reflex/app.py
@@ -718,13 +718,22 @@ class App(MiddlewareMixin, LifespanMixin):
 
     @contextlib.asynccontextmanager
     async def _setup_event_processor(self) -> AsyncIterator[None]:
+        """Configure event processing with a fresh worker socket identity.
+
+        Yields:
+            None while the event processor is active.
+        """
+        # The app may have been imported before the server forked its workers.
+        event_namespace = self.event_namespace
+        if event_namespace is not None:
+            event_namespace._token_manager._reset_instance_id()
         # Create the event processor.
         self._event_processor = BaseStateEventProcessor(
             middleware=self, backend_exception_handler=self.backend_exception_handler
         )
         async with self._event_processor.configure(
             state_manager=self.state_manager,
-            event_namespace=self.event_namespace,
+            event_namespace=event_namespace,
         ):
             yield
 

--- a/reflex/utils/token_manager.py
+++ b/reflex/utils/token_manager.py
@@ -55,11 +55,15 @@ class TokenManager(ABC):
     def __init__(self):
         """Initialize the token manager with local dictionaries."""
         # Each process has an instance_id to identify its own sockets.
-        self.instance_id: str = _get_new_token()
+        self._reset_instance_id()
         # Keep a mapping between client token and socket ID.
         self.token_to_socket: dict[str, SocketRecord] = {}
         # Keep a mapping between socket ID and client token.
         self.sid_to_token: dict[str, str] = {}
+
+    def _reset_instance_id(self) -> None:
+        """Assign a fresh socket-owner identity when a server worker starts."""
+        self.instance_id: str = _get_new_token()
 
     @property
     def token_to_sid(self) -> MappingProxyType[str, str]:

--- a/tests/units/test_app.py
+++ b/tests/units/test_app.py
@@ -7,6 +7,8 @@ import functools
 import io
 import json
 import logging
+import multiprocessing
+import pickle
 import re
 import unittest.mock
 import uuid
@@ -72,9 +74,16 @@ from reflex.istate.manager.redis import StateManagerRedis
 from reflex.istate.manager.token import BaseStateToken
 from reflex.istate.storage import Cookie, LocalStorage, SessionStorage
 from reflex.model import Model
-from reflex.state import BaseState, OnLoadInternalState, State, reload_state_module
+from reflex.state import (
+    BaseState,
+    OnLoadInternalState,
+    State,
+    StateUpdate,
+    reload_state_module,
+)
 from reflex.utils import build
 from reflex.utils import exec as exec_utils
+from reflex.utils.token_manager import RedisTokenManager, SocketRecord
 
 from .conftest import active_tracer, chdir, metric_points
 from .states import GenState
@@ -86,6 +95,8 @@ from .states.upload import (
 )
 
 if TYPE_CHECKING:
+    from multiprocessing.connection import Connection
+
     from sqlalchemy.engine.base import Engine
 
 
@@ -3178,6 +3189,85 @@ def test_call_app():
     app._compile = unittest.mock.Mock()
     api = app()
     assert isinstance(api, Starlette)
+
+
+def _probe_worker_token_identity(app: App, redis: AsyncMock, sender: Connection):
+    """Run the server startup path in a forked worker and report delta routing.
+
+    Args:
+        app: The application created before the fork.
+        redis: The mock Redis connection carrying another worker's socket record.
+        sender: The pipe used to report the worker's result.
+    """
+
+    async def probe():
+        """Start event processing and publish a delta to the socket owner."""
+        async with app._setup_event_processor():
+            assert app.event_namespace is not None
+            manager = app.event_namespace._token_manager
+            assert isinstance(manager, RedisTokenManager)
+            published = await manager.emit_lost_and_found(
+                "client", StateUpdate(delta={"state": {"count": 1}})
+            )
+            sender.send((
+                manager.instance_id,
+                published,
+                redis.publish.call_args.args if published else None,
+            ))
+
+    try:
+        asyncio.run(probe())
+    finally:
+        sender.close()
+
+
+@pytest.mark.skipif(
+    "fork" not in multiprocessing.get_all_start_methods(),
+    reason="Requires a server that forks after importing the app",
+)
+def test_forked_workers_publish_deltas_to_the_socket_owner():
+    """Give forked workers distinct identities before routing backend deltas."""
+    app = App()
+    app._state_manager = StateManagerMemory()
+    redis = AsyncMock()
+    manager = RedisTokenManager(redis)
+    assert app.event_namespace is not None
+    app.event_namespace._token_manager = manager
+    owner_id = manager.instance_id
+    redis.get.return_value = pickle.dumps(
+        SocketRecord(instance_id=owner_id, sid="remote")
+    )
+    workers = multiprocessing.get_context("fork")
+    worker_ids = set()
+
+    for _ in range(2):
+        receiver, sender = workers.Pipe(duplex=False)
+        process = workers.Process(
+            target=_probe_worker_token_identity, args=(app, redis, sender)
+        )
+        process.start()
+        sender.close()
+        try:
+            assert receiver.poll(10), "The forked worker did not report a result"
+            worker_id, published, publish_args = receiver.recv()
+            process.join(timeout=10)
+            assert process.exitcode == 0
+            assert published, "A live socket owned by another worker was discarded"
+            assert worker_id != owner_id
+            assert worker_id not in worker_ids
+            worker_ids.add(worker_id)
+            assert publish_args[0] == f"channel:token_manager_lost_and_found_{owner_id}"
+            record = pickle.loads(publish_args[1])
+            assert record.token == "client"
+            assert record.update.delta == {"state": {"count": 1}}
+        finally:
+            receiver.close()
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=10)
+            process.close()
+
+    assert manager.instance_id == owner_id
 
 
 @pytest.fixture


### PR DESCRIPTION
When an app is imported before a production server forks, every worker inherits the same token-manager instance ID. A worker receiving a backend-initiated delta then mistakes another worker's live socket record for its own stale record and drops the update.

Assign a fresh socket-owner identity at event-processor startup, after the fork and before events are processed. The change adds no per-event PID checks or allocations. Addresses prerelease finding 003; the defect is verified on the forked-worker path and is pre-existing.

Validation:
- A new test forks the already-created app into two workers. Before the fix it fails because publishing the remote delta returns false; afterward both workers have distinct IDs and publish the expected payload to the owner's channel.
- A separate probe using two forked processes and a temporary real Redis server delivered all six backend-initiated updates through `EventNamespace.emit_update`, with different parent/owner/sender identities. All probe processes were stopped.
- App, token-manager, shared-state, and lifespan suites: 201 passed, 5 skipped. Ruff checks pass.

Reviewed the startup ordering, stable identity during event processing, and preservation of stale-local-socket rejection. This is independent of the production preload optimization in #7079, which makes the same lifecycle boundary particularly relevant.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/7108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

