### PR TITLE
fix(vars): stop masking AttributeErrors raised in cached var computations

### DIFF
--- a/packages/reflex-base/news/+cached-var-attribute-error.bugfix.md
+++ b/packages/reflex-base/news/+cached-var-attribute-error.bugfix.md
@@ -1,0 +1,1 @@
+An `AttributeError` raised while computing a var, such as a typo inside an `@rx.serializer`, is now re-raised as a `RuntimeError` chained to the original error instead of a misleading `Attribute _cached_var_name not found` error.

--- a/packages/reflex-base/news/+cached-var-attribute-error.bugfix.md
+++ b/packages/reflex-base/news/+cached-var-attribute-error.bugfix.md
@@ -1,1 +1,1 @@
-An `AttributeError` raised while computing a var, such as a typo inside an `@rx.serializer`, is now re-raised as a `RuntimeError` chained to the original error instead of a misleading `Attribute _cached_var_name not found` error.
+An `AttributeError` raised while computing a var, such as a typo inside an `@rx.serializer`, is now re-raised as a `ReflexRuntimeError` chained to the original error instead of a misleading `Attribute _cached_var_name not found` error.

--- a/packages/reflex-base/src/reflex_base/vars/base.py
+++ b/packages/reflex-base/src/reflex_base/vars/base.py
@@ -2061,6 +2061,7 @@ class cached_property:  # noqa: N801
 
         Raises:
             TypeError: If the class does not have __set_name__.
+            RuntimeError: If computing the property raises an AttributeError.
         """
         if self._attrname is None:
             msg = "Cannot use cached_property on a class without __set_name__."
@@ -2072,7 +2073,15 @@ class cached_property:  # noqa: N801
             unique_id = uuid.uuid4().int
             object.__setattr__(instance, cached_field_name, unique_id)
         if unique_id not in GLOBAL_CACHE:
-            GLOBAL_CACHE[unique_id] = self._func(instance)
+            try:
+                GLOBAL_CACHE[unique_id] = self._func(instance)
+            except AttributeError as err:
+                # CPython would swallow an AttributeError here and fall back to __getattr__
+                msg = (
+                    f"Computing cached property {type(instance).__name__}."
+                    f"{self._attrname} raised {type(err).__name__}: {err}"
+                )
+                raise RuntimeError(msg) from err
         return GLOBAL_CACHE[unique_id]
 
 

--- a/packages/reflex-base/src/reflex_base/vars/base.py
+++ b/packages/reflex-base/src/reflex_base/vars/base.py
@@ -48,6 +48,7 @@ from reflex_base.utils.compat import annotations_from_namespace
 from reflex_base.utils.decorator import once
 from reflex_base.utils.exceptions import (
     ComputedVarSignatureError,
+    ReflexRuntimeError,
     UntypedComputedVarError,
     VarAttributeError,
     VarDependencyError,
@@ -2061,7 +2062,7 @@ class cached_property:  # noqa: N801
 
         Raises:
             TypeError: If the class does not have __set_name__.
-            RuntimeError: If computing the property raises an AttributeError.
+            ReflexRuntimeError: If computing the property raises an AttributeError.
         """
         if self._attrname is None:
             msg = "Cannot use cached_property on a class without __set_name__."
@@ -2081,7 +2082,7 @@ class cached_property:  # noqa: N801
                     f"Computing cached property {type(instance).__name__}."
                     f"{self._attrname} raised {type(err).__name__}: {err}"
                 )
-                raise RuntimeError(msg) from err
+                raise ReflexRuntimeError(msg) from err
         return GLOBAL_CACHE[unique_id]
 
 

--- a/tests/units/reflex_base/vars/test_base.py
+++ b/tests/units/reflex_base/vars/test_base.py
@@ -1,5 +1,6 @@
 """Tests for reflex_base.vars.base state metaclass field handling."""
 
+import dataclasses
 import threading
 import traceback
 import typing
@@ -9,10 +10,12 @@ import pytest
 from reflex_base.utils import serializers
 from reflex_base.utils.types import get_field_type
 from reflex_base.vars.base import (
+    CachedVarOperation,
     EvenMoreBasicBaseState,
     LiteralVar,
     Var,
     _linearize_bases,
+    cached_property_no_lock,
     field,
 )
 from reflex_base.vars.object import ObjectVar
@@ -278,3 +281,23 @@ def test_serializer_attribute_error_is_not_masked() -> None:
     assert isinstance(cause, AttributeError)
     assert "'label'" in str(cause)
     assert traceback.extract_tb(cause.__traceback__)[-1].name == "serialize_point"
+
+
+def test_cached_var_attribute_error_is_chained() -> None:
+    """An AttributeError raised in a cached var computation surfaces as the cause."""
+
+    @dataclasses.dataclass(eq=False, frozen=True, slots=True)
+    class BrokenVar(CachedVarOperation, Var):
+        @cached_property_no_lock
+        def _cached_var_name(self) -> str:
+            return "broken"
+
+        @cached_property_no_lock
+        def _cached_get_all_var_data(self):
+            msg = "the real error message"
+            raise AttributeError(msg)
+
+    with pytest.raises(RuntimeError, match="the real error message") as exc_info:
+        BrokenVar(_js_expr="")._get_all_var_data()
+    assert isinstance(exc_info.value.__cause__, AttributeError)
+    assert str(exc_info.value.__cause__) == "the real error message"

--- a/tests/units/reflex_base/vars/test_base.py
+++ b/tests/units/reflex_base/vars/test_base.py
@@ -8,6 +8,7 @@ from typing import Any, Literal, TypeVar
 
 import pytest
 from reflex_base.utils import serializers
+from reflex_base.utils.exceptions import ReflexRuntimeError
 from reflex_base.utils.types import get_field_type
 from reflex_base.vars.base import (
     CachedVarOperation,
@@ -270,7 +271,7 @@ def test_serializer_attribute_error_is_not_masked() -> None:
 
     serializers.serializer(serialize_point)
     try:
-        with pytest.raises(RuntimeError, match=r"_cached_var_name") as exc_info:
+        with pytest.raises(ReflexRuntimeError, match=r"_cached_var_name") as exc_info:
             str(LiteralVar.create([Point()]))
     finally:
         serializers.SERIALIZERS.pop(Point)
@@ -297,7 +298,7 @@ def test_cached_var_attribute_error_is_chained() -> None:
             msg = "the real error message"
             raise AttributeError(msg)
 
-    with pytest.raises(RuntimeError, match="the real error message") as exc_info:
+    with pytest.raises(ReflexRuntimeError, match="the real error message") as exc_info:
         BrokenVar(_js_expr="")._get_all_var_data()
     assert isinstance(exc_info.value.__cause__, AttributeError)
     assert str(exc_info.value.__cause__) == "the real error message"

--- a/tests/units/reflex_base/vars/test_base.py
+++ b/tests/units/reflex_base/vars/test_base.py
@@ -1,12 +1,25 @@
 """Tests for reflex_base.vars.base state metaclass field handling."""
 
+import dataclasses
 import threading
+import traceback
 import typing
+from collections.abc import Callable
 from typing import Any, Literal, TypeVar
 
 import pytest
+from reflex_base.utils import serializers
 from reflex_base.utils.types import get_field_type
-from reflex_base.vars.base import EvenMoreBasicBaseState, Var, _linearize_bases, field
+from reflex_base.vars.base import (
+    CachedVarOperation,
+    EvenMoreBasicBaseState,
+    LiteralVar,
+    Var,
+    VarData,
+    _linearize_bases,
+    cached_property_no_lock,
+    field,
+)
 from reflex_base.vars.object import ObjectVar
 from reflex_base.vars.sequence import ArrayVar, StringVar
 from typing_extensions import TypeAliasType, TypeVarTuple, Unpack
@@ -246,3 +259,155 @@ def test_linearize_bases_compares_by_identity() -> None:
             _linearize_bases((b, c)), created.__mro__[1:], strict=True
         )
     )
+
+
+_REAL_ERROR = "the real error"
+
+
+@dataclasses.dataclass(eq=False, frozen=True, slots=True)
+class _BrokenVarData(CachedVarOperation, Var):
+    @cached_property_no_lock
+    def _cached_var_name(self) -> str:
+        return "broken"
+
+    @cached_property_no_lock
+    def _cached_get_all_var_data(self) -> VarData | None:
+        raise AttributeError(_REAL_ERROR)
+
+
+@dataclasses.dataclass(eq=False, frozen=True, slots=True)
+class _BrokenVarName(CachedVarOperation, Var):
+    @cached_property_no_lock
+    def _cached_var_name(self) -> str:
+        raise AttributeError(_REAL_ERROR)
+
+
+@dataclasses.dataclass(eq=False, frozen=True, slots=True)
+class _BrokenObjectVarName(CachedVarOperation, ObjectVar):
+    @cached_property_no_lock
+    def _cached_var_name(self) -> str:
+        raise AttributeError(_REAL_ERROR)
+
+
+@dataclasses.dataclass(eq=False, frozen=True, slots=True)
+class _OuterVarName(CachedVarOperation, Var):
+    @cached_property_no_lock
+    def _cached_var_name(self) -> str:
+        return str(_BrokenVarName(_js_expr=""))
+
+
+@dataclasses.dataclass(eq=False, frozen=True, slots=True)
+class _ValueErrorVarName(CachedVarOperation, Var):
+    @cached_property_no_lock
+    def _cached_var_name(self) -> str:
+        raise ValueError(_REAL_ERROR)
+
+
+@pytest.mark.parametrize(
+    ("access", "property_name"),
+    [
+        pytest.param(
+            lambda: _BrokenVarData(_js_expr="")._get_all_var_data(),
+            "_BrokenVarData._cached_get_all_var_data",
+            id="get_all_var_data",
+        ),
+        pytest.param(
+            lambda: str(_BrokenVarName(_js_expr="")),
+            "_BrokenVarName._cached_var_name",
+            id="str",
+        ),
+        pytest.param(
+            lambda: _BrokenVarName(_js_expr="")._js_expr,
+            "_BrokenVarName._cached_var_name",
+            id="js_expr",
+        ),
+        pytest.param(
+            lambda: str(_BrokenObjectVarName(_js_expr="", _var_type=dict)),
+            "_BrokenObjectVarName._cached_var_name",
+            id="mapping_object_var",
+        ),
+        # the outer property sees a RuntimeError, so the error is wrapped once
+        pytest.param(
+            lambda: str(_OuterVarName(_js_expr="")),
+            "_BrokenVarName._cached_var_name",
+            id="nested",
+        ),
+    ],
+)
+def test_cached_property_attribute_error_is_chained(
+    access: Callable[[], object], property_name: str
+) -> None:
+    """An AttributeError raised while computing a cached property is not masked.
+
+    CPython would otherwise treat it as a failed lookup and fall back to
+    ``__getattr__``, which reported a bogus missing attribute or, for Mapping
+    vars, fabricated an item access.
+
+    Args:
+        access: Triggers the failing cached property.
+        property_name: The class and attribute name of the failing property.
+    """
+    with pytest.raises(RuntimeError) as exc_info:
+        access()
+    assert str(exc_info.value) == (
+        f"Computing cached property {property_name} raised AttributeError: {_REAL_ERROR}"
+    )
+    cause = exc_info.value.__cause__
+    assert type(cause) is AttributeError
+    assert str(cause) == _REAL_ERROR
+
+
+def test_cached_property_other_errors_propagate_unwrapped() -> None:
+    """Exceptions other than AttributeError keep their type and have no cause."""
+    with pytest.raises(ValueError, match=_REAL_ERROR) as exc_info:
+        str(_ValueErrorVarName(_js_expr=""))
+    assert exc_info.type is ValueError
+    assert exc_info.value.__cause__ is None
+
+
+def test_cached_property_failure_is_not_cached() -> None:
+    """A failed computation runs again on the next access, then caches."""
+    attempts = []
+
+    @dataclasses.dataclass(eq=False, frozen=True, slots=True)
+    class FlakyVar(CachedVarOperation, Var):
+        @cached_property_no_lock
+        def _cached_var_name(self) -> str:
+            attempts.append(None)
+            if len(attempts) == 1:
+                raise AttributeError(_REAL_ERROR)
+            return "recovered"
+
+    var = FlakyVar(_js_expr="")
+    with pytest.raises(RuntimeError):
+        str(var)
+    assert str(var) == "recovered"
+    assert str(var) == "recovered"
+    assert len(attempts) == 2
+
+
+def test_serializer_attribute_error_is_not_masked() -> None:
+    """A typo in a user serializer surfaces with the serializer's own frame."""
+
+    class Point:
+        pass
+
+    def serialize_point(value: Point) -> str:
+        return value.label  # pyright: ignore[reportAttributeAccessIssue]
+
+    serializers.serializer(serialize_point)
+    try:
+        with pytest.raises(
+            RuntimeError, match=r"LiteralArrayVar\._cached_var_name"
+        ) as exc_info:
+            str(LiteralVar.create([Point()]))
+    finally:
+        serializers.SERIALIZERS.pop(Point)
+        serializers.SERIALIZER_TYPES.pop(Point)
+        serializers.get_serializer.cache_clear()
+        serializers.get_serializer_type.cache_clear()
+    cause = exc_info.value.__cause__
+    assert isinstance(cause, AttributeError)
+    assert "'label'" in str(cause)
+    frames = traceback.extract_tb(cause.__traceback__)
+    assert frames[-1].name == serialize_point.__name__

--- a/tests/units/reflex_base/vars/test_base.py
+++ b/tests/units/reflex_base/vars/test_base.py
@@ -1,23 +1,18 @@
 """Tests for reflex_base.vars.base state metaclass field handling."""
 
-import dataclasses
 import threading
 import traceback
 import typing
-from collections.abc import Callable
 from typing import Any, Literal, TypeVar
 
 import pytest
 from reflex_base.utils import serializers
 from reflex_base.utils.types import get_field_type
 from reflex_base.vars.base import (
-    CachedVarOperation,
     EvenMoreBasicBaseState,
     LiteralVar,
     Var,
-    VarData,
     _linearize_bases,
-    cached_property_no_lock,
     field,
 )
 from reflex_base.vars.object import ObjectVar
@@ -261,133 +256,8 @@ def test_linearize_bases_compares_by_identity() -> None:
     )
 
 
-_REAL_ERROR = "the real error"
-
-
-@dataclasses.dataclass(eq=False, frozen=True, slots=True)
-class _BrokenVarData(CachedVarOperation, Var):
-    @cached_property_no_lock
-    def _cached_var_name(self) -> str:
-        return "broken"
-
-    @cached_property_no_lock
-    def _cached_get_all_var_data(self) -> VarData | None:
-        raise AttributeError(_REAL_ERROR)
-
-
-@dataclasses.dataclass(eq=False, frozen=True, slots=True)
-class _BrokenVarName(CachedVarOperation, Var):
-    @cached_property_no_lock
-    def _cached_var_name(self) -> str:
-        raise AttributeError(_REAL_ERROR)
-
-
-@dataclasses.dataclass(eq=False, frozen=True, slots=True)
-class _BrokenObjectVarName(CachedVarOperation, ObjectVar):
-    @cached_property_no_lock
-    def _cached_var_name(self) -> str:
-        raise AttributeError(_REAL_ERROR)
-
-
-@dataclasses.dataclass(eq=False, frozen=True, slots=True)
-class _OuterVarName(CachedVarOperation, Var):
-    @cached_property_no_lock
-    def _cached_var_name(self) -> str:
-        return str(_BrokenVarName(_js_expr=""))
-
-
-@dataclasses.dataclass(eq=False, frozen=True, slots=True)
-class _ValueErrorVarName(CachedVarOperation, Var):
-    @cached_property_no_lock
-    def _cached_var_name(self) -> str:
-        raise ValueError(_REAL_ERROR)
-
-
-@pytest.mark.parametrize(
-    ("access", "property_name"),
-    [
-        pytest.param(
-            lambda: _BrokenVarData(_js_expr="")._get_all_var_data(),
-            "_BrokenVarData._cached_get_all_var_data",
-            id="get_all_var_data",
-        ),
-        pytest.param(
-            lambda: str(_BrokenVarName(_js_expr="")),
-            "_BrokenVarName._cached_var_name",
-            id="str",
-        ),
-        pytest.param(
-            lambda: _BrokenVarName(_js_expr="")._js_expr,
-            "_BrokenVarName._cached_var_name",
-            id="js_expr",
-        ),
-        pytest.param(
-            lambda: str(_BrokenObjectVarName(_js_expr="", _var_type=dict)),
-            "_BrokenObjectVarName._cached_var_name",
-            id="mapping_object_var",
-        ),
-        # the outer property sees a RuntimeError, so the error is wrapped once
-        pytest.param(
-            lambda: str(_OuterVarName(_js_expr="")),
-            "_BrokenVarName._cached_var_name",
-            id="nested",
-        ),
-    ],
-)
-def test_cached_property_attribute_error_is_chained(
-    access: Callable[[], object], property_name: str
-) -> None:
-    """An AttributeError raised while computing a cached property is not masked.
-
-    CPython would otherwise treat it as a failed lookup and fall back to
-    ``__getattr__``, which reported a bogus missing attribute or, for Mapping
-    vars, fabricated an item access.
-
-    Args:
-        access: Triggers the failing cached property.
-        property_name: The class and attribute name of the failing property.
-    """
-    with pytest.raises(RuntimeError) as exc_info:
-        access()
-    assert str(exc_info.value) == (
-        f"Computing cached property {property_name} raised AttributeError: {_REAL_ERROR}"
-    )
-    cause = exc_info.value.__cause__
-    assert type(cause) is AttributeError
-    assert str(cause) == _REAL_ERROR
-
-
-def test_cached_property_other_errors_propagate_unwrapped() -> None:
-    """Exceptions other than AttributeError keep their type and have no cause."""
-    with pytest.raises(ValueError, match=_REAL_ERROR) as exc_info:
-        str(_ValueErrorVarName(_js_expr=""))
-    assert exc_info.type is ValueError
-    assert exc_info.value.__cause__ is None
-
-
-def test_cached_property_failure_is_not_cached() -> None:
-    """A failed computation runs again on the next access, then caches."""
-    attempts = []
-
-    @dataclasses.dataclass(eq=False, frozen=True, slots=True)
-    class FlakyVar(CachedVarOperation, Var):
-        @cached_property_no_lock
-        def _cached_var_name(self) -> str:
-            attempts.append(None)
-            if len(attempts) == 1:
-                raise AttributeError(_REAL_ERROR)
-            return "recovered"
-
-    var = FlakyVar(_js_expr="")
-    with pytest.raises(RuntimeError):
-        str(var)
-    assert str(var) == "recovered"
-    assert str(var) == "recovered"
-    assert len(attempts) == 2
-
-
 def test_serializer_attribute_error_is_not_masked() -> None:
-    """A typo in a user serializer surfaces with the serializer's own frame."""
+    """An AttributeError raised inside a serializer surfaces chained, with its own frame."""
 
     class Point:
         pass
@@ -397,9 +267,7 @@ def test_serializer_attribute_error_is_not_masked() -> None:
 
     serializers.serializer(serialize_point)
     try:
-        with pytest.raises(
-            RuntimeError, match=r"LiteralArrayVar\._cached_var_name"
-        ) as exc_info:
+        with pytest.raises(RuntimeError, match=r"_cached_var_name") as exc_info:
             str(LiteralVar.create([Point()]))
     finally:
         serializers.SERIALIZERS.pop(Point)
@@ -409,5 +277,4 @@ def test_serializer_attribute_error_is_not_masked() -> None:
     cause = exc_info.value.__cause__
     assert isinstance(cause, AttributeError)
     assert "'label'" in str(cause)
-    frames = traceback.extract_tb(cause.__traceback__)
-    assert frames[-1].name == serialize_point.__name__
+    assert traceback.extract_tb(cause.__traceback__)[-1].name == "serialize_point"


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the guidelines stated in [CONTRIBUTING.md](https://github.com/reflex-dev/reflex/blob/main/CONTRIBUTING.md) file?
- [x] Have you checked to ensure there aren't any other open [Pull Requests](https://github.com/reflex-dev/reflex/pulls) for the desired changed?

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### New Feature Submission:

- [x] Does your submission pass the tests?
- [x] Have you linted your code locally prior to submission?

### Changes To Core Features:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
- [x] Have you successfully ran tests with your changes locally?

### **After** these steps, you're ready to open a pull request.

closes #6978

**Problem.** When a cached var computation (`_cached_var_name`, `_cached_get_all_var_data`) raises `AttributeError`, CPython treats it as a failed attribute lookup and calls `__getattr__`. `Var.__getattr__` then raises an unchained `VarAttributeError: Attribute _cached_get_all_var_data not found.`, and on Mapping-typed vars `ObjectVar.__getattr__` fabricates an item access that later fails as `TypeError: __str__ returned non-string` or `RecursionError`. A typo inside a user `@rx.serializer` is enough to hit this, and the user's own frame never appears in the traceback.

**Change.** `cached_property.__get__` in `reflex_base/vars/base.py` wraps only the computation (`self._func(instance)`) and re-raises an `AttributeError` as a `ReflexRuntimeError` chained with `from err`:

```
ReflexRuntimeError: Computing cached property LiteralArrayVar._cached_var_name raised AttributeError: 'Point' object has no attribute 'label'
```

`ReflexRuntimeError` is the existing `ReflexError` subclass from `reflex_base.utils.exceptions`; it still subclasses `RuntimeError`, so the fix direction from the issue holds.

- Other exception types (`ValueError`, `VarTypeError`, `UntypedVarError`) pass through unchanged.
- The cache id lookup and class-level access stay outside the `try`, so they behave as before.
- A failed computation is still not stored in `GLOBAL_CACHE`, and the next access retries.
- Nested cached properties wrap once, because the outer one sees a `ReflexRuntimeError`.
- Missing public attributes (`State.x.nonexistent`) still raise `VarAttributeError`, since that path never enters a cached computation.
- One visible difference: on a var whose computation is broken, `hasattr(var, "_js_expr")` and `getattr(var, "_js_expr", default)` now raise instead of returning `False` or the default. Nothing in the repo relies on the old result.

**Tests** (in `tests/units/reflex_base/vars/test_base.py`):

- `test_cached_var_attribute_error_is_chained`: the repro from #6978, a `CachedVarOperation` whose `_cached_get_all_var_data` raises `AttributeError`. Asserts the `ReflexRuntimeError` message and that `__cause__` is the original `AttributeError`.
- `test_serializer_attribute_error_is_not_masked`: a serializer typo in `LiteralVar.create([obj])` surfaces chained, with the serializer's own frame last in the cause traceback.

Both fail on `main` with `VarAttributeError` and pass with the fix.

**Verification**

- `uv run pytest tests/units`: passes.
- `ruff check`, `ruff format --check` and `pyright` on the changed files: clean.
- Exercised in a real app: `rx.foreach([Point(1)], ...)`, `rx.box(custom_attrs={"data-p": {"a": Point(1)}})` (a `RecursionError` before) and `rx.Var.create({"k": [Point(1)]})` (a `TypeError` before) now all fail at `reflex compile` with the chained error, and the traceback ends at the user's serializer line. An app with a working serializer, Mapping-typed item access, nested var ops, `rx.cond` and `rx.foreach` runs unchanged in the browser with no console errors.

A news fragment is added at `packages/reflex-base/news/+cached-var-attribute-error.bugfix.md`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/7115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture>``&lt;source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;&lt;source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"&gt;&lt;img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;``</picture></a>
<!-- End of auto-generated description by cubic. -->
