### PR TITLE
Isolate Moment component locales across siblings and routes

### DIFF
--- a/docs/library/data-display/moment.md
+++ b/docs/library/data-display/moment.md
@@ -173,6 +173,18 @@ rx.vstack(
 )
 ```
 
+### Locales
+
+Each `rx.moment` defaults to English. Set `locale` on a component to render it
+in another language; other components and pages keep their own locale.
+
+```python demo
+rx.vstack(
+    rx.moment(MomentState.date_now, format="dddd D MMMM YYYY"),
+    rx.moment(MomentState.date_now, format="dddd D MMMM YYYY", locale="fr"),
+)
+```
+
 ### Timezones
 
 You can also set dates to display in a specific timezone:

--- a/packages/reflex-components-moment/news/+isolate-moment-locales.bugfix.md
+++ b/packages/reflex-components-moment/news/+isolate-moment-locales.bugfix.md
@@ -1,0 +1,1 @@
+Keep `rx.moment` locales independent: components without a `locale` render in English even when another component or route imports a different locale. Explicit `locale="en"` also works without importing a nonexistent locale module.

--- a/packages/reflex-components-moment/src/reflex_components_moment/moment.py
+++ b/packages/reflex-components-moment/src/reflex_components_moment/moment.py
@@ -110,7 +110,10 @@ class Moment(NoSSRComponent, MemoizationLeaf):
 
     tz: Var[str] = field(doc="Display the date in the given timezone.")
 
-    locale: Var[str] = field(doc="The locale to use when rendering.")
+    locale: Var[str] = field(
+        default=Var.create("en"),
+        doc="The locale for this component. Defaults to English independently of other Moment components.",
+    )
 
     on_change: EventHandler[passthrough_event_spec(str)] = field(
         doc="Fires when the date changes."
@@ -125,7 +128,9 @@ class Moment(NoSSRComponent, MemoizationLeaf):
         imports = {}
 
         if isinstance(self.locale, LiteralVar):
-            imports[""] = f"moment/locale/{self.locale._var_value}"
+            # English is built into Moment and has no separate locale module.
+            if self.locale._var_value != "en":
+                imports[""] = f"moment/locale/{self.locale._var_value}"
         elif self.locale is not None:
             # If the user is using a variable for the locale, we can't know the
             # value at compile time so import all locales available.

--- a/pyi_hashes.json
+++ b/pyi_hashes.json
@@ -41,7 +41,7 @@
   "packages/reflex-components-gridjs/src/reflex_components_gridjs/datatable.pyi": "2ce1c076ecf5c2fa4945b4abdbf2f91d",
   "packages/reflex-components-lucide/src/reflex_components_lucide/icon.pyi": "1e331a3d6420b97e5b1ce7f63ad53de8",
   "packages/reflex-components-markdown/src/reflex_components_markdown/markdown.pyi": "79d0a59b1ba12a2f2c4a09fa6b5c776f",
-  "packages/reflex-components-moment/src/reflex_components_moment/moment.pyi": "92cc72695f0868cdbcec912e916541f2",
+  "packages/reflex-components-moment/src/reflex_components_moment/moment.pyi": "cd08dea286bddce9ea500466c3643353",
   "packages/reflex-components-plotly/src/reflex_components_plotly/plotly.pyi": "beb057e382e527224597c320dbb72385",
   "packages/reflex-components-radix/src/reflex_components_radix/__init__.pyi": "a77352f60fb6f4135b5d08a6e56efa6d",
   "packages/reflex-components-radix/src/reflex_components_radix/primitives/__init__.pyi": "bbd4d1a4fa73275a882c33ba485d0165",

--- a/tests/integration/test_moment.py
+++ b/tests/integration/test_moment.py
@@ -4,8 +4,9 @@ from collections.abc import Generator
 
 import pytest
 from selenium.webdriver.common.by import By
+from selenium.webdriver.remote.webdriver import WebDriver
 
-from reflex.testing import AppHarness, WebDriver
+from reflex.testing import AppHarness
 
 
 def MomentApp():
@@ -38,7 +39,37 @@ def MomentApp():
                 trim="large",
                 id="moment-duration",
             ),
+            rx.moment(
+                "2024-03-14T15:09:26",
+                format="dddd D MMMM YYYY",
+                id="moment-default-locale",
+            ),
+            rx.moment(
+                "2024-03-14T15:09:26",
+                format="dddd D MMMM YYYY",
+                locale="fr",
+                id="moment-french",
+            ),
+            rx.link("Plain page", href="/plain", id="plain-link"),
         )
+
+    def plain():
+        """Render moments after another route has loaded a foreign locale.
+
+        Returns:
+            The page used to check date and relative-time locale isolation.
+        """
+        return rx.vstack(
+            rx.moment(
+                "2024-03-14T15:09:26",
+                format="dddd D MMMM YYYY",
+                id="plain-date",
+            ),
+            rx.moment("2020-01-01", from_now=True, id="plain-relative"),
+            rx.link("Home", href="/", id="home-link"),
+        )
+
+    app.add_page(plain, route="/plain")
 
 
 @pytest.fixture(scope="module")
@@ -85,3 +116,41 @@ def test_moment_2_props_render(driver: WebDriver) -> None:
         lambda: driver.find_element(By.ID, "moment-duration")
     )
     AppHarness.expect(lambda: moment_duration.text == "30 mins")
+
+
+def test_moment_locales_are_isolated(driver: WebDriver) -> None:
+    """Keep default moments in English across sibling locales, navigation and reload.
+
+    Args:
+        driver: The browser connected to the Moment app.
+    """
+    AppHarness.expect(
+        lambda: (
+            driver.find_element(By.ID, "moment-default-locale").text
+            == "Thursday 14 March 2024"
+        )
+    )
+    assert driver.find_element(By.ID, "moment-french").text == "jeudi 14 mars 2024"
+    driver.find_element(By.ID, "plain-link").click()
+    AppHarness.expect(
+        lambda: (
+            driver.find_element(By.ID, "plain-date").text == "Thursday 14 March 2024"
+        )
+    )
+    AppHarness.expect(
+        lambda: driver.find_element(By.ID, "plain-relative").text.endswith("ago")
+    )
+    driver.find_element(By.ID, "home-link").click()
+    AppHarness.expect(
+        lambda: (
+            driver.find_element(By.ID, "moment-default-locale").text
+            == "Thursday 14 March 2024"
+        )
+    )
+    driver.refresh()
+    AppHarness.expect(
+        lambda: (
+            driver.find_element(By.ID, "moment-default-locale").text
+            == "Thursday 14 March 2024"
+        )
+    )

--- a/tests/units/reflex_components_moment/test_moment.py
+++ b/tests/units/reflex_components_moment/test_moment.py
@@ -1,0 +1,32 @@
+"""Tests for per-component Moment locale configuration."""
+
+import pytest
+from reflex_base.vars.base import Var
+from reflex_components_moment.moment import Moment
+
+
+@pytest.mark.parametrize("props", [{}, {"locale": None}, {"locale": "en"}])
+def test_default_locale_is_explicit_english(props):
+    """Omitted and English locales do not inherit another component's locale.
+
+    Args:
+        props: The omitted or explicitly English locale configuration.
+    """
+    moment = Moment.create("2024-03-14", **props)
+    assert 'locale:"en"' in moment.render()["props"]
+    assert "moment/locale/en" not in moment.add_imports().values()
+
+
+def test_literal_locale_import_is_preserved():
+    """A component that requests French still imports and renders that locale."""
+    moment = Moment.create("2024-03-14", locale="fr")
+    assert 'locale:"fr"' in moment.render()["props"]
+    assert moment.add_imports()[""] == "moment/locale/fr"
+
+
+def test_reactive_locale_imports_all_locales():
+    """Reactive locale selection remains available independently of the default."""
+    locale = Var(_js_expr="selectedLocale", _var_type=str)
+    moment = Moment.create("2024-03-14", locale=locale)
+    assert "locale:selectedLocale" in moment.render()["props"]
+    assert moment.add_imports()[""] == "moment/min/locales"


### PR DESCRIPTION
Importing a literal locale for one `rx.moment` changes Moment's global locale, which react-moment 2.x then uses for siblings and later routes without an explicit locale. Give each wrapper an explicit English default, retain explicit/reactive locale selection, and avoid importing the nonexistent `moment/locale/en` module.

Addresses prerelease finding 033. Document the per-component default and regenerate component stubs.

Validation: three new unit cases failed before the fix, and all five pass afterward. The browser locale-isolation regression also failed before the fix; all four Moment integration cases pass afterward in dev and prod, covering French beside default-English moments, relative dates on another route, navigation back, reload, and existing duration-format behavior. Ruff checks and generated stubs are verified. Reviewed omitted/None/explicit-English props and reactive locale imports.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/7110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

