### PR TITLE
Hold the dev backend listen socket in the granian supervisor

### DIFF
--- a/news/+dev-reload-hold-socket.bugfix.md
+++ b/news/+dev-reload-hold-socket.bugfix.md
@@ -1,0 +1,1 @@
+Keep the development backend port open while hot reload restarts the worker, so requests made during a reload wait for the new worker instead of being refused.

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -10,6 +10,7 @@ import logging
 import os
 import platform
 import re
+import socket
 import subprocess
 import sys
 from collections.abc import Mapping, Sequence
@@ -669,13 +670,31 @@ def run_granian_backend(host: str, port: int, loglevel: LogLevel):
 
     from granian.constants import Interfaces
     from granian.log import LogLevels
+    from granian.net import SocketSpec  # pyright: ignore[reportPrivateImportUsage]
     from granian.server import Server as Granian
     from reflex_base.environment import _load_dotenv_from_env
+
+    class ParentBoundGranian(Granian):  # pyright: ignore[reportGeneralTypeIssues]
+        """Granian server that binds the listen socket in the supervisor.
+
+        On Linux each worker otherwise binds only after loading the app, so
+        requests during a reload are refused. With the supervisor holding the
+        socket they wait in the accept backlog for the new worker.
+        """
+
+        def _init_shared_socket(self):
+            self._ssp = SocketSpec(self.bind_addr, self.bind_port, self.backlog)
+            self._shd = self._ssp.build()
+            self._sfd = self._shd.get_fd()
+            self._ssp = None
+            sock = socket.socket(fileno=self._sfd)
+            sock.set_inheritable(True)
+            self._sso = sock
 
     reset_dev_backend_reload_marker()
     environment.REFLEX_DEV_BACKEND_RELOAD_ACTIVE.set(True)
 
-    granian_app = Granian(
+    granian_app = ParentBoundGranian(
         target=get_app_instance_from_file(),
         factory=True,
         address=host,

--- a/tests/units/utils/test_exec.py
+++ b/tests/units/utils/test_exec.py
@@ -1,6 +1,7 @@
 """Tests for development backend launchers in ``reflex.utils.exec``."""
 
 import os
+import socket
 from pathlib import Path
 
 import pytest
@@ -78,6 +79,55 @@ def test_run_granian_backend_sets_reload_env_var_and_clears_marker(
     )
 
     assert seen["value"] == "True"
+
+
+def test_run_granian_backend_binds_listen_socket_in_supervisor(
+    tmp_path: Path, mocker: MockerFixture
+):
+    """The dev server holds the listen socket so requests queue across worker restarts."""
+    mocker.patch.object(
+        exec_utils,
+        "get_dev_backend_reload_marker",
+        return_value=tmp_path / exec_utils.DEV_BACKEND_RELOAD_MARKER,
+    )
+    mocker.patch.object(
+        exec_utils, "get_app_instance_from_file", return_value="app:app"
+    )
+    mocker.patch.object(exec_utils, "get_reload_paths", return_value=[])
+    granian_server = pytest.importorskip("granian.server")
+    servers: list[object] = []
+
+    class FakeGranian:
+        def __init__(self, *_args, **_kwargs):
+            self.bind_addr = "127.0.0.1"
+            self.bind_port = 0
+            self.backlog = 16
+            servers.append(self)
+
+        def on_reload(self, _callback):
+            pass
+
+        def serve(self):
+            pass
+
+    mocker.patch.object(granian_server, "Server", FakeGranian)
+
+    exec_utils.run_granian_backend(
+        host="127.0.0.1", port=0, loglevel=exec_utils.LogLevel.INFO
+    )
+
+    (server,) = servers
+    server._init_shared_socket()  # pyright: ignore[reportAttributeAccessIssue]
+    listener: socket.socket = server._sso  # pyright: ignore[reportAttributeAccessIssue]
+    try:
+        assert listener.get_inheritable()
+        # Once a worker calls listen the supervisor's descriptor keeps the
+        # socket listening, so connections queue while no worker accepts.
+        listener.listen()
+        with socket.create_connection(listener.getsockname(), timeout=1):
+            pass
+    finally:
+        listener.close()
 
 
 def test_with_development_condition_sets_node_and_bun_options():


### PR DESCRIPTION
## Problem

On Linux, granian 2.8 gives each worker a bare socket spec. The worker binds with `SO_REUSEPORT` only after it has imported and compiled the app, and the file-watch reload stops the old worker before it spawns the new one. Nothing listens during the whole worker boot, so every request made while hot reload runs gets connection refused. Granian 2.7.4, the minimum version we pin, bound the socket in the supervisor, so this is a behaviour change we inherited.

## Change

`run_granian_backend` (dev only) subclasses the granian server and overrides `_init_shared_socket` to bind once in the supervisor and pass the inheritable descriptor down to workers. This is the path granian already takes on macOS and Windows. Requests during a reload now wait in the kernel accept backlog and are answered by the new worker. Production (`run_granian_backend_prod`) is untouched.

## Measurements

Probing `/ping` every 50 ms across two edits, 60-page app, full dev mode:

| | refused probes | held probes | longest wait |
|---|---|---|---|
| before | 21 to 22 (from +0.20 s to +1.26 s) | 0 | - |
| after | 0 | 22 to 24 | 1.3 s |

Blank app, backend-only: 0 refused, longest wait 0.5 s. Reload cycle length is unchanged; only the failure mode changes.

Single-worker throughput, blank app `/ping`, best of 3: 4071 vs 4017 req/s keep-alive, 3097 vs 3059 req/s new connection per request. Noise.

## Trade-off

When an edit has a syntax error the worker dies and nothing accepts. Before, requests in that state were refused immediately. Now they wait until the client times out, and once the file is fixed the queued request is answered about 0.6 s later.

https://claude.ai/code/session_01CtZAjq1esmYw7iRHd5TAbG


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/7114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

