### PR TITLE
Fix backend-only compile marker cleanup

### DIFF
--- a/news/7089.bugfix.md
+++ b/news/7089.bugfix.md
@@ -1,0 +1,1 @@
+Backend-only development runs no longer leave a compile-skip marker that can cause the next full run to skip frontend compilation.

--- a/reflex/utils/exec.py
+++ b/reflex/utils/exec.py
@@ -506,9 +506,14 @@ def run_backend(
         frontend_present: Whether the frontend is present.
     """
     web_dir = get_web_dir()
-    # Create a .nocompile file to skip compile for backend.
+    # Only a backend running with a frontend needs to skip its own compile.
+    # Backend-only runs must not leave this marker for the next full run.
     if web_dir.exists():
-        (web_dir / constants.NOCOMPILE_FILE).touch()
+        nocompile = web_dir / constants.NOCOMPILE_FILE
+        if frontend_present:
+            nocompile.touch()
+        else:
+            nocompile.unlink(missing_ok=True)
 
     if not frontend_present:
         notify_backend(host)

--- a/tests/units/utils/test_exec.py
+++ b/tests/units/utils/test_exec.py
@@ -23,7 +23,8 @@ def test_run_backend_manages_nocompile_marker(
 ) -> None:
     """Only full-stack backend runs leave the compile-skip marker."""
     marker = tmp_path / exec_utils.constants.NOCOMPILE_FILE
-    marker.touch()
+    if not frontend_present:
+        marker.touch()
     mocker.patch.object(exec_utils, "get_web_dir", return_value=tmp_path)
     mocker.patch.object(exec_utils, "should_use_granian", return_value=True)
     mocker.patch.object(exec_utils, "run_granian_backend")

--- a/tests/units/utils/test_exec.py
+++ b/tests/units/utils/test_exec.py
@@ -15,6 +15,25 @@ from reflex.utils import exec as exec_utils
 DEV_BACKEND_RELOAD_ENV_NAME = environment.REFLEX_DEV_BACKEND_RELOAD_ACTIVE.name
 
 
+@pytest.mark.parametrize("frontend_present", [False, True])
+def test_run_backend_manages_nocompile_marker(
+    tmp_path: Path,
+    mocker: MockerFixture,
+    frontend_present: bool,
+) -> None:
+    """Only full-stack backend runs leave the compile-skip marker."""
+    marker = tmp_path / exec_utils.constants.NOCOMPILE_FILE
+    marker.touch()
+    mocker.patch.object(exec_utils, "get_web_dir", return_value=tmp_path)
+    mocker.patch.object(exec_utils, "should_use_granian", return_value=True)
+    mocker.patch.object(exec_utils, "run_granian_backend")
+    mocker.patch.object(exec_utils, "notify_backend")
+
+    exec_utils.run_backend("127.0.0.1", 8000, frontend_present=frontend_present)
+
+    assert marker.exists() is frontend_present
+
+
 def test_run_backend_skips_app_preload_for_spawn(
     tmp_path: Path, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Closes #7089

  ## Summary

  Fix backend-only development runs leaving `.web/nocompile`, causing the
  next full `reflex run` to skip frontend compilation.

  ## Root Cause

  `run_backend()` created the compile-skip marker unconditionally, including
  when started with `--backend-only`.

  ## Changes

  - Only full-stack backend runs create `.web/nocompile`.
  - Backend-only runs remove any stale marker.
  - Added regression tests covering backend-only and full-stack behavior.
  - Added a bugfix news fragment.

  ## Testing

  - `git diff --check`
  - Ruff formatting check
  - Added unit coverage in `tests/units/utils/test_exec.py`


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/reflex-dev/reflex/pull/7125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

